### PR TITLE
[Swift Export] Add external binary compilation tests and test kotlinx-coroutines-core

### DIFF
--- a/native/swift/swift-export-embeddable/test/org/jetbrains/kotlin/swiftexport/standalone/test/EmbeddableExternalProjectWithBinaryCompilationTests.kt
+++ b/native/swift/swift-export-embeddable/test/org/jetbrains/kotlin/swiftexport/standalone/test/EmbeddableExternalProjectWithBinaryCompilationTests.kt
@@ -13,4 +13,4 @@ import org.jetbrains.kotlin.test.TestMetadata
 @TestDataPath("\$PROJECT_ROOT")
 @UseExtTestCaseGroupProvider
 @Suppress("JUnitTestCaseWithNoTests")
-class EmbeddableExternalProjectGenerationTests : AbstractExternalProjectGenerationTest()
+class EmbeddableExternalProjectWithBinaryCompilationTests : AbstractExternalProjectWithBinaryCompilationTest()

--- a/native/swift/swift-export-embeddable/test/org/jetbrains/kotlin/swiftexport/standalone/test/EmbeddableExternalProjectWithResultValidationTests.kt
+++ b/native/swift/swift-export-embeddable/test/org/jetbrains/kotlin/swiftexport/standalone/test/EmbeddableExternalProjectWithResultValidationTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -13,4 +13,4 @@ import org.jetbrains.kotlin.test.TestMetadata
 @TestDataPath("\$PROJECT_ROOT")
 @UseExtTestCaseGroupProvider
 @Suppress("JUnitTestCaseWithNoTests")
-class ExternalProjectGenerationTests : AbstractExternalProjectGenerationTest()
+class EmbeddableExternalProjectWithResultValidationTests : AbstractExternalProjectWithResultValidationTest()

--- a/native/swift/swift-export-standalone-integration-tests/external/test/org/jetbrains/kotlin/swiftexport/standalone/test/ExternalProjectWithBinaryCompilationTests.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/test/org/jetbrains/kotlin/swiftexport/standalone/test/ExternalProjectWithBinaryCompilationTests.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.swiftexport.standalone.test
+
+import com.intellij.testFramework.TestDataPath
+import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
+import org.jetbrains.kotlin.test.TestMetadata
+
+@TestMetadata("native/swift/swift-export-standalone-integration-tests/external/testData/generation")
+@TestDataPath("\$PROJECT_ROOT")
+@UseExtTestCaseGroupProvider
+@Suppress("JUnitTestCaseWithNoTests")
+class ExternalProjectWithBinaryCompilationTests : AbstractExternalProjectWithBinaryCompilationTest()

--- a/native/swift/swift-export-standalone-integration-tests/external/test/org/jetbrains/kotlin/swiftexport/standalone/test/ExternalProjectWithResultValidationTests.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/test/org/jetbrains/kotlin/swiftexport/standalone/test/ExternalProjectWithResultValidationTests.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.swiftexport.standalone.test
+
+import com.intellij.testFramework.TestDataPath
+import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
+import org.jetbrains.kotlin.test.TestMetadata
+
+@TestMetadata("native/swift/swift-export-standalone-integration-tests/external/testData/generation")
+@TestDataPath("\$PROJECT_ROOT")
+@UseExtTestCaseGroupProvider
+@Suppress("JUnitTestCaseWithNoTests")
+class ExternalProjectWithResultValidationTests : AbstractExternalProjectWithResultValidationTest()

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
@@ -1,0 +1,34 @@
+public enum kotlin {
+    public enum collections {
+    }
+    public enum coroutines {
+        public enum cancellation {
+        }
+    }
+    public enum sequences {
+    }
+    public enum time {
+    }
+}
+public enum kotlinx {
+    public enum atomicfu {
+        public enum locks {
+        }
+    }
+    public enum coroutines {
+        public enum channels {
+        }
+        public enum flow {
+            public enum `internal` {
+            }
+        }
+        public enum `internal` {
+        }
+        public enum intrinsics {
+        }
+        public enum selects {
+        }
+        public enum sync {
+        }
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.h
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.h
@@ -1,0 +1,638 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+void * _Nullable kotlin_Throwable_cause_get__reverse_swift(void * self);
+
+NSString * _Nullable kotlin_Throwable_message_get__reverse_swift(void * self);
+
+NSString * kotlin_Throwable_toString__reverse_swift(void * self);
+
+_Bool kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_Collection_isEmpty__reverse_swift(void * self);
+
+void * kotlin_collections_Collection_iterator__reverse_swift(void * self);
+
+int32_t kotlin_collections_Collection_size_get__reverse_swift(void * self);
+
+int32_t kotlin_collections_IntIterator_nextInt__reverse_swift(void * self);
+
+void * kotlin_collections_Iterable_iterator__reverse_swift(void * self);
+
+_Bool kotlin_collections_Iterator_hasNext__reverse_swift(void * self);
+
+void * _Nullable kotlin_collections_Iterator_next__reverse_swift(void * self);
+
+_Bool kotlin_collections_ListIterator_hasNext__reverse_swift(void * self);
+
+_Bool kotlin_collections_ListIterator_hasPrevious__reverse_swift(void * self);
+
+int32_t kotlin_collections_ListIterator_nextIndex__reverse_swift(void * self);
+
+void * _Nullable kotlin_collections_ListIterator_next__reverse_swift(void * self);
+
+int32_t kotlin_collections_ListIterator_previousIndex__reverse_swift(void * self);
+
+void * _Nullable kotlin_collections_ListIterator_previous__reverse_swift(void * self);
+
+_Bool kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+void * _Nullable kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t index);
+
+int32_t kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_List_isEmpty__reverse_swift(void * self);
+
+void * kotlin_collections_List_iterator__reverse_swift(void * self);
+
+int32_t kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+void * kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t index);
+
+void * kotlin_collections_List_listIterator__reverse_swift(void * self);
+
+int32_t kotlin_collections_List_size_get__reverse_swift(void * self);
+
+NSArray<id> * kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(void * self, int32_t fromIndex, int32_t toIndex);
+
+int64_t kotlin_collections_LongIterator_nextLong__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableCollection_clear__reverse_swift(void * self);
+
+void * kotlin_collections_MutableCollection_iterator__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+void * kotlin_collections_MutableIterable_iterator__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableIterator_remove__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableListIterator_hasNext__reverse_swift(void * self);
+
+void * _Nullable kotlin_collections_MutableListIterator_next__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableListIterator_remove__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, int32_t index, void * elements);
+
+_Bool kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, int32_t index, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_clear__reverse_swift(void * self);
+
+void * kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t index);
+
+void * kotlin_collections_MutableList_listIterator__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+void * _Nullable kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t index);
+
+_Bool kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+void * _Nullable kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, int32_t index, void * _Nullable element);
+
+void * kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(void * self, int32_t fromIndex, int32_t toIndex);
+
+_Bool kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableSet_clear__reverse_swift(void * self);
+
+void * kotlin_collections_MutableSet_iterator__reverse_swift(void * self);
+
+_Bool kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(void * self, void * elements);
+
+_Bool kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_Set_isEmpty__reverse_swift(void * self);
+
+void * kotlin_collections_Set_iterator__reverse_swift(void * self);
+
+int32_t kotlin_collections_Set_size_get__reverse_swift(void * self);
+
+void * kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse_swift(void * self);
+
+void * _Nullable kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(void * self, void * key);
+
+void * kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(void * self, void * continuation);
+
+void * kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(void * self, void * key);
+
+_Bool kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(void * self, void * continuation);
+
+void * kotlin_coroutines_Continuation_context_get__reverse_swift(void * self);
+
+_Bool kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse_swift(void * self, void * result);
+
+void * _Nullable kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_Element_key_get__reverse_swift(void * self);
+
+void * kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(void * self, void * key);
+
+void * _Nullable kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(void * self, void * context);
+
+void * kotlin_sequences_Sequence_iterator__reverse_swift(void * self);
+
+void * _Nullable kotlin_Array_get__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+void * kotlin_Array_iterator(void * self);
+
+_Bool kotlin_Array_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, int32_t index, void * _Nullable value);
+
+int32_t kotlin_Array_size_get(void * self);
+
+void * kotlin_Exception_init_allocate();
+
+_Bool kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+_Bool kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, NSString * _Nullable message, void * _Nullable cause);
+
+_Bool kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, void * _Nullable cause);
+
+void * kotlin_IllegalStateException_init_allocate();
+
+_Bool kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+_Bool kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, NSString * _Nullable message, void * _Nullable cause);
+
+_Bool kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, void * _Nullable cause);
+
+int32_t kotlin_IntArray_get__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+void * kotlin_IntArray_iterator(void * self);
+
+_Bool kotlin_IntArray_set__TypesOfArguments__Swift_Int32_Swift_Int32__(void * self, int32_t index, int32_t value);
+
+int32_t kotlin_IntArray_size_get(void * self);
+
+int64_t kotlin_LongArray_get__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+void * kotlin_LongArray_iterator(void * self);
+
+_Bool kotlin_LongArray_set__TypesOfArguments__Swift_Int32_Swift_Int64__(void * self, int32_t index, int64_t value);
+
+int32_t kotlin_LongArray_size_get(void * self);
+
+void * kotlin_NoSuchElementException_init_allocate();
+
+_Bool kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+void * kotlin_Result_Companion_failure__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * exception);
+
+void * kotlin_Result_Companion_get();
+
+void * kotlin_Result_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value);
+
+_Bool kotlin_Result_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable other);
+
+void * _Nullable kotlin_Result_exceptionOrNull(void * self);
+
+void * _Nullable kotlin_Result_getOrNull(void * self);
+
+int32_t kotlin_Result_hashCode(void * self);
+
+_Bool kotlin_Result_isFailure_get(void * self);
+
+_Bool kotlin_Result_isSuccess_get(void * self);
+
+NSString * kotlin_Result_toString(void * self);
+
+void * kotlin_RuntimeException_init_allocate();
+
+_Bool kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+_Bool kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, NSString * _Nullable message, void * _Nullable cause);
+
+_Bool kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, void * _Nullable cause);
+
+void * _Nullable kotlin_Throwable_cause_get(void * self);
+
+void * _Nullable kotlin_Throwable_cause_get_direct(void * self);
+
+void * kotlin_Throwable_getStackTrace(void * self);
+
+void * kotlin_Throwable_init_allocate();
+
+_Bool kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, NSString * _Nullable message, void * _Nullable cause);
+
+_Bool kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+_Bool kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, void * _Nullable cause);
+
+_Bool kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+NSString * _Nullable kotlin_Throwable_message_get(void * self);
+
+NSString * _Nullable kotlin_Throwable_message_get_direct(void * self);
+
+_Bool kotlin_Throwable_printStackTrace(void * self);
+
+NSString * kotlin_Throwable_toString(void * self);
+
+NSString * kotlin_Throwable_toString_direct(void * self);
+
+_Bool kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_Collection_isEmpty(void * self);
+
+void * kotlin_collections_Collection_iterator(void * self);
+
+int32_t kotlin_collections_Collection_size_get(void * self);
+
+void * kotlin_collections_IndexedValue_copy__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, int32_t index, void * _Nullable value);
+
+_Bool kotlin_collections_IndexedValue_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable other);
+
+int32_t kotlin_collections_IndexedValue_hashCode(void * self);
+
+int32_t kotlin_collections_IndexedValue_index_get(void * self);
+
+void * kotlin_collections_IndexedValue_init_allocate();
+
+_Bool kotlin_collections_IndexedValue_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * __kt, int32_t index, void * _Nullable value);
+
+NSString * kotlin_collections_IndexedValue_toString(void * self);
+
+void * _Nullable kotlin_collections_IndexedValue_value_get(void * self);
+
+_Bool kotlin_collections_IntIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+int32_t kotlin_collections_IntIterator_next(void * self);
+
+int32_t kotlin_collections_IntIterator_nextInt(void * self);
+
+void * kotlin_collections_Iterable_iterator(void * self);
+
+_Bool kotlin_collections_Iterator_hasNext(void * self);
+
+void * _Nullable kotlin_collections_Iterator_next(void * self);
+
+_Bool kotlin_collections_ListIterator_hasNext(void * self);
+
+_Bool kotlin_collections_ListIterator_hasPrevious(void * self);
+
+void * _Nullable kotlin_collections_ListIterator_next(void * self);
+
+int32_t kotlin_collections_ListIterator_nextIndex(void * self);
+
+void * _Nullable kotlin_collections_ListIterator_previous(void * self);
+
+int32_t kotlin_collections_ListIterator_previousIndex(void * self);
+
+_Bool kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+void * _Nullable kotlin_collections_List_get__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+int32_t kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_List_isEmpty(void * self);
+
+void * kotlin_collections_List_iterator(void * self);
+
+int32_t kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+void * kotlin_collections_List_listIterator(void * self);
+
+void * kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+int32_t kotlin_collections_List_size_get(void * self);
+
+NSArray<id> * kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32__(void * self, int32_t fromIndex, int32_t toIndex);
+
+_Bool kotlin_collections_LongIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+int64_t kotlin_collections_LongIterator_next(void * self);
+
+int64_t kotlin_collections_LongIterator_nextLong(void * self);
+
+_Bool kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_MutableCollection_clear(void * self);
+
+void * kotlin_collections_MutableCollection_iterator(void * self);
+
+_Bool kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+void * kotlin_collections_MutableIterable_iterator(void * self);
+
+_Bool kotlin_collections_MutableIterator_remove(void * self);
+
+_Bool kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableListIterator_hasNext(void * self);
+
+void * _Nullable kotlin_collections_MutableListIterator_next(void * self);
+
+_Bool kotlin_collections_MutableListIterator_remove(void * self);
+
+_Bool kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, int32_t index, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, int32_t index, void * elements);
+
+_Bool kotlin_collections_MutableList_clear(void * self);
+
+void * kotlin_collections_MutableList_listIterator(void * self);
+
+void * kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+_Bool kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+void * _Nullable kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32__(void * self, int32_t index);
+
+_Bool kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+void * _Nullable kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, int32_t index, void * _Nullable element);
+
+void * kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32__(void * self, int32_t fromIndex, int32_t toIndex);
+
+_Bool kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_MutableSet_clear(void * self);
+
+void * kotlin_collections_MutableSet_iterator(void * self);
+
+_Bool kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(void * self, void * elements);
+
+_Bool kotlin_collections_Set_isEmpty(void * self);
+
+void * kotlin_collections_Set_iterator(void * self);
+
+int32_t kotlin_collections_Set_size_get(void * self);
+
+_Bool kotlin_coroutines_AbstractCoroutineContextElement_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * __kt, void * key);
+
+void * kotlin_coroutines_AbstractCoroutineContextElement_key_get(void * self);
+
+void * kotlin_coroutines_AbstractCoroutineContextElement_key_get_direct(void * self);
+
+_Bool kotlin_coroutines_AbstractCoroutineContextKey_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key_U28anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element___(void * __kt, void * baseKey, void * _Nullable (^safeCast)(void *));
+
+void * kotlin_coroutines_ContinuationInterceptor_Key_get();
+
+void * _Nullable kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * self, void * key);
+
+void * _Nullable kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(void * self, void * key);
+
+void * kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(void * self, void * continuation);
+
+void * kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * self, void * key);
+
+void * kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(void * self, void * key);
+
+_Bool kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(void * self, void * continuation);
+
+_Bool kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation___direct(void * self, void * continuation);
+
+void * kotlin_coroutines_Continuation_context_get(void * self);
+
+_Bool kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__(void * self, void * result);
+
+void * _Nullable kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable initial, void * _Nullable (^operation)(void * _Nullable , void *));
+
+void * _Nullable kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(void * self, void * _Nullable initial, void * _Nullable (^operation)(void * _Nullable , void *));
+
+void * _Nullable kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * self, void * key);
+
+void * _Nullable kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_Element_key_get(void * self);
+
+void * kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(void * self, void * key);
+
+void * _Nullable kotlin_coroutines_CoroutineContext_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable initial, void * _Nullable (^operation)(void * _Nullable , void *));
+
+void * _Nullable kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(void * self, void * key);
+
+void * kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * self, void * context);
+
+void * kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(void * self, void * context);
+
+void * kotlin_coroutines_cancellation_CancellationException_init_allocate();
+
+_Bool kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+_Bool kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, NSString * _Nullable message, void * _Nullable cause);
+
+_Bool kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * __kt, void * _Nullable cause);
+
+void * kotlin_sequences_Sequence_iterator(void * self);
+
+void * kotlin_time_DurationUnit_DAYS();
+
+void * kotlin_time_DurationUnit_HOURS();
+
+void * kotlin_time_DurationUnit_MICROSECONDS();
+
+void * kotlin_time_DurationUnit_MILLISECONDS();
+
+void * kotlin_time_DurationUnit_MINUTES();
+
+void * kotlin_time_DurationUnit_NANOSECONDS();
+
+void * kotlin_time_DurationUnit_SECONDS();
+
+int32_t kotlin_time_DurationUnit_ordinal(void * self);
+
+void * kotlin_time_Duration_Companion_INFINITE_get(void * self);
+
+void * kotlin_time_Duration_Companion_ZERO_get(void * self);
+
+double kotlin_time_Duration_Companion_convert__TypesOfArguments__Swift_Double_ExportedKotlinPackages_kotlin_time_DurationUnit_ExportedKotlinPackages_kotlin_time_DurationUnit__(void * self, double value, void * sourceUnit, void * targetUnit);
+
+void * kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_Companion_get();
+
+void * kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_Companion_parse__TypesOfArguments__Swift_String__(void * self, NSString * value);
+
+void * kotlin_time_Duration_Companion_parseIsoString__TypesOfArguments__Swift_String__(void * self, NSString * value);
+
+void * _Nullable kotlin_time_Duration_Companion_parseIsoStringOrNull__TypesOfArguments__Swift_String__(void * self, NSString * value);
+
+void * _Nullable kotlin_time_Duration_Companion_parseOrNull__TypesOfArguments__Swift_String__(void * self, NSString * value);
+
+void * kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int32__(void * self, int32_t receiver);
+
+void * kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int64__(void * self, int64_t receiver);
+
+void * kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Double__(void * self, double receiver);
+
+void * kotlin_time_Duration_absoluteValue_get(void * self);
+
+int32_t kotlin_time_Duration_compareTo__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(void * self, void * other);
+
+void * kotlin_time_Duration_div__TypesOfArguments__Swift_Int32__(void * self, int32_t scale);
+
+void * kotlin_time_Duration_div__TypesOfArguments__Swift_Double__(void * self, double scale);
+
+double kotlin_time_Duration_div__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(void * self, void * other);
+
+_Bool kotlin_time_Duration_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable other);
+
+int32_t kotlin_time_Duration_hashCode(void * self);
+
+int64_t kotlin_time_Duration_inWholeDays_get(void * self);
+
+int64_t kotlin_time_Duration_inWholeHours_get(void * self);
+
+int64_t kotlin_time_Duration_inWholeMicroseconds_get(void * self);
+
+int64_t kotlin_time_Duration_inWholeMilliseconds_get(void * self);
+
+int64_t kotlin_time_Duration_inWholeMinutes_get(void * self);
+
+int64_t kotlin_time_Duration_inWholeNanoseconds_get(void * self);
+
+int64_t kotlin_time_Duration_inWholeSeconds_get(void * self);
+
+_Bool kotlin_time_Duration_isFinite(void * self);
+
+_Bool kotlin_time_Duration_isInfinite(void * self);
+
+_Bool kotlin_time_Duration_isNegative(void * self);
+
+_Bool kotlin_time_Duration_isPositive(void * self);
+
+void * kotlin_time_Duration_minus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(void * self, void * other);
+
+void * kotlin_time_Duration_plus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(void * self, void * other);
+
+void * kotlin_time_Duration_times__TypesOfArguments__Swift_Int32__(void * self, int32_t scale);
+
+void * kotlin_time_Duration_times__TypesOfArguments__Swift_Double__(void * self, double scale);
+
+void * _Nullable kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable (^action)(int64_t, int32_t, int32_t, int32_t, int32_t));
+
+void * _Nullable kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable (^action)(int64_t, int32_t, int32_t, int32_t));
+
+void * _Nullable kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable (^action)(int64_t, int32_t, int32_t));
+
+void * _Nullable kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable (^action)(int64_t, int32_t));
+
+double kotlin_time_Duration_toDouble__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(void * self, void * unit);
+
+int32_t kotlin_time_Duration_toInt__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(void * self, void * unit);
+
+NSString * kotlin_time_Duration_toIsoString(void * self);
+
+int64_t kotlin_time_Duration_toLong__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(void * self, void * unit);
+
+NSString * kotlin_time_Duration_toString(void * self);
+
+NSString * kotlin_time_Duration_toString__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit_Swift_Int32__(void * self, void * unit, int32_t decimals);
+
+void * kotlin_time_Duration_unaryMinus(void * self);
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -1,0 +1,2743 @@
+@file:OptIn(kotlin.ExperimentalStdlibApi::class)
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Array::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE5ArrayC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Exception::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE9ExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.IllegalStateException::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE21IllegalStateExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.IntArray::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE8IntArrayC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.LongArray::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE9LongArrayC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.NoSuchElementException::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE22NoSuchElementExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Result::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE6ResultC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Result.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE6ResultC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.RuntimeException::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE16RuntimeExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Throwable::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE9ThrowableC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.IndexedValue::class, "22ExportedKotlinPackages6kotlinO11collectionsO12KotlinStdlibE12IndexedValueC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.IntIterator::class, "22ExportedKotlinPackages6kotlinO11collectionsO12KotlinStdlibE11IntIteratorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.LongIterator::class, "22ExportedKotlinPackages6kotlinO11collectionsO12KotlinStdlibE12LongIteratorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.Collection::class, "_ExportedKotlinPackages_kotlin_collections_Collection")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.Iterable::class, "_ExportedKotlinPackages_kotlin_collections_Iterable")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.Iterator::class, "_ExportedKotlinPackages_kotlin_collections_Iterator")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.ListIterator::class, "_ExportedKotlinPackages_kotlin_collections_ListIterator")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.MutableCollection::class, "_ExportedKotlinPackages_kotlin_collections_MutableCollection")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.MutableIterable::class, "_ExportedKotlinPackages_kotlin_collections_MutableIterable")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.MutableIterator::class, "_ExportedKotlinPackages_kotlin_collections_MutableIterator")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.MutableListIterator::class, "_ExportedKotlinPackages_kotlin_collections_MutableListIterator")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.AbstractCoroutineContextElement::class, "22ExportedKotlinPackages6kotlinO10coroutinesO12KotlinStdlibE31AbstractCoroutineContextElementC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.AbstractCoroutineContextKey::class, "22ExportedKotlinPackages6kotlinO10coroutinesO12KotlinStdlibE27AbstractCoroutineContextKeyC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.Continuation::class, "_ExportedKotlinPackages_kotlin_coroutines_Continuation")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.ContinuationInterceptor::class, "_ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.CoroutineContext::class, "_ExportedKotlinPackages_kotlin_coroutines_CoroutineContext")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.cancellation.CancellationException::class, "22ExportedKotlinPackages6kotlinO10coroutinesO12cancellationO12KotlinStdlibE21CancellationExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.sequences.Sequence::class, "_ExportedKotlinPackages_kotlin_sequences_Sequence")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.time.Duration::class, "22ExportedKotlinPackages6kotlinO4timeO12KotlinStdlibE8DurationC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.time.Duration.Companion::class, "22ExportedKotlinPackages6kotlinO4timeO12KotlinStdlibE8DurationC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.ContinuationInterceptor.Key::class, "12KotlinStdlib69_ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor_KeyC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.CoroutineContext.Element::class, "_KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.coroutines.CoroutineContext.Key::class, "_KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key")
+
+import kotlin.native.internal.objc.BindReverseBridgeToMethod
+import kotlin.native.internal.ImportedBridge
+import kotlinx.cinterop.*
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ImportedBridge("kotlin_Throwable_cause_get__reverse_swift")
+internal external fun kotlin_Throwable_cause_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.Throwable::class, "<get-cause>")
+public fun kotlin_Throwable_cause_get__reverse(self: kotlin.Throwable): kotlin.Throwable? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Throwable_cause_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Throwable
+}
+
+@ImportedBridge("kotlin_Throwable_message_get__reverse_swift")
+internal external fun kotlin_Throwable_message_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.Throwable::class, "<get-message>")
+public fun kotlin_Throwable_message_get__reverse(self: kotlin.Throwable): kotlin.String? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Throwable_message_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlin_Throwable_toString__reverse_swift")
+internal external fun kotlin_Throwable_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.Throwable::class, "toString")
+public fun kotlin_Throwable_toString__reverse(self: kotlin.Throwable): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Throwable_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "containsAll")
+public fun kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.Collection<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "contains")
+public fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.Collection<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_isEmpty__reverse_swift")
+internal external fun kotlin_collections_Collection_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "isEmpty")
+public fun kotlin_collections_Collection_isEmpty__reverse(self: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Collection_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_iterator__reverse_swift")
+internal external fun kotlin_collections_Collection_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "iterator")
+public fun kotlin_collections_Collection_iterator__reverse(self: kotlin.collections.Collection<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Collection_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_Collection_size_get__reverse_swift")
+internal external fun kotlin_collections_Collection_size_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "<get-size>")
+public fun kotlin_collections_Collection_size_get__reverse(self: kotlin.collections.Collection<kotlin.Any?>): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Collection_size_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_IntIterator_nextInt__reverse_swift")
+internal external fun kotlin_collections_IntIterator_nextInt__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.IntIterator::class, "nextInt")
+public fun kotlin_collections_IntIterator_nextInt__reverse(self: kotlin.collections.IntIterator): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_IntIterator_nextInt__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Iterable_iterator__reverse_swift")
+internal external fun kotlin_collections_Iterable_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Iterable::class, "iterator")
+public fun kotlin_collections_Iterable_iterator__reverse(self: kotlin.collections.Iterable<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Iterable_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_Iterator_hasNext__reverse_swift")
+internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
+public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
+internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
+public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_ListIterator_hasNext__reverse_swift")
+internal external fun kotlin_collections_ListIterator_hasNext__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "hasNext")
+public fun kotlin_collections_ListIterator_hasNext__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ListIterator_hasNext__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_ListIterator_hasPrevious__reverse_swift")
+internal external fun kotlin_collections_ListIterator_hasPrevious__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "hasPrevious")
+public fun kotlin_collections_ListIterator_hasPrevious__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ListIterator_hasPrevious__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_ListIterator_nextIndex__reverse_swift")
+internal external fun kotlin_collections_ListIterator_nextIndex__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "nextIndex")
+public fun kotlin_collections_ListIterator_nextIndex__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ListIterator_nextIndex__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_ListIterator_next__reverse_swift")
+internal external fun kotlin_collections_ListIterator_next__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "next")
+public fun kotlin_collections_ListIterator_next__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ListIterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_ListIterator_previousIndex__reverse_swift")
+internal external fun kotlin_collections_ListIterator_previousIndex__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "previousIndex")
+public fun kotlin_collections_ListIterator_previousIndex__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ListIterator_previousIndex__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_ListIterator_previous__reverse_swift")
+internal external fun kotlin_collections_ListIterator_previous__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "previous")
+public fun kotlin_collections_ListIterator_previous__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ListIterator_previous__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "containsAll")
+public fun kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.List<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "contains")
+public fun kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.List<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "get")
+public fun kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse(self: kotlin.collections.List<kotlin.Any?>, index: Int): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "indexOf")
+public fun kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.List<kotlin.Any?>, element: kotlin.Any?): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_List_isEmpty__reverse_swift")
+internal external fun kotlin_collections_List_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "isEmpty")
+public fun kotlin_collections_List_isEmpty__reverse(self: kotlin.collections.List<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_List_iterator__reverse_swift")
+internal external fun kotlin_collections_List_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "iterator")
+public fun kotlin_collections_List_iterator__reverse(self: kotlin.collections.List<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "lastIndexOf")
+public fun kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.List<kotlin.Any?>, element: kotlin.Any?): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "listIterator")
+public fun kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse(self: kotlin.collections.List<kotlin.Any?>, index: Int): kotlin.collections.ListIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.ListIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_List_listIterator__reverse_swift")
+internal external fun kotlin_collections_List_listIterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "listIterator")
+public fun kotlin_collections_List_listIterator__reverse(self: kotlin.collections.List<kotlin.Any?>): kotlin.collections.ListIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_listIterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.ListIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_List_size_get__reverse_swift")
+internal external fun kotlin_collections_List_size_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "<get-size>")
+public fun kotlin_collections_List_size_get__reverse(self: kotlin.collections.List<kotlin.Any?>): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_size_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
+internal external fun kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, fromIndex: Int, toIndex: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.List::class, "subList")
+public fun kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse(self: kotlin.collections.List<kotlin.Any?>, fromIndex: Int, toIndex: Int): kotlin.collections.List<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, fromIndex, toIndex)
+    return interpretObjCPointer<kotlin.collections.List<kotlin.Any?>>(_result)
+}
+
+@ImportedBridge("kotlin_collections_LongIterator_nextLong__reverse_swift")
+internal external fun kotlin_collections_LongIterator_nextLong__reverse_swift(self: kotlin.native.internal.NativePtr): Long
+
+@BindReverseBridgeToMethod(kotlin.collections.LongIterator::class, "nextLong")
+public fun kotlin_collections_LongIterator_nextLong__reverse(self: kotlin.collections.LongIterator): Long {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_LongIterator_nextLong__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "addAll")
+public fun kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "add")
+public fun kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_clear__reverse_swift")
+internal external fun kotlin_collections_MutableCollection_clear__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "clear")
+public fun kotlin_collections_MutableCollection_clear__reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableCollection_clear__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_iterator__reverse_swift")
+internal external fun kotlin_collections_MutableCollection_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "iterator")
+public fun kotlin_collections_MutableCollection_iterator__reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>): kotlin.collections.MutableIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableCollection_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.MutableIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "removeAll")
+public fun kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "remove")
+public fun kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableCollection::class, "retainAll")
+public fun kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableCollection<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableIterable_iterator__reverse_swift")
+internal external fun kotlin_collections_MutableIterable_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableIterable::class, "iterator")
+public fun kotlin_collections_MutableIterable_iterator__reverse(self: kotlin.collections.MutableIterable<kotlin.Any?>): kotlin.collections.MutableIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableIterable_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.MutableIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_MutableIterator_remove__reverse_swift")
+internal external fun kotlin_collections_MutableIterator_remove__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableIterator::class, "remove")
+public fun kotlin_collections_MutableIterator_remove__reverse(self: kotlin.collections.MutableIterator<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableIterator_remove__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableListIterator::class, "add")
+public fun kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableListIterator<kotlin.Any?>, element: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableListIterator_hasNext__reverse_swift")
+internal external fun kotlin_collections_MutableListIterator_hasNext__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableListIterator::class, "hasNext")
+public fun kotlin_collections_MutableListIterator_hasNext__reverse(self: kotlin.collections.MutableListIterator<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableListIterator_hasNext__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableListIterator_next__reverse_swift")
+internal external fun kotlin_collections_MutableListIterator_next__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableListIterator::class, "next")
+public fun kotlin_collections_MutableListIterator_next__reverse(self: kotlin.collections.MutableListIterator<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableListIterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_MutableListIterator_remove__reverse_swift")
+internal external fun kotlin_collections_MutableListIterator_remove__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableListIterator::class, "remove")
+public fun kotlin_collections_MutableListIterator_remove__reverse(self: kotlin.collections.MutableListIterator<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableListIterator_remove__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableListIterator::class, "set")
+public fun kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableListIterator<kotlin.Any?>, element: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "addAll")
+public fun kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, index: Int, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, index, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "addAll")
+public fun kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "add")
+public fun kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, index: Int, element: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, index, __element)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "add")
+public fun kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableList_clear__reverse_swift")
+internal external fun kotlin_collections_MutableList_clear__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "clear")
+public fun kotlin_collections_MutableList_clear__reverse(self: kotlin.collections.MutableList<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableList_clear__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "listIterator")
+public fun kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, index: Int): kotlin.collections.MutableListIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.MutableListIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_MutableList_listIterator__reverse_swift")
+internal external fun kotlin_collections_MutableList_listIterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "listIterator")
+public fun kotlin_collections_MutableList_listIterator__reverse(self: kotlin.collections.MutableList<kotlin.Any?>): kotlin.collections.MutableListIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableList_listIterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.MutableListIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "removeAll")
+public fun kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "removeAt")
+public fun kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, index: Int): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "remove")
+public fun kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "retainAll")
+public fun kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int, element: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "set")
+public fun kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, index: Int, element: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, index, __element)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
+internal external fun kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, fromIndex: Int, toIndex: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableList::class, "subList")
+public fun kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse(self: kotlin.collections.MutableList<kotlin.Any?>, fromIndex: Int, toIndex: Int): kotlin.collections.MutableList<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, fromIndex, toIndex)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.MutableList<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "addAll")
+public fun kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableSet<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "add")
+public fun kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableSet<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_clear__reverse_swift")
+internal external fun kotlin_collections_MutableSet_clear__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "clear")
+public fun kotlin_collections_MutableSet_clear__reverse(self: kotlin.collections.MutableSet<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableSet_clear__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_iterator__reverse_swift")
+internal external fun kotlin_collections_MutableSet_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "iterator")
+public fun kotlin_collections_MutableSet_iterator__reverse(self: kotlin.collections.MutableSet<kotlin.Any?>): kotlin.collections.MutableIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_MutableSet_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.MutableIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "removeAll")
+public fun kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableSet<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "remove")
+public fun kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.MutableSet<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.MutableSet::class, "retainAll")
+public fun kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.MutableSet<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Set::class, "containsAll")
+public fun kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.Set<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Set::class, "contains")
+public fun kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.Set<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Set_isEmpty__reverse_swift")
+internal external fun kotlin_collections_Set_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Set::class, "isEmpty")
+public fun kotlin_collections_Set_isEmpty__reverse(self: kotlin.collections.Set<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Set_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Set_iterator__reverse_swift")
+internal external fun kotlin_collections_Set_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Set::class, "iterator")
+public fun kotlin_collections_Set_iterator__reverse(self: kotlin.collections.Set<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Set_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_Set_size_get__reverse_swift")
+internal external fun kotlin_collections_Set_size_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.Set::class, "<get-size>")
+public fun kotlin_collections_Set_size_get__reverse(self: kotlin.collections.Set<kotlin.Any?>): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Set_size_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse_swift")
+internal external fun kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.AbstractCoroutineContextElement::class, "<get-key>")
+public fun kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse(self: kotlin.coroutines.AbstractCoroutineContextElement): kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+}
+
+@ImportedBridge("kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+internal external fun kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.ContinuationInterceptor::class, "get")
+public fun kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse(self: kotlin.coroutines.ContinuationInterceptor, key: kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>): kotlin.coroutines.CoroutineContext.Element? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __key = kotlin.native.internal.ref.createRetainedExternalRCRef(key)
+    val _result = kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(__self, __key)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext.Element
+}
+
+@ImportedBridge("kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift")
+internal external fun kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.ContinuationInterceptor::class, "interceptContinuation")
+public fun kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse(self: kotlin.coroutines.ContinuationInterceptor, continuation: kotlin.coroutines.Continuation<kotlin.Any?>): kotlin.coroutines.Continuation<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+    val _result = kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(__self, __continuation)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.Continuation<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+internal external fun kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.ContinuationInterceptor::class, "minusKey")
+public fun kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse(self: kotlin.coroutines.ContinuationInterceptor, key: kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __key = kotlin.native.internal.ref.createRetainedExternalRCRef(key)
+    val _result = kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(__self, __key)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift")
+internal external fun kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.coroutines.ContinuationInterceptor::class, "releaseInterceptedContinuation")
+public fun kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse(self: kotlin.coroutines.ContinuationInterceptor, continuation: kotlin.coroutines.Continuation<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+    val _result = kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(__self, __continuation)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_coroutines_Continuation_context_get__reverse_swift")
+internal external fun kotlin_coroutines_Continuation_context_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.Continuation::class, "<get-context>")
+public fun kotlin_coroutines_Continuation_context_get__reverse(self: kotlin.coroutines.Continuation<kotlin.Any?>): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_coroutines_Continuation_context_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse_swift")
+internal external fun kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse_swift(self: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.coroutines.Continuation::class, "resumeWith")
+public fun kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse(self: kotlin.coroutines.Continuation<kotlin.Any?>, result: kotlin.Result<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __result = kotlin.native.internal.ref.createRetainedExternalRCRef(result)
+    val _result = kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse_swift(__self, __result)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+internal external fun kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.CoroutineContext.Element::class, "get")
+public fun kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse(self: kotlin.coroutines.CoroutineContext.Element, key: kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>): kotlin.coroutines.CoroutineContext.Element? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __key = kotlin.native.internal.ref.createRetainedExternalRCRef(key)
+    val _result = kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(__self, __key)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext.Element
+}
+
+@ImportedBridge("kotlin_coroutines_CoroutineContext_Element_key_get__reverse_swift")
+internal external fun kotlin_coroutines_CoroutineContext_Element_key_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.CoroutineContext.Element::class, "<get-key>")
+public fun kotlin_coroutines_CoroutineContext_Element_key_get__reverse(self: kotlin.coroutines.CoroutineContext.Element): kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_coroutines_CoroutineContext_Element_key_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+}
+
+@ImportedBridge("kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+internal external fun kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.CoroutineContext.Element::class, "minusKey")
+public fun kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse(self: kotlin.coroutines.CoroutineContext.Element, key: kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __key = kotlin.native.internal.ref.createRetainedExternalRCRef(key)
+    val _result = kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(__self, __key)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+internal external fun kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.CoroutineContext::class, "get")
+public fun kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse(self: kotlin.coroutines.CoroutineContext, key: kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>): kotlin.coroutines.CoroutineContext.Element? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __key = kotlin.native.internal.ref.createRetainedExternalRCRef(key)
+    val _result = kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(__self, __key)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext.Element
+}
+
+@ImportedBridge("kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+internal external fun kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.CoroutineContext::class, "minusKey")
+public fun kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse(self: kotlin.coroutines.CoroutineContext, key: kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __key = kotlin.native.internal.ref.createRetainedExternalRCRef(key)
+    val _result = kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(__self, __key)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift")
+internal external fun kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.coroutines.CoroutineContext::class, "plus")
+public fun kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse(self: kotlin.coroutines.CoroutineContext, context: kotlin.coroutines.CoroutineContext): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val _result = kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(__self, __context)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlin_sequences_Sequence_iterator__reverse_swift")
+internal external fun kotlin_sequences_Sequence_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.sequences.Sequence::class, "iterator")
+public fun kotlin_sequences_Sequence_iterator__reverse(self: kotlin.sequences.Sequence<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_sequences_Sequence_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ExportedBridge("kotlin_Array_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Array_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Array_iterator")
+public fun kotlin_Array_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Array_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Array_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val __index = index
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.`set`(__index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Array_size_get")
+public fun kotlin_Array_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_Exception_init_allocate")
+public fun kotlin_Exception_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.Exception>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalStateException_init_allocate")
+public fun kotlin_IllegalStateException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.IllegalStateException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalStateException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalStateException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalStateException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalStateException(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IntArray_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_IntArray_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlin_IntArray_iterator")
+public fun kotlin_IntArray_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_IntArray_set__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlin_IntArray_set__TypesOfArguments__Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val __index = index
+    val __value = value
+    val _result = run { __self.`set`(__index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IntArray_size_get")
+public fun kotlin_IntArray_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_LongArray_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_LongArray_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.LongArray
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlin_LongArray_iterator")
+public fun kotlin_LongArray_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.LongArray
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_LongArray_set__TypesOfArguments__Swift_Int32_Swift_Int64__")
+public fun kotlin_LongArray_set__TypesOfArguments__Swift_Int32_Swift_Int64__(self: kotlin.native.internal.NativePtr, index: Int, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.LongArray
+    val __index = index
+    val __value = value
+    val _result = run { __self.`set`(__index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_LongArray_size_get")
+public fun kotlin_LongArray_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.LongArray
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_NoSuchElementException_init_allocate")
+public fun kotlin_NoSuchElementException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.NoSuchElementException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.NoSuchElementException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.NoSuchElementException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Result_Companion_failure__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+public fun kotlin_Result_Companion_failure__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result.Companion
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { __self.failure<kotlin.Any?>(__exception) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Result_Companion_get")
+public fun kotlin_Result_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Result.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Result_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Result_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result.Companion
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.success<kotlin.Any?>(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Result_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Result_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Result_exceptionOrNull")
+public fun kotlin_Result_exceptionOrNull(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.exceptionOrNull() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Result_getOrNull")
+public fun kotlin_Result_getOrNull(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.getOrNull() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Result_hashCode")
+public fun kotlin_Result_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Result_isFailure_get")
+public fun kotlin_Result_isFailure_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.isFailure }
+    return _result
+}
+
+@ExportedBridge("kotlin_Result_isSuccess_get")
+public fun kotlin_Result_isSuccess_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.isSuccess }
+    return _result
+}
+
+@ExportedBridge("kotlin_Result_toString")
+public fun kotlin_Result_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_allocate")
+public fun kotlin_RuntimeException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.RuntimeException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_cause_get")
+public fun kotlin_Throwable_cause_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.cause }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_cause_get_direct", nonVirtualTargetMethod = "<get-cause>")
+public fun kotlin_Throwable_cause_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.cause }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_getStackTrace")
+@OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+public fun kotlin_Throwable_getStackTrace(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.getStackTrace() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_init_allocate")
+public fun kotlin_Throwable_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.Throwable>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_message_get")
+public fun kotlin_Throwable_message_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.message }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_message_get_direct", nonVirtualTargetMethod = "<get-message>")
+public fun kotlin_Throwable_message_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.message }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_printStackTrace")
+public fun kotlin_Throwable_printStackTrace(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.printStackTrace() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_toString")
+public fun kotlin_Throwable_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlin_Throwable_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.contains(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.containsAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_isEmpty")
+public fun kotlin_collections_Collection_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_iterator")
+public fun kotlin_collections_Collection_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_Collection_size_get")
+public fun kotlin_collections_Collection_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_copy__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_IndexedValue_copy__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IndexedValue<kotlin.Any?>
+    val __index = index
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.copy(__index, __value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_IndexedValue_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IndexedValue<kotlin.Any?>
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_hashCode")
+public fun kotlin_collections_IndexedValue_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IndexedValue<kotlin.Any?>
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_index_get")
+public fun kotlin_collections_IndexedValue_index_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IndexedValue<kotlin.Any?>
+    val _result = run { __self.index }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_init_allocate")
+public fun kotlin_collections_IndexedValue_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.collections.IndexedValue<kotlin.Any?>>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_IndexedValue_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(__kt: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __index = index
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.collections.IndexedValue<kotlin.Any?>(__index, __value)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_toString")
+public fun kotlin_collections_IndexedValue_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IndexedValue<kotlin.Any?>
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_collections_IndexedValue_value_get")
+public fun kotlin_collections_IndexedValue_value_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IndexedValue<kotlin.Any?>
+    val _result = run { __self.value }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_IntIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_collections_IntIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.collections.IntIterator()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_IntIterator_next")
+public fun kotlin_collections_IntIterator_next(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IntIterator
+    val _result = run { __self.next() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IntIterator_nextInt")
+public fun kotlin_collections_IntIterator_nextInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IntIterator
+    val _result = run { __self.nextInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Iterable_iterator")
+public fun kotlin_collections_Iterable_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Iterable<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_Iterator_hasNext")
+public fun kotlin_collections_Iterator_hasNext(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = run { __self.hasNext() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Iterator_next")
+public fun kotlin_collections_Iterator_next(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = run { __self.next() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_ListIterator_hasNext")
+public fun kotlin_collections_ListIterator_hasNext(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = run { __self.hasNext() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_ListIterator_hasPrevious")
+public fun kotlin_collections_ListIterator_hasPrevious(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = run { __self.hasPrevious() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_ListIterator_next")
+public fun kotlin_collections_ListIterator_next(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = run { __self.next() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_ListIterator_nextIndex")
+public fun kotlin_collections_ListIterator_nextIndex(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = run { __self.nextIndex() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_ListIterator_previous")
+public fun kotlin_collections_ListIterator_previous(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = run { __self.previous() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_ListIterator_previousIndex")
+public fun kotlin_collections_ListIterator_previousIndex(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = run { __self.previousIndex() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.contains(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.containsAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_collections_List_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.indexOf(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_isEmpty")
+public fun kotlin_collections_List_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_iterator")
+public fun kotlin_collections_List_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.lastIndexOf(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_listIterator")
+public fun kotlin_collections_List_listIterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val _result = run { __self.listIterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32__")
+public fun kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __index = index
+    val _result = run { __self.listIterator(__index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_List_size_get")
+public fun kotlin_collections_List_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, fromIndex: Int, toIndex: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.List<kotlin.Any?>
+    val __fromIndex = fromIndex
+    val __toIndex = toIndex
+    val _result = run { __self.subList(__fromIndex, __toIndex) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_collections_LongIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_collections_LongIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.collections.LongIterator()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_LongIterator_next")
+public fun kotlin_collections_LongIterator_next(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.LongIterator
+    val _result = run { __self.next() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_LongIterator_nextLong")
+public fun kotlin_collections_LongIterator_nextLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.LongIterator
+    val _result = run { __self.nextLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.add(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.addAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_clear")
+public fun kotlin_collections_MutableCollection_clear(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val _result = run { __self.clear() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_iterator")
+public fun kotlin_collections_MutableCollection_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.remove(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.removeAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.retainAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableIterable_iterator")
+public fun kotlin_collections_MutableIterable_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableIterable<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableIterator_remove")
+public fun kotlin_collections_MutableIterator_remove(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableIterator<kotlin.Any?>
+    val _result = run { __self.remove() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableListIterator<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.add(__element) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableListIterator_hasNext")
+public fun kotlin_collections_MutableListIterator_hasNext(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableListIterator<kotlin.Any?>
+    val _result = run { __self.hasNext() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableListIterator_next")
+public fun kotlin_collections_MutableListIterator_next(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableListIterator<kotlin.Any?>
+    val _result = run { __self.next() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableListIterator_remove")
+public fun kotlin_collections_MutableListIterator_remove(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableListIterator<kotlin.Any?>
+    val _result = run { __self.remove() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableListIterator<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.`set`(__element) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.add(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, index: Int, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __index = index
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.add(__index, __element) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.addAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, index: Int, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __index = index
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.addAll(__index, __elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableList_clear")
+public fun kotlin_collections_MutableList_clear(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val _result = run { __self.clear() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableList_listIterator")
+public fun kotlin_collections_MutableList_listIterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val _result = run { __self.listIterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32__")
+public fun kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __index = index
+    val _result = run { __self.listIterator(__index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.remove(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.removeAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32__")
+public fun kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __index = index
+    val _result = run { __self.removeAt(__index) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.retainAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, index: Int, element: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __index = index
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.`set`(__index, __element) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, fromIndex: Int, toIndex: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableList<kotlin.Any?>
+    val __fromIndex = fromIndex
+    val __toIndex = toIndex
+    val _result = run { __self.subList(__fromIndex, __toIndex) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.add(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.addAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_clear")
+public fun kotlin_collections_MutableSet_clear(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val _result = run { __self.clear() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_iterator")
+public fun kotlin_collections_MutableSet_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.remove(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.removeAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.retainAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Set<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.contains(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Set<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.containsAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Set_isEmpty")
+public fun kotlin_collections_Set_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Set<kotlin.Any?>
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Set_iterator")
+public fun kotlin_collections_Set_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Set<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_Set_size_get")
+public fun kotlin_collections_Set_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Set<kotlin.Any?>
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_coroutines_AbstractCoroutineContextElement_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_coroutines_AbstractCoroutineContextElement_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(__kt: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.coroutines.AbstractCoroutineContextElement(__key)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_AbstractCoroutineContextElement_key_get")
+public fun kotlin_coroutines_AbstractCoroutineContextElement_key_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.AbstractCoroutineContextElement
+    val _result = run { __self.key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_AbstractCoroutineContextElement_key_get_direct", nonVirtualTargetMethod = "<get-key>")
+public fun kotlin_coroutines_AbstractCoroutineContextElement_key_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.AbstractCoroutineContextElement
+    val _result = run { __self.key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_AbstractCoroutineContextKey_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key_U28anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element___", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlin.ExperimentalStdlibApi::class)
+public fun kotlin_coroutines_AbstractCoroutineContextKey_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key_U28anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element___(__kt: kotlin.native.internal.NativePtr, baseKey: kotlin.native.internal.NativePtr, safeCast: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __baseKey = kotlin.native.internal.ref.dereferenceExternalRCRef(baseKey) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val __safeCast = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(safeCast);
+        { arg0: kotlin.coroutines.CoroutineContext.Element ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext.Element
+        }
+    }
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.coroutines.AbstractCoroutineContextKey<kotlin.coroutines.CoroutineContext.Element, kotlin.coroutines.CoroutineContext.Element>(__baseKey, __safeCast)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_Key_get")
+public fun kotlin_coroutines_ContinuationInterceptor_Key_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.coroutines.ContinuationInterceptor.Key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__")
+public fun kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.`get`<kotlin.coroutines.CoroutineContext.Element>(__key) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct", nonVirtualTargetMethod = "get")
+public fun kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.`get`<kotlin.coroutines.CoroutineContext.Element>(__key) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__")
+public fun kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __continuation = kotlin.native.internal.ref.dereferenceExternalRCRef(continuation) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.interceptContinuation<kotlin.Any?>(__continuation) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__")
+public fun kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.minusKey(__key) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct", nonVirtualTargetMethod = "minusKey")
+public fun kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.minusKey(__key) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__")
+public fun kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __continuation = kotlin.native.internal.ref.dereferenceExternalRCRef(continuation) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.releaseInterceptedContinuation(__continuation) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation___direct", nonVirtualTargetMethod = "releaseInterceptedContinuation")
+public fun kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation___direct(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.ContinuationInterceptor
+    val __continuation = kotlin.native.internal.ref.dereferenceExternalRCRef(continuation) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.releaseInterceptedContinuation(__continuation) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_Continuation_context_get")
+public fun kotlin_coroutines_Continuation_context_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.context }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__")
+public fun kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__(self: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val __result = kotlin.native.internal.ref.dereferenceExternalRCRef(result) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.resumeWith(__result) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, initial: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val __initial = if (initial == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initial) as kotlin.Any
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(operation);
+        { arg0: kotlin.Any?, arg1: kotlin.coroutines.CoroutineContext.Element ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+            val _result = kotlinFun(_arg0, _arg1)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.fold<kotlin.Any?>(__initial, __operation) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "fold")
+public fun kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, initial: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val __initial = if (initial == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initial) as kotlin.Any
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(operation);
+        { arg0: kotlin.Any?, arg1: kotlin.coroutines.CoroutineContext.Element ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+            val _result = kotlinFun(_arg0, _arg1)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.fold<kotlin.Any?>(__initial, __operation) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__")
+public fun kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.`get`<kotlin.coroutines.CoroutineContext.Element>(__key) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct", nonVirtualTargetMethod = "get")
+public fun kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.`get`<kotlin.coroutines.CoroutineContext.Element>(__key) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_key_get")
+public fun kotlin_coroutines_CoroutineContext_Element_key_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val _result = run { __self.key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__")
+public fun kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.minusKey(__key) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct", nonVirtualTargetMethod = "minusKey")
+public fun kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext.Element
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.minusKey(__key) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_coroutines_CoroutineContext_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, initial: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext
+    val __initial = if (initial == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initial) as kotlin.Any
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(operation);
+        { arg0: kotlin.Any?, arg1: kotlin.coroutines.CoroutineContext.Element ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+            val _result = kotlinFun(_arg0, _arg1)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.fold<kotlin.Any?>(__initial, __operation) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__")
+public fun kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.`get`<kotlin.coroutines.CoroutineContext.Element>(__key) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__")
+public fun kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self: kotlin.native.internal.NativePtr, key: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext
+    val __key = kotlin.native.internal.ref.dereferenceExternalRCRef(key) as kotlin.coroutines.CoroutineContext.Key<kotlin.coroutines.CoroutineContext.Element>
+    val _result = run { __self.minusKey(__key) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __self.plus(__context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct", nonVirtualTargetMethod = "plus")
+public fun kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.coroutines.CoroutineContext
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __self.plus(__context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_cancellation_CancellationException_init_allocate")
+public fun kotlin_coroutines_cancellation_CancellationException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.coroutines.cancellation.CancellationException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.coroutines.cancellation.CancellationException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.coroutines.cancellation.CancellationException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.coroutines.cancellation.CancellationException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.coroutines.cancellation.CancellationException(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_sequences_Sequence_iterator")
+public fun kotlin_sequences_Sequence_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.sequences.Sequence<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_DAYS")
+public fun kotlin_time_DurationUnit_DAYS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.DAYS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_HOURS")
+public fun kotlin_time_DurationUnit_HOURS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.HOURS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_MICROSECONDS")
+public fun kotlin_time_DurationUnit_MICROSECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.MICROSECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_MILLISECONDS")
+public fun kotlin_time_DurationUnit_MILLISECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.MILLISECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_MINUTES")
+public fun kotlin_time_DurationUnit_MINUTES(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.MINUTES }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_NANOSECONDS")
+public fun kotlin_time_DurationUnit_NANOSECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.NANOSECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_SECONDS")
+public fun kotlin_time_DurationUnit_SECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.SECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_ordinal")
+public fun kotlin_time_DurationUnit_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.DurationUnit
+    val _result = run { __self.ordinal }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_INFINITE_get")
+public fun kotlin_time_Duration_Companion_INFINITE_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val _result = run { __self.INFINITE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_ZERO_get")
+public fun kotlin_time_Duration_Companion_ZERO_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val _result = run { __self.ZERO }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_convert__TypesOfArguments__Swift_Double_ExportedKotlinPackages_kotlin_time_DurationUnit_ExportedKotlinPackages_kotlin_time_DurationUnit__")
+@OptIn(kotlin.time.ExperimentalTime::class)
+public fun kotlin_time_Duration_Companion_convert__TypesOfArguments__Swift_Double_ExportedKotlinPackages_kotlin_time_DurationUnit_ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, value: Double, sourceUnit: kotlin.native.internal.NativePtr, targetUnit: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = value
+    val __sourceUnit = kotlin.native.internal.ref.dereferenceExternalRCRef(sourceUnit) as kotlin.time.DurationUnit
+    val __targetUnit = kotlin.native.internal.ref.dereferenceExternalRCRef(targetUnit) as kotlin.time.DurationUnit
+    val _result = run { __self.convert(__value, __sourceUnit, __targetUnit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.days } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.days } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.days } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_get")
+public fun kotlin_time_Duration_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.Duration.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.hours } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.hours } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.hours } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.microseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.microseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.microseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.milliseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.milliseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.milliseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.minutes } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.minutes } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.minutes } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.nanoseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.nanoseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.nanoseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parse__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parse__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parse(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parseIsoString__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parseIsoString__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parseIsoString(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parseIsoStringOrNull__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parseIsoStringOrNull__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parseIsoStringOrNull(__value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parseOrNull__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parseOrNull__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parseOrNull(__value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.seconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.seconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.seconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_absoluteValue_get")
+public fun kotlin_time_Duration_absoluteValue_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.absoluteValue }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_compareTo__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_compareTo__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_time_Duration_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, scale: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.div(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_time_Duration_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, scale: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.div(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_div__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_div__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_hashCode")
+public fun kotlin_time_Duration_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeDays_get")
+public fun kotlin_time_Duration_inWholeDays_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeDays }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeHours_get")
+public fun kotlin_time_Duration_inWholeHours_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeHours }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeMicroseconds_get")
+public fun kotlin_time_Duration_inWholeMicroseconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeMicroseconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeMilliseconds_get")
+public fun kotlin_time_Duration_inWholeMilliseconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeMilliseconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeMinutes_get")
+public fun kotlin_time_Duration_inWholeMinutes_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeMinutes }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeNanoseconds_get")
+public fun kotlin_time_Duration_inWholeNanoseconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeNanoseconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeSeconds_get")
+public fun kotlin_time_Duration_inWholeSeconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeSeconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isFinite")
+public fun kotlin_time_Duration_isFinite(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isFinite() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isInfinite")
+public fun kotlin_time_Duration_isInfinite(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isInfinite() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isNegative")
+public fun kotlin_time_Duration_isNegative(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isNegative() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isPositive")
+public fun kotlin_time_Duration_isPositive(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isPositive() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_minus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_minus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.minus(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_plus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_plus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.plus(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_time_Duration_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, scale: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.times(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_time_Duration_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, scale: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.times(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int, Int, Int, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int, arg2: Int, arg3: Int, arg4: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _arg2 = arg2
+            val _arg3 = arg3
+            val _arg4 = arg4
+            val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _arg4)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int, Int, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int, arg2: Int, arg3: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _arg2 = arg2
+            val _arg3 = arg3
+            val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int, arg2: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _arg2 = arg2
+            val _result = kotlinFun(_arg0, _arg1, _arg2)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _result = kotlinFun(_arg0, _arg1)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toDouble__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__")
+public fun kotlin_time_Duration_toDouble__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val _result = run { __self.toDouble(__unit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_toInt__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__")
+public fun kotlin_time_Duration_toInt__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val _result = run { __self.toInt(__unit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_toIsoString")
+public fun kotlin_time_Duration_toIsoString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.toIsoString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_time_Duration_toLong__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__")
+public fun kotlin_time_Duration_toLong__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val _result = run { __self.toLong(__unit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_toString")
+public fun kotlin_time_Duration_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_time_Duration_toString__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit_Swift_Int32__")
+public fun kotlin_time_Duration_toString__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit_Swift_Int32__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr, decimals: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val __decimals = decimals
+    val _result = run { __self.toString(__unit, __decimals) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_time_Duration_unaryMinus")
+public fun kotlin_time_Duration_unaryMinus(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.unaryMinus() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -1,0 +1,2794 @@
+@_exported import ExportedKotlinPackages
+import KotlinRuntime
+import KotlinRuntimeSupport
+@_exported import KotlinCoroutineSupport
+@_implementationOnly import KotlinBridges_KotlinStdlib
+
+public protocol _ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key: KotlinRuntime.KotlinBase, KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+}
+@objc(_KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+public protocol __ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+}
+public protocol ___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol _ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    var key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+        get
+    }
+    func _get(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)?
+    func fold(
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    func minusKey(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+}
+@objc(_KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)
+public protocol __ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element: ExportedKotlinPackages.kotlin.coroutines._CoroutineContext {
+}
+public protocol ___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.coroutines.__CoroutineContext {
+}
+public final class _ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor_Key: KotlinRuntime.KotlinBase {
+    public static var shared: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor_Key {
+        get {
+            return KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor_Key.__createClassWrapper(externalRCRef: kotlin_coroutines_ContinuationInterceptor_Key_get())
+        }
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+    private init() {
+        fatalError()
+    }
+}
+extension ExportedKotlinPackages.kotlin {
+    public final class Array: KotlinRuntime.KotlinBase {
+        public var size: Swift.Int32 {
+            get {
+                return kotlin_Array_size_get(self.__externalRCRef())
+            }
+        }
+        public func _get(
+            index: Swift.Int32
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlin_Array_get__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func _set(
+            index: Swift.Int32,
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void {
+            return { kotlin_Array_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), index, value.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_Array_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+        }
+        public init(
+            size: Swift.Int32,
+            `init`: @escaping (Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) {
+            fatalError()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        public subscript(
+            index: Swift.Int32
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            get {
+                _get(index: index)
+            }
+            set(value) {
+                _set(index: index, value: value)
+            }
+        }
+    }
+    public final class IntArray: KotlinRuntime.KotlinBase {
+        public var size: Swift.Int32 {
+            get {
+                return kotlin_IntArray_size_get(self.__externalRCRef())
+            }
+        }
+        public func _get(
+            index: Swift.Int32
+        ) -> Swift.Int32 {
+            return kotlin_IntArray_get__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index)
+        }
+        public func _set(
+            index: Swift.Int32,
+            value: Swift.Int32
+        ) -> Swift.Void {
+            return { kotlin_IntArray_set__TypesOfArguments__Swift_Int32_Swift_Int32__(self.__externalRCRef(), index, value); return () }()
+        }
+        public func iterator() -> ExportedKotlinPackages.kotlin.collections.IntIterator {
+            return ExportedKotlinPackages.kotlin.collections.IntIterator.__createClassWrapper(externalRCRef: kotlin_IntArray_iterator(self.__externalRCRef()))
+        }
+        public init(
+            size: Swift.Int32
+        ) {
+            fatalError()
+        }
+        public init(
+            size: Swift.Int32,
+            `init`: @escaping (Swift.Int32) -> Swift.Int32
+        ) {
+            fatalError()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        public subscript(
+            index: Swift.Int32
+        ) -> Swift.Int32 {
+            get {
+                _get(index: index)
+            }
+            set(value) {
+                _set(index: index, value: value)
+            }
+        }
+    }
+    public final class LongArray: KotlinRuntime.KotlinBase {
+        public var size: Swift.Int32 {
+            get {
+                return kotlin_LongArray_size_get(self.__externalRCRef())
+            }
+        }
+        public func _get(
+            index: Swift.Int32
+        ) -> Swift.Int64 {
+            return kotlin_LongArray_get__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index)
+        }
+        public func _set(
+            index: Swift.Int32,
+            value: Swift.Int64
+        ) -> Swift.Void {
+            return { kotlin_LongArray_set__TypesOfArguments__Swift_Int32_Swift_Int64__(self.__externalRCRef(), index, value); return () }()
+        }
+        public func iterator() -> ExportedKotlinPackages.kotlin.collections.LongIterator {
+            return ExportedKotlinPackages.kotlin.collections.LongIterator.__createClassWrapper(externalRCRef: kotlin_LongArray_iterator(self.__externalRCRef()))
+        }
+        public init(
+            size: Swift.Int32
+        ) {
+            fatalError()
+        }
+        public init(
+            size: Swift.Int32,
+            `init`: @escaping (Swift.Int32) -> Swift.Int64
+        ) {
+            fatalError()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        public subscript(
+            index: Swift.Int32
+        ) -> Swift.Int64 {
+            get {
+                _get(index: index)
+            }
+            set(value) {
+                _set(index: index, value: value)
+            }
+        }
+    }
+    open class Throwable: KotlinRuntime.KotlinBase, Swift.Error {
+        open var message: Swift.String? {
+            get {
+                if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                    return kotlin_Throwable_message_get(self.__externalRCRef())
+                } else {
+                    return kotlin_Throwable_message_get_direct(self.__externalRCRef())
+                }
+            }
+        }
+        open var cause: ExportedKotlinPackages.kotlin.Throwable? {
+            get {
+                if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                    return { switch kotlin_Throwable_cause_get(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                } else {
+                    return { switch kotlin_Throwable_cause_get_direct(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                }
+            }
+        }
+        @_spi(kotlin$experimental$ExperimentalNativeApi)
+        public final func getStackTrace() -> ExportedKotlinPackages.kotlin.Array {
+            return ExportedKotlinPackages.kotlin.Array.__createClassWrapper(externalRCRef: kotlin_Throwable_getStackTrace(self.__externalRCRef()))
+        }
+        public final func printStackTrace() -> Swift.Void {
+            return { kotlin_Throwable_printStackTrace(self.__externalRCRef()); return () }()
+        }
+        open func toString() -> Swift.String {
+            if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                return kotlin_Throwable_toString(self.__externalRCRef())
+            } else {
+                return kotlin_Throwable_toString_direct(self.__externalRCRef())
+            }
+        }
+        public init(
+            message: Swift.String?,
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                 __kt = kotlin_Throwable_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, message ?? nil, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public init(
+            message: Swift.String?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                 __kt = kotlin_Throwable_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        public init(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                 __kt = kotlin_Throwable_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Throwable.self {
+                 __kt = kotlin_Throwable_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class Exception: ExportedKotlinPackages.kotlin.Throwable {
+        public override init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Exception.self {
+                 __kt = kotlin_Exception_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        public override init(
+            message: Swift.String?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Exception.self {
+                 __kt = kotlin_Exception_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        public override init(
+            message: Swift.String?,
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Exception.self {
+                 __kt = kotlin_Exception_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, message ?? nil, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public override init(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.Exception.self {
+                 __kt = kotlin_Exception_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class RuntimeException: ExportedKotlinPackages.kotlin.Exception {
+        public override init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.RuntimeException.self {
+                 __kt = kotlin_RuntimeException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        public override init(
+            message: Swift.String?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.RuntimeException.self {
+                 __kt = kotlin_RuntimeException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        public override init(
+            message: Swift.String?,
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.RuntimeException.self {
+                 __kt = kotlin_RuntimeException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, message ?? nil, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public override init(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.RuntimeException.self {
+                 __kt = kotlin_RuntimeException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class IllegalStateException: ExportedKotlinPackages.kotlin.RuntimeException {
+        public override init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.IllegalStateException.self {
+                 __kt = kotlin_IllegalStateException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        public override init(
+            message: Swift.String?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.IllegalStateException.self {
+                 __kt = kotlin_IllegalStateException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        public override init(
+            message: Swift.String?,
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.IllegalStateException.self {
+                 __kt = kotlin_IllegalStateException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, message ?? nil, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public override init(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.IllegalStateException.self {
+                 __kt = kotlin_IllegalStateException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_IllegalStateException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class NoSuchElementException: ExportedKotlinPackages.kotlin.RuntimeException {
+        public override init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.NoSuchElementException.self {
+                 __kt = kotlin_NoSuchElementException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        public override init(
+            message: Swift.String?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.NoSuchElementException.self {
+                 __kt = kotlin_NoSuchElementException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_NoSuchElementException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    public final class Result: KotlinRuntime.KotlinBase {
+        public final class Companion: KotlinRuntime.KotlinBase {
+            public static var shared: ExportedKotlinPackages.kotlin.Result.Companion {
+                get {
+                    return ExportedKotlinPackages.kotlin.Result.Companion.__createClassWrapper(externalRCRef: kotlin_Result_Companion_get())
+                }
+            }
+            public func success(
+                value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+            ) -> ExportedKotlinPackages.kotlin.Result {
+                return ExportedKotlinPackages.kotlin.Result.__createClassWrapper(externalRCRef: kotlin_Result_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil))
+            }
+            public func failure(
+                exception: ExportedKotlinPackages.kotlin.Throwable
+            ) -> ExportedKotlinPackages.kotlin.Result {
+                return ExportedKotlinPackages.kotlin.Result.__createClassWrapper(externalRCRef: kotlin_Result_Companion_failure__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), exception.__externalRCRef()))
+            }
+            package override init(
+                __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+                options: KotlinRuntime.KotlinBaseConstructionOptions
+            ) {
+                super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+            }
+            private init() {
+                fatalError()
+            }
+        }
+        public var isSuccess: Swift.Bool {
+            get {
+                return kotlin_Result_isSuccess_get(self.__externalRCRef())
+            }
+        }
+        public var isFailure: Swift.Bool {
+            get {
+                return kotlin_Result_isFailure_get(self.__externalRCRef())
+            }
+        }
+        public func getOrNull() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlin_Result_getOrNull(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func exceptionOrNull() -> ExportedKotlinPackages.kotlin.Throwable? {
+            return { switch kotlin_Result_exceptionOrNull(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+        }
+        public func toString() -> Swift.String {
+            return kotlin_Result_toString(self.__externalRCRef())
+        }
+        public func equals(
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            return kotlin_Result_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), other.map { it in it.__externalRCRef() } ?? nil)
+        }
+        public static func ==(
+            this: ExportedKotlinPackages.kotlin.Result,
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            this.equals(other: other)
+        }
+        public func hashCode() -> Swift.Int32 {
+            return kotlin_Result_hashCode(self.__externalRCRef())
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlin.collections {
+    public protocol MutableCollection: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Collection, ExportedKotlinPackages.kotlin.collections.MutableIterable, ExportedKotlinPackages.kotlin.collections._MutableCollection {
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.MutableIterator
+        func add(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func remove(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func addAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func removeAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func retainAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func clear() -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_MutableCollection)
+    public protocol _MutableCollection: ExportedKotlinPackages.kotlin.collections._Collection, ExportedKotlinPackages.kotlin.collections._MutableIterable {
+    }
+    public protocol __MutableCollection: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Collection, ExportedKotlinPackages.kotlin.collections.__MutableIterable {
+    }
+    public protocol Iterable: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections._Iterable {
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_Iterable)
+    public protocol _Iterable {
+    }
+    public protocol __Iterable: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol Iterator: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections._Iterator {
+        func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func hasNext() -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_Iterator)
+    public protocol _Iterator {
+    }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol MutableList: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.List, ExportedKotlinPackages.kotlin.collections.MutableCollection, ExportedKotlinPackages.kotlin.collections._MutableList {
+        func add(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func add(
+            index: Swift.Int32,
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        func remove(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func addAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func addAll(
+            index: Swift.Int32,
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func removeAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func retainAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func clear() -> Swift.Void
+        func _set(
+            index: Swift.Int32,
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func removeAt(
+            index: Swift.Int32
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func listIterator() -> any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+        func listIterator(
+            index: Swift.Int32
+        ) -> any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+        func subList(
+            fromIndex: Swift.Int32,
+            toIndex: Swift.Int32
+        ) -> any ExportedKotlinPackages.kotlin.collections.MutableList
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_MutableList)
+    public protocol _MutableList: ExportedKotlinPackages.kotlin.collections._List, ExportedKotlinPackages.kotlin.collections._MutableCollection {
+    }
+    public protocol __MutableList: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__List, ExportedKotlinPackages.kotlin.collections.__MutableCollection {
+    }
+    public protocol MutableSet: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Set, ExportedKotlinPackages.kotlin.collections.MutableCollection, ExportedKotlinPackages.kotlin.collections._MutableSet {
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.MutableIterator
+        func add(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func remove(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func addAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func removeAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func retainAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func clear() -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_MutableSet)
+    public protocol _MutableSet: ExportedKotlinPackages.kotlin.collections._Set, ExportedKotlinPackages.kotlin.collections._MutableCollection {
+    }
+    public protocol __MutableSet: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Set, ExportedKotlinPackages.kotlin.collections.__MutableCollection {
+    }
+    public protocol Collection: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Iterable, ExportedKotlinPackages.kotlin.collections._Collection {
+        var size: Swift.Int32 {
+            get
+        }
+        func isEmpty() -> Swift.Bool
+        func contains(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator
+        func containsAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_Collection)
+    public protocol _Collection: ExportedKotlinPackages.kotlin.collections._Iterable {
+    }
+    public protocol __Collection: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Iterable {
+    }
+    public protocol MutableIterable: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Iterable, ExportedKotlinPackages.kotlin.collections._MutableIterable {
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.MutableIterator
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_MutableIterable)
+    public protocol _MutableIterable: ExportedKotlinPackages.kotlin.collections._Iterable {
+    }
+    public protocol __MutableIterable: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Iterable {
+    }
+    public protocol MutableIterator: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections._MutableIterator {
+        func remove() -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_MutableIterator)
+    public protocol _MutableIterator: ExportedKotlinPackages.kotlin.collections._Iterator {
+    }
+    public protocol __MutableIterator: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Iterator {
+    }
+    public protocol MutableListIterator: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.ListIterator, ExportedKotlinPackages.kotlin.collections.MutableIterator, ExportedKotlinPackages.kotlin.collections._MutableListIterator {
+        func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func hasNext() -> Swift.Bool
+        func remove() -> Swift.Void
+        func set(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        func add(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_MutableListIterator)
+    public protocol _MutableListIterator: ExportedKotlinPackages.kotlin.collections._ListIterator, ExportedKotlinPackages.kotlin.collections._MutableIterator {
+    }
+    public protocol __MutableListIterator: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__ListIterator, ExportedKotlinPackages.kotlin.collections.__MutableIterator {
+    }
+    public protocol List: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Collection, ExportedKotlinPackages.kotlin.collections._List {
+        var size: Swift.Int32 {
+            get
+        }
+        func isEmpty() -> Swift.Bool
+        func contains(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator
+        func containsAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+        func _get(
+            index: Swift.Int32
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func indexOf(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Int32
+        func lastIndexOf(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Int32
+        func listIterator() -> any ExportedKotlinPackages.kotlin.collections.ListIterator
+        func listIterator(
+            index: Swift.Int32
+        ) -> any ExportedKotlinPackages.kotlin.collections.ListIterator
+        func subList(
+            fromIndex: Swift.Int32,
+            toIndex: Swift.Int32
+        ) -> [(any KotlinRuntimeSupport._KotlinBridgeable)?]
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_List)
+    public protocol _List: ExportedKotlinPackages.kotlin.collections._Collection {
+    }
+    public protocol __List: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Collection {
+    }
+    public protocol Set: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Collection, ExportedKotlinPackages.kotlin.collections._Set {
+        var size: Swift.Int32 {
+            get
+        }
+        func isEmpty() -> Swift.Bool
+        func contains(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator
+        func containsAll(
+            elements: any ExportedKotlinPackages.kotlin.collections.Collection
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_Set)
+    public protocol _Set: ExportedKotlinPackages.kotlin.collections._Collection {
+    }
+    public protocol __Set: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Collection {
+    }
+    public protocol ListIterator: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections._ListIterator {
+        func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func hasNext() -> Swift.Bool
+        func hasPrevious() -> Swift.Bool
+        func previous() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func nextIndex() -> Swift.Int32
+        func previousIndex() -> Swift.Int32
+    }
+    @objc(_ExportedKotlinPackages_kotlin_collections_ListIterator)
+    public protocol _ListIterator: ExportedKotlinPackages.kotlin.collections._Iterator {
+    }
+    public protocol __ListIterator: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.collections.__Iterator {
+    }
+    public final class IndexedValue: KotlinRuntime.KotlinBase {
+        public var index: Swift.Int32 {
+            get {
+                return kotlin_collections_IndexedValue_index_get(self.__externalRCRef())
+            }
+        }
+        public var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            get {
+                return { switch kotlin_collections_IndexedValue_value_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+            }
+        }
+        public func copy(
+            index: Swift.Int32,
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> ExportedKotlinPackages.kotlin.collections.IndexedValue {
+            return ExportedKotlinPackages.kotlin.collections.IndexedValue.__createClassWrapper(externalRCRef: kotlin_collections_IndexedValue_copy__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), index, value.map { it in it.__externalRCRef() } ?? nil))
+        }
+        public func equals(
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            return kotlin_collections_IndexedValue_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), other.map { it in it.__externalRCRef() } ?? nil)
+        }
+        public static func ==(
+            this: ExportedKotlinPackages.kotlin.collections.IndexedValue,
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            this.equals(other: other)
+        }
+        public func hashCode() -> Swift.Int32 {
+            return kotlin_collections_IndexedValue_hashCode(self.__externalRCRef())
+        }
+        public func toString() -> Swift.String {
+            return kotlin_collections_IndexedValue_toString(self.__externalRCRef())
+        }
+        public init(
+            index: Swift.Int32,
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) {
+            let __kt = kotlin_collections_IndexedValue_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_collections_IndexedValue_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(__kt, index, value.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class IntIterator: KotlinRuntime.KotlinBase {
+        public final func next() -> Swift.Int32 {
+            return kotlin_collections_IntIterator_next(self.__externalRCRef())
+        }
+        open func nextInt() -> Swift.Int32 {
+            if Self.self == ExportedKotlinPackages.kotlin.collections.IntIterator.self {
+                return kotlin_collections_IntIterator_nextInt(self.__externalRCRef())
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlin.collections.IntIterator.nextInt': a Swift subclass must override it and must not call super.")
+            }
+        }
+        public init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlin.collections.IntIterator.self, "ExportedKotlinPackages.kotlin.collections.IntIterator is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_collections_IntIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class LongIterator: KotlinRuntime.KotlinBase {
+        public final func next() -> Swift.Int64 {
+            return kotlin_collections_LongIterator_next(self.__externalRCRef())
+        }
+        open func nextLong() -> Swift.Int64 {
+            if Self.self == ExportedKotlinPackages.kotlin.collections.LongIterator.self {
+                return kotlin_collections_LongIterator_nextLong(self.__externalRCRef())
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlin.collections.LongIterator.nextLong': a Swift subclass must override it and must not call super.")
+            }
+        }
+        public init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlin.collections.LongIterator.self, "ExportedKotlinPackages.kotlin.collections.LongIterator is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_collections_LongIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines {
+    public protocol Continuation: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.coroutines._Continuation {
+        var context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            get
+        }
+        func resumeWith(
+            result: ExportedKotlinPackages.kotlin.Result
+        ) -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlin_coroutines_Continuation)
+    public protocol _Continuation {
+    }
+    public protocol __Continuation: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol ContinuationInterceptor: KotlinRuntime.KotlinBase, KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element, ExportedKotlinPackages.kotlin.coroutines._ContinuationInterceptor {
+        func interceptContinuation(
+            continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        ) -> any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        func releaseInterceptedContinuation(
+            continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        ) -> Swift.Void
+        func _get(
+            key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+        ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)?
+        func minusKey(
+            key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+        ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    @objc(_ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor)
+    public protocol _ContinuationInterceptor: KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    }
+    public protocol __ContinuationInterceptor: KotlinRuntimeSupport._KotlinBridgeable, KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    }
+    public protocol CoroutineContext: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.coroutines._CoroutineContext {
+        func _get(
+            key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+        ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)?
+        func fold(
+            initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func _plus(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        func minusKey(
+            key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+        ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    @objc(_ExportedKotlinPackages_kotlin_coroutines_CoroutineContext)
+    public protocol _CoroutineContext {
+    }
+    public protocol __CoroutineContext: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    open class AbstractCoroutineContextElement: KotlinRuntime.KotlinBase, KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element, KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+        open var key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+            get {
+                if Self.self == ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement.self {
+                    return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_AbstractCoroutineContextElement_key_get(self.__externalRCRef()), conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+                } else {
+                    return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_AbstractCoroutineContextElement_key_get_direct(self.__externalRCRef()), conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+                }
+            }
+        }
+        public init(
+            key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+        ) {
+            precondition(Self.self != ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement.self, "ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_coroutines_AbstractCoroutineContextElement_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(__kt, key.__externalRCRef()); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @available(*, deprecated, message: "Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage depending on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.") @_spi(kotlin$ExperimentalStdlibApi)
+    open class AbstractCoroutineContextKey: KotlinRuntime.KotlinBase {
+        @_spi(kotlin$ExperimentalStdlibApi)
+        public init(
+            baseKey: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key,
+            safeCast: @escaping (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)?
+        ) {
+            precondition(Self.self != ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextKey.self, "ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextKey is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_coroutines_AbstractCoroutineContextKey_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key_U28anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element___(__kt, baseKey.__externalRCRef(), {
+                let originalBlock: (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> Swift.Optional<any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element> = safeCast
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+                    let _result = originalBlock(_arg0)
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }()); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.cancellation {
+    open class CancellationException: ExportedKotlinPackages.kotlin.IllegalStateException {
+        public override init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.self {
+                 __kt = kotlin_coroutines_cancellation_CancellationException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        public override init(
+            message: Swift.String?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.self {
+                 __kt = kotlin_coroutines_cancellation_CancellationException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        public override init(
+            message: Swift.String?,
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.self {
+                 __kt = kotlin_coroutines_cancellation_CancellationException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, message ?? nil, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        public override init(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.self {
+                 __kt = kotlin_coroutines_cancellation_CancellationException_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlin_coroutines_cancellation_CancellationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlin.sequences {
+    public protocol Sequence: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.sequences._Sequence {
+        func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+    @objc(_ExportedKotlinPackages_kotlin_sequences_Sequence)
+    public protocol _Sequence {
+    }
+    public protocol __Sequence: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+}
+extension ExportedKotlinPackages.kotlin.time {
+    public enum DurationUnit: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {
+        case NANOSECONDS
+        case MICROSECONDS
+        case MILLISECONDS
+        case SECONDS
+        case MINUTES
+        case HOURS
+        case DAYS
+        public var description: Swift.String {
+            get {
+                switch self {
+                case .NANOSECONDS: "NANOSECONDS"
+                case .MICROSECONDS: "MICROSECONDS"
+                case .MILLISECONDS: "MILLISECONDS"
+                case .SECONDS: "SECONDS"
+                case .MINUTES: "MINUTES"
+                case .HOURS: "HOURS"
+                case .DAYS: "DAYS"
+                default: fatalError()
+                }
+            }
+        }
+        public var rawValue: Swift.Int32 {
+            get {
+                switch self {
+                case .NANOSECONDS: 0
+                case .MICROSECONDS: 1
+                case .MILLISECONDS: 2
+                case .SECONDS: 3
+                case .MINUTES: 4
+                case .HOURS: 5
+                case .DAYS: 6
+                default: fatalError()
+                }
+            }
+        }
+        public init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer!,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            switch kotlin_time_DurationUnit_ordinal(__externalRCRefUnsafe) {
+            case 0: self = .NANOSECONDS
+            case 1: self = .MICROSECONDS
+            case 2: self = .MILLISECONDS
+            case 3: self = .SECONDS
+            case 4: self = .MINUTES
+            case 5: self = .HOURS
+            case 6: self = .DAYS
+            default: fatalError()
+            }
+        }
+        public func __externalRCRef() -> Swift.UnsafeMutableRawPointer! {
+            return switch self {
+            case .NANOSECONDS: kotlin_time_DurationUnit_NANOSECONDS()
+            case .MICROSECONDS: kotlin_time_DurationUnit_MICROSECONDS()
+            case .MILLISECONDS: kotlin_time_DurationUnit_MILLISECONDS()
+            case .SECONDS: kotlin_time_DurationUnit_SECONDS()
+            case .MINUTES: kotlin_time_DurationUnit_MINUTES()
+            case .HOURS: kotlin_time_DurationUnit_HOURS()
+            case .DAYS: kotlin_time_DurationUnit_DAYS()
+            default: fatalError()
+            }
+        }
+        public init?(
+            _ description: Swift.String
+        ) {
+            switch description {
+            case "NANOSECONDS": self = .NANOSECONDS
+            case "MICROSECONDS": self = .MICROSECONDS
+            case "MILLISECONDS": self = .MILLISECONDS
+            case "SECONDS": self = .SECONDS
+            case "MINUTES": self = .MINUTES
+            case "HOURS": self = .HOURS
+            case "DAYS": self = .DAYS
+            default: return nil
+            }
+        }
+        public init?(
+            rawValue: Swift.Int32
+        ) {
+            guard 0..<7 ~= rawValue else { return nil }
+            self = DurationUnit.allCases[Int(rawValue)]
+        }
+    }
+    public final class Duration: KotlinRuntime.KotlinBase {
+        public final class Companion: KotlinRuntime.KotlinBase {
+            public var ZERO: ExportedKotlinPackages.kotlin.time.Duration {
+                get {
+                    return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_ZERO_get(self.__externalRCRef()))
+                }
+            }
+            public var INFINITE: ExportedKotlinPackages.kotlin.time.Duration {
+                get {
+                    return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_INFINITE_get(self.__externalRCRef()))
+                }
+            }
+            public static var shared: ExportedKotlinPackages.kotlin.time.Duration.Companion {
+                get {
+                    return ExportedKotlinPackages.kotlin.time.Duration.Companion.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_get())
+                }
+            }
+            @_spi(kotlin$time$ExperimentalTime)
+            public func convert(
+                value: Swift.Double,
+                sourceUnit: ExportedKotlinPackages.kotlin.time.DurationUnit,
+                targetUnit: ExportedKotlinPackages.kotlin.time.DurationUnit
+            ) -> Swift.Double {
+                return kotlin_time_Duration_Companion_convert__TypesOfArguments__Swift_Double_ExportedKotlinPackages_kotlin_time_DurationUnit_ExportedKotlinPackages_kotlin_time_DurationUnit__(self.__externalRCRef(), value, sourceUnit.__externalRCRef(), targetUnit.__externalRCRef())
+            }
+            public func parse(
+                value: Swift.String
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_parse__TypesOfArguments__Swift_String__(self.__externalRCRef(), value))
+            }
+            public func parseIsoString(
+                value: Swift.String
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_parseIsoString__TypesOfArguments__Swift_String__(self.__externalRCRef(), value))
+            }
+            public func parseOrNull(
+                value: Swift.String
+            ) -> ExportedKotlinPackages.kotlin.time.Duration? {
+                return { switch kotlin_time_Duration_Companion_parseOrNull__TypesOfArguments__Swift_String__(self.__externalRCRef(), value) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: res); } }()
+            }
+            public func parseIsoStringOrNull(
+                value: Swift.String
+            ) -> ExportedKotlinPackages.kotlin.time.Duration? {
+                return { switch kotlin_time_Duration_Companion_parseIsoStringOrNull__TypesOfArguments__Swift_String__(self.__externalRCRef(), value) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: res); } }()
+            }
+            public func getNanoseconds(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getNanoseconds(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getNanoseconds(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            public func getMicroseconds(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getMicroseconds(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getMicroseconds(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            public func getMilliseconds(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getMilliseconds(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getMilliseconds(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            public func getSeconds(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getSeconds(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getSeconds(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            public func getMinutes(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getMinutes(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getMinutes(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            public func getHours(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getHours(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getHours(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            public func getDays(
+                _ receiver: Swift.Int32
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int32__(self.__externalRCRef(), receiver))
+            }
+            public func getDays(
+                _ receiver: Swift.Int64
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int64__(self.__externalRCRef(), receiver))
+            }
+            public func getDays(
+                _ receiver: Swift.Double
+            ) -> ExportedKotlinPackages.kotlin.time.Duration {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Double__(self.__externalRCRef(), receiver))
+            }
+            package override init(
+                __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+                options: KotlinRuntime.KotlinBaseConstructionOptions
+            ) {
+                super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+            }
+            private init() {
+                fatalError()
+            }
+        }
+        public var absoluteValue: ExportedKotlinPackages.kotlin.time.Duration {
+            get {
+                return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_absoluteValue_get(self.__externalRCRef()))
+            }
+        }
+        public var inWholeDays: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeDays_get(self.__externalRCRef())
+            }
+        }
+        public var inWholeHours: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeHours_get(self.__externalRCRef())
+            }
+        }
+        public var inWholeMinutes: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeMinutes_get(self.__externalRCRef())
+            }
+        }
+        public var inWholeSeconds: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeSeconds_get(self.__externalRCRef())
+            }
+        }
+        public var inWholeMilliseconds: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeMilliseconds_get(self.__externalRCRef())
+            }
+        }
+        public var inWholeMicroseconds: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeMicroseconds_get(self.__externalRCRef())
+            }
+        }
+        public var inWholeNanoseconds: Swift.Int64 {
+            get {
+                return kotlin_time_Duration_inWholeNanoseconds_get(self.__externalRCRef())
+            }
+        }
+        public func _unaryMinus() -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_unaryMinus(self.__externalRCRef()))
+        }
+        public static prefix func -(
+            this: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._unaryMinus()
+        }
+        public func _plus(
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_plus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self.__externalRCRef(), other.__externalRCRef()))
+        }
+        public static func +(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._plus(other: other)
+        }
+        public func _minus(
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_minus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self.__externalRCRef(), other.__externalRCRef()))
+        }
+        public static func -(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._minus(other: other)
+        }
+        public func _times(
+            scale: Swift.Int32
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_times__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), scale))
+        }
+        public static func *(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            scale: Swift.Int32
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._times(scale: scale)
+        }
+        public func _times(
+            scale: Swift.Double
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_times__TypesOfArguments__Swift_Double__(self.__externalRCRef(), scale))
+        }
+        public static func *(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            scale: Swift.Double
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._times(scale: scale)
+        }
+        public func _div(
+            scale: Swift.Int32
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_div__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), scale))
+        }
+        public static func /(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            scale: Swift.Int32
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._div(scale: scale)
+        }
+        public func _div(
+            scale: Swift.Double
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            return ExportedKotlinPackages.kotlin.time.Duration.__createClassWrapper(externalRCRef: kotlin_time_Duration_div__TypesOfArguments__Swift_Double__(self.__externalRCRef(), scale))
+        }
+        public static func /(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            scale: Swift.Double
+        ) -> ExportedKotlinPackages.kotlin.time.Duration {
+            this._div(scale: scale)
+        }
+        public func _div(
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Double {
+            return kotlin_time_Duration_div__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self.__externalRCRef(), other.__externalRCRef())
+        }
+        public static func /(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Double {
+            this._div(other: other)
+        }
+        public func isNegative() -> Swift.Bool {
+            return kotlin_time_Duration_isNegative(self.__externalRCRef())
+        }
+        public func isPositive() -> Swift.Bool {
+            return kotlin_time_Duration_isPositive(self.__externalRCRef())
+        }
+        public func isInfinite() -> Swift.Bool {
+            return kotlin_time_Duration_isInfinite(self.__externalRCRef())
+        }
+        public func isFinite() -> Swift.Bool {
+            return kotlin_time_Duration_isFinite(self.__externalRCRef())
+        }
+        public func _compareTo(
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Int32 {
+            return kotlin_time_Duration_compareTo__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self.__externalRCRef(), other.__externalRCRef())
+        }
+        public static func <(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Bool {
+            this._compareTo(other: other) < 0
+        }
+        public static func <=(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Bool {
+            this._compareTo(other: other) <= 0
+        }
+        public static func >(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Bool {
+            this._compareTo(other: other) > 0
+        }
+        public static func >=(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: ExportedKotlinPackages.kotlin.time.Duration
+        ) -> Swift.Bool {
+            this._compareTo(other: other) >= 0
+        }
+        public func toComponents(
+            action: @escaping (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
+                let originalBlock: (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
+                return { (arg0: Swift.Int64, arg1: Swift.Int32, arg2: Swift.Int32, arg3: Swift.Int32, arg4: Swift.Int32) in
+                    let _arg0: Swift.Int64 = arg0
+                    let _arg1: Swift.Int32 = arg1
+                    let _arg2: Swift.Int32 = arg2
+                    let _arg3: Swift.Int32 = arg3
+                    let _arg4: Swift.Int32 = arg4
+                    let _result = originalBlock(_arg0, _arg1, _arg2, _arg3, _arg4)
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func toComponents(
+            action: @escaping (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
+                let originalBlock: (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
+                return { (arg0: Swift.Int64, arg1: Swift.Int32, arg2: Swift.Int32, arg3: Swift.Int32) in
+                    let _arg0: Swift.Int64 = arg0
+                    let _arg1: Swift.Int32 = arg1
+                    let _arg2: Swift.Int32 = arg2
+                    let _arg3: Swift.Int32 = arg3
+                    let _result = originalBlock(_arg0, _arg1, _arg2, _arg3)
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func toComponents(
+            action: @escaping (Swift.Int64, Swift.Int32, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
+                let originalBlock: (Swift.Int64, Swift.Int32, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
+                return { (arg0: Swift.Int64, arg1: Swift.Int32, arg2: Swift.Int32) in
+                    let _arg0: Swift.Int64 = arg0
+                    let _arg1: Swift.Int32 = arg1
+                    let _arg2: Swift.Int32 = arg2
+                    let _result = originalBlock(_arg0, _arg1, _arg2)
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func toComponents(
+            action: @escaping (Swift.Int64, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
+                let originalBlock: (Swift.Int64, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
+                return { (arg0: Swift.Int64, arg1: Swift.Int32) in
+                    let _arg0: Swift.Int64 = arg0
+                    let _arg1: Swift.Int32 = arg1
+                    let _result = originalBlock(_arg0, _arg1)
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func toDouble(
+            unit: ExportedKotlinPackages.kotlin.time.DurationUnit
+        ) -> Swift.Double {
+            return kotlin_time_Duration_toDouble__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self.__externalRCRef(), unit.__externalRCRef())
+        }
+        public func toLong(
+            unit: ExportedKotlinPackages.kotlin.time.DurationUnit
+        ) -> Swift.Int64 {
+            return kotlin_time_Duration_toLong__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self.__externalRCRef(), unit.__externalRCRef())
+        }
+        public func toInt(
+            unit: ExportedKotlinPackages.kotlin.time.DurationUnit
+        ) -> Swift.Int32 {
+            return kotlin_time_Duration_toInt__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self.__externalRCRef(), unit.__externalRCRef())
+        }
+        public func toString() -> Swift.String {
+            return kotlin_time_Duration_toString(self.__externalRCRef())
+        }
+        public func toString(
+            unit: ExportedKotlinPackages.kotlin.time.DurationUnit,
+            decimals: Swift.Int32
+        ) -> Swift.String {
+            return kotlin_time_Duration_toString__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit_Swift_Int32__(self.__externalRCRef(), unit.__externalRCRef(), decimals)
+        }
+        public func toIsoString() -> Swift.String {
+            return kotlin_time_Duration_toIsoString(self.__externalRCRef())
+        }
+        public func equals(
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            return kotlin_time_Duration_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), other.map { it in it.__externalRCRef() } ?? nil)
+        }
+        public static func ==(
+            this: ExportedKotlinPackages.kotlin.time.Duration,
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            this.equals(other: other)
+        }
+        public func hashCode() -> Swift.Int32 {
+            return kotlin_time_Duration_hashCode(self.__externalRCRef())
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.MutableCollection where Self : ExportedKotlinPackages.kotlin.collections.__MutableCollection {
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.MutableIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_MutableCollection_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.MutableIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableIterator
+    }
+    public func add(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func remove(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func addAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func removeAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func retainAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func clear() -> Swift.Void {
+        return { kotlin_collections_MutableCollection_clear(self.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._MutableCollection {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.MutableCollection, ExportedKotlinPackages.kotlin.collections.__MutableCollection where Wrapped : ExportedKotlinPackages.kotlin.collections._MutableCollection {
+}
+extension ExportedKotlinPackages.kotlin.collections.MutableCollection {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.Iterable where Self : ExportedKotlinPackages.kotlin.collections.__Iterable {
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_Iterable_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterable {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterable, ExportedKotlinPackages.kotlin.collections.__Iterable where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterable {
+}
+extension ExportedKotlinPackages.kotlin.collections.Iterable {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
+    public func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_Iterator_next(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func hasNext() -> Swift.Bool {
+        return kotlin_collections_Iterator_hasNext(self.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterator {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+}
+extension ExportedKotlinPackages.kotlin.collections.Iterator {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.MutableList where Self : ExportedKotlinPackages.kotlin.collections.__MutableList {
+    public func add(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func add(
+        index: Swift.Int32,
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), index, element.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public func remove(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func addAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func addAll(
+        index: Swift.Int32,
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), index, elements.__externalRCRef())
+    }
+    public func removeAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func retainAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func clear() -> Swift.Void {
+        return { kotlin_collections_MutableList_clear(self.__externalRCRef()); return () }()
+    }
+    public func _set(
+        index: Swift.Int32,
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), index, element.map { it in it.__externalRCRef() } ?? nil) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func removeAt(
+        index: Swift.Int32
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func listIterator() -> any ExportedKotlinPackages.kotlin.collections.MutableListIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_MutableList_listIterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    }
+    public func listIterator(
+        index: Swift.Int32
+    ) -> any ExportedKotlinPackages.kotlin.collections.MutableListIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index), conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    }
+    public func subList(
+        fromIndex: Swift.Int32,
+        toIndex: Swift.Int32
+    ) -> any ExportedKotlinPackages.kotlin.collections.MutableList {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32__(self.__externalRCRef(), fromIndex, toIndex), conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._MutableList {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.MutableList, ExportedKotlinPackages.kotlin.collections.__MutableList where Wrapped : ExportedKotlinPackages.kotlin.collections._MutableList {
+}
+extension ExportedKotlinPackages.kotlin.collections.MutableList {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.MutableSet where Self : ExportedKotlinPackages.kotlin.collections.__MutableSet {
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.MutableIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_MutableSet_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.MutableIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableIterator
+    }
+    public func add(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func remove(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func addAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func removeAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func retainAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func clear() -> Swift.Void {
+        return { kotlin_collections_MutableSet_clear(self.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._MutableSet {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.MutableSet, ExportedKotlinPackages.kotlin.collections.__MutableSet where Wrapped : ExportedKotlinPackages.kotlin.collections._MutableSet {
+}
+extension ExportedKotlinPackages.kotlin.collections.MutableSet {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.coroutines.Continuation where Self : ExportedKotlinPackages.kotlin.coroutines.__Continuation {
+    public var context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_Continuation_context_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        }
+    }
+    public func resumeWith(
+        result: ExportedKotlinPackages.kotlin.Result
+    ) -> Swift.Void {
+        return { kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__(self.__externalRCRef(), result.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.coroutines._Continuation {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.coroutines.Continuation, ExportedKotlinPackages.kotlin.coroutines.__Continuation where Wrapped : ExportedKotlinPackages.kotlin.coroutines._Continuation {
+}
+extension ExportedKotlinPackages.kotlin.coroutines.Continuation {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor where Self : ExportedKotlinPackages.kotlin.coroutines.__ContinuationInterceptor {
+    public func interceptContinuation(
+        continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.Continuation {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self.__externalRCRef(), continuation.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.Continuation.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    }
+    public func releaseInterceptedContinuation(
+        continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    ) -> Swift.Void {
+        return { kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self.__externalRCRef(), continuation.__externalRCRef()); return () }()
+    }
+    public func _get(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        return { switch kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self.__externalRCRef(), key.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element; } }()
+    }
+    public func minusKey(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self.__externalRCRef(), key.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public subscript(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        get {
+            _get(key: key)
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.coroutines._ContinuationInterceptor {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor, ExportedKotlinPackages.kotlin.coroutines.__ContinuationInterceptor where Wrapped : ExportedKotlinPackages.kotlin.coroutines._ContinuationInterceptor {
+}
+extension ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor {
+    public typealias Key = KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_ContinuationInterceptor_Key
+    public func releaseInterceptedContinuation(
+        continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    ) -> Swift.Void {
+        return { kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation___direct(self.__externalRCRef(), continuation.__externalRCRef()); return () }()
+    }
+    public func _get(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        return { switch kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self.__externalRCRef(), key.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element; } }()
+    }
+    public func minusKey(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self.__externalRCRef(), key.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext where Self : ExportedKotlinPackages.kotlin.coroutines.__CoroutineContext {
+    public func _get(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        return { switch kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self.__externalRCRef(), key.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element; } }()
+    }
+    public func fold(
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_coroutines_CoroutineContext_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), initial.map { it in it.__externalRCRef() } ?? nil, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg1, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+                let _result = originalBlock(_arg0, _arg1)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func _plus(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(self.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public static func +(
+        this: Self,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        this._plus(context: context)
+    }
+    public func minusKey(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self.__externalRCRef(), key.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public subscript(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        get {
+            _get(key: key)
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.coroutines._CoroutineContext {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, ExportedKotlinPackages.kotlin.coroutines.__CoroutineContext where Wrapped : ExportedKotlinPackages.kotlin.coroutines._CoroutineContext {
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public typealias Key = KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    public typealias Element = KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+    public func _plus(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(self.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.sequences.Sequence where Self : ExportedKotlinPackages.kotlin.sequences.__Sequence {
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_sequences_Sequence_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.sequences._Sequence {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.sequences.Sequence, ExportedKotlinPackages.kotlin.sequences.__Sequence where Wrapped : ExportedKotlinPackages.kotlin.sequences._Sequence {
+}
+extension ExportedKotlinPackages.kotlin.sequences.Sequence {
+}
+@_documentation(visibility: internal)
+extension KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key where Self : KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key, KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key where Wrapped : KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+}
+extension KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+}
+@_documentation(visibility: internal)
+extension KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element where Self : KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    public var key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_CoroutineContext_Element_key_get(self.__externalRCRef()), conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+        }
+    }
+    public func _get(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        return { switch kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self.__externalRCRef(), key.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element; } }()
+    }
+    public func fold(
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), initial.map { it in it.__externalRCRef() } ?? nil, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg1, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+                let _result = originalBlock(_arg0, _arg1)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func minusKey(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key__(self.__externalRCRef(), key.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public subscript(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        get {
+            _get(key: key)
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element, KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element where Wrapped : KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+}
+extension KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    public func _get(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> (any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element)? {
+        return { switch kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self.__externalRCRef(), key.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element; } }()
+    }
+    public func fold(
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_coroutines_CoroutineContext_Element_fold__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ElementU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self.__externalRCRef(), initial.map { it in it.__externalRCRef() } ?? nil, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg1, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+                let _result = originalBlock(_arg0, _arg1)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func minusKey(
+        key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key___direct(self.__externalRCRef(), key.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.Collection where Self : ExportedKotlinPackages.kotlin.collections.__Collection {
+    public var size: Swift.Int32 {
+        get {
+            return kotlin_collections_Collection_size_get(self.__externalRCRef())
+        }
+    }
+    public func isEmpty() -> Swift.Bool {
+        return kotlin_collections_Collection_isEmpty(self.__externalRCRef())
+    }
+    public func contains(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public static func ~=(
+        this: Self,
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        this.contains(element: element)
+    }
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_Collection_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+    public func containsAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Collection {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Collection, ExportedKotlinPackages.kotlin.collections.__Collection where Wrapped : ExportedKotlinPackages.kotlin.collections._Collection {
+}
+extension ExportedKotlinPackages.kotlin.collections.Collection {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.MutableIterable where Self : ExportedKotlinPackages.kotlin.collections.__MutableIterable {
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.MutableIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_MutableIterable_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.MutableIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableIterator
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._MutableIterable {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.MutableIterable, ExportedKotlinPackages.kotlin.collections.__MutableIterable where Wrapped : ExportedKotlinPackages.kotlin.collections._MutableIterable {
+}
+extension ExportedKotlinPackages.kotlin.collections.MutableIterable {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.MutableIterator where Self : ExportedKotlinPackages.kotlin.collections.__MutableIterator {
+    public func remove() -> Swift.Void {
+        return { kotlin_collections_MutableIterator_remove(self.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._MutableIterator {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.MutableIterator, ExportedKotlinPackages.kotlin.collections.__MutableIterator where Wrapped : ExportedKotlinPackages.kotlin.collections._MutableIterator {
+}
+extension ExportedKotlinPackages.kotlin.collections.MutableIterator {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.MutableListIterator where Self : ExportedKotlinPackages.kotlin.collections.__MutableListIterator {
+    public func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_MutableListIterator_next(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func hasNext() -> Swift.Bool {
+        return kotlin_collections_MutableListIterator_hasNext(self.__externalRCRef())
+    }
+    public func remove() -> Swift.Void {
+        return { kotlin_collections_MutableListIterator_remove(self.__externalRCRef()); return () }()
+    }
+    public func set(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public func add(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._MutableListIterator {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.MutableListIterator, ExportedKotlinPackages.kotlin.collections.__MutableListIterator where Wrapped : ExportedKotlinPackages.kotlin.collections._MutableListIterator {
+}
+extension ExportedKotlinPackages.kotlin.collections.MutableListIterator {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.List where Self : ExportedKotlinPackages.kotlin.collections.__List {
+    public var size: Swift.Int32 {
+        get {
+            return kotlin_collections_List_size_get(self.__externalRCRef())
+        }
+    }
+    public func isEmpty() -> Swift.Bool {
+        return kotlin_collections_List_isEmpty(self.__externalRCRef())
+    }
+    public func contains(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public static func ~=(
+        this: Self,
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        this.contains(element: element)
+    }
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_List_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+    public func containsAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+    public func _get(
+        index: Swift.Int32
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_List_get__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func indexOf(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Int32 {
+        return kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func lastIndexOf(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Int32 {
+        return kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func listIterator() -> any ExportedKotlinPackages.kotlin.collections.ListIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_List_listIterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    }
+    public func listIterator(
+        index: Swift.Int32
+    ) -> any ExportedKotlinPackages.kotlin.collections.ListIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), index), conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    }
+    public func subList(
+        fromIndex: Swift.Int32,
+        toIndex: Swift.Int32
+    ) -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+        return kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32__(self.__externalRCRef(), fromIndex, toIndex) as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    }
+    public subscript(
+        index: Swift.Int32
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        get {
+            _get(index: index)
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._List {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.List, ExportedKotlinPackages.kotlin.collections.__List where Wrapped : ExportedKotlinPackages.kotlin.collections._List {
+}
+extension ExportedKotlinPackages.kotlin.collections.List {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.Set where Self : ExportedKotlinPackages.kotlin.collections.__Set {
+    public var size: Swift.Int32 {
+        get {
+            return kotlin_collections_Set_size_get(self.__externalRCRef())
+        }
+    }
+    public func isEmpty() -> Swift.Bool {
+        return kotlin_collections_Set_isEmpty(self.__externalRCRef())
+    }
+    public func contains(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public static func ~=(
+        this: Self,
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        this.contains(element: element)
+    }
+    public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_Set_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    }
+    public func containsAll(
+        elements: any ExportedKotlinPackages.kotlin.collections.Collection
+    ) -> Swift.Bool {
+        return kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self.__externalRCRef(), elements.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Set {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Set, ExportedKotlinPackages.kotlin.collections.__Set where Wrapped : ExportedKotlinPackages.kotlin.collections._Set {
+}
+extension ExportedKotlinPackages.kotlin.collections.Set {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlin.collections.ListIterator where Self : ExportedKotlinPackages.kotlin.collections.__ListIterator {
+    public func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_ListIterator_next(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func hasNext() -> Swift.Bool {
+        return kotlin_collections_ListIterator_hasNext(self.__externalRCRef())
+    }
+    public func hasPrevious() -> Swift.Bool {
+        return kotlin_collections_ListIterator_hasPrevious(self.__externalRCRef())
+    }
+    public func previous() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlin_collections_ListIterator_previous(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public func nextIndex() -> Swift.Int32 {
+        return kotlin_collections_ListIterator_nextIndex(self.__externalRCRef())
+    }
+    public func previousIndex() -> Swift.Int32 {
+        return kotlin_collections_ListIterator_previousIndex(self.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._ListIterator {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.ListIterator, ExportedKotlinPackages.kotlin.collections.__ListIterator where Wrapped : ExportedKotlinPackages.kotlin.collections._ListIterator {
+}
+extension ExportedKotlinPackages.kotlin.collections.ListIterator {
+}
+@_cdecl("kotlin_Throwable_cause_get__reverse_swift")
+package func kotlin_Throwable_cause_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = _self.cause
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_Throwable_message_get__reverse_swift")
+package func kotlin_Throwable_message_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String? {
+    let _self = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Optional<Swift.String> = _self.message
+    return _result ?? nil
+}
+
+@_cdecl("kotlin_Throwable_toString__reverse_swift")
+package func kotlin_Throwable_toString__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String {
+    let _self = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.String = _self.toString()
+    return _result
+}
+
+@_cdecl("kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection
+    let _result: Swift.Bool = _self.containsAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection
+    let _result: Swift.Bool = _self.contains(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_Collection_isEmpty__reverse_swift")
+package func kotlin_collections_Collection_isEmpty__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection
+    let _result: Swift.Bool = _self.isEmpty()
+    return _result
+}
+
+@_cdecl("kotlin_collections_Collection_iterator__reverse_swift")
+package func kotlin_collections_Collection_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection
+    let _result: any ExportedKotlinPackages.kotlin.collections.Iterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_Collection_size_get__reverse_swift")
+package func kotlin_collections_Collection_size_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection
+    let _result: Swift.Int32 = _self.size
+    return _result
+}
+
+@_cdecl("kotlin_collections_IntIterator_nextInt__reverse_swift")
+package func kotlin_collections_IntIterator_nextInt__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = ExportedKotlinPackages.kotlin.collections.IntIterator.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Int32 = _self.nextInt()
+    return _result
+}
+
+@_cdecl("kotlin_collections_Iterable_iterator__reverse_swift")
+package func kotlin_collections_Iterable_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Iterable.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterable
+    let _result: any ExportedKotlinPackages.kotlin.collections.Iterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_Iterator_hasNext__reverse_swift")
+package func kotlin_collections_Iterator_hasNext__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    let _result: Swift.Bool = _self.hasNext()
+    return _result
+}
+
+@_cdecl("kotlin_collections_Iterator_next__reverse_swift")
+package func kotlin_collections_Iterator_next__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Iterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Iterator
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.next()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_ListIterator_hasNext__reverse_swift")
+package func kotlin_collections_ListIterator_hasNext__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    let _result: Swift.Bool = _self.hasNext()
+    return _result
+}
+
+@_cdecl("kotlin_collections_ListIterator_hasPrevious__reverse_swift")
+package func kotlin_collections_ListIterator_hasPrevious__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    let _result: Swift.Bool = _self.hasPrevious()
+    return _result
+}
+
+@_cdecl("kotlin_collections_ListIterator_nextIndex__reverse_swift")
+package func kotlin_collections_ListIterator_nextIndex__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    let _result: Swift.Int32 = _self.nextIndex()
+    return _result
+}
+
+@_cdecl("kotlin_collections_ListIterator_next__reverse_swift")
+package func kotlin_collections_ListIterator_next__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.next()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_ListIterator_previousIndex__reverse_swift")
+package func kotlin_collections_ListIterator_previousIndex__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    let _result: Swift.Int32 = _self.previousIndex()
+    return _result
+}
+
+@_cdecl("kotlin_collections_ListIterator_previous__reverse_swift")
+package func kotlin_collections_ListIterator_previous__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.ListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.ListIterator
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.previous()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_List_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Bool = _self.containsAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Bool = _self.contains(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self._get(index: index)
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Int32 = _self.indexOf(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_List_isEmpty__reverse_swift")
+package func kotlin_collections_List_isEmpty__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Bool = _self.isEmpty()
+    return _result
+}
+
+@_cdecl("kotlin_collections_List_iterator__reverse_swift")
+package func kotlin_collections_List_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: any ExportedKotlinPackages.kotlin.collections.Iterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Int32 = _self.lastIndexOf(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: any ExportedKotlinPackages.kotlin.collections.ListIterator = _self.listIterator(index: index)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_List_listIterator__reverse_swift")
+package func kotlin_collections_List_listIterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: any ExportedKotlinPackages.kotlin.collections.ListIterator = _self.listIterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_List_size_get__reverse_swift")
+package func kotlin_collections_List_size_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Int32 = _self.size
+    return _result
+}
+
+@_cdecl("kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
+package func kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ fromIndex: Swift.Int32, _ toIndex: Swift.Int32) -> Any {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.List.Type.self) as! any ExportedKotlinPackages.kotlin.collections.List
+    let _result: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = _self.subList(fromIndex: fromIndex, toIndex: toIndex)
+    return _result.map { it in it as! NSObject? ?? NSNull() }
+}
+
+@_cdecl("kotlin_collections_LongIterator_nextLong__reverse_swift")
+package func kotlin_collections_LongIterator_nextLong__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int64 {
+    let _self = ExportedKotlinPackages.kotlin.collections.LongIterator.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Int64 = _self.nextLong()
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableCollection_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: Swift.Bool = _self.addAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableCollection_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: Swift.Bool = _self.add(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableCollection_clear__reverse_swift")
+package func kotlin_collections_MutableCollection_clear__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: Swift.Void = _self.clear()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableCollection_iterator__reverse_swift")
+package func kotlin_collections_MutableCollection_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: any ExportedKotlinPackages.kotlin.collections.MutableIterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableCollection_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: Swift.Bool = _self.removeAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableCollection_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: Swift.Bool = _self.remove(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableCollection_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    let _result: Swift.Bool = _self.retainAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableIterable_iterator__reverse_swift")
+package func kotlin_collections_MutableIterable_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableIterable.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableIterable
+    let _result: any ExportedKotlinPackages.kotlin.collections.MutableIterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_MutableIterator_remove__reverse_swift")
+package func kotlin_collections_MutableIterator_remove__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableIterator
+    let _result: Swift.Void = _self.remove()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableListIterator_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    let _result: Swift.Void = _self.add(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableListIterator_hasNext__reverse_swift")
+package func kotlin_collections_MutableListIterator_hasNext__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    let _result: Swift.Bool = _self.hasNext()
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableListIterator_next__reverse_swift")
+package func kotlin_collections_MutableListIterator_next__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.next()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_MutableListIterator_remove__reverse_swift")
+package func kotlin_collections_MutableListIterator_remove__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    let _result: Swift.Void = _self.remove()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableListIterator_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableListIterator.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableListIterator
+    let _result: Swift.Void = _self.set(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableList_addAll__TypesOfArguments__Swift_Int32_anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Bool = _self.addAll(index: index, elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableList_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Bool = _self.addAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableList_add__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Void = _self.add(index: index, element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableList_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Bool = _self.add(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableList_clear__reverse_swift")
+package func kotlin_collections_MutableList_clear__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Void = _self.clear()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlin_collections_MutableList_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: any ExportedKotlinPackages.kotlin.collections.MutableListIterator = _self.listIterator(index: index)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_MutableList_listIterator__reverse_swift")
+package func kotlin_collections_MutableList_listIterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: any ExportedKotlinPackages.kotlin.collections.MutableListIterator = _self.listIterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableList_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Bool = _self.removeAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlin_collections_MutableList_removeAt__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.removeAt(index: index)
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableList_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Bool = _self.remove(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableList_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Bool = _self.retainAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableList_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ index: Swift.Int32, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self._set(index: index, element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
+package func kotlin_collections_MutableList_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ fromIndex: Swift.Int32, _ toIndex: Swift.Int32) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableList.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableList
+    let _result: any ExportedKotlinPackages.kotlin.collections.MutableList = _self.subList(fromIndex: fromIndex, toIndex: toIndex)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableSet_addAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: Swift.Bool = _self.addAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableSet_add__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: Swift.Bool = _self.add(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableSet_clear__reverse_swift")
+package func kotlin_collections_MutableSet_clear__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: Swift.Void = _self.clear()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_collections_MutableSet_iterator__reverse_swift")
+package func kotlin_collections_MutableSet_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: any ExportedKotlinPackages.kotlin.collections.MutableIterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableSet_removeAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: Swift.Bool = _self.removeAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_MutableSet_remove__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: Swift.Bool = _self.remove(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_MutableSet_retainAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableSet.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableSet
+    let _result: Swift.Bool = _self.retainAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+package func kotlin_collections_Set_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ elements: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Set.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Set
+    let _result: Swift.Bool = _self.containsAll(elements: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: elements, conformsTo: ExportedKotlinPackages.kotlin.collections.Collection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Collection)
+    return _result
+}
+
+@_cdecl("kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlin_collections_Set_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Set.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Set
+    let _result: Swift.Bool = _self.contains(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlin_collections_Set_isEmpty__reverse_swift")
+package func kotlin_collections_Set_isEmpty__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Set.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Set
+    let _result: Swift.Bool = _self.isEmpty()
+    return _result
+}
+
+@_cdecl("kotlin_collections_Set_iterator__reverse_swift")
+package func kotlin_collections_Set_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Set.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Set
+    let _result: any ExportedKotlinPackages.kotlin.collections.Iterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_collections_Set_size_get__reverse_swift")
+package func kotlin_collections_Set_size_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.collections.Set.Type.self) as! any ExportedKotlinPackages.kotlin.collections.Set
+    let _result: Swift.Int32 = _self.size
+    return _result
+}
+
+@_cdecl("kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse_swift")
+package func kotlin_coroutines_AbstractCoroutineContextElement_key_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement.__createClassWrapper(externalRCRef: `self`)!
+    let _result: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key = _self.key
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+package func kotlin_coroutines_ContinuationInterceptor_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ key: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor
+    let _result: Swift.Optional<any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element> = _self._get(key: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: key, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift")
+package func kotlin_coroutines_ContinuationInterceptor_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.Continuation = _self.interceptContinuation(continuation: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: continuation, conformsTo: ExportedKotlinPackages.kotlin.coroutines.Continuation.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.Continuation)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+package func kotlin_coroutines_ContinuationInterceptor_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ key: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self.minusKey(key: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: key, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift")
+package func kotlin_coroutines_ContinuationInterceptor_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor
+    let _result: Swift.Void = _self.releaseInterceptedContinuation(continuation: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: continuation, conformsTo: ExportedKotlinPackages.kotlin.coroutines.Continuation.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.Continuation)
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_coroutines_Continuation_context_get__reverse_swift")
+package func kotlin_coroutines_Continuation_context_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.Continuation.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self.context
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse_swift")
+package func kotlin_coroutines_Continuation_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ result: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.Continuation.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    let _result: Swift.Void = _self.resumeWith(result: ExportedKotlinPackages.kotlin.Result.__createClassWrapper(externalRCRef: result))
+    return { _result; return true }()
+}
+
+@_cdecl("kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+package func kotlin_coroutines_CoroutineContext_Element_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ key: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+    let _result: Swift.Optional<any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element> = _self._get(key: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: key, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_coroutines_CoroutineContext_Element_key_get__reverse_swift")
+package func kotlin_coroutines_CoroutineContext_Element_key_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+    let _result: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key = _self.key
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+package func kotlin_coroutines_CoroutineContext_Element_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ key: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self.minusKey(key: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: key, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+package func kotlin_coroutines_CoroutineContext_get__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ key: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    let _result: Swift.Optional<any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element> = _self._get(key: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: key, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift")
+package func kotlin_coroutines_CoroutineContext_minusKey__TypesOfArguments__anyU20KotlinStdlib__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ key: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self.minusKey(key: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: key, conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift")
+package func kotlin_coroutines_CoroutineContext_plus__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self._plus(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlin_sequences_Sequence_iterator__reverse_swift")
+package func kotlin_sequences_Sequence_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlin.sequences.Sequence.Type.self) as! any ExportedKotlinPackages.kotlin.sequences.Sequence
+    let _result: any ExportedKotlinPackages.kotlin.collections.Iterator = _self.iterator()
+    return _result.__externalRCRef()
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxAtomicFu/KotlinxAtomicFu.h
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxAtomicFu/KotlinxAtomicFu.h
@@ -1,0 +1,16 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+void * kotlinx_atomicfu_locks_SynchronizedObject_init_allocate();
+
+_Bool kotlinx_atomicfu_locks_SynchronizedObject_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlinx_atomicfu_locks_SynchronizedObject_lock(void * self);
+
+_Bool kotlinx_atomicfu_locks_SynchronizedObject_tryLock(void * self);
+
+_Bool kotlinx_atomicfu_locks_SynchronizedObject_unlock(void * self);
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxAtomicFu/KotlinxAtomicFu.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxAtomicFu/KotlinxAtomicFu.kt
@@ -1,0 +1,40 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.atomicfu.locks.SynchronizedObject::class, "22ExportedKotlinPackages7kotlinxO8atomicfuO5locksO15KotlinxAtomicFuE18SynchronizedObjectC")
+
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("kotlinx_atomicfu_locks_SynchronizedObject_init_allocate")
+public fun kotlinx_atomicfu_locks_SynchronizedObject_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.atomicfu.locks.SynchronizedObject>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_atomicfu_locks_SynchronizedObject_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlinx_atomicfu_locks_SynchronizedObject_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.atomicfu.locks.SynchronizedObject()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_atomicfu_locks_SynchronizedObject_lock")
+public fun kotlinx_atomicfu_locks_SynchronizedObject_lock(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.atomicfu.locks.SynchronizedObject
+    val _result = run { __self.lock() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_atomicfu_locks_SynchronizedObject_tryLock")
+public fun kotlinx_atomicfu_locks_SynchronizedObject_tryLock(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.atomicfu.locks.SynchronizedObject
+    val _result = run { __self.tryLock() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_atomicfu_locks_SynchronizedObject_unlock")
+public fun kotlinx_atomicfu_locks_SynchronizedObject_unlock(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.atomicfu.locks.SynchronizedObject
+    val _result = run { __self.unlock() }
+    return run { _result; true }
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxAtomicFu/KotlinxAtomicFu.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxAtomicFu/KotlinxAtomicFu.swift
@@ -1,0 +1,36 @@
+@_exported import ExportedKotlinPackages
+import KotlinRuntimeSupport
+@_exported import KotlinCoroutineSupport
+import KotlinRuntime
+@_implementationOnly import KotlinBridges_KotlinxAtomicFu
+
+public typealias locks = ExportedKotlinPackages.kotlinx.atomicfu.locks
+extension ExportedKotlinPackages.kotlinx.atomicfu.locks {
+    open class SynchronizedObject: KotlinRuntime.KotlinBase {
+        public final func lock() -> Swift.Void {
+            return { kotlinx_atomicfu_locks_SynchronizedObject_lock(self.__externalRCRef()); return () }()
+        }
+        public final func tryLock() -> Swift.Bool {
+            return kotlinx_atomicfu_locks_SynchronizedObject_tryLock(self.__externalRCRef())
+        }
+        public final func unlock() -> Swift.Void {
+            return { kotlinx_atomicfu_locks_SynchronizedObject_unlock(self.__externalRCRef()); return () }()
+        }
+        public init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlinx.atomicfu.locks.SynchronizedObject.self {
+                 __kt = kotlinx_atomicfu_locks_SynchronizedObject_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_atomicfu_locks_SynchronizedObject_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.h
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.h
@@ -1,0 +1,1226 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+_Bool kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(void * self, void * token);
+
+_Bool kotlinx_coroutines_CancellableContinuation_initCancellability__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_isActive_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(void * self, void * receiver, void * exception);
+
+_Bool kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * receiver, void * _Nullable value);
+
+void * _Nullable kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(void * self, void * exception);
+
+void * _Nullable kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable value, void * _Nullable idempotent);
+
+_Bool kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(void * self, void * exception);
+
+_Bool kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable value);
+
+_Bool kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(void * self, void * exception);
+
+_Bool kotlinx_coroutines_CompletableJob_complete__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(void * self, void * context, void * block);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(void * self, void * context, void * block);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(void * self, void * context);
+
+void * kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t parallelism);
+
+NSString * kotlinx_coroutines_CoroutineDispatcher_toString__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(void * self, void * context, void * exception);
+
+void * kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Deferred_await__reverse_swift(void * self, void * continuation, void * exception, void * cancellation);
+
+void * _Nullable kotlinx_coroutines_Deferred_getCompleted__reverse_swift(void * self);
+
+void * _Nullable kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse_swift(void * self);
+
+void * kotlinx_coroutines_Deferred_onAwait_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(void * self, int64_t timeMillis, void * block, void * context);
+
+_Bool kotlinx_coroutines_DisposableHandle_dispose__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_Job_children_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_Job_getCancellationException__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Job_isActive_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Job_isCancelled_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Job_isCompleted_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Job_join__reverse_swift(void * self, void * continuation, void * exception, void * cancellation);
+
+void * kotlinx_coroutines_Job_onJoin_get__reverse_swift(void * self);
+
+void * _Nullable kotlinx_coroutines_Job_parent_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Job_start__reverse_swift(void * self);
+
+void * kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t parallelism);
+
+NSString * kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_Runnable_run__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse_swift(void * self, void * continuation, void * exception, void * cancellation);
+
+void * _Nullable kotlinx_coroutines_channels_ChannelIterator_next__reverse_swift(void * self);
+
+void * kotlinx_coroutines_channels_ProducerScope_channel_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse_swift(void * self);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse_swift(void * self, void * continuation, void * exception, void * cancellation);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_receive__reverse_swift(void * self, void * continuation, void * exception, void * cancellation);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_channels_SendChannel_onSend_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element, void * continuation, void * exception, void * cancellation);
+
+void * kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable element);
+
+_Bool kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(void * self, void * collector, void * continuation, void * exception, void * cancellation);
+
+_Bool kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable value, void * continuation, void * exception, void * cancellation);
+
+_Bool kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(void * self, void * collector, void * continuation, void * exception, void * cancellation);
+
+_Bool kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable value, void * continuation, void * exception, void * cancellation);
+
+_Bool kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift(void * self);
+
+void * kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable value);
+
+_Bool kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable expect, void * _Nullable update);
+
+void * _Nullable kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable newValue);
+
+_Bool kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(void * self, void * collector, void * continuation, void * exception, void * cancellation);
+
+NSArray<id> * kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse_swift(void * self, void * subscriptionCount);
+
+void * _Nullable kotlinx_coroutines_flow_StateFlow_value_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(void * self, void * collector, void * continuation, void * exception, void * cancellation);
+
+void * _Nullable kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse_swift(void * self);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(void * self, void * context, int32_t capacity, void * onBufferOverflow);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse_swift(void * self, void * scope);
+
+NSString * kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse_swift(void * self);
+
+void * kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(void * self, void * context, int32_t capacity, void * onBufferOverflow);
+
+void * kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable affected, void * _Nullable failure);
+
+void * _Nullable kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable affected);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse_swift(void * self);
+
+NSString * kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse_swift(void * self);
+
+void * kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse_swift(void * self, NSArray<id> * allFactories);
+
+NSString * _Nullable kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse_swift(void * self);
+
+int32_t kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse_swift(void * self);
+
+void * _Nullable kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse_swift(void * self);
+
+void * _Nullable kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable affected);
+
+NSString * kotlinx_coroutines_internal_OpDescriptor_toString__reverse_swift(void * self);
+
+int32_t kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse_swift(void * self, int32_t newValue);
+
+void * kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse_swift(void * self);
+
+void * kotlinx_coroutines_selects_SelectInstance_context_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse_swift(void * self, void * disposableHandle);
+
+_Bool kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable internalResult);
+
+_Bool kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * clauseObject, void * _Nullable result);
+
+_Bool kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(void * self, void * owner);
+
+_Bool kotlinx_coroutines_sync_Mutex_isLocked_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable owner, void * continuation, void * exception, void * cancellation);
+
+void * kotlinx_coroutines_sync_Mutex_onLock_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable owner);
+
+_Bool kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(void * self, void * _Nullable owner);
+
+_Bool kotlinx_coroutines_sync_Semaphore_acquire__reverse_swift(void * self, void * continuation, void * exception, void * cancellation);
+
+int32_t kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse_swift(void * self);
+
+_Bool kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse_swift(void * self);
+
+_Bool KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * pointerToBlock, void * _Nullable _1);
+
+_Bool KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(void * pointerToBlock, void * _Nullable _1);
+
+_Bool KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(void * pointerToBlock, _Bool _1);
+
+_Bool KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(void * pointerToBlock, _Bool _1);
+
+_Bool KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult__(void * pointerToBlock, void * _1);
+
+_Bool KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * pointerToBlock, void * _1);
+
+void * kotlin_ranges_intRange_create_int_KotlinxCoroutinesCore(int32_t start, int32_t end);
+
+int32_t kotlin_ranges_intRange_getEndInclusive_int_KotlinxCoroutinesCore(void * nativePtr);
+
+int32_t kotlin_ranges_intRange_getStart_int_KotlinxCoroutinesCore(void * nativePtr);
+
+void * kotlin_ranges_longRange_create_long_KotlinxCoroutinesCore(int64_t start, int64_t end);
+
+int64_t kotlin_ranges_longRange_getEndInclusive_long_KotlinxCoroutinesCore(void * nativePtr);
+
+int64_t kotlin_ranges_longRange_getStart_long_KotlinxCoroutinesCore(void * nativePtr);
+
+void * kotlinx_coroutines_AbstractCoroutine_context_get(void * self);
+
+void * kotlinx_coroutines_AbstractCoroutine_coroutineContext_get(void * self);
+
+_Bool kotlinx_coroutines_AbstractCoroutine_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Bool_Swift_Bool__(void * __kt, void * parentContext, _Bool initParentJob, _Bool active);
+
+_Bool kotlinx_coroutines_AbstractCoroutine_isActive_get(void * self);
+
+_Bool kotlinx_coroutines_AbstractCoroutine_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__(void * self, void * result);
+
+_Bool kotlinx_coroutines_AbstractCoroutine_start__TypesOfArguments__ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * start, void * _Nullable receiver, _Bool (^block)(void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(void * self, void * token);
+
+_Bool kotlinx_coroutines_CancellableContinuation_initCancellability(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_invokeOnCancellation__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool (^handler)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_CancellableContinuation_isActive_get(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_isCancelled_get(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_isCompleted_get(void * self);
+
+_Bool kotlinx_coroutines_CancellableContinuation_resume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(void * self, void * _Nullable value, _Bool (^_Nullable onCancellation)(void *));
+
+_Bool kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * receiver, void * _Nullable value);
+
+_Bool kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable__(void * self, void * receiver, void * exception);
+
+void * _Nullable kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value, void * _Nullable idempotent);
+
+void * _Nullable kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(void * self, void * _Nullable value, void * _Nullable idempotent, _Bool (^_Nullable onCancellation)(void *));
+
+void * _Nullable kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * exception);
+
+void * kotlinx_coroutines_CancellationException__TypesOfArguments__Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(NSString * _Nullable message, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_ChildHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * cause);
+
+void * _Nullable kotlinx_coroutines_ChildHandle_parent_get(void * self);
+
+_Bool kotlinx_coroutines_CloseableCoroutineDispatcher_close(void * self);
+
+_Bool kotlinx_coroutines_CloseableCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * _Nullable value);
+
+void * kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(void * _Nullable parent);
+
+_Bool kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value);
+
+_Bool kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * exception);
+
+_Bool kotlinx_coroutines_CompletableJob_complete(void * self);
+
+_Bool kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * exception);
+
+void * kotlinx_coroutines_CompletionHandlerException_init_allocate();
+
+_Bool kotlinx_coroutines_CompletionHandlerException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String_ExportedKotlinPackages_kotlin_Throwable__(void * __kt, NSString * message, void * cause);
+
+void * kotlinx_coroutines_CoroutineDispatcher_Key_get();
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__(void * self, void * context, void * block);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__(void * self, void * context, void * block);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable___direct(void * self, void * context, void * block);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * kotlinx_coroutines_CoroutineDispatcher_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(void * self, void * continuation);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * self, void * context);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(void * self, void * context);
+
+void * kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__(void * self, int32_t parallelism);
+
+void * kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct(void * self, int32_t parallelism);
+
+_Bool kotlinx_coroutines_CoroutineDispatcher_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(void * self, void * continuation);
+
+NSString * kotlinx_coroutines_CoroutineDispatcher_toString(void * self);
+
+NSString * kotlinx_coroutines_CoroutineDispatcher_toString_direct(void * self);
+
+void * kotlinx_coroutines_CoroutineExceptionHandler__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U20ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void__(_Bool (^handler)(void *, void *));
+
+void * kotlinx_coroutines_CoroutineExceptionHandler_Key_get();
+
+_Bool kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__(void * self, void * context, void * exception);
+
+void * kotlinx_coroutines_CoroutineName_Key_get();
+
+void * kotlinx_coroutines_CoroutineName_copy__TypesOfArguments__Swift_String__(void * self, NSString * name);
+
+_Bool kotlinx_coroutines_CoroutineName_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable other);
+
+int32_t kotlinx_coroutines_CoroutineName_hashCode(void * self);
+
+void * kotlinx_coroutines_CoroutineName_init_allocate();
+
+_Bool kotlinx_coroutines_CoroutineName_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String__(void * __kt, NSString * name);
+
+NSString * kotlinx_coroutines_CoroutineName_name_get(void * self);
+
+NSString * kotlinx_coroutines_CoroutineName_toString(void * self);
+
+void * kotlinx_coroutines_CoroutineScope__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * context);
+
+void * kotlinx_coroutines_CoroutineScope_coroutineContext_get(void * self);
+
+void * kotlinx_coroutines_CoroutineStart_ATOMIC();
+
+void * kotlinx_coroutines_CoroutineStart_DEFAULT();
+
+void * kotlinx_coroutines_CoroutineStart_LAZY();
+
+void * kotlinx_coroutines_CoroutineStart_UNDISPATCHED();
+
+_Bool kotlinx_coroutines_CoroutineStart_invoke__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(void * self, _Bool (^block)(void * _Nullable , void *, void *, void *), void * _Nullable receiver, void * completion);
+
+_Bool kotlinx_coroutines_CoroutineStart_isLazy_get(void * self);
+
+int32_t kotlinx_coroutines_CoroutineStart_ordinal(void * self);
+
+_Bool kotlinx_coroutines_Deferred_await(void * self, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * _Nullable kotlinx_coroutines_Deferred_getCompleted(void * self);
+
+void * _Nullable kotlinx_coroutines_Deferred_getCompletionExceptionOrNull(void * self);
+
+void * kotlinx_coroutines_Deferred_onAwait_get(void * self);
+
+void * kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * self, int64_t timeMillis, void * block, void * context);
+
+void * kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(void * self, int64_t timeMillis, void * block, void * context);
+
+void * kotlinx_coroutines_Dispatchers_Default_get(void * self);
+
+void * kotlinx_coroutines_Dispatchers_Main_get(void * self);
+
+void * kotlinx_coroutines_Dispatchers_Unconfined_get(void * self);
+
+void * kotlinx_coroutines_Dispatchers_get();
+
+void * kotlinx_coroutines_DisposableHandle__TypesOfArguments__U2829202D_U20Swift_Void__(_Bool (^function)(void));
+
+_Bool kotlinx_coroutines_DisposableHandle_dispose(void * self);
+
+void * kotlinx_coroutines_GlobalScope_coroutineContext_get(void * self);
+
+void * kotlinx_coroutines_GlobalScope_get();
+
+void * kotlinx_coroutines_IO_get__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_Dispatchers__(void * receiver);
+
+void * kotlinx_coroutines_Job__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(void * _Nullable parent);
+
+_Bool kotlinx_coroutines_JobSupport_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_JobSupport_cancelCoroutine__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_JobSupport_cancelInternal__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * cause);
+
+_Bool kotlinx_coroutines_JobSupport_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * cause);
+
+void * kotlinx_coroutines_JobSupport_children_get(void * self);
+
+void * kotlinx_coroutines_JobSupport_getCancellationException(void * self);
+
+void * kotlinx_coroutines_JobSupport_getChildJobCancellationCause(void * self);
+
+void * _Nullable kotlinx_coroutines_JobSupport_getCompletionExceptionOrNull(void * self);
+
+void * kotlinx_coroutines_JobSupport_init_allocate();
+
+_Bool kotlinx_coroutines_JobSupport_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(void * __kt, _Bool active);
+
+void * kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool onCancelling, _Bool invokeImmediately, _Bool (^handler)(void * _Nullable ));
+
+void * kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool (^handler)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_JobSupport_isActive_get(void * self);
+
+_Bool kotlinx_coroutines_JobSupport_isCancelled_get(void * self);
+
+_Bool kotlinx_coroutines_JobSupport_isCompletedExceptionally_get(void * self);
+
+_Bool kotlinx_coroutines_JobSupport_isCompleted_get(void * self);
+
+_Bool kotlinx_coroutines_JobSupport_join(void * self, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_JobSupport_key_get(void * self);
+
+void * kotlinx_coroutines_JobSupport_onJoin_get(void * self);
+
+void * _Nullable kotlinx_coroutines_JobSupport_parent_get(void * self);
+
+_Bool kotlinx_coroutines_JobSupport_start(void * self);
+
+NSString * kotlinx_coroutines_JobSupport_toDebugString(void * self);
+
+NSString * kotlinx_coroutines_JobSupport_toString(void * self);
+
+void * kotlinx_coroutines_Job_Key_get();
+
+_Bool kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_Job_children_get(void * self);
+
+void * kotlinx_coroutines_Job_getCancellationException(void * self);
+
+void * kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool onCancelling, _Bool invokeImmediately, _Bool (^handler)(void * _Nullable ));
+
+void * kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool (^handler)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_Job_isActive_get(void * self);
+
+_Bool kotlinx_coroutines_Job_isCancelled_get(void * self);
+
+_Bool kotlinx_coroutines_Job_isCompleted_get(void * self);
+
+_Bool kotlinx_coroutines_Job_join(void * self, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_Job_onJoin_get(void * self);
+
+void * _Nullable kotlinx_coroutines_Job_parent_get(void * self);
+
+_Bool kotlinx_coroutines_Job_start(void * self);
+
+void * kotlinx_coroutines_MainCoroutineDispatcher_immediate_get(void * self);
+
+_Bool kotlinx_coroutines_MainCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__(void * self, int32_t parallelism);
+
+void * kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct(void * self, int32_t parallelism);
+
+NSString * kotlinx_coroutines_MainCoroutineDispatcher_toString(void * self);
+
+NSString * kotlinx_coroutines_MainCoroutineDispatcher_toString_direct(void * self);
+
+void * kotlinx_coroutines_MainScope();
+
+_Bool kotlinx_coroutines_NonCancellable_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_NonCancellable_children_get(void * self);
+
+void * kotlinx_coroutines_NonCancellable_get();
+
+void * kotlinx_coroutines_NonCancellable_getCancellationException(void * self);
+
+void * kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool onCancelling, _Bool invokeImmediately, _Bool (^handler)(void * _Nullable ));
+
+void * kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool (^handler)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_NonCancellable_isActive_get(void * self);
+
+_Bool kotlinx_coroutines_NonCancellable_isCancelled_get(void * self);
+
+_Bool kotlinx_coroutines_NonCancellable_isCompleted_get(void * self);
+
+_Bool kotlinx_coroutines_NonCancellable_join(void * self, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_NonCancellable_onJoin_get(void * self);
+
+void * _Nullable kotlinx_coroutines_NonCancellable_parent_get(void * self);
+
+_Bool kotlinx_coroutines_NonCancellable_start(void * self);
+
+NSString * kotlinx_coroutines_NonCancellable_toString(void * self);
+
+_Bool kotlinx_coroutines_NonDisposableHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(void * self, void * cause);
+
+_Bool kotlinx_coroutines_NonDisposableHandle_dispose(void * self);
+
+void * kotlinx_coroutines_NonDisposableHandle_get();
+
+void * _Nullable kotlinx_coroutines_NonDisposableHandle_parent_get(void * self);
+
+NSString * kotlinx_coroutines_NonDisposableHandle_toString(void * self);
+
+void * kotlinx_coroutines_ParentJob_getChildJobCancellationCause(void * self);
+
+void * kotlinx_coroutines_Runnable__TypesOfArguments__U2829202D_U20Swift_Void__(_Bool (^block)(void));
+
+_Bool kotlinx_coroutines_Runnable_run(void * self);
+
+void * kotlinx_coroutines_SupervisorJob__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(void * _Nullable parent);
+
+void * kotlinx_coroutines_async__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * context, void * start, _Bool (^block)(void *, void *, void *, void *));
+
+_Bool kotlinx_coroutines_awaitAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Deferred__Vararg___(NSArray<id> * deferreds, _Bool (^continuation)(NSArray<id> *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_awaitCancellation(_Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * receiver, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * receiver, NSString * message, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * receiver, NSString * message, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * receiver, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_cancelAndJoin__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__(void * receiver, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * receiver, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * receiver, void * _Nullable cause);
+
+void * kotlinx_coroutines_channels_BroadcastChannel__TypesOfArguments__Swift_Int32__(int32_t capacity);
+
+_Bool kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_channels_BroadcastChannel_openSubscription(void * self);
+
+void * kotlinx_coroutines_channels_BufferOverflow_DROP_LATEST();
+
+void * kotlinx_coroutines_channels_BufferOverflow_DROP_OLDEST();
+
+void * kotlinx_coroutines_channels_BufferOverflow_SUSPEND();
+
+int32_t kotlinx_coroutines_channels_BufferOverflow_ordinal(void * self);
+
+void * kotlinx_coroutines_channels_Channel__TypesOfArguments__Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow_Swift_Optional_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void___(int32_t capacity, void * onBufferOverflow, _Bool (^_Nullable onUndeliveredElement)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_channels_ChannelIterator_hasNext(void * self, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * _Nullable kotlinx_coroutines_channels_ChannelIterator_next(void * self);
+
+void * kotlinx_coroutines_channels_ChannelResult_Companion_closed__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_channels_ChannelResult_Companion_failure(void * self);
+
+void * kotlinx_coroutines_channels_ChannelResult_Companion_get();
+
+void * kotlinx_coroutines_channels_ChannelResult_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value);
+
+_Bool kotlinx_coroutines_channels_ChannelResult_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable other);
+
+void * _Nullable kotlinx_coroutines_channels_ChannelResult_exceptionOrNull(void * self);
+
+void * _Nullable kotlinx_coroutines_channels_ChannelResult_getOrNull(void * self);
+
+void * _Nullable kotlinx_coroutines_channels_ChannelResult_getOrThrow(void * self);
+
+int32_t kotlinx_coroutines_channels_ChannelResult_hashCode(void * self);
+
+_Bool kotlinx_coroutines_channels_ChannelResult_isClosed_get(void * self);
+
+_Bool kotlinx_coroutines_channels_ChannelResult_isFailure_get(void * self);
+
+_Bool kotlinx_coroutines_channels_ChannelResult_isSuccess_get(void * self);
+
+NSString * kotlinx_coroutines_channels_ChannelResult_toString(void * self);
+
+int32_t kotlinx_coroutines_channels_Channel_Factory_BUFFERED_get(void * self);
+
+int32_t kotlinx_coroutines_channels_Channel_Factory_CONFLATED_get(void * self);
+
+NSString * kotlinx_coroutines_channels_Channel_Factory_DEFAULT_BUFFER_PROPERTY_NAME_get(void * self);
+
+int32_t kotlinx_coroutines_channels_Channel_Factory_RENDEZVOUS_get(void * self);
+
+int32_t kotlinx_coroutines_channels_Channel_Factory_UNLIMITED_get(void * self);
+
+void * kotlinx_coroutines_channels_Channel_Factory_get();
+
+void * kotlinx_coroutines_channels_ClosedReceiveChannelException_init_allocate();
+
+_Bool kotlinx_coroutines_channels_ClosedReceiveChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+void * kotlinx_coroutines_channels_ClosedSendChannelException_init_allocate();
+
+_Bool kotlinx_coroutines_channels_ClosedSendChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(void * __kt, NSString * _Nullable message);
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * self, void * _Nullable cause);
+
+void * kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_allocate();
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * __kt, void * _Nullable value);
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool (^handler)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_isClosedForSend_get(void * self);
+
+void * kotlinx_coroutines_channels_ConflatedBroadcastChannel_onSend_get(void * self);
+
+void * kotlinx_coroutines_channels_ConflatedBroadcastChannel_openSubscription(void * self);
+
+_Bool kotlinx_coroutines_channels_ConflatedBroadcastChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_channels_ConflatedBroadcastChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+void * _Nullable kotlinx_coroutines_channels_ConflatedBroadcastChannel_valueOrNull_get(void * self);
+
+void * _Nullable kotlinx_coroutines_channels_ConflatedBroadcastChannel_value_get(void * self);
+
+void * kotlinx_coroutines_channels_ProducerScope_channel_get(void * self);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get(void * self);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get(void * self);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_iterator(void * self);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get(void * self);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_onReceive_get(void * self);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_receive(void * self, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_channels_ReceiveChannel_receiveCatching(void * self, _Bool (^continuation)(void *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_channels_ReceiveChannel_tryReceive(void * self);
+
+_Bool kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(void * self, void * _Nullable cause);
+
+_Bool kotlinx_coroutines_channels_SendChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * self, _Bool (^handler)(void * _Nullable ));
+
+_Bool kotlinx_coroutines_channels_SendChannel_isClosedForSend_get(void * self);
+
+void * kotlinx_coroutines_channels_SendChannel_onSend_get(void * self);
+
+_Bool kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable element);
+
+_Bool kotlinx_coroutines_channels_awaitClose__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScope_U2829202D_U20Swift_Void__(void * receiver, _Bool (^block)(void), _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, void * context, int32_t capacity, void * start, _Bool (^_Nullable onCompletion)(void * _Nullable ), _Bool (^block)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart__(void * receiver, int32_t capacity, void * start);
+
+void * _Nullable kotlinx_coroutines_channels_consume__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannelU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^block)(void *));
+
+_Bool kotlinx_coroutines_channels_consumeEach__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(void * receiver, _Bool (^action)(void * _Nullable ), _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * _Nullable kotlinx_coroutines_channels_getOrElse__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^onFailure)(void * _Nullable ));
+
+void * kotlinx_coroutines_channels_onClosed__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * receiver, _Bool (^action)(void * _Nullable ));
+
+void * kotlinx_coroutines_channels_onFailure__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(void * receiver, _Bool (^action)(void * _Nullable ));
+
+void * kotlinx_coroutines_channels_onSuccess__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(void * receiver, _Bool (^action)(void * _Nullable ));
+
+void * kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, void * context, int32_t capacity, void * start, _Bool (^_Nullable onCompletion)(void * _Nullable ), _Bool (^block)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, void * context, int32_t capacity, _Bool (^block)(void *, void *, void *, void *));
+
+_Bool kotlinx_coroutines_channels_toList__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(void * receiver, _Bool (^continuation)(NSArray<id> *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_channels_trySendBlocking__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable element);
+
+_Bool kotlinx_coroutines_completeWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CompletableDeferred_ExportedKotlinPackages_kotlin_Result__(void * receiver, void * result);
+
+_Bool kotlinx_coroutines_coroutineScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(_Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_currentCoroutineContext(_Bool (^continuation)(void *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_delay__TypesOfArguments__Swift_Int64__(int64_t timeMillis, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_delay__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(void * duration, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_disposeOnCancellation__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuation_anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__(void * receiver, void * handle);
+
+_Bool kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver);
+
+_Bool kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__(void * receiver);
+
+_Bool kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(void * receiver);
+
+_Bool kotlinx_coroutines_flow_AbstractFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * self, void * collector, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * self, void * collector, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_AbstractFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+NSString * kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_PROPERTY_NAME_get();
+
+int32_t kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_get();
+
+void * kotlinx_coroutines_flow_FlowCollector__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(_Bool (^function)(void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * self, void * collector, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_MutableSharedFlow__TypesOfArguments__Swift_Int32_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(int32_t replay, int32_t extraBufferCapacity, void * onBufferOverflow);
+
+_Bool kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache(void * self);
+
+void * kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get(void * self);
+
+_Bool kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value);
+
+void * kotlinx_coroutines_flow_MutableStateFlow__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * _Nullable value);
+
+_Bool kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable expect, void * _Nullable update);
+
+void * _Nullable kotlinx_coroutines_flow_MutableStateFlow_value_get(void * self);
+
+_Bool kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable newValue);
+
+_Bool kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * self, void * collector, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+NSArray<id> * kotlinx_coroutines_flow_SharedFlow_replayCache_get(void * self);
+
+void * kotlinx_coroutines_flow_SharingCommand_START();
+
+void * kotlinx_coroutines_flow_SharingCommand_STOP();
+
+void * kotlinx_coroutines_flow_SharingCommand_STOP_AND_RESET_REPLAY_CACHE();
+
+int32_t kotlinx_coroutines_flow_SharingCommand_ordinal(void * self);
+
+void * kotlinx_coroutines_flow_SharingStarted__TypesOfArguments__U28anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_U29202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingCommand___(void * (^function)(void *));
+
+void * kotlinx_coroutines_flow_SharingStarted_Companion_Eagerly_get(void * self);
+
+void * kotlinx_coroutines_flow_SharingStarted_Companion_Lazily_get(void * self);
+
+void * kotlinx_coroutines_flow_SharingStarted_Companion_WhileSubscribed__TypesOfArguments__Swift_Int64_Swift_Int64__(void * self, int64_t stopTimeoutMillis, int64_t replayExpirationMillis);
+
+void * kotlinx_coroutines_flow_SharingStarted_Companion_get();
+
+void * kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32___(void * self, void * subscriptionCount);
+
+void * _Nullable kotlinx_coroutines_flow_StateFlow_value_get(void * self);
+
+void * kotlinx_coroutines_flow_WhileSubscribed__TypesOfArgumentsE__KotlinxCoroutinesCore__ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion_ExportedKotlinPackages_kotlin_time_Duration_ExportedKotlinPackages_kotlin_time_Duration__(void * receiver, void * stopTimeout, void * replayExpiration);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * _Nullable (^receiver)(void));
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Array__(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_IntArray__(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_LongArray__(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterable__(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterator__(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int32___(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int64___(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_sequences_Sequence__(void * receiver);
+
+void * kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(_Bool (^receiver)(void *, void *, void *));
+
+void * kotlinx_coroutines_flow_asSharedFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+void * kotlinx_coroutines_flow_asStateFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+void * kotlinx_coroutines_flow_buffer__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(void * receiver, int32_t capacity, void * onBufferOverflow);
+
+void * kotlinx_coroutines_flow_callbackFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(_Bool (^block)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_cancellable__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+void * kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void *, void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void *, void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_channelFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(_Bool (^block)(void *, void *, void *, void *));
+
+_Bool kotlinx_coroutines_flow_collect__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_Flow__(void * receiver, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_collectIndexed__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Int32_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(int32_t, void * _Nullable , void *, void *, void *), _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_collectLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void * _Nullable , void *, void *, void *), _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * flow, void * flow2, void * flow3, void * flow4, void * flow5, _Bool (^transform)(void * _Nullable , void * _Nullable , void * _Nullable , void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * flow, void * flow2, void * flow3, void * flow4, _Bool (^transform)(void * _Nullable , void * _Nullable , void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * flow, void * flow2, void * flow3, _Bool (^transform)(void * _Nullable , void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * flow, void * flow2, _Bool (^transform)(void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combine__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * flow, _Bool (^transform)(void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * flow, void * flow2, void * flow3, void * flow4, void * flow5, _Bool (^transform)(void *, void * _Nullable , void * _Nullable , void * _Nullable , void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * flow, void * flow2, void * flow3, void * flow4, _Bool (^transform)(void *, void * _Nullable , void * _Nullable , void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * flow, void * flow2, void * flow3, _Bool (^transform)(void *, void * _Nullable , void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * flow, void * flow2, _Bool (^transform)(void *, void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_combineTransform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, void * flow, _Bool (^transform)(void *, void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_conflate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+void * kotlinx_coroutines_flow_consumeAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(void * receiver);
+
+void * kotlinx_coroutines_flow_coroutineContext_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * receiver);
+
+_Bool kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(int32_t), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *), _Bool (^continuation)(int32_t), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(int32_t), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Int64__(void * receiver, int64_t (^timeoutMillis)(void * _Nullable ));
+
+void * kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20ExportedKotlinPackages_kotlin_time_Duration__(void * receiver, void * (^timeout)(void * _Nullable ));
+
+void * kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__(void * receiver, int64_t timeoutMillis);
+
+void * kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(void * receiver, void * timeout);
+
+void * kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+void * kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Bool__(void * receiver, _Bool (^areEquivalent)(void * _Nullable , void * _Nullable ));
+
+void * kotlinx_coroutines_flow_distinctUntilChangedBy__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^keySelector)(void * _Nullable ));
+
+void * kotlinx_coroutines_flow_drop__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__(void * receiver, int32_t count);
+
+void * kotlinx_coroutines_flow_dropWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(void * receiver, void * channel, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, void * flow, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_emptyFlow();
+
+void * kotlinx_coroutines_flow_filter__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_filterNot__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_filterNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+_Bool kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_flatMapConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^transform)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_flatMapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^transform)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_flatMapMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, int32_t concurrency, _Bool (^transform)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_flattenConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____(void * receiver);
+
+void * kotlinx_coroutines_flow_flattenMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Swift_Int32__(void * receiver, int32_t concurrency);
+
+void * kotlinx_coroutines_flow_flow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(_Bool (^block)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * _Nullable value);
+
+void * kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Array_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Vararg___(NSArray<id> * elements);
+
+void * kotlinx_coroutines_flow_flowOn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver, void * context);
+
+_Bool kotlinx_coroutines_flow_fold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable initial, _Bool (^operation)(void * _Nullable , void * _Nullable , void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * _Nullable kotlinx_coroutines_flow_getAndUpdate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^function)(void * _Nullable ));
+
+int32_t kotlinx_coroutines_flow_internal_ChannelFlow_capacity_get(void * self);
+
+_Bool kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * self, void * collector, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector___direct(void * self, void * collector, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_context_get(void * self);
+
+void * _Nullable kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators(void * self);
+
+void * _Nullable kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators_direct(void * self);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(void * self, void * context, int32_t capacity, void * onBufferOverflow);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow___direct(void * self, void * context, int32_t capacity, void * onBufferOverflow);
+
+_Bool kotlinx_coroutines_flow_internal_ChannelFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(void * __kt, void * context, int32_t capacity, void * onBufferOverflow);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_onBufferOverflow_get(void * self);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(void * self, void * scope);
+
+void * kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope___direct(void * self, void * scope);
+
+NSString * kotlinx_coroutines_flow_internal_ChannelFlow_toString(void * self);
+
+NSString * kotlinx_coroutines_flow_internal_ChannelFlow_toString_direct(void * self);
+
+void * kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(void * self, void * context, int32_t capacity, void * onBufferOverflow);
+
+_Bool kotlinx_coroutines_flow_internal_SendingCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable value, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_internal_SendingCollector_init_allocate();
+
+_Bool kotlinx_coroutines_flow_internal_SendingCollector_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel__(void * __kt, void * channel);
+
+_Bool kotlinx_coroutines_flow_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(void * receiver);
+
+_Bool kotlinx_coroutines_flow_last__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_lastOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_launchIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(void * receiver, void * scope);
+
+void * kotlinx_coroutines_flow_map__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, _Bool (^transform)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_mapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, _Bool (^transform)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_mapNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, _Bool (^transform)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_merge__TypesOfArguments__Swift_Array_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Vararg___(NSArray<id> * flows);
+
+void * kotlinx_coroutines_flow_onCompletion__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void *, void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_onEach__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_onEmpty__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_onStart__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_onSubscription__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^action)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_produceIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(void * receiver, void * scope);
+
+void * kotlinx_coroutines_flow_receiveAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(void * receiver);
+
+_Bool kotlinx_coroutines_flow_reduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, _Bool (^operation)(void * _Nullable , void * _Nullable , void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, int64_t retries, _Bool (^predicate)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, int64_t retries, _Bool (^predicate)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void *, void *, int64_t, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void *, void *, int64_t, void *, void *, void *));
+
+void * kotlinx_coroutines_flow_runningFold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable initial, _Bool (^operation)(void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_runningReduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, _Bool (^operation)(void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__(void * receiver, int64_t periodMillis);
+
+void * kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(void * receiver, void * period);
+
+void * kotlinx_coroutines_flow_scan__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable initial, _Bool (^operation)(void * _Nullable , void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_shareIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Int32__(void * receiver, void * scope, void * started, int32_t replay);
+
+_Bool kotlinx_coroutines_flow_single__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_singleOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(void * receiver, void * scope, _Bool (^continuation)(void *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * scope, void * started, void * _Nullable initialValue);
+
+void * kotlinx_coroutines_flow_take__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__(void * receiver, int32_t count);
+
+void * kotlinx_coroutines_flow_takeWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^predicate)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_timeout__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(void * receiver, void * timeout);
+
+_Bool kotlinx_coroutines_flow_toCollection__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableCollection__(void * receiver, void * destination, _Bool (^continuation)(void *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__(void * receiver, void * destination, _Bool (^continuation)(NSArray<id> *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(NSArray<id> *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__(void * receiver, void * destination, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__(void * receiver, void * destination, _Bool (^continuation)(NSSet<id> *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver, _Bool (^continuation)(NSSet<id> *), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__(void * receiver, void * destination, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_flow_transform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^transform)(void *, void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_transformLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, _Bool (^transform)(void *, void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_flow_transformWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(void * receiver, _Bool (^transform)(void *, void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_flow_update__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^function)(void * _Nullable ));
+
+void * _Nullable kotlinx_coroutines_flow_updateAndGet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^function)(void * _Nullable ));
+
+void * kotlinx_coroutines_flow_withIndex__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(void * receiver);
+
+void * kotlinx_coroutines_flow_zip__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * other, _Bool (^transform)(void * _Nullable , void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_handleCoroutineException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__(void * context, void * exception);
+
+void * kotlinx_coroutines_internal_AtomicOp_atomicOp_get(void * self);
+
+void * kotlinx_coroutines_internal_AtomicOp_atomicOp_get_direct(void * self);
+
+_Bool kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable affected, void * _Nullable failure);
+
+_Bool kotlinx_coroutines_internal_AtomicOp_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * _Nullable kotlinx_coroutines_internal_AtomicOp_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable affected);
+
+void * _Nullable kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable affected);
+
+void * kotlinx_coroutines_internal_LockFreeLinkedListHead_init_allocate();
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListHead_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListHead_isEmpty_get(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get_direct(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListHead_remove(void * self) __attribute((noreturn));
+
+void * kotlinx_coroutines_internal_LockFreeLinkedListNode_init_allocate();
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get_direct(void * self);
+
+void * kotlinx_coroutines_internal_LockFreeLinkedListNode_next_get(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_remove(void * self);
+
+_Bool kotlinx_coroutines_internal_LockFreeLinkedListNode_remove_direct(void * self);
+
+NSString * kotlinx_coroutines_internal_LockFreeLinkedListNode_toString(void * self);
+
+NSString * kotlinx_coroutines_internal_LockFreeLinkedListNode_toString_direct(void * self);
+
+void * kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory___(void * self, NSArray<id> * allFactories);
+
+NSString * _Nullable kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError(void * self);
+
+NSString * _Nullable kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError_direct(void * self);
+
+int32_t kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get(void * self);
+
+void * _Nullable kotlinx_coroutines_internal_OpDescriptor_atomicOp_get(void * self);
+
+_Bool kotlinx_coroutines_internal_OpDescriptor_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * _Nullable kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable affected);
+
+NSString * kotlinx_coroutines_internal_OpDescriptor_toString(void * self);
+
+NSString * kotlinx_coroutines_internal_OpDescriptor_toString_direct(void * self);
+
+int32_t kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get(void * self);
+
+_Bool kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32__(void * self, int32_t newValue);
+
+_Bool kotlinx_coroutines_internal_resumeCancellableWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation_ExportedKotlinPackages_kotlin_Result_Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(void * receiver, void * result, _Bool (^_Nullable onCancellation)(void *));
+
+void * _Nullable kotlinx_coroutines_internal_synchronized__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * lock, void * _Nullable (^block)(void));
+
+void * _Nullable kotlinx_coroutines_internal_synchronizedImpl__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * lock, void * _Nullable (^block)(void));
+
+_Bool kotlinx_coroutines_intrinsics_startCoroutineCancellable__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(_Bool (^receiver)(void *, void *, void *), void * completion);
+
+_Bool kotlinx_coroutines_invoke__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, _Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver);
+
+_Bool kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(void * receiver);
+
+void * kotlinx_coroutines_job_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver);
+
+_Bool kotlinx_coroutines_joinAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__Vararg___(NSArray<id> * jobs, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_launch__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Void__(void * receiver, void * context, void * start, _Bool (^block)(void *, void *, void *, void *));
+
+void * kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver, void * addedContext);
+
+void * kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver, void * context);
+
+void * kotlinx_coroutines_newFixedThreadPoolContext__TypesOfArguments__Swift_Int32_Swift_String__(int32_t nThreads, NSString * name);
+
+void * kotlinx_coroutines_newSingleThreadContext__TypesOfArguments__Swift_String__(NSString * name);
+
+void * kotlinx_coroutines_plus__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(void * receiver, void * context);
+
+void * _Nullable kotlinx_coroutines_runBlocking__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * context, _Bool (^block)(void *, void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause0_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * receiver, _Bool (^block)(void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause1_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * receiver, _Bool (^block)(void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * receiver, void * _Nullable param, _Bool (^block)(void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * receiver, _Bool (^block)(void * _Nullable , void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(void * self, void * receiver, _Bool (^block)(void * _Nullable , void *, void *, void *));
+
+void * kotlinx_coroutines_selects_SelectClause_clauseObject_get(void * self);
+
+void * kotlinx_coroutines_selects_SelectInstance_context_get(void * self);
+
+_Bool kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__(void * self, void * disposableHandle);
+
+_Bool kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable internalResult);
+
+_Bool kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * clauseObject, void * _Nullable result);
+
+_Bool kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_Swift_Int64_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, int64_t timeMillis, _Bool (^block)(void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_ExportedKotlinPackages_kotlin_time_Duration_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * timeout, _Bool (^block)(void *, void *, void *));
+
+_Bool kotlinx_coroutines_selects_select__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__(_Bool (^builder)(void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_selects_selectUnbiased__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__(_Bool (^builder)(void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_supervisorScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(_Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_suspendCancellableCoroutine__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuationU29202D_U20Swift_Void__(_Bool (^block)(void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_sync_Mutex__TypesOfArguments__Swift_Bool__(_Bool locked);
+
+_Bool kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(void * self, void * owner);
+
+_Bool kotlinx_coroutines_sync_Mutex_isLocked_get(void * self);
+
+_Bool kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable owner, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+void * kotlinx_coroutines_sync_Mutex_onLock_get(void * self);
+
+_Bool kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable owner);
+
+_Bool kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * self, void * _Nullable owner);
+
+void * kotlinx_coroutines_sync_Semaphore__TypesOfArguments__Swift_Int32_Swift_Int32__(int32_t permits, int32_t acquiredPermits);
+
+_Bool kotlinx_coroutines_sync_Semaphore_acquire(void * self, _Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+int32_t kotlinx_coroutines_sync_Semaphore_availablePermits_get(void * self);
+
+_Bool kotlinx_coroutines_sync_Semaphore_tryAcquire(void * self);
+
+_Bool kotlinx_coroutines_sync_withLock__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Mutex_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable owner, void * _Nullable (^action)(void), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_sync_withPermit__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Semaphore_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * receiver, void * _Nullable (^action)(void), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_withContext__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * context, _Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_withTimeout__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(int64_t timeMillis, _Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_withTimeout__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * timeout, _Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(int64_t timeMillis, _Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(void * timeout, _Bool (^block)(void *, void *, void *, void *), _Bool (^continuation)(void * _Nullable ), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+_Bool kotlinx_coroutines_yield(_Bool (^continuation)(_Bool), _Bool (^exception)(void * _Nullable ), void * cancellation);
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
@@ -1,0 +1,7836 @@
+@file:OptIn(kotlin.ExperimentalStdlibApi::class, kotlinx.coroutines.DelicateCoroutinesApi::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.InternalCoroutinesApi::class, kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.AbstractCoroutine::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE17AbstractCoroutineC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CloseableCoroutineDispatcher::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE28CloseableCoroutineDispatcherC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CompletionHandlerException::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE26CompletionHandlerExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineDispatcher::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE19CoroutineDispatcherC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineDispatcher.Key::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE19CoroutineDispatcherC3KeyC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineName::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE13CoroutineNameC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineName.Key::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE13CoroutineNameC3KeyC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.Dispatchers::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE11DispatchersC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.GlobalScope::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE11GlobalScopeC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.JobSupport::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE10JobSupportC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.MainCoroutineDispatcher::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE23MainCoroutineDispatcherC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.NonCancellable::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE14NonCancellableC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.NonDisposableHandle::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE19NonDisposableHandleC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.TimeoutCancellationException::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO21KotlinxCoroutinesCoreE28TimeoutCancellationExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CancellableContinuation::class, "_ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuation")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.ChildHandle::class, "_ExportedKotlinPackages_kotlinx_coroutines_ChildHandle")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.ChildJob::class, "_ExportedKotlinPackages_kotlinx_coroutines_ChildJob")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CompletableDeferred::class, "_ExportedKotlinPackages_kotlinx_coroutines_CompletableDeferred")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CompletableJob::class, "_ExportedKotlinPackages_kotlinx_coroutines_CompletableJob")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineExceptionHandler::class, "_ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineScope::class, "_ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.Deferred::class, "_ExportedKotlinPackages_kotlinx_coroutines_Deferred")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.Delay::class, "_ExportedKotlinPackages_kotlinx_coroutines_Delay")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.DisposableHandle::class, "_ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.Job::class, "_ExportedKotlinPackages_kotlinx_coroutines_Job")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.ParentJob::class, "_ExportedKotlinPackages_kotlinx_coroutines_ParentJob")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.Runnable::class, "_ExportedKotlinPackages_kotlinx_coroutines_Runnable")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.internal.AtomicOp::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8internalO21KotlinxCoroutinesCoreE8AtomicOpC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.internal.LockFreeLinkedListHead::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8internalO21KotlinxCoroutinesCoreE22LockFreeLinkedListHeadC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.internal.LockFreeLinkedListNode::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8internalO21KotlinxCoroutinesCoreE22LockFreeLinkedListNodeC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.internal.OpDescriptor::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8internalO21KotlinxCoroutinesCoreE12OpDescriptorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.internal.MainDispatcherFactory::class, "_ExportedKotlinPackages_kotlinx_coroutines_internal_MainDispatcherFactory")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.internal.ThreadSafeHeapNode::class, "_ExportedKotlinPackages_kotlinx_coroutines_internal_ThreadSafeHeapNode")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ChannelResult::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8channelsO21KotlinxCoroutinesCoreE13ChannelResultC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ChannelResult.Companion::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8channelsO21KotlinxCoroutinesCoreE13ChannelResultC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ClosedReceiveChannelException::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8channelsO21KotlinxCoroutinesCoreE29ClosedReceiveChannelExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ClosedSendChannelException::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8channelsO21KotlinxCoroutinesCoreE26ClosedSendChannelExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ConflatedBroadcastChannel::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO8channelsO21KotlinxCoroutinesCoreE25ConflatedBroadcastChannelC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.BroadcastChannel::class, "_ExportedKotlinPackages_kotlinx_coroutines_channels_BroadcastChannel")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.Channel::class, "_ExportedKotlinPackages_kotlinx_coroutines_channels_Channel")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ChannelIterator::class, "_ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelIterator")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ProducerScope::class, "_ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScope")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.ReceiveChannel::class, "_ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.SendChannel::class, "_ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.AbstractFlow::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO4flowO21KotlinxCoroutinesCoreE12AbstractFlowC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.Flow::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_Flow")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.FlowCollector::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.MutableSharedFlow::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_MutableSharedFlow")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.MutableStateFlow::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_MutableStateFlow")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.SharedFlow::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_SharedFlow")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.SharingStarted::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.StateFlow::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_StateFlow")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.internal.ChannelFlow::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO4flowO8internalO21KotlinxCoroutinesCoreE11ChannelFlowC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.internal.SendingCollector::class, "22ExportedKotlinPackages7kotlinxO10coroutinesO4flowO8internalO21KotlinxCoroutinesCoreE16SendingCollectorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.internal.FusibleFlow::class, "_ExportedKotlinPackages_kotlinx_coroutines_flow_internal_FusibleFlow")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.selects.SelectBuilder::class, "_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.selects.SelectClause::class, "_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.selects.SelectClause0::class, "_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause0")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.selects.SelectClause1::class, "_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause1")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.selects.SelectClause2::class, "_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.selects.SelectInstance::class, "_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectInstance")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.sync.Mutex::class, "_ExportedKotlinPackages_kotlinx_coroutines_sync_Mutex")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.sync.Semaphore::class, "_ExportedKotlinPackages_kotlinx_coroutines_sync_Semaphore")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.CoroutineExceptionHandler.Key::class, "21KotlinxCoroutinesCore72_ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler_KeyC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.Job.Key::class, "21KotlinxCoroutinesCore50_ExportedKotlinPackages_kotlinx_coroutines_Job_KeyC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.channels.Channel.Factory::class, "21KotlinxCoroutinesCore67_ExportedKotlinPackages_kotlinx_coroutines_channels_Channel_FactoryC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.coroutines.flow.SharingStarted.Companion::class, "21KotlinxCoroutinesCore72_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_CompanionC")
+
+import kotlin.native.internal.objc.BindReverseBridgeToMethod
+import kotlin.native.internal.ImportedBridge
+import kotlinx.cinterop.*
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch as kotlinx_coroutines_launch
+import kotlinx.coroutines.IO as kotlinx_coroutines_IO
+import kotlinx.coroutines.async as kotlinx_coroutines_async
+import kotlinx.coroutines.cancel as kotlinx_coroutines_cancel
+import kotlinx.coroutines.cancelAndJoin as kotlinx_coroutines_cancelAndJoin
+import kotlinx.coroutines.cancelChildren as kotlinx_coroutines_cancelChildren
+import kotlinx.coroutines.channels.awaitClose as kotlinx_coroutines_channels_awaitClose
+import kotlinx.coroutines.channels.broadcast as kotlinx_coroutines_channels_broadcast
+import kotlinx.coroutines.channels.consume as kotlinx_coroutines_channels_consume
+import kotlinx.coroutines.channels.consumeEach as kotlinx_coroutines_channels_consumeEach
+import kotlinx.coroutines.channels.getOrElse as kotlinx_coroutines_channels_getOrElse
+import kotlinx.coroutines.channels.onClosed as kotlinx_coroutines_channels_onClosed
+import kotlinx.coroutines.channels.onFailure as kotlinx_coroutines_channels_onFailure
+import kotlinx.coroutines.channels.onSuccess as kotlinx_coroutines_channels_onSuccess
+import kotlinx.coroutines.channels.produce as kotlinx_coroutines_channels_produce
+import kotlinx.coroutines.channels.toList as kotlinx_coroutines_channels_toList
+import kotlinx.coroutines.channels.trySendBlocking as kotlinx_coroutines_channels_trySendBlocking
+import kotlinx.coroutines.completeWith as kotlinx_coroutines_completeWith
+import kotlinx.coroutines.disposeOnCancellation as kotlinx_coroutines_disposeOnCancellation
+import kotlinx.coroutines.ensureActive as kotlinx_coroutines_ensureActive
+import kotlinx.coroutines.flow.WhileSubscribed as kotlinx_coroutines_flow_WhileSubscribed
+import kotlinx.coroutines.flow.asFlow as kotlinx_coroutines_flow_asFlow
+import kotlinx.coroutines.flow.asSharedFlow as kotlinx_coroutines_flow_asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow as kotlinx_coroutines_flow_asStateFlow
+import kotlinx.coroutines.flow.buffer as kotlinx_coroutines_flow_buffer
+import kotlinx.coroutines.flow.cancellable as kotlinx_coroutines_flow_cancellable
+import kotlinx.coroutines.flow.`catch` as kotlinx_coroutines_flow_catch
+import kotlinx.coroutines.flow.collect as kotlinx_coroutines_flow_collect
+import kotlinx.coroutines.flow.collectIndexed as kotlinx_coroutines_flow_collectIndexed
+import kotlinx.coroutines.flow.collectLatest as kotlinx_coroutines_flow_collectLatest
+import kotlinx.coroutines.flow.combine as kotlinx_coroutines_flow_combine
+import kotlinx.coroutines.flow.combineTransform as kotlinx_coroutines_flow_combineTransform
+import kotlinx.coroutines.flow.conflate as kotlinx_coroutines_flow_conflate
+import kotlinx.coroutines.flow.consumeAsFlow as kotlinx_coroutines_flow_consumeAsFlow
+import kotlinx.coroutines.flow.coroutineContext as kotlinx_coroutines_flow_coroutineContext
+import kotlinx.coroutines.flow.count as kotlinx_coroutines_flow_count
+import kotlinx.coroutines.flow.debounce as kotlinx_coroutines_flow_debounce
+import kotlinx.coroutines.flow.distinctUntilChanged as kotlinx_coroutines_flow_distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy as kotlinx_coroutines_flow_distinctUntilChangedBy
+import kotlinx.coroutines.flow.drop as kotlinx_coroutines_flow_drop
+import kotlinx.coroutines.flow.dropWhile as kotlinx_coroutines_flow_dropWhile
+import kotlinx.coroutines.flow.emitAll as kotlinx_coroutines_flow_emitAll
+import kotlinx.coroutines.flow.filter as kotlinx_coroutines_flow_filter
+import kotlinx.coroutines.flow.filterNot as kotlinx_coroutines_flow_filterNot
+import kotlinx.coroutines.flow.filterNotNull as kotlinx_coroutines_flow_filterNotNull
+import kotlinx.coroutines.flow.first as kotlinx_coroutines_flow_first
+import kotlinx.coroutines.flow.firstOrNull as kotlinx_coroutines_flow_firstOrNull
+import kotlinx.coroutines.flow.flatMapConcat as kotlinx_coroutines_flow_flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest as kotlinx_coroutines_flow_flatMapLatest
+import kotlinx.coroutines.flow.flatMapMerge as kotlinx_coroutines_flow_flatMapMerge
+import kotlinx.coroutines.flow.flattenConcat as kotlinx_coroutines_flow_flattenConcat
+import kotlinx.coroutines.flow.flattenMerge as kotlinx_coroutines_flow_flattenMerge
+import kotlinx.coroutines.flow.flowOn as kotlinx_coroutines_flow_flowOn
+import kotlinx.coroutines.flow.fold as kotlinx_coroutines_flow_fold
+import kotlinx.coroutines.flow.getAndUpdate as kotlinx_coroutines_flow_getAndUpdate
+import kotlinx.coroutines.flow.isActive as kotlinx_coroutines_flow_isActive
+import kotlinx.coroutines.flow.last as kotlinx_coroutines_flow_last
+import kotlinx.coroutines.flow.lastOrNull as kotlinx_coroutines_flow_lastOrNull
+import kotlinx.coroutines.flow.launchIn as kotlinx_coroutines_flow_launchIn
+import kotlinx.coroutines.flow.map as kotlinx_coroutines_flow_map
+import kotlinx.coroutines.flow.mapLatest as kotlinx_coroutines_flow_mapLatest
+import kotlinx.coroutines.flow.mapNotNull as kotlinx_coroutines_flow_mapNotNull
+import kotlinx.coroutines.flow.onCompletion as kotlinx_coroutines_flow_onCompletion
+import kotlinx.coroutines.flow.onEach as kotlinx_coroutines_flow_onEach
+import kotlinx.coroutines.flow.onEmpty as kotlinx_coroutines_flow_onEmpty
+import kotlinx.coroutines.flow.onStart as kotlinx_coroutines_flow_onStart
+import kotlinx.coroutines.flow.onSubscription as kotlinx_coroutines_flow_onSubscription
+import kotlinx.coroutines.flow.produceIn as kotlinx_coroutines_flow_produceIn
+import kotlinx.coroutines.flow.receiveAsFlow as kotlinx_coroutines_flow_receiveAsFlow
+import kotlinx.coroutines.flow.reduce as kotlinx_coroutines_flow_reduce
+import kotlinx.coroutines.flow.retry as kotlinx_coroutines_flow_retry
+import kotlinx.coroutines.flow.retryWhen as kotlinx_coroutines_flow_retryWhen
+import kotlinx.coroutines.flow.runningFold as kotlinx_coroutines_flow_runningFold
+import kotlinx.coroutines.flow.runningReduce as kotlinx_coroutines_flow_runningReduce
+import kotlinx.coroutines.flow.sample as kotlinx_coroutines_flow_sample
+import kotlinx.coroutines.flow.scan as kotlinx_coroutines_flow_scan
+import kotlinx.coroutines.flow.shareIn as kotlinx_coroutines_flow_shareIn
+import kotlinx.coroutines.flow.single as kotlinx_coroutines_flow_single
+import kotlinx.coroutines.flow.singleOrNull as kotlinx_coroutines_flow_singleOrNull
+import kotlinx.coroutines.flow.stateIn as kotlinx_coroutines_flow_stateIn
+import kotlinx.coroutines.flow.take as kotlinx_coroutines_flow_take
+import kotlinx.coroutines.flow.takeWhile as kotlinx_coroutines_flow_takeWhile
+import kotlinx.coroutines.flow.timeout as kotlinx_coroutines_flow_timeout
+import kotlinx.coroutines.flow.toCollection as kotlinx_coroutines_flow_toCollection
+import kotlinx.coroutines.flow.toList as kotlinx_coroutines_flow_toList
+import kotlinx.coroutines.flow.toSet as kotlinx_coroutines_flow_toSet
+import kotlinx.coroutines.flow.transform as kotlinx_coroutines_flow_transform
+import kotlinx.coroutines.flow.transformLatest as kotlinx_coroutines_flow_transformLatest
+import kotlinx.coroutines.flow.transformWhile as kotlinx_coroutines_flow_transformWhile
+import kotlinx.coroutines.flow.update as kotlinx_coroutines_flow_update
+import kotlinx.coroutines.flow.updateAndGet as kotlinx_coroutines_flow_updateAndGet
+import kotlinx.coroutines.flow.withIndex as kotlinx_coroutines_flow_withIndex
+import kotlinx.coroutines.flow.zip as kotlinx_coroutines_flow_zip
+import kotlinx.coroutines.`internal`.resumeCancellableWith as kotlinx_coroutines_internal_resumeCancellableWith
+import kotlinx.coroutines.intrinsics.startCoroutineCancellable as kotlinx_coroutines_intrinsics_startCoroutineCancellable
+import kotlinx.coroutines.invoke as kotlinx_coroutines_invoke
+import kotlinx.coroutines.isActive as kotlinx_coroutines_isActive
+import kotlinx.coroutines.job as kotlinx_coroutines_job
+import kotlinx.coroutines.newCoroutineContext as kotlinx_coroutines_newCoroutineContext
+import kotlinx.coroutines.plus as kotlinx_coroutines_plus
+import kotlinx.coroutines.selects.onTimeout as kotlinx_coroutines_selects_onTimeout
+import kotlinx.coroutines.sync.withLock as kotlinx_coroutines_sync_withLock
+import kotlinx.coroutines.sync.withPermit as kotlinx_coroutines_sync_withPermit
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "cancel")
+public fun kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>, cause: kotlin.Throwable?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __cause = if (cause == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(cause)
+    val _result = kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(__self, __cause)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(self: kotlin.native.internal.NativePtr, token: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "completeResume")
+public fun kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>, token: kotlin.Any): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __token = kotlin.native.internal.ref.createRetainedExternalRCRef(token)
+    val _result = kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(__self, __token)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_initCancellability__reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_initCancellability__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "initCancellability")
+public fun kotlinx_coroutines_CancellableContinuation_initCancellability__reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CancellableContinuation_initCancellability__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_isActive_get__reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_isActive_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "<get-isActive>")
+public fun kotlinx_coroutines_CancellableContinuation_isActive_get__reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CancellableContinuation_isActive_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "<get-isCancelled>")
+public fun kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "<get-isCompleted>")
+public fun kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "resumeUndispatchedWithException")
+public fun kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>, `receiver`: kotlinx.coroutines.CoroutineDispatcher, exception: kotlin.Throwable): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __receiver = kotlin.native.internal.ref.createRetainedExternalRCRef(`receiver`)
+    val __exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+    val _result = kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(__self, __receiver, __exception)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "resumeUndispatched")
+public fun kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>, `receiver`: kotlinx.coroutines.CoroutineDispatcher, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __receiver = kotlin.native.internal.ref.createRetainedExternalRCRef(`receiver`)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __receiver, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "tryResumeWithException")
+public fun kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>, exception: kotlin.Throwable): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+    val _result = kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(__self, __exception)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, idempotent: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CancellableContinuation::class, "tryResume")
+public fun kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.CancellableContinuation<kotlin.Any?>, value: kotlin.Any?, idempotent: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val __idempotent = if (idempotent == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(idempotent)
+    val _result = kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, __idempotent)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse_swift")
+internal external fun kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CloseableCoroutineDispatcher::class, "close")
+public fun kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse(self: kotlinx.coroutines.CloseableCoroutineDispatcher): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+internal external fun kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CompletableDeferred::class, "completeExceptionally")
+public fun kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse(self: kotlinx.coroutines.CompletableDeferred<kotlin.Any?>, exception: kotlin.Throwable): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+    val _result = kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(__self, __exception)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CompletableDeferred::class, "complete")
+public fun kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.CompletableDeferred<kotlin.Any?>, value: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+internal external fun kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CompletableJob::class, "completeExceptionally")
+public fun kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse(self: kotlinx.coroutines.CompletableJob, exception: kotlin.Throwable): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+    val _result = kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(__self, __exception)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CompletableJob_complete__reverse_swift")
+internal external fun kotlinx_coroutines_CompletableJob_complete__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CompletableJob::class, "complete")
+public fun kotlinx_coroutines_CompletableJob_complete__reverse(self: kotlinx.coroutines.CompletableJob): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CompletableJob_complete__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineDispatcher::class, "dispatchYield")
+public fun kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse(self: kotlinx.coroutines.CoroutineDispatcher, context: kotlin.coroutines.CoroutineContext, block: kotlinx.coroutines.Runnable): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val __block = kotlin.native.internal.ref.createRetainedExternalRCRef(block)
+    val _result = kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(__self, __context, __block)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineDispatcher::class, "dispatch")
+public fun kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse(self: kotlinx.coroutines.CoroutineDispatcher, context: kotlin.coroutines.CoroutineContext, block: kotlinx.coroutines.Runnable): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val __block = kotlin.native.internal.ref.createRetainedExternalRCRef(block)
+    val _result = kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(__self, __context, __block)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineDispatcher::class, "isDispatchNeeded")
+public fun kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse(self: kotlinx.coroutines.CoroutineDispatcher, context: kotlin.coroutines.CoroutineContext): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val _result = kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(__self, __context)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, parallelism: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineDispatcher::class, "limitedParallelism")
+public fun kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.coroutines.CoroutineDispatcher, parallelism: Int): kotlinx.coroutines.CoroutineDispatcher {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(__self, parallelism)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.CoroutineDispatcher
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineDispatcher_toString__reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineDispatcher_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineDispatcher::class, "toString")
+public fun kotlinx_coroutines_CoroutineDispatcher_toString__reverse(self: kotlinx.coroutines.CoroutineDispatcher): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CoroutineDispatcher_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineExceptionHandler::class, "handleException")
+public fun kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse(self: kotlinx.coroutines.CoroutineExceptionHandler, context: kotlin.coroutines.CoroutineContext, exception: kotlin.Throwable): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val __exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+    val _result = kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(__self, __context, __exception)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse_swift")
+internal external fun kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.CoroutineScope::class, "<get-coroutineContext>")
+public fun kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse(self: kotlinx.coroutines.CoroutineScope): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlinx_coroutines_Deferred_await__reverse_swift")
+internal external fun kotlinx_coroutines_Deferred_await__reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Deferred::class, "await")
+public suspend fun kotlinx_coroutines_Deferred_await__reverse(self: kotlinx.coroutines.Deferred<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_Deferred_await__reverse_swift(__self, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_Deferred_getCompleted__reverse_swift")
+internal external fun kotlinx_coroutines_Deferred_getCompleted__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Deferred::class, "getCompleted")
+public fun kotlinx_coroutines_Deferred_getCompleted__reverse(self: kotlinx.coroutines.Deferred<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Deferred_getCompleted__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse_swift")
+internal external fun kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Deferred::class, "getCompletionExceptionOrNull")
+public fun kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse(self: kotlinx.coroutines.Deferred<kotlin.Any?>): kotlin.Throwable? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Throwable
+}
+
+@ImportedBridge("kotlinx_coroutines_Deferred_onAwait_get__reverse_swift")
+internal external fun kotlinx_coroutines_Deferred_onAwait_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Deferred::class, "<get-onAwait>")
+public fun kotlinx_coroutines_Deferred_onAwait_get__reverse(self: kotlinx.coroutines.Deferred<kotlin.Any?>): kotlinx.coroutines.selects.SelectClause1<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Deferred_onAwait_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.selects.SelectClause1<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift")
+internal external fun kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(self: kotlin.native.internal.NativePtr, timeMillis: Long, block: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Delay::class, "invokeOnTimeout")
+public fun kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse(self: kotlinx.coroutines.Delay, timeMillis: Long, block: kotlinx.coroutines.Runnable, context: kotlin.coroutines.CoroutineContext): kotlinx.coroutines.DisposableHandle {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __block = kotlin.native.internal.ref.createRetainedExternalRCRef(block)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val _result = kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(__self, timeMillis, __block, __context)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.DisposableHandle
+}
+
+@ImportedBridge("kotlinx_coroutines_DisposableHandle_dispose__reverse_swift")
+internal external fun kotlinx_coroutines_DisposableHandle_dispose__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.DisposableHandle::class, "dispose")
+public fun kotlinx_coroutines_DisposableHandle_dispose__reverse(self: kotlinx.coroutines.DisposableHandle): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_DisposableHandle_dispose__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift")
+internal external fun kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "cancel")
+public fun kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse(self: kotlinx.coroutines.Job, cause: kotlin.coroutines.cancellation.CancellationException?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __cause = if (cause == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(cause)
+    val _result = kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(__self, __cause)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_children_get__reverse_swift")
+internal external fun kotlinx_coroutines_Job_children_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "<get-children>")
+public fun kotlinx_coroutines_Job_children_get__reverse(self: kotlinx.coroutines.Job): kotlin.sequences.Sequence<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_children_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.sequences.Sequence<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_getCancellationException__reverse_swift")
+internal external fun kotlinx_coroutines_Job_getCancellationException__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "getCancellationException")
+public fun kotlinx_coroutines_Job_getCancellationException__reverse(self: kotlinx.coroutines.Job): kotlin.coroutines.cancellation.CancellationException {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_getCancellationException__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.cancellation.CancellationException
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_isActive_get__reverse_swift")
+internal external fun kotlinx_coroutines_Job_isActive_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "<get-isActive>")
+public fun kotlinx_coroutines_Job_isActive_get__reverse(self: kotlinx.coroutines.Job): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_isActive_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_isCancelled_get__reverse_swift")
+internal external fun kotlinx_coroutines_Job_isCancelled_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "<get-isCancelled>")
+public fun kotlinx_coroutines_Job_isCancelled_get__reverse(self: kotlinx.coroutines.Job): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_isCancelled_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_isCompleted_get__reverse_swift")
+internal external fun kotlinx_coroutines_Job_isCompleted_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "<get-isCompleted>")
+public fun kotlinx_coroutines_Job_isCompleted_get__reverse(self: kotlinx.coroutines.Job): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_isCompleted_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_join__reverse_swift")
+internal external fun kotlinx_coroutines_Job_join__reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "join")
+public suspend fun kotlinx_coroutines_Job_join__reverse(self: kotlinx.coroutines.Job): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_Job_join__reverse_swift(__self, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_onJoin_get__reverse_swift")
+internal external fun kotlinx_coroutines_Job_onJoin_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "<get-onJoin>")
+public fun kotlinx_coroutines_Job_onJoin_get__reverse(self: kotlinx.coroutines.Job): kotlinx.coroutines.selects.SelectClause0 {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_onJoin_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.selects.SelectClause0
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_parent_get__reverse_swift")
+internal external fun kotlinx_coroutines_Job_parent_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "<get-parent>")
+public fun kotlinx_coroutines_Job_parent_get__reverse(self: kotlinx.coroutines.Job): kotlinx.coroutines.Job? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_parent_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.Job
+}
+
+@ImportedBridge("kotlinx_coroutines_Job_start__reverse_swift")
+internal external fun kotlinx_coroutines_Job_start__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Job::class, "start")
+public fun kotlinx_coroutines_Job_start__reverse(self: kotlinx.coroutines.Job): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Job_start__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse_swift")
+internal external fun kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.MainCoroutineDispatcher::class, "<get-immediate>")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse(self: kotlinx.coroutines.MainCoroutineDispatcher): kotlinx.coroutines.MainCoroutineDispatcher {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.MainCoroutineDispatcher
+}
+
+@ImportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, parallelism: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.MainCoroutineDispatcher::class, "limitedParallelism")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.coroutines.MainCoroutineDispatcher, parallelism: Int): kotlinx.coroutines.CoroutineDispatcher {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(__self, parallelism)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.CoroutineDispatcher
+}
+
+@ImportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse_swift")
+internal external fun kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.MainCoroutineDispatcher::class, "toString")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse(self: kotlinx.coroutines.MainCoroutineDispatcher): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_Runnable_run__reverse_swift")
+internal external fun kotlinx_coroutines_Runnable_run__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.Runnable::class, "run")
+public fun kotlinx_coroutines_Runnable_run__reverse(self: kotlinx.coroutines.Runnable): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_Runnable_run__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift")
+internal external fun kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.BroadcastChannel::class, "cancel")
+public fun kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse(self: kotlinx.coroutines.channels.BroadcastChannel<kotlin.Any?>, cause: kotlin.coroutines.cancellation.CancellationException?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __cause = if (cause == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(cause)
+    val _result = kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(__self, __cause)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse_swift")
+internal external fun kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.BroadcastChannel::class, "openSubscription")
+public fun kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse(self: kotlinx.coroutines.channels.BroadcastChannel<kotlin.Any?>): kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ChannelIterator::class, "hasNext")
+public suspend fun kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse(self: kotlinx.coroutines.channels.ChannelIterator<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    return suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse_swift(__self, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ChannelIterator_next__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ChannelIterator_next__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ChannelIterator::class, "next")
+public fun kotlinx_coroutines_channels_ChannelIterator_next__reverse(self: kotlinx.coroutines.channels.ChannelIterator<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ChannelIterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ProducerScope_channel_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ProducerScope_channel_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ProducerScope::class, "<get-channel>")
+public fun kotlinx_coroutines_channels_ProducerScope_channel_get__reverse(self: kotlinx.coroutines.channels.ProducerScope<kotlin.Any?>): kotlinx.coroutines.channels.SendChannel<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ProducerScope_channel_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "cancel")
+public fun kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>, cause: kotlin.coroutines.cancellation.CancellationException?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __cause = if (cause == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(cause)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(__self, __cause)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "<get-isClosedForReceive>")
+public fun kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "<get-isEmpty>")
+public fun kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "iterator")
+public fun kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): kotlinx.coroutines.channels.ChannelIterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.channels.ChannelIterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "<get-onReceiveCatching>")
+public fun kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): kotlinx.coroutines.selects.SelectClause1<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.selects.SelectClause1<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "<get-onReceive>")
+public fun kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): kotlinx.coroutines.selects.SelectClause1<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.selects.SelectClause1<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "receiveCatching")
+public suspend fun kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): kotlinx.coroutines.channels.ChannelResult<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    return suspendSwiftCoroutine { continuation: Function1<kotlinx.coroutines.channels.ChannelResult<*>, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse_swift(__self, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_receive__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_receive__reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "receive")
+public suspend fun kotlinx_coroutines_channels_ReceiveChannel_receive__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_channels_ReceiveChannel_receive__reverse_swift(__self, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse_swift")
+internal external fun kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.ReceiveChannel::class, "tryReceive")
+public fun kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse(self: kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>): kotlinx.coroutines.channels.ChannelResult<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift")
+internal external fun kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.SendChannel::class, "close")
+public fun kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse(self: kotlinx.coroutines.channels.SendChannel<kotlin.Any?>, cause: kotlin.Throwable?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __cause = if (cause == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(cause)
+    val _result = kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(__self, __cause)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.SendChannel::class, "<get-isClosedForSend>")
+public fun kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse(self: kotlinx.coroutines.channels.SendChannel<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_SendChannel_onSend_get__reverse_swift")
+internal external fun kotlinx_coroutines_channels_SendChannel_onSend_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.SendChannel::class, "<get-onSend>")
+public fun kotlinx_coroutines_channels_SendChannel_onSend_get__reverse(self: kotlinx.coroutines.channels.SendChannel<kotlin.Any?>): kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_channels_SendChannel_onSend_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.SendChannel::class, "send")
+public suspend fun kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.channels.SendChannel<kotlin.Any?>, element: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.channels.SendChannel::class, "trySend")
+public fun kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.channels.SendChannel<kotlin.Any?>, element: kotlin.Any?): kotlinx.coroutines.channels.ChannelResult<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+internal external fun kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.AbstractFlow::class, "collectSafely")
+public suspend fun kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse(self: kotlinx.coroutines.flow.AbstractFlow<kotlin.Any?>, collector: kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __collector = kotlin.native.internal.ref.createRetainedExternalRCRef(collector)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(__self, __collector, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.FlowCollector::class, "emit")
+public suspend fun kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+internal external fun kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.Flow::class, "collect")
+public suspend fun kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse(self: kotlinx.coroutines.flow.Flow<kotlin.Any?>, collector: kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __collector = kotlin.native.internal.ref.createRetainedExternalRCRef(collector)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(__self, __collector, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableSharedFlow::class, "emit")
+public suspend fun kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableSharedFlow::class, "resetReplayCache")
+public fun kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableSharedFlow::class, "<get-subscriptionCount>")
+public fun kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>): kotlinx.coroutines.flow.StateFlow<Int> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.StateFlow<Int>
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableSharedFlow::class, "tryEmit")
+public fun kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>, value: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, `expect`: kotlin.native.internal.NativePtr, update: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableStateFlow::class, "compareAndSet")
+public fun kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>, `expect`: kotlin.Any?, update: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __expect = if (`expect` == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(`expect`)
+    val __update = if (update == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(update)
+    val _result = kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __expect, __update)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableStateFlow::class, "<get-value>")
+public fun kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse(self: kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, newValue: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableStateFlow::class, "<set-value>")
+public fun kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>, newValue: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __newValue = if (newValue == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(newValue)
+    val _result = kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __newValue)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+internal external fun kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.SharedFlow::class, "collect")
+public suspend fun kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse(self: kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>, collector: kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>): Nothing {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __collector = kotlin.native.internal.ref.createRetainedExternalRCRef(collector)
+    return suspendSwiftCoroutine { continuation: Function1<Nothing, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(__self, __collector, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse_swift")
+internal external fun kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.SharedFlow::class, "<get-replayCache>")
+public fun kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse(self: kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>): kotlin.collections.List<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.collections.List<kotlin.Any?>>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse_swift")
+internal external fun kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse_swift(self: kotlin.native.internal.NativePtr, subscriptionCount: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.SharingStarted::class, "command")
+public fun kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse(self: kotlinx.coroutines.flow.SharingStarted, subscriptionCount: kotlinx.coroutines.flow.StateFlow<Int>): kotlinx.coroutines.flow.Flow<kotlinx.coroutines.flow.SharingCommand> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __subscriptionCount = kotlin.native.internal.ref.createRetainedExternalRCRef(subscriptionCount)
+    val _result = kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse_swift(__self, __subscriptionCount)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<kotlinx.coroutines.flow.SharingCommand>
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_StateFlow_value_get__reverse_swift")
+internal external fun kotlinx_coroutines_flow_StateFlow_value_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.StateFlow::class, "<get-value>")
+public fun kotlinx_coroutines_flow_StateFlow_value_get__reverse(self: kotlinx.coroutines.flow.StateFlow<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_StateFlow_value_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+internal external fun kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.internal.ChannelFlow::class, "collect")
+public suspend fun kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse(self: kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>, collector: kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __collector = kotlin.native.internal.ref.createRetainedExternalRCRef(collector)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(__self, __collector, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse_swift")
+internal external fun kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.internal.ChannelFlow::class, "dropChannelOperators")
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse(self: kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?>? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift")
+internal external fun kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.internal.ChannelFlow::class, "fuse")
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse(self: kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>, context: kotlin.coroutines.CoroutineContext, capacity: Int, onBufferOverflow: kotlinx.coroutines.channels.BufferOverflow): kotlinx.coroutines.flow.Flow<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val __onBufferOverflow = kotlin.native.internal.ref.createRetainedExternalRCRef(onBufferOverflow)
+    val _result = kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(__self, __context, capacity, __onBufferOverflow)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse_swift")
+internal external fun kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse_swift(self: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.internal.ChannelFlow::class, "produceImpl")
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse(self: kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>, scope: kotlinx.coroutines.CoroutineScope): kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __scope = kotlin.native.internal.ref.createRetainedExternalRCRef(scope)
+    val _result = kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse_swift(__self, __scope)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse_swift")
+internal external fun kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.internal.ChannelFlow::class, "toString")
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse(self: kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift")
+internal external fun kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.flow.internal.FusibleFlow::class, "fuse")
+public fun kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse(self: kotlinx.coroutines.flow.internal.FusibleFlow<kotlin.Any?>, context: kotlin.coroutines.CoroutineContext, capacity: Int, onBufferOverflow: kotlinx.coroutines.channels.BufferOverflow): kotlinx.coroutines.flow.Flow<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __context = kotlin.native.internal.ref.createRetainedExternalRCRef(context)
+    val __onBufferOverflow = kotlin.native.internal.ref.createRetainedExternalRCRef(onBufferOverflow)
+    val _result = kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(__self, __context, capacity, __onBufferOverflow)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse_swift")
+internal external fun kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.AtomicOp::class, "<get-atomicOp>")
+public fun kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse(self: kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>): kotlinx.coroutines.internal.AtomicOp<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr, failure: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.AtomicOp::class, "complete")
+public fun kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>, affected: kotlin.Any?, failure: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __affected = if (affected == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(affected)
+    val __failure = if (failure == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(failure)
+    val _result = kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __affected, __failure)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.AtomicOp::class, "prepare")
+public fun kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>, affected: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __affected = if (affected == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(affected)
+    val _result = kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __affected)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse_swift")
+internal external fun kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.LockFreeLinkedListHead::class, "<get-isRemoved>")
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse(self: kotlinx.coroutines.internal.LockFreeLinkedListHead): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse_swift")
+internal external fun kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.LockFreeLinkedListNode::class, "<get-isRemoved>")
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse(self: kotlinx.coroutines.internal.LockFreeLinkedListNode): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse_swift")
+internal external fun kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.LockFreeLinkedListNode::class, "remove")
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse(self: kotlinx.coroutines.internal.LockFreeLinkedListNode): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse_swift")
+internal external fun kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.LockFreeLinkedListNode::class, "toString")
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse(self: kotlinx.coroutines.internal.LockFreeLinkedListNode): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse_swift")
+internal external fun kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse_swift(self: kotlin.native.internal.NativePtr, allFactories: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.MainDispatcherFactory::class, "createDispatcher")
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse(self: kotlinx.coroutines.internal.MainDispatcherFactory, allFactories: kotlin.collections.List<kotlinx.coroutines.internal.MainDispatcherFactory>): kotlinx.coroutines.MainCoroutineDispatcher {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __allFactories = allFactories.objcPtr()
+    val _result = kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse_swift(__self, __allFactories)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.MainCoroutineDispatcher
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse_swift")
+internal external fun kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.MainDispatcherFactory::class, "hintOnError")
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse(self: kotlinx.coroutines.internal.MainDispatcherFactory): kotlin.String? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse_swift")
+internal external fun kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.MainDispatcherFactory::class, "<get-loadPriority>")
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse(self: kotlinx.coroutines.internal.MainDispatcherFactory): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse_swift")
+internal external fun kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.OpDescriptor::class, "<get-atomicOp>")
+public fun kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse(self: kotlinx.coroutines.internal.OpDescriptor): kotlinx.coroutines.internal.AtomicOp<*>? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.OpDescriptor::class, "perform")
+public fun kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.internal.OpDescriptor, affected: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __affected = if (affected == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(affected)
+    val _result = kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __affected)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_OpDescriptor_toString__reverse_swift")
+internal external fun kotlinx_coroutines_internal_OpDescriptor_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.OpDescriptor::class, "toString")
+public fun kotlinx_coroutines_internal_OpDescriptor_toString__reverse(self: kotlinx.coroutines.internal.OpDescriptor): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_OpDescriptor_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse_swift")
+internal external fun kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.ThreadSafeHeapNode::class, "<get-index>")
+public fun kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse(self: kotlinx.coroutines.internal.ThreadSafeHeapNode): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, newValue: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.internal.ThreadSafeHeapNode::class, "<set-index>")
+public fun kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.coroutines.internal.ThreadSafeHeapNode, newValue: Int): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse_swift(__self, newValue)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse_swift")
+internal external fun kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.selects.SelectClause::class, "<get-clauseObject>")
+public fun kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse(self: kotlinx.coroutines.selects.SelectClause): kotlin.Any {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_coroutines_selects_SelectInstance_context_get__reverse_swift")
+internal external fun kotlinx_coroutines_selects_SelectInstance_context_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.selects.SelectInstance::class, "<get-context>")
+public fun kotlinx_coroutines_selects_SelectInstance_context_get__reverse(self: kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>): kotlin.coroutines.CoroutineContext {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_selects_SelectInstance_context_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.coroutines.CoroutineContext
+}
+
+@ImportedBridge("kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse_swift")
+internal external fun kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse_swift(self: kotlin.native.internal.NativePtr, disposableHandle: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.selects.SelectInstance::class, "disposeOnCompletion")
+public fun kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse(self: kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>, disposableHandle: kotlinx.coroutines.DisposableHandle): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __disposableHandle = kotlin.native.internal.ref.createRetainedExternalRCRef(disposableHandle)
+    val _result = kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse_swift(__self, __disposableHandle)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, internalResult: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.selects.SelectInstance::class, "selectInRegistrationPhase")
+public fun kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>, internalResult: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __internalResult = if (internalResult == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(internalResult)
+    val _result = kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __internalResult)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, clauseObject: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.selects.SelectInstance::class, "trySelect")
+public fun kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>, clauseObject: kotlin.Any, result: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __clauseObject = kotlin.native.internal.ref.createRetainedExternalRCRef(clauseObject)
+    val __result = if (result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(result)
+    val _result = kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __clauseObject, __result)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+internal external fun kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Mutex::class, "holdsLock")
+public fun kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse(self: kotlinx.coroutines.sync.Mutex, owner: kotlin.Any): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __owner = kotlin.native.internal.ref.createRetainedExternalRCRef(owner)
+    val _result = kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(__self, __owner)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Mutex_isLocked_get__reverse_swift")
+internal external fun kotlinx_coroutines_sync_Mutex_isLocked_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Mutex::class, "<get-isLocked>")
+public fun kotlinx_coroutines_sync_Mutex_isLocked_get__reverse(self: kotlinx.coroutines.sync.Mutex): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_sync_Mutex_isLocked_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Mutex::class, "lock")
+public suspend fun kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.sync.Mutex, owner: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __owner = if (owner == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(owner)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __owner, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Mutex_onLock_get__reverse_swift")
+internal external fun kotlinx_coroutines_sync_Mutex_onLock_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Mutex::class, "<get-onLock>")
+public fun kotlinx_coroutines_sync_Mutex_onLock_get__reverse(self: kotlinx.coroutines.sync.Mutex): kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_sync_Mutex_onLock_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Mutex::class, "tryLock")
+public fun kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.sync.Mutex, owner: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __owner = if (owner == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(owner)
+    val _result = kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __owner)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Mutex::class, "unlock")
+public fun kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.sync.Mutex, owner: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __owner = if (owner == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(owner)
+    val _result = kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __owner)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Semaphore_acquire__reverse_swift")
+internal external fun kotlinx_coroutines_sync_Semaphore_acquire__reverse_swift(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Semaphore::class, "acquire")
+public suspend fun kotlinx_coroutines_sync_Semaphore_acquire__reverse(self: kotlinx.coroutines.sync.Semaphore): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_sync_Semaphore_acquire__reverse_swift(__self, _continuation, _exception, _cancellation)
+    }
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse_swift")
+internal external fun kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Semaphore::class, "<get-availablePermits>")
+public fun kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse(self: kotlinx.coroutines.sync.Semaphore): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse_swift")
+internal external fun kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.coroutines.sync.Semaphore::class, "tryAcquire")
+public fun kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse(self: kotlinx.coroutines.sync.Semaphore): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse_swift(__self)
+    return _result
+}
+
+@ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock: kotlin.native.internal.NativePtr, _1: kotlin.native.internal.NativePtr): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = if (_1 == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_1) as kotlin.Any
+    val _result = run { (__pointerToBlock as Function1<kotlin.Any?, Unit>).invoke(___1) }
+    return run { _result; true }
+}
+
+@ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___")
+public fun KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock: kotlin.native.internal.NativePtr, _1: kotlin.native.internal.NativePtr): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = if (_1 == kotlin.native.internal.NativePtr.NULL) null else throwableFromReverseBridge(_1)
+    val _result = run { (__pointerToBlock as Function1<kotlin.Throwable?, Unit>).invoke(___1) }
+    return run { _result; true }
+}
+
+@ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__")
+public fun KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock: kotlin.native.internal.NativePtr, _1: Boolean): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = run<Unit> { _1 }
+    val _result = run { (__pointerToBlock as Function1<Unit, Unit>).invoke(___1) }
+    return run { _result; true }
+}
+
+@ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__")
+public fun KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock: kotlin.native.internal.NativePtr, _1: Boolean): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = _1
+    val _result = run { (__pointerToBlock as Function1<Boolean, Unit>).invoke(___1) }
+    return run { _result; true }
+}
+
+@ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult__")
+public fun KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult__(pointerToBlock: kotlin.native.internal.NativePtr, _1: kotlin.native.internal.NativePtr): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = kotlin.native.internal.ref.dereferenceExternalRCRef(_1) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { (__pointerToBlock as Function1<kotlinx.coroutines.channels.ChannelResult<*>, Unit>).invoke(___1) }
+    return run { _result; true }
+}
+
+@ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(pointerToBlock: kotlin.native.internal.NativePtr, _1: kotlin.native.internal.NativePtr): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = kotlin.native.internal.ref.dereferenceExternalRCRef(_1) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val _result = run { (__pointerToBlock as Function1<kotlinx.coroutines.flow.Flow<kotlin.Any?>, Unit>).invoke(___1) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_ranges_intRange_create_int_KotlinxCoroutinesCore")
+fun kotlin_ranges_intRange_create_int_KotlinxCoroutinesCore(start: Int, end: Int): kotlin.native.internal.NativePtr {
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(start .. end)
+}
+
+@ExportedBridge("kotlin_ranges_intRange_getEndInclusive_int_KotlinxCoroutinesCore")
+fun kotlin_ranges_intRange_getEndInclusive_int_KotlinxCoroutinesCore(nativePtr: kotlin.native.internal.NativePtr): Int {
+    val intRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as IntRange
+    return intRange.endInclusive
+}
+
+@ExportedBridge("kotlin_ranges_intRange_getStart_int_KotlinxCoroutinesCore")
+fun kotlin_ranges_intRange_getStart_int_KotlinxCoroutinesCore(nativePtr: kotlin.native.internal.NativePtr): Int {
+    val intRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as IntRange
+    return intRange.start
+}
+
+@ExportedBridge("kotlin_ranges_longRange_create_long_KotlinxCoroutinesCore")
+fun kotlin_ranges_longRange_create_long_KotlinxCoroutinesCore(start: Long, end: Long): kotlin.native.internal.NativePtr {
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(start .. end)
+}
+
+@ExportedBridge("kotlin_ranges_longRange_getEndInclusive_long_KotlinxCoroutinesCore")
+fun kotlin_ranges_longRange_getEndInclusive_long_KotlinxCoroutinesCore(nativePtr: kotlin.native.internal.NativePtr): Long {
+    val longRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as LongRange
+    return longRange.endInclusive
+}
+
+@ExportedBridge("kotlin_ranges_longRange_getStart_long_KotlinxCoroutinesCore")
+fun kotlin_ranges_longRange_getStart_long_KotlinxCoroutinesCore(nativePtr: kotlin.native.internal.NativePtr): Long {
+    val longRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as LongRange
+    return longRange.start
+}
+
+@ExportedBridge("kotlinx_coroutines_AbstractCoroutine_context_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_AbstractCoroutine_context_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.AbstractCoroutine<kotlin.Any?>
+    val _result = run { __self.context }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_AbstractCoroutine_coroutineContext_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_AbstractCoroutine_coroutineContext_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.AbstractCoroutine<kotlin.Any?>
+    val _result = run { __self.coroutineContext }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_AbstractCoroutine_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Bool_Swift_Bool__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_AbstractCoroutine_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Bool_Swift_Bool__(__kt: kotlin.native.internal.NativePtr, parentContext: kotlin.native.internal.NativePtr, initParentJob: Boolean, active: Boolean): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __parentContext = kotlin.native.internal.ref.dereferenceExternalRCRef(parentContext) as kotlin.coroutines.CoroutineContext
+    val __initParentJob = initParentJob
+    val __active = active
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.AbstractCoroutine<kotlin.Any?>(__parentContext, __initParentJob, __active)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_AbstractCoroutine_isActive_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_AbstractCoroutine_isActive_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.AbstractCoroutine<kotlin.Any?>
+    val _result = run { __self.isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_AbstractCoroutine_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_AbstractCoroutine_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__(self: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.AbstractCoroutine<kotlin.Any?>
+    val __result = kotlin.native.internal.ref.dereferenceExternalRCRef(result) as kotlin.Result<kotlin.Any?>
+    val _result = run { __self.resumeWith(__result) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_AbstractCoroutine_start__TypesOfArguments__ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_AbstractCoroutine_start__TypesOfArguments__ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, start: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.AbstractCoroutine<kotlin.Any?>
+    val __start = kotlin.native.internal.ref.dereferenceExternalRCRef(start) as kotlinx.coroutines.CoroutineStart
+    val __receiver = if (`receiver` == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Any
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __self.start<kotlin.Any?>(__start, __receiver, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.cancel(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, token: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __token = kotlin.native.internal.ref.dereferenceExternalRCRef(token) as kotlin.Any
+    val _result = run { __self.completeResume(__token) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_initCancellability")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_initCancellability(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val _result = run { __self.initCancellability() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_invokeOnCancellation__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_CancellableContinuation_invokeOnCancellation__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, handler: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCancellation(__handler) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_isActive_get")
+public fun kotlinx_coroutines_CancellableContinuation_isActive_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val _result = run { __self.isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_isCancelled_get")
+public fun kotlinx_coroutines_CancellableContinuation_isCancelled_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val _result = run { __self.isCancelled }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_isCompleted_get")
+public fun kotlinx_coroutines_CancellableContinuation_isCompleted_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val _result = run { __self.isCompleted }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_resume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_resume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, onCancellation: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val __onCancellation = if (onCancellation == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(onCancellation);
+        { arg0: kotlin.Throwable ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.resume(__value, __onCancellation) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineDispatcher
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.run { __receiver.resumeUndispatched(__value) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineDispatcher
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { __self.run { __receiver.resumeUndispatchedWithException(__exception) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, idempotent: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val __idempotent = if (idempotent == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(idempotent) as kotlin.Any
+    val _result = run { __self.tryResume(__value, __idempotent) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, idempotent: kotlin.native.internal.NativePtr, onCancellation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val __idempotent = if (idempotent == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(idempotent) as kotlin.Any
+    val __onCancellation = if (onCancellation == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(onCancellation);
+        { arg0: kotlin.Throwable ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.tryResume(__value, __idempotent, __onCancellation) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { __self.tryResumeWithException(__exception) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CancellationException__TypesOfArguments__Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_coroutines_CancellationException__TypesOfArguments__Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlinx.coroutines.CancellationException(__message, __cause) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_ChildHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_ChildHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.ChildHandle
+    val __cause = kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.childCancelled(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_ChildHandle_parent_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_ChildHandle_parent_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.ChildHandle
+    val _result = run { __self.parent }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CloseableCoroutineDispatcher_close")
+public fun kotlinx_coroutines_CloseableCoroutineDispatcher_close(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CloseableCoroutineDispatcher
+    val _result = run { __self.close() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CloseableCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlinx_coroutines_CloseableCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.CloseableCoroutineDispatcher()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { kotlinx.coroutines.CompletableDeferred<kotlin.Any?>(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___")
+public fun kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(parent: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __parent = if (parent == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(parent) as kotlinx.coroutines.Job
+    val _result = run { kotlinx.coroutines.CompletableDeferred<kotlin.Any?>(__parent) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CompletableDeferred<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.complete(__value) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+public fun kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CompletableDeferred<kotlin.Any?>
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { __self.completeExceptionally(__exception) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletableJob_complete")
+public fun kotlinx_coroutines_CompletableJob_complete(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CompletableJob
+    val _result = run { __self.complete() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+public fun kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CompletableJob
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { __self.completeExceptionally(__exception) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletionHandlerException_init_allocate")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CompletionHandlerException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.CompletionHandlerException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CompletionHandlerException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String_ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CompletionHandlerException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String_ExportedKotlinPackages_kotlin_Throwable__(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = interpretObjCPointer<kotlin.String>(message)
+    val __cause = kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.CompletionHandlerException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_Key_get")
+public fun kotlinx_coroutines_CoroutineDispatcher_Key_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineDispatcher.Key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__")
+public fun kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __block = kotlin.native.internal.ref.dereferenceExternalRCRef(block) as kotlinx.coroutines.Runnable
+    val _result = run { __self.dispatch(__context, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __block = kotlin.native.internal.ref.dereferenceExternalRCRef(block) as kotlinx.coroutines.Runnable
+    val _result = run { __self.dispatchYield(__context, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable___direct", nonVirtualTargetMethod = "dispatchYield")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable___direct(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __block = kotlin.native.internal.ref.dereferenceExternalRCRef(block) as kotlinx.coroutines.Runnable
+    val _result = run { __self.dispatchYield(__context, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlinx_coroutines_CoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.CoroutineDispatcher()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__")
+public fun kotlinx_coroutines_CoroutineDispatcher_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __continuation = kotlin.native.internal.ref.dereferenceExternalRCRef(continuation) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.interceptContinuation<kotlin.Any?>(__continuation) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __self.isDispatchNeeded(__context) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct", nonVirtualTargetMethod = "isDispatchNeeded")
+public fun kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __self.isDispatchNeeded(__context) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, parallelism: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __parallelism = parallelism
+    val _result = run { __self.limitedParallelism(__parallelism) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct", nonVirtualTargetMethod = "limitedParallelism")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct(self: kotlin.native.internal.NativePtr, parallelism: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __parallelism = parallelism
+    val _result = run { __self.limitedParallelism(__parallelism) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__")
+public fun kotlinx_coroutines_CoroutineDispatcher_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val __continuation = kotlin.native.internal.ref.dereferenceExternalRCRef(continuation) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.releaseInterceptedContinuation(__continuation) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_toString")
+public fun kotlinx_coroutines_CoroutineDispatcher_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineDispatcher_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlinx_coroutines_CoroutineDispatcher_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineDispatcher
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineExceptionHandler__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U20ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_CoroutineExceptionHandler__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U20ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void__(handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.coroutines.CoroutineContext, arg1: kotlin.Throwable ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+            val _result = kotlinFun(_arg0, _arg1)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.coroutines.CoroutineExceptionHandler(__handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineExceptionHandler_Key_get")
+public fun kotlinx_coroutines_CoroutineExceptionHandler_Key_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineExceptionHandler.Key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__")
+public fun kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineExceptionHandler
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { __self.handleException(__context, __exception) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_Key_get")
+public fun kotlinx_coroutines_CoroutineName_Key_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineName.Key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_copy__TypesOfArguments__Swift_String__")
+public fun kotlinx_coroutines_CoroutineName_copy__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, name: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineName
+    val __name = interpretObjCPointer<kotlin.String>(name)
+    val _result = run { __self.copy(__name) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_CoroutineName_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineName
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_hashCode")
+public fun kotlinx_coroutines_CoroutineName_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineName
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_init_allocate")
+public fun kotlinx_coroutines_CoroutineName_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.CoroutineName>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String__")
+public fun kotlinx_coroutines_CoroutineName_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String__(__kt: kotlin.native.internal.NativePtr, name: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __name = interpretObjCPointer<kotlin.String>(name)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.CoroutineName(__name)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_name_get")
+public fun kotlinx_coroutines_CoroutineName_name_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineName
+    val _result = run { __self.name }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineName_toString")
+public fun kotlinx_coroutines_CoroutineName_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineName
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineScope__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_CoroutineScope__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { kotlinx.coroutines.CoroutineScope(__context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineScope_coroutineContext_get")
+public fun kotlinx_coroutines_CoroutineScope_coroutineContext_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __self.coroutineContext }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_ATOMIC")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineStart_ATOMIC(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineStart.ATOMIC }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_DEFAULT")
+public fun kotlinx_coroutines_CoroutineStart_DEFAULT(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineStart.DEFAULT }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_LAZY")
+public fun kotlinx_coroutines_CoroutineStart_LAZY(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineStart.LAZY }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_UNDISPATCHED")
+public fun kotlinx_coroutines_CoroutineStart_UNDISPATCHED(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.CoroutineStart.UNDISPATCHED }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_invoke__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineStart_invoke__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, completion: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineStart
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __receiver = if (`receiver` == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Any
+    val __completion = kotlin.native.internal.ref.dereferenceExternalRCRef(completion) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __self.invoke<kotlin.Any?, kotlin.Any?>(__block, __receiver, __completion) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_isLazy_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_CoroutineStart_isLazy_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineStart
+    val _result = run { __self.isLazy }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_CoroutineStart_ordinal")
+public fun kotlinx_coroutines_CoroutineStart_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.CoroutineStart
+    val _result = run { __self.ordinal }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_Deferred_await")
+public fun kotlinx_coroutines_Deferred_await(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Deferred<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.await()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_Deferred_getCompleted")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_Deferred_getCompleted(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Deferred<kotlin.Any?>
+    val _result = run { __self.getCompleted() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Deferred_getCompletionExceptionOrNull")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_Deferred_getCompletionExceptionOrNull(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Deferred<kotlin.Any?>
+    val _result = run { __self.getCompletionExceptionOrNull() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Deferred_onAwait_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_Deferred_onAwait_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Deferred<kotlin.Any?>
+    val _result = run { __self.onAwait }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(self: kotlin.native.internal.NativePtr, timeMillis: Long, block: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Delay
+    val __timeMillis = timeMillis
+    val __block = kotlin.native.internal.ref.dereferenceExternalRCRef(block) as kotlinx.coroutines.Runnable
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __self.invokeOnTimeout(__timeMillis, __block, __context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct", nonVirtualTargetMethod = "invokeOnTimeout")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(self: kotlin.native.internal.NativePtr, timeMillis: Long, block: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Delay
+    val __timeMillis = timeMillis
+    val __block = kotlin.native.internal.ref.dereferenceExternalRCRef(block) as kotlinx.coroutines.Runnable
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __self.invokeOnTimeout(__timeMillis, __block, __context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Dispatchers_Default_get")
+public fun kotlinx_coroutines_Dispatchers_Default_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Dispatchers
+    val _result = run { __self.Default }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Dispatchers_Main_get")
+public fun kotlinx_coroutines_Dispatchers_Main_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Dispatchers
+    val _result = run { __self.Main }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Dispatchers_Unconfined_get")
+public fun kotlinx_coroutines_Dispatchers_Unconfined_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Dispatchers
+    val _result = run { __self.Unconfined }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Dispatchers_get")
+public fun kotlinx_coroutines_Dispatchers_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.Dispatchers }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_DisposableHandle__TypesOfArguments__U2829202D_U20Swift_Void__")
+public fun kotlinx_coroutines_DisposableHandle__TypesOfArguments__U2829202D_U20Swift_Void__(function: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __function = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->Boolean>(function);
+        {
+            val _result = kotlinFun()
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.coroutines.DisposableHandle(__function) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_DisposableHandle_dispose")
+public fun kotlinx_coroutines_DisposableHandle_dispose(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.DisposableHandle
+    val _result = run { __self.dispose() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_GlobalScope_coroutineContext_get")
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+public fun kotlinx_coroutines_GlobalScope_coroutineContext_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.GlobalScope
+    val _result = run { __self.coroutineContext }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_GlobalScope_get")
+public fun kotlinx_coroutines_GlobalScope_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.GlobalScope }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_IO_get__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_Dispatchers__")
+public fun kotlinx_coroutines_IO_get__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_Dispatchers__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.Dispatchers
+    val _result = run { __receiver.kotlinx_coroutines_IO }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___")
+public fun kotlinx_coroutines_Job__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(parent: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __parent = if (parent == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(parent) as kotlinx.coroutines.Job
+    val _result = run { kotlinx.coroutines.Job(__parent) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __self.cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_cancelCoroutine__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_cancelCoroutine__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.cancelCoroutine(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_cancelInternal__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_cancelInternal__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __cause = kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.cancelInternal(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __cause = kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.childCancelled(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_children_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_children_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.children }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_getCancellationException")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_getCancellationException(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.getCancellationException() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_getChildJobCancellationCause")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_getChildJobCancellationCause(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.getChildJobCancellationCause() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_getCompletionExceptionOrNull")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_getCompletionExceptionOrNull(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.getCompletionExceptionOrNull() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_init_allocate")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.JobSupport>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(__kt: kotlin.native.internal.NativePtr, active: Boolean): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __active = active
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.JobSupport(__active)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, onCancelling: Boolean, invokeImmediately: Boolean, handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __onCancelling = onCancelling
+    val __invokeImmediately = invokeImmediately
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCompletion(__onCancelling, __invokeImmediately, __handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCompletion(__handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_isActive_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_isActive_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_isCancelled_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_isCancelled_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.isCancelled }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_isCompletedExceptionally_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_isCompletedExceptionally_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.isCompletedExceptionally }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_isCompleted_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_isCompleted_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.isCompleted }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_join")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_join(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.join()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_key_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_key_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_onJoin_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_onJoin_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.onJoin }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_parent_get")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_parent_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.parent }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_start")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_start(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.start() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_toDebugString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_toDebugString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.toDebugString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_JobSupport_toString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_JobSupport_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.JobSupport
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_Key_get")
+public fun kotlinx_coroutines_Job_Key_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.Job.Key }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __self.cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_children_get")
+public fun kotlinx_coroutines_Job_children_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.children }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_getCancellationException")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_Job_getCancellationException(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.getCancellationException() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, onCancelling: Boolean, invokeImmediately: Boolean, handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val __onCancelling = onCancelling
+    val __invokeImmediately = invokeImmediately
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCompletion(__onCancelling, __invokeImmediately, __handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCompletion(__handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_isActive_get")
+public fun kotlinx_coroutines_Job_isActive_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_isCancelled_get")
+public fun kotlinx_coroutines_Job_isCancelled_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.isCancelled }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_isCompleted_get")
+public fun kotlinx_coroutines_Job_isCompleted_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.isCompleted }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_join")
+public fun kotlinx_coroutines_Job_join(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.join()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_onJoin_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_Job_onJoin_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.onJoin }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_parent_get")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_Job_parent_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.parent }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Job_start")
+public fun kotlinx_coroutines_Job_start(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Job
+    val _result = run { __self.start() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_immediate_get")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_immediate_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.MainCoroutineDispatcher
+    val _result = run { __self.immediate }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.MainCoroutineDispatcher()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, parallelism: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.MainCoroutineDispatcher
+    val __parallelism = parallelism
+    val _result = run { __self.limitedParallelism(__parallelism) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct", nonVirtualTargetMethod = "limitedParallelism")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct(self: kotlin.native.internal.NativePtr, parallelism: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.MainCoroutineDispatcher
+    val __parallelism = parallelism
+    val _result = run { __self.limitedParallelism(__parallelism) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_toString")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.MainCoroutineDispatcher
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_MainCoroutineDispatcher_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlinx_coroutines_MainCoroutineDispatcher_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.MainCoroutineDispatcher
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_MainScope")
+public fun kotlinx_coroutines_MainScope(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.MainScope() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_NonCancellable_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __self.cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_children_get")
+public fun kotlinx_coroutines_NonCancellable_children_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.children }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_get")
+public fun kotlinx_coroutines_NonCancellable_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.NonCancellable }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_getCancellationException")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonCancellable_getCancellationException(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.getCancellationException() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, onCancelling: Boolean, invokeImmediately: Boolean, handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val __onCancelling = onCancelling
+    val __invokeImmediately = invokeImmediately
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCompletion(__onCancelling, __invokeImmediately, __handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, handler: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnCompletion(__handler) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_isActive_get")
+public fun kotlinx_coroutines_NonCancellable_isActive_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_isCancelled_get")
+public fun kotlinx_coroutines_NonCancellable_isCancelled_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.isCancelled }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_isCompleted_get")
+public fun kotlinx_coroutines_NonCancellable_isCompleted_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.isCompleted }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_join")
+public fun kotlinx_coroutines_NonCancellable_join(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.join()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_onJoin_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonCancellable_onJoin_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.onJoin }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_parent_get")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonCancellable_parent_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.parent }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_start")
+public fun kotlinx_coroutines_NonCancellable_start(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.start() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_NonCancellable_toString")
+public fun kotlinx_coroutines_NonCancellable_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonCancellable
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_NonDisposableHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonDisposableHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonDisposableHandle
+    val __cause = kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.childCancelled(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_NonDisposableHandle_dispose")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonDisposableHandle_dispose(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonDisposableHandle
+    val _result = run { __self.dispose() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_NonDisposableHandle_get")
+public fun kotlinx_coroutines_NonDisposableHandle_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.NonDisposableHandle }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonDisposableHandle_parent_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonDisposableHandle_parent_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonDisposableHandle
+    val _result = run { __self.parent }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_NonDisposableHandle_toString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_NonDisposableHandle_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.NonDisposableHandle
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_ParentJob_getChildJobCancellationCause")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_ParentJob_getChildJobCancellationCause(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.ParentJob
+    val _result = run { __self.getChildJobCancellationCause() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Runnable__TypesOfArguments__U2829202D_U20Swift_Void__")
+public fun kotlinx_coroutines_Runnable__TypesOfArguments__U2829202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->Boolean>(block);
+        {
+            val _result = kotlinFun()
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.coroutines.Runnable(__block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_Runnable_run")
+public fun kotlinx_coroutines_Runnable_run(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.Runnable
+    val _result = run { __self.run() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_SupervisorJob__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___")
+public fun kotlinx_coroutines_SupervisorJob__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(parent: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __parent = if (parent == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(parent) as kotlinx.coroutines.Job
+    val _result = run { kotlinx.coroutines.SupervisorJob(__parent) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_async__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_async__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, start: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __start = kotlin.native.internal.ref.dereferenceExternalRCRef(start) as kotlinx.coroutines.CoroutineStart
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_async<kotlin.Any?>(__context, __start, __block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_awaitAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Deferred__Vararg___")
+public fun kotlinx_coroutines_awaitAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Deferred__Vararg___(deferreds: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __deferreds = interpretObjCPointer<kotlin.collections.List<kotlinx.coroutines.Deferred<kotlin.Any?>>>(deferreds).toTypedArray()
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.List<kotlin.Any?> ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.awaitAll<kotlin.Any?>(*__deferreds)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_awaitCancellation")
+public fun kotlinx_coroutines_awaitCancellation(continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Nothing ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.awaitCancellation()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(`receiver`: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.CoroutineContext
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __receiver.kotlinx_coroutines_cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(`receiver`: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.Job
+    val __message = interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __receiver.kotlinx_coroutines_cancel(__message, __cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(`receiver`: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __message = interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __receiver.kotlinx_coroutines_cancel(__message, __cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(`receiver`: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __receiver.kotlinx_coroutines_cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancelAndJoin__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__")
+public fun kotlinx_coroutines_cancelAndJoin__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.Job
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_cancelAndJoin()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(`receiver`: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.CoroutineContext
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __receiver.kotlinx_coroutines_cancelChildren(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(`receiver`: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.Job
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __receiver.kotlinx_coroutines_cancelChildren(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BroadcastChannel__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_BroadcastChannel__TypesOfArguments__Swift_Int32__(capacity: Int): kotlin.native.internal.NativePtr {
+    val __capacity = capacity
+    val _result = run { kotlinx.coroutines.channels.BroadcastChannel<kotlin.Any?>(__capacity) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.BroadcastChannel<kotlin.Any?>
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __self.cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BroadcastChannel_openSubscription")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_BroadcastChannel_openSubscription(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.BroadcastChannel<kotlin.Any?>
+    val _result = run { __self.openSubscription() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BufferOverflow_DROP_LATEST")
+public fun kotlinx_coroutines_channels_BufferOverflow_DROP_LATEST(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.channels.BufferOverflow.DROP_LATEST }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BufferOverflow_DROP_OLDEST")
+public fun kotlinx_coroutines_channels_BufferOverflow_DROP_OLDEST(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BufferOverflow_SUSPEND")
+public fun kotlinx_coroutines_channels_BufferOverflow_SUSPEND(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.channels.BufferOverflow.SUSPEND }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_BufferOverflow_ordinal")
+public fun kotlinx_coroutines_channels_BufferOverflow_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { __self.ordinal }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel__TypesOfArguments__Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow_Swift_Optional_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void___")
+public fun kotlinx_coroutines_channels_Channel__TypesOfArguments__Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow_Swift_Optional_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void___(capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr, onUndeliveredElement: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __capacity = capacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val __onUndeliveredElement = if (onUndeliveredElement == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(onUndeliveredElement);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.coroutines.channels.Channel<kotlin.Any?>(__capacity, __onBufferOverflow, __onUndeliveredElement) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelIterator_hasNext")
+public fun kotlinx_coroutines_channels_ChannelIterator_hasNext(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelIterator<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Boolean ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.hasNext()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelIterator_next")
+public fun kotlinx_coroutines_channels_ChannelIterator_next(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelIterator<kotlin.Any?>
+    val _result = run { __self.next() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_Companion_closed__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ChannelResult_Companion_closed__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult.Companion
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.closed<kotlin.Any?>(__cause) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_Companion_failure")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ChannelResult_Companion_failure(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult.Companion
+    val _result = run { __self.failure<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_Companion_get")
+public fun kotlinx_coroutines_channels_ChannelResult_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.channels.ChannelResult.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ChannelResult_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult.Companion
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.success<kotlin.Any?>(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_channels_ChannelResult_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_exceptionOrNull")
+public fun kotlinx_coroutines_channels_ChannelResult_exceptionOrNull(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.exceptionOrNull() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_getOrNull")
+public fun kotlinx_coroutines_channels_ChannelResult_getOrNull(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.getOrNull() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_getOrThrow")
+public fun kotlinx_coroutines_channels_ChannelResult_getOrThrow(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.getOrThrow() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_hashCode")
+public fun kotlinx_coroutines_channels_ChannelResult_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_isClosed_get")
+public fun kotlinx_coroutines_channels_ChannelResult_isClosed_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.isClosed }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_isFailure_get")
+public fun kotlinx_coroutines_channels_ChannelResult_isFailure_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.isFailure }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_isSuccess_get")
+public fun kotlinx_coroutines_channels_ChannelResult_isSuccess_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.isSuccess }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ChannelResult_toString")
+public fun kotlinx_coroutines_channels_ChannelResult_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel_Factory_BUFFERED_get")
+public fun kotlinx_coroutines_channels_Channel_Factory_BUFFERED_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.Channel.Factory
+    val _result = run { __self.BUFFERED }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel_Factory_CONFLATED_get")
+public fun kotlinx_coroutines_channels_Channel_Factory_CONFLATED_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.Channel.Factory
+    val _result = run { __self.CONFLATED }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel_Factory_DEFAULT_BUFFER_PROPERTY_NAME_get")
+public fun kotlinx_coroutines_channels_Channel_Factory_DEFAULT_BUFFER_PROPERTY_NAME_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.Channel.Factory
+    val _result = run { __self.DEFAULT_BUFFER_PROPERTY_NAME }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel_Factory_RENDEZVOUS_get")
+public fun kotlinx_coroutines_channels_Channel_Factory_RENDEZVOUS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.Channel.Factory
+    val _result = run { __self.RENDEZVOUS }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel_Factory_UNLIMITED_get")
+public fun kotlinx_coroutines_channels_Channel_Factory_UNLIMITED_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.Channel.Factory
+    val _result = run { __self.UNLIMITED }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_Channel_Factory_get")
+public fun kotlinx_coroutines_channels_Channel_Factory_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.channels.Channel.Factory }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ClosedReceiveChannelException_init_allocate")
+public fun kotlinx_coroutines_channels_ClosedReceiveChannelException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.channels.ClosedReceiveChannelException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ClosedReceiveChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlinx_coroutines_channels_ClosedReceiveChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.channels.ClosedReceiveChannelException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ClosedSendChannelException_init_allocate")
+public fun kotlinx_coroutines_channels_ClosedSendChannelException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.channels.ClosedSendChannelException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ClosedSendChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlinx_coroutines_channels_ClosedSendChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.channels.ClosedSendChannelException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __self.cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.close(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_allocate")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(__kt: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>(__value)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, handler: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnClose(__handler) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_isClosedForSend_get")
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class, kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_isClosedForSend_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val _result = run { __self.isClosedForSend }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_onSend_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class, kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_onSend_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val _result = run { __self.onSend }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_openSubscription")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_openSubscription(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val _result = run { __self.openSubscription() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.send(__element)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.trySend(__element) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_valueOrNull_get")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_valueOrNull_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val _result = run { __self.valueOrNull }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ConflatedBroadcastChannel_value_get")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ConflatedBroadcastChannel_value_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ConflatedBroadcastChannel<kotlin.Any?>
+    val _result = run { __self.value }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ProducerScope_channel_get")
+public fun kotlinx_coroutines_channels_ProducerScope_channel_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ProducerScope<kotlin.Any?>
+    val _result = run { __self.channel }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___")
+public fun kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.coroutines.cancellation.CancellationException
+    val _result = run { __self.cancel(__cause) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get")
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __self.isClosedForReceive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __self.isEmpty }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_iterator")
+public fun kotlinx_coroutines_channels_ReceiveChannel_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __self.onReceiveCatching }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_onReceive_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_ReceiveChannel_onReceive_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __self.onReceive }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_receive")
+public fun kotlinx_coroutines_channels_ReceiveChannel_receive(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.receive()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_receiveCatching")
+public fun kotlinx_coroutines_channels_ReceiveChannel_receiveCatching(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlinx.coroutines.channels.ChannelResult<*> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.receiveCatching()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_ReceiveChannel_tryReceive")
+public fun kotlinx_coroutines_channels_ReceiveChannel_tryReceive(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __self.tryReceive() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { __self.close(__cause) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_SendChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_channels_SendChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, handler: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val __handler = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(handler);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.invokeOnClose(__handler) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_SendChannel_isClosedForSend_get")
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_SendChannel_isClosedForSend_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val _result = run { __self.isClosedForSend }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_SendChannel_onSend_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_SendChannel_onSend_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val _result = run { __self.onSend }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.send(__element)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.trySend(__element) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_awaitClose__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScope_U2829202D_U20Swift_Void__")
+public fun kotlinx_coroutines_channels_awaitClose__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScope_U2829202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ProducerScope<kotlin.Any?>
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->Boolean>(block);
+        {
+            val _result = kotlinFun()
+            run<Unit> { _result }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_channels_awaitClose(__block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, start: kotlin.native.internal.NativePtr, onCompletion: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __start = kotlin.native.internal.ref.dereferenceExternalRCRef(start) as kotlinx.coroutines.CoroutineStart
+    val __onCompletion = if (onCompletion == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(onCompletion);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.channels.ProducerScope<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_broadcast<kotlin.Any?>(__context, __capacity, __start, __onCompletion, __block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart__")
+@OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart__(`receiver`: kotlin.native.internal.NativePtr, capacity: Int, start: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __capacity = capacity
+    val __start = kotlin.native.internal.ref.dereferenceExternalRCRef(start) as kotlinx.coroutines.CoroutineStart
+    val _result = run { __receiver.kotlinx_coroutines_channels_broadcast<kotlin.Any?>(__capacity, __start) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_consume__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannelU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_channels_consume__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannelU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(block);
+        { arg0: kotlinx.coroutines.channels.ReceiveChannel<*> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_consume<kotlin.Any?, kotlin.Any?>(__block) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_consumeEach__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_channels_consumeEach__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(action);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_channels_consumeEach<kotlin.Any?>(__action)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_getOrElse__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_channels_getOrElse__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, onFailure: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val __onFailure = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(onFailure);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_getOrElse<kotlin.Any?>(__onFailure) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_onClosed__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_channels_onClosed__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(action);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_onClosed<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_onFailure__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_channels_onFailure__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(action);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_onFailure<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_onSuccess__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_channels_onSuccess__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ChannelResult<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(action);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_onSuccess<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, start: kotlin.native.internal.NativePtr, onCompletion: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __start = kotlin.native.internal.ref.dereferenceExternalRCRef(start) as kotlinx.coroutines.CoroutineStart
+    val __onCompletion = if (onCompletion == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(onCompletion);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.channels.ProducerScope<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_produce<kotlin.Any?>(__context, __capacity, __start, __onCompletion, __block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.channels.ProducerScope<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_channels_produce<kotlin.Any?>(__context, __capacity, __block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_toList__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__")
+public fun kotlinx_coroutines_channels_toList__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.List<kotlin.Any?> ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_channels_toList<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_channels_trySendBlocking__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_channels_trySendBlocking__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __receiver.kotlinx_coroutines_channels_trySendBlocking<kotlin.Any?>(__element) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_completeWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CompletableDeferred_ExportedKotlinPackages_kotlin_Result__")
+public fun kotlinx_coroutines_completeWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CompletableDeferred_ExportedKotlinPackages_kotlin_Result__(`receiver`: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CompletableDeferred<kotlin.Any?>
+    val __result = kotlin.native.internal.ref.dereferenceExternalRCRef(result) as kotlin.Result<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_completeWith<kotlin.Any?>(__result) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_coroutineScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_coroutineScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.coroutineScope<kotlin.Any?>(__block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_currentCoroutineContext")
+public fun kotlinx_coroutines_currentCoroutineContext(continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.coroutines.CoroutineContext ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.currentCoroutineContext()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_delay__TypesOfArguments__Swift_Int64__")
+public fun kotlinx_coroutines_delay__TypesOfArguments__Swift_Int64__(timeMillis: Long, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __timeMillis = timeMillis
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.delay(__timeMillis)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_delay__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlinx_coroutines_delay__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(duration: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __duration = kotlin.native.internal.ref.dereferenceExternalRCRef(duration) as kotlin.time.Duration
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.delay(__duration)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_disposeOnCancellation__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuation_anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_disposeOnCancellation__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuation_anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__(`receiver`: kotlin.native.internal.NativePtr, handle: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CancellableContinuation<kotlin.Any?>
+    val __handle = kotlin.native.internal.ref.dereferenceExternalRCRef(handle) as kotlinx.coroutines.DisposableHandle
+    val _result = run { __receiver.kotlinx_coroutines_disposeOnCancellation(__handle) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_ensureActive() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__")
+public fun kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__(`receiver`: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.Job
+    val _result = run { __receiver.kotlinx_coroutines_ensureActive() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__")
+public fun kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(`receiver`: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __receiver.kotlinx_coroutines_ensureActive() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_AbstractFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_AbstractFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.AbstractFlow<kotlin.Any?>
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.collect(__collector)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.AbstractFlow<kotlin.Any?>
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.collectSafely(__collector)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_AbstractFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_AbstractFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.flow.AbstractFlow<kotlin.Any?>()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_PROPERTY_NAME_get")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_PROPERTY_NAME_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.flow.DEFAULT_CONCURRENCY_PROPERTY_NAME }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_get")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_get(): Int {
+    val _result = run { kotlinx.coroutines.flow.DEFAULT_CONCURRENCY }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_FlowCollector__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_FlowCollector__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(function: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __function = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(function);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>(__function) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.emit(__value)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+public fun kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.collect(__collector)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow__TypesOfArguments__Swift_Int32_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__")
+public fun kotlinx_coroutines_flow_MutableSharedFlow__TypesOfArguments__Swift_Int32_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(replay: Int, extraBufferCapacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __replay = replay
+    val __extraBufferCapacity = extraBufferCapacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>(__replay, __extraBufferCapacity, __onBufferOverflow) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.emit(__value)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>
+    val _result = run { __self.resetReplayCache() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get")
+public fun kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>
+    val _result = run { __self.subscriptionCount }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.tryEmit(__value) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableStateFlow__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_MutableStateFlow__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, `expect`: kotlin.native.internal.NativePtr, update: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val __expect = if (`expect` == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(`expect`) as kotlin.Any
+    val __update = if (update == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(update) as kotlin.Any
+    val _result = run { __self.compareAndSet(__expect, __update) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableStateFlow_value_get")
+public fun kotlinx_coroutines_flow_MutableStateFlow_value_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val _result = run { __self.value }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, newValue: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val __newValue = if (newValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(newValue) as kotlin.Any
+    val _result = run { __self.value = __newValue }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+public fun kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Nothing ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.collect(__collector)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharedFlow_replayCache_get")
+public fun kotlinx_coroutines_flow_SharedFlow_replayCache_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val _result = run { __self.replayCache }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingCommand_START")
+public fun kotlinx_coroutines_flow_SharingCommand_START(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.flow.SharingCommand.START }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingCommand_STOP")
+public fun kotlinx_coroutines_flow_SharingCommand_STOP(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.flow.SharingCommand.STOP }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingCommand_STOP_AND_RESET_REPLAY_CACHE")
+public fun kotlinx_coroutines_flow_SharingCommand_STOP_AND_RESET_REPLAY_CACHE(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.flow.SharingCommand.STOP_AND_RESET_REPLAY_CACHE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingCommand_ordinal")
+public fun kotlinx_coroutines_flow_SharingCommand_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharingCommand
+    val _result = run { __self.ordinal }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingStarted__TypesOfArguments__U28anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_U29202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingCommand___")
+public fun kotlinx_coroutines_flow_SharingStarted__TypesOfArguments__U28anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_U29202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingCommand___(function: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __function = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(function);
+        { arg0: kotlinx.coroutines.flow.StateFlow<Int> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<kotlinx.coroutines.flow.SharingCommand>
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.SharingStarted(__function) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingStarted_Companion_Eagerly_get")
+public fun kotlinx_coroutines_flow_SharingStarted_Companion_Eagerly_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharingStarted.Companion
+    val _result = run { __self.Eagerly }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingStarted_Companion_Lazily_get")
+public fun kotlinx_coroutines_flow_SharingStarted_Companion_Lazily_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharingStarted.Companion
+    val _result = run { __self.Lazily }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingStarted_Companion_WhileSubscribed__TypesOfArguments__Swift_Int64_Swift_Int64__")
+public fun kotlinx_coroutines_flow_SharingStarted_Companion_WhileSubscribed__TypesOfArguments__Swift_Int64_Swift_Int64__(self: kotlin.native.internal.NativePtr, stopTimeoutMillis: Long, replayExpirationMillis: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharingStarted.Companion
+    val __stopTimeoutMillis = stopTimeoutMillis
+    val __replayExpirationMillis = replayExpirationMillis
+    val _result = run { __self.WhileSubscribed(__stopTimeoutMillis, __replayExpirationMillis) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingStarted_Companion_get")
+public fun kotlinx_coroutines_flow_SharingStarted_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.flow.SharingStarted.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32___")
+public fun kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32___(self: kotlin.native.internal.NativePtr, subscriptionCount: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.SharingStarted
+    val __subscriptionCount = kotlin.native.internal.ref.dereferenceExternalRCRef(subscriptionCount) as kotlinx.coroutines.flow.StateFlow<Int>
+    val _result = run { __self.command(__subscriptionCount) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_StateFlow_value_get")
+public fun kotlinx_coroutines_flow_StateFlow_value_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.StateFlow<kotlin.Any?>
+    val _result = run { __self.value }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_WhileSubscribed__TypesOfArgumentsE__KotlinxCoroutinesCore__ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion_ExportedKotlinPackages_kotlin_time_Duration_ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlinx_coroutines_flow_WhileSubscribed__TypesOfArgumentsE__KotlinxCoroutinesCore__ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion_ExportedKotlinPackages_kotlin_time_Duration_ExportedKotlinPackages_kotlin_time_Duration__(`receiver`: kotlin.native.internal.NativePtr, stopTimeout: kotlin.native.internal.NativePtr, replayExpiration: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharingStarted.Companion
+    val __stopTimeout = kotlin.native.internal.ref.dereferenceExternalRCRef(stopTimeout) as kotlin.time.Duration
+    val __replayExpiration = kotlin.native.internal.ref.dereferenceExternalRCRef(replayExpiration) as kotlin.time.Duration
+    val _result = run { __receiver.kotlinx_coroutines_flow_WhileSubscribed(__stopTimeout, __replayExpiration) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->kotlin.native.internal.NativePtr>(`receiver`);
+        {
+            val _result = kotlinFun()
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Array__")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Array__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Array<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_IntArray__")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_IntArray__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.IntArray
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_LongArray__")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_LongArray__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.LongArray
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterable__")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterable__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.collections.Iterable<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterator__")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterator__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int32___")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int32___(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.ranges.IntRange
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int64___")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int64___(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.ranges.LongRange
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_sequences_Sequence__")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_sequences_Sequence__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.sequences.Sequence<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(`receiver`);
+        suspend {
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_asFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asSharedFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_asSharedFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_asSharedFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_asStateFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_asStateFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_asStateFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_buffer__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__")
+public fun kotlinx_coroutines_flow_buffer__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(`receiver`: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __capacity = capacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { __receiver.kotlinx_coroutines_flow_buffer<kotlin.Any?>(__capacity, __onBufferOverflow) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_callbackFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_callbackFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.channels.ProducerScope<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.callbackFlow<kotlin.Any?>(__block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_cancellable__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_cancellable__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_cancellable<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Throwable ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_catch<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Throwable ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_catch<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_channelFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_channelFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.channels.ProducerScope<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.channelFlow<kotlin.Any?>(__block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_collect__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_Flow__")
+public fun kotlinx_coroutines_flow_collect__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_Flow__(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_collect()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_collectIndexed__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Int32_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_collectIndexed__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Int32_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Int, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: Int, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = arg0
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_collectIndexed<kotlin.Any?>(__action)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_collectLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_collectLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_collectLatest<kotlin.Any?>(__action)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, flow3: kotlin.native.internal.NativePtr, flow4: kotlin.native.internal.NativePtr, flow5: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow3 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow3) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow4 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow4) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow5 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow5) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any?, arg2: kotlin.Any?, arg3: kotlin.Any?, arg4: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _arg3 = if (arg3 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg3)
+                val _arg4 = if (arg4 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg4)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _arg4, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combine<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __flow3, __flow4, __flow5, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, flow3: kotlin.native.internal.NativePtr, flow4: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow3 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow3) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow4 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow4) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any?, arg2: kotlin.Any?, arg3: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _arg3 = if (arg3 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg3)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combine<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __flow3, __flow4, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, flow3: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow3 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow3) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any?, arg2: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combine<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __flow3, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combine<kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combine__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_combine__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, flow: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_combine<kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, flow3: kotlin.native.internal.NativePtr, flow4: kotlin.native.internal.NativePtr, flow5: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow3 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow3) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow4 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow4) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow5 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow5) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any?, arg2: kotlin.Any?, arg3: kotlin.Any?, arg4: kotlin.Any?, arg5: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _arg3 = if (arg3 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg3)
+                val _arg4 = if (arg4 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg4)
+                val _arg5 = if (arg5 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg5)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combineTransform<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __flow3, __flow4, __flow5, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, flow3: kotlin.native.internal.NativePtr, flow4: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow3 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow3) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow4 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow4) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any?, arg2: kotlin.Any?, arg3: kotlin.Any?, arg4: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _arg3 = if (arg3 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg3)
+                val _arg4 = if (arg4 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg4)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _arg4, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combineTransform<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __flow3, __flow4, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, flow3: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow3 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow3) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any?, arg2: kotlin.Any?, arg3: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _arg3 = if (arg3 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg3)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combineTransform<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __flow3, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow: kotlin.native.internal.NativePtr, flow2: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow2 = kotlin.native.internal.ref.dereferenceExternalRCRef(flow2) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any?, arg2: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.combineTransform<kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __flow2, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_combineTransform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_combineTransform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, flow: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any?, arg2: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_combineTransform<kotlin.Any?, kotlin.Any?, kotlin.Any?>(__flow, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_conflate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_conflate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_conflate<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_consumeAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__")
+public fun kotlinx_coroutines_flow_consumeAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_consumeAsFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_coroutineContext_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+public fun kotlinx_coroutines_flow_coroutineContext_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_coroutineContext }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Int)->Boolean>(continuation);
+        { arg0: Int ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_count<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Int)->Boolean>(continuation);
+        { arg0: Int ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_count<kotlin.Any?>(__predicate)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Int)->Boolean>(continuation);
+        { arg0: Int ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_count<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Int64__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Int64__(`receiver`: kotlin.native.internal.NativePtr, timeoutMillis: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __timeoutMillis = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Long>(timeoutMillis);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            _result
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_debounce<kotlin.Any?>(__timeoutMillis) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20ExportedKotlinPackages_kotlin_time_Duration__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20ExportedKotlinPackages_kotlin_time_Duration__(`receiver`: kotlin.native.internal.NativePtr, timeout: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __timeout = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(timeout);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.time.Duration
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_debounce<kotlin.Any?>(__timeout) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__(`receiver`: kotlin.native.internal.NativePtr, timeoutMillis: Long): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __timeoutMillis = timeoutMillis
+    val _result = run { __receiver.kotlinx_coroutines_flow_debounce<kotlin.Any?>(__timeoutMillis) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(`receiver`: kotlin.native.internal.NativePtr, timeout: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __timeout = kotlin.native.internal.ref.dereferenceExternalRCRef(timeout) as kotlin.time.Duration
+    val _result = run { __receiver.kotlinx_coroutines_flow_debounce<kotlin.Any?>(__timeout) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_distinctUntilChanged<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, areEquivalent: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __areEquivalent = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(areEquivalent);
+        { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+            val _result = kotlinFun(_arg0, _arg1)
+            _result
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_distinctUntilChanged<kotlin.Any?>(__areEquivalent) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_distinctUntilChangedBy__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_distinctUntilChangedBy__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, keySelector: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __keySelector = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(keySelector);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_distinctUntilChangedBy<kotlin.Any?, kotlin.Any?>(__keySelector) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_drop__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__")
+public fun kotlinx_coroutines_flow_drop__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__(`receiver`: kotlin.native.internal.NativePtr, count: Int): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __count = count
+    val _result = run { __receiver.kotlinx_coroutines_flow_drop<kotlin.Any?>(__count) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_dropWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_dropWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_dropWhile<kotlin.Any?>(__predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__")
+public fun kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(`receiver`: kotlin.native.internal.NativePtr, channel: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __channel = kotlin.native.internal.ref.dereferenceExternalRCRef(channel) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_emitAll<kotlin.Any?>(__channel)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, flow: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __flow = kotlin.native.internal.ref.dereferenceExternalRCRef(flow) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_emitAll<kotlin.Any?>(__flow)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_emptyFlow")
+public fun kotlinx_coroutines_flow_emptyFlow(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.coroutines.flow.emptyFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_filter__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_filter__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_filter<kotlin.Any?>(__predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_filterNot__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_filterNot__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_filterNot<kotlin.Any?>(__predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_filterNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_filterNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_filterNotNull<kotlin.Any>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_first<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_first<kotlin.Any?>(__predicate)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_firstOrNull<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_firstOrNull<kotlin.Any?>(__predicate)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flatMapConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_flatMapConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlinx.coroutines.flow.Flow<kotlin.Any?>, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_flatMapConcat<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flatMapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_flatMapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlinx.coroutines.flow.Flow<kotlin.Any?>, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_flatMapLatest<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flatMapMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_flatMapMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, concurrency: Int, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __concurrency = concurrency
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlinx.coroutines.flow.Flow<kotlin.Any?>, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_flatMapMerge<kotlin.Any?, kotlin.Any?>(__concurrency, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flattenConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_flattenConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlinx.coroutines.flow.Flow<kotlin.Any?>>
+    val _result = run { __receiver.kotlinx_coroutines_flow_flattenConcat<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flattenMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Swift_Int32__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_flattenMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Swift_Int32__(`receiver`: kotlin.native.internal.NativePtr, concurrency: Int): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlinx.coroutines.flow.Flow<kotlin.Any?>>
+    val __concurrency = concurrency
+    val _result = run { __receiver.kotlinx_coroutines_flow_flattenMerge<kotlin.Any?>(__concurrency) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_flow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.flow.flow<kotlin.Any?>(__block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { kotlinx.coroutines.flow.flowOf<kotlin.Any?>(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Array_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Vararg___")
+public fun kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Array_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Vararg___(elements: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __elements = interpretObjCPointer<kotlin.collections.List<kotlin.Any?>>(elements).toTypedArray()
+    val _result = run { kotlinx.coroutines.flow.flowOf<kotlin.Any?>(*__elements) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_flowOn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_flow_flowOn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_flow_flowOn<kotlin.Any?>(__context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_fold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_fold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, initial: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __initial = if (initial == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initial) as kotlin.Any
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(operation);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_fold<kotlin.Any?, kotlin.Any?>(__initial, __operation)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_getAndUpdate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_getAndUpdate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, function: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val __function = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(function);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_getAndUpdate<kotlin.Any?>(__function) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_capacity_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_capacity_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.capacity }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.collect(__collector)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector___direct", nonVirtualTargetMethod = "collect")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector___direct(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.collect(__collector)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_context_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_context_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.context }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.dropChannelOperators() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators_direct", nonVirtualTargetMethod = "dropChannelOperators")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.dropChannelOperators() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { __self.fuse(__context, __capacity, __onBufferOverflow) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow___direct", nonVirtualTargetMethod = "fuse")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow___direct(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { __self.fuse(__context, __capacity, __onBufferOverflow) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(__kt: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>(__context, __capacity, __onBufferOverflow)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_onBufferOverflow_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_onBufferOverflow_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.onBufferOverflow }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(self: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __self.produceImpl(__scope) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope___direct", nonVirtualTargetMethod = "produceImpl")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope___direct(self: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __self.produceImpl(__scope) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_toString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_ChannelFlow_toString_direct", nonVirtualTargetMethod = "toString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_ChannelFlow_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.ChannelFlow<kotlin.Any?>
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(self: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, capacity: Int, onBufferOverflow: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.FusibleFlow<kotlin.Any?>
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __capacity = capacity
+    val __onBufferOverflow = kotlin.native.internal.ref.dereferenceExternalRCRef(onBufferOverflow) as kotlinx.coroutines.channels.BufferOverflow
+    val _result = run { __self.fuse(__context, __capacity, __onBufferOverflow) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_SendingCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_SendingCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.flow.internal.SendingCollector<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.emit(__value)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_SendingCollector_init_allocate")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_SendingCollector_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.flow.internal.SendingCollector<kotlin.Any?>>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_internal_SendingCollector_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_internal_SendingCollector_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel__(__kt: kotlin.native.internal.NativePtr, channel: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __channel = kotlin.native.internal.ref.dereferenceExternalRCRef(channel) as kotlinx.coroutines.channels.SendChannel<kotlin.Any?>
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.flow.internal.SendingCollector<kotlin.Any?>(__channel)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__")
+public fun kotlinx_coroutines_flow_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(`receiver`: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_last__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_last__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_last<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_lastOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_lastOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_lastOrNull<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_launchIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__")
+public fun kotlinx_coroutines_flow_launchIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(`receiver`: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __receiver.kotlinx_coroutines_flow_launchIn<kotlin.Any?>(__scope) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_map__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_map__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_map<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_mapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_mapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_mapLatest<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_mapNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_mapNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_mapNotNull<kotlin.Any?, kotlin.Any>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_merge__TypesOfArguments__Swift_Array_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Vararg___")
+public fun kotlinx_coroutines_flow_merge__TypesOfArguments__Swift_Array_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Vararg___(flows: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __flows = interpretObjCPointer<kotlin.collections.List<kotlinx.coroutines.flow.Flow<kotlin.Any?>>>(flows).toTypedArray()
+    val _result = run { kotlinx.coroutines.flow.merge<kotlin.Any?>(*__flows) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_onCompletion__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_onCompletion__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Throwable? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_onCompletion<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_onEach__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_onEach__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_onEach<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_onEmpty__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_onEmpty__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_onEmpty<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_onStart__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_onStart__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_onStart<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_onSubscription__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_onSubscription__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(action);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*> ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_onSubscription<kotlin.Any?>(__action) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_produceIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__")
+public fun kotlinx_coroutines_flow_produceIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(`receiver`: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __receiver.kotlinx_coroutines_flow_produceIn<kotlin.Any?>(__scope) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_receiveAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__")
+public fun kotlinx_coroutines_flow_receiveAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.channels.ReceiveChannel<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_receiveAsFlow<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_reduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_reduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(operation);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_reduce<kotlin.Any?, kotlin.Any?>(__operation)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, retries: Long, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __retries = retries
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Throwable ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_retry<kotlin.Any?>(__retries, __predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, retries: Long, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __retries = retries
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Throwable ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_retry<kotlin.Any?>(__retries, __predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, Long, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Throwable, arg2: Long ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = arg2
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_retryWhen<kotlin.Any?>(__predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, Long, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Throwable, arg2: Long ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _arg2 = arg2
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _arg2, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_retryWhen<kotlin.Any?>(__predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_runningFold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_runningFold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, initial: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __initial = if (initial == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initial) as kotlin.Any
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(operation);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_runningFold<kotlin.Any?, kotlin.Any?>(__initial, __operation) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_runningReduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_runningReduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(operation);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_runningReduce<kotlin.Any?>(__operation) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__(`receiver`: kotlin.native.internal.NativePtr, periodMillis: Long): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __periodMillis = periodMillis
+    val _result = run { __receiver.kotlinx_coroutines_flow_sample<kotlin.Any?>(__periodMillis) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(`receiver`: kotlin.native.internal.NativePtr, period: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __period = kotlin.native.internal.ref.dereferenceExternalRCRef(period) as kotlin.time.Duration
+    val _result = run { __receiver.kotlinx_coroutines_flow_sample<kotlin.Any?>(__period) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_scan__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_scan__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, initial: kotlin.native.internal.NativePtr, operation: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __initial = if (initial == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initial) as kotlin.Any
+    val __operation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(operation);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_scan<kotlin.Any?, kotlin.Any?>(__initial, __operation) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_shareIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Int32__")
+public fun kotlinx_coroutines_flow_shareIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Int32__(`receiver`: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr, started: kotlin.native.internal.NativePtr, replay: Int): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val __started = kotlin.native.internal.ref.dereferenceExternalRCRef(started) as kotlinx.coroutines.flow.SharingStarted
+    val __replay = replay
+    val _result = run { __receiver.kotlinx_coroutines_flow_shareIn<kotlin.Any?>(__scope, __started, __replay) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_single__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_single__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_single<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_singleOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_singleOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_singleOrNull<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__")
+public fun kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(`receiver`: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlinx.coroutines.flow.StateFlow<kotlin.Any?> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_stateIn<kotlin.Any?>(__scope)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, scope: kotlin.native.internal.NativePtr, started: kotlin.native.internal.NativePtr, initialValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __scope = kotlin.native.internal.ref.dereferenceExternalRCRef(scope) as kotlinx.coroutines.CoroutineScope
+    val __started = kotlin.native.internal.ref.dereferenceExternalRCRef(started) as kotlinx.coroutines.flow.SharingStarted
+    val __initialValue = if (initialValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(initialValue) as kotlin.Any
+    val _result = run { __receiver.kotlinx_coroutines_flow_stateIn<kotlin.Any?>(__scope, __started, __initialValue) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_take__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__")
+public fun kotlinx_coroutines_flow_take__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__(`receiver`: kotlin.native.internal.NativePtr, count: Int): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __count = count
+    val _result = run { __receiver.kotlinx_coroutines_flow_take<kotlin.Any?>(__count) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_takeWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_takeWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, predicate: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __predicate = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(predicate);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_takeWhile<kotlin.Any?>(__predicate) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_timeout__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__")
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+public fun kotlinx_coroutines_flow_timeout__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(`receiver`: kotlin.native.internal.NativePtr, timeout: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __timeout = kotlin.native.internal.ref.dereferenceExternalRCRef(timeout) as kotlin.time.Duration
+    val _result = run { __receiver.kotlinx_coroutines_flow_timeout<kotlin.Any?>(__timeout) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toCollection__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableCollection__")
+public fun kotlinx_coroutines_flow_toCollection__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableCollection__(`receiver`: kotlin.native.internal.NativePtr, destination: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __destination = kotlin.native.internal.ref.dereferenceExternalRCRef(destination) as kotlin.collections.MutableCollection<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.MutableCollection<*> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toCollection<kotlin.Any?, kotlin.collections.MutableCollection<kotlin.Any?>>(__destination)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__")
+public fun kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__(`receiver`: kotlin.native.internal.NativePtr, destination: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __destination = kotlin.native.internal.ref.dereferenceExternalRCRef(destination) as kotlin.collections.MutableList<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.List<kotlin.Any?> ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toList<kotlin.Any?>(__destination)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.List<kotlin.Any?> ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toList<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__")
+public fun kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__(`receiver`: kotlin.native.internal.NativePtr, destination: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __destination = kotlin.native.internal.ref.dereferenceExternalRCRef(destination) as kotlin.collections.MutableList<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Nothing ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toList<kotlin.Any?>(__destination)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__")
+public fun kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__(`receiver`: kotlin.native.internal.NativePtr, destination: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __destination = kotlin.native.internal.ref.dereferenceExternalRCRef(destination) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.Set<kotlin.Any?> ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toSet<kotlin.Any?>(__destination)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.collections.Set<kotlin.Any?> ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toSet<kotlin.Any?>()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__")
+public fun kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__(`receiver`: kotlin.native.internal.NativePtr, destination: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.SharedFlow<kotlin.Any?>
+    val __destination = kotlin.native.internal.ref.dereferenceExternalRCRef(destination) as kotlin.collections.MutableSet<kotlin.Any?>
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Nothing ->
+            val _arg0 = arg0
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_flow_toSet<kotlin.Any?>(__destination)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_transform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_flow_transform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_transform<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_transformLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_flow_transformLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_transformLatest<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_transformWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__")
+public fun kotlinx_coroutines_flow_transformWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(`receiver`: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlinx.coroutines.flow.FlowCollector<*>, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<Boolean, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_transformWhile<kotlin.Any?, kotlin.Any?>(__transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_update__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_update__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, function: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val __function = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(function);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_update<kotlin.Any?>(__function) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_updateAndGet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_updateAndGet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, function: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.MutableStateFlow<kotlin.Any?>
+    val __function = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(function);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_updateAndGet<kotlin.Any?>(__function) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_withIndex__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____")
+public fun kotlinx_coroutines_flow_withIndex__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_flow_withIndex<kotlin.Any?>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_flow_zip__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_flow_zip__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr, transform: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlinx.coroutines.flow.Flow<kotlin.Any?>
+    val __transform = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(transform);
+        suspend { arg0: kotlin.Any?, arg1: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _arg1, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_flow_zip<kotlin.Any?, kotlin.Any?, kotlin.Any?>(__other, __transform) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_handleCoroutineException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_handleCoroutineException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__(context: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr): Boolean {
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __exception = kotlin.native.internal.ref.dereferenceExternalRCRef(exception) as kotlin.Throwable
+    val _result = run { kotlinx.coroutines.handleCoroutineException(__context, __exception) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_AtomicOp_atomicOp_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_AtomicOp_atomicOp_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+    val _result = run { __self.atomicOp }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_AtomicOp_atomicOp_get_direct", nonVirtualTargetMethod = "<get-atomicOp>")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_AtomicOp_atomicOp_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+    val _result = run { __self.atomicOp }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr, failure: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+    val __affected = if (affected == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(affected) as kotlin.Any
+    val __failure = if (failure == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(failure) as kotlin.Any
+    val _result = run { __self.complete(__affected, __failure) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_AtomicOp_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_AtomicOp_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_AtomicOp_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_AtomicOp_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+    val __affected = if (affected == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(affected) as kotlin.Any
+    val _result = run { __self.perform(__affected) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.AtomicOp<kotlin.Any?>
+    val __affected = if (affected == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(affected) as kotlin.Any
+    val _result = run { __self.prepare(__affected) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_init_allocate")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.internal.LockFreeLinkedListHead>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.internal.LockFreeLinkedListHead()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_isEmpty_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_isEmpty_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListHead
+    val _result = run { __self.isEmpty }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListHead
+    val _result = run { __self.isRemoved }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get_direct", nonVirtualTargetMethod = "<get-isRemoved>")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListHead
+    val _result = run { __self.isRemoved }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListHead_remove")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListHead_remove(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListHead
+    val _result = run { __self.remove() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_init_allocate")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.coroutines.internal.LockFreeLinkedListNode>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.internal.LockFreeLinkedListNode()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.isRemoved }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get_direct", nonVirtualTargetMethod = "<get-isRemoved>")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.isRemoved }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_next_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_next_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.next }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_remove")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_remove(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.remove() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_remove_direct", nonVirtualTargetMethod = "remove")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_remove_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.remove() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_toString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_LockFreeLinkedListNode_toString_direct", nonVirtualTargetMethod = "toString")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_LockFreeLinkedListNode_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.LockFreeLinkedListNode
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory___(self: kotlin.native.internal.NativePtr, allFactories: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.MainDispatcherFactory
+    val __allFactories = interpretObjCPointer<kotlin.collections.List<kotlinx.coroutines.internal.MainDispatcherFactory>>(allFactories)
+    val _result = run { __self.createDispatcher(__allFactories) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.MainDispatcherFactory
+    val _result = run { __self.hintOnError() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError_direct", nonVirtualTargetMethod = "hintOnError")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.MainDispatcherFactory
+    val _result = run { __self.hintOnError() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.MainDispatcherFactory
+    val _result = run { __self.loadPriority }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_OpDescriptor_atomicOp_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_OpDescriptor_atomicOp_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.OpDescriptor
+    val _result = run { __self.atomicOp }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_OpDescriptor_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlinx_coroutines_internal_OpDescriptor_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.coroutines.internal.OpDescriptor()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, affected: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.OpDescriptor
+    val __affected = if (affected == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(affected) as kotlin.Any
+    val _result = run { __self.perform(__affected) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_OpDescriptor_toString")
+public fun kotlinx_coroutines_internal_OpDescriptor_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.OpDescriptor
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_OpDescriptor_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlinx_coroutines_internal_OpDescriptor_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.OpDescriptor
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.ThreadSafeHeapNode
+    val _result = run { __self.index }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, newValue: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.internal.ThreadSafeHeapNode
+    val __newValue = newValue
+    val _result = run { __self.index = __newValue }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_resumeCancellableWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation_ExportedKotlinPackages_kotlin_Result_Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_resumeCancellableWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation_ExportedKotlinPackages_kotlin_Result_Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(`receiver`: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr, onCancellation: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val __result = kotlin.native.internal.ref.dereferenceExternalRCRef(result) as kotlin.Result<kotlin.Any?>
+    val __onCancellation = if (onCancellation == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(onCancellation);
+        { arg0: kotlin.Throwable ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_internal_resumeCancellableWith<kotlin.Any?>(__result, __onCancellation) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_synchronized__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_synchronized__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(lock: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __lock = kotlin.native.internal.ref.dereferenceExternalRCRef(lock) as kotlinx.atomicfu.locks.SynchronizedObject
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->kotlin.native.internal.NativePtr>(block);
+        {
+            val _result = kotlinFun()
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { kotlinx.coroutines.`internal`.synchronized<kotlin.Any?>(__lock, __block) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_internal_synchronizedImpl__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_internal_synchronizedImpl__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(lock: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __lock = kotlin.native.internal.ref.dereferenceExternalRCRef(lock) as kotlinx.atomicfu.locks.SynchronizedObject
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->kotlin.native.internal.NativePtr>(block);
+        {
+            val _result = kotlinFun()
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { kotlinx.coroutines.`internal`.synchronizedImpl<kotlin.Any?>(__lock, __block) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_intrinsics_startCoroutineCancellable__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_intrinsics_startCoroutineCancellable__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(`receiver`: kotlin.native.internal.NativePtr, completion: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(`receiver`);
+        suspend {
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __completion = kotlin.native.internal.ref.dereferenceExternalRCRef(completion) as kotlin.coroutines.Continuation<kotlin.Any?>
+    val _result = run { __receiver.kotlinx_coroutines_intrinsics_startCoroutineCancellable<kotlin.Any?>(__completion) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_invoke__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_invoke__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineDispatcher
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_invoke<kotlin.Any?>(__block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__")
+public fun kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(`receiver`: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val _result = run { __receiver.kotlinx_coroutines_isActive }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_job_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_job_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_job }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_joinAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__Vararg___")
+public fun kotlinx_coroutines_joinAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__Vararg___(jobs: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __jobs = interpretObjCPointer<kotlin.collections.List<kotlinx.coroutines.Job>>(jobs).toTypedArray()
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.joinAll(*__jobs)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_launch__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Void__")
+public fun kotlinx_coroutines_launch__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr, start: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __start = kotlin.native.internal.ref.dereferenceExternalRCRef(start) as kotlinx.coroutines.CoroutineStart
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_launch(__context, __start, __block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr, addedContext: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.coroutines.CoroutineContext
+    val __addedContext = kotlin.native.internal.ref.dereferenceExternalRCRef(addedContext) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_newCoroutineContext(__addedContext) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_newCoroutineContext(__context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_newFixedThreadPoolContext__TypesOfArguments__Swift_Int32_Swift_String__")
+public fun kotlinx_coroutines_newFixedThreadPoolContext__TypesOfArguments__Swift_Int32_Swift_String__(nThreads: Int, name: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __nThreads = nThreads
+    val __name = interpretObjCPointer<kotlin.String>(name)
+    val _result = run { kotlinx.coroutines.newFixedThreadPoolContext(__nThreads, __name) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_newSingleThreadContext__TypesOfArguments__Swift_String__")
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_newSingleThreadContext__TypesOfArguments__Swift_String__(name: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __name = interpretObjCPointer<kotlin.String>(name)
+    val _result = run { kotlinx.coroutines.newSingleThreadContext(__name) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_plus__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__")
+public fun kotlinx_coroutines_plus__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(`receiver`: kotlin.native.internal.NativePtr, context: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.CoroutineScope
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val _result = run { __receiver.kotlinx_coroutines_plus(__context) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_runBlocking__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_runBlocking__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { kotlinx.coroutines.runBlocking<kotlin.Any?>(__context, __block) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause0_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause0_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectClause0
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend {
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __self.run { __receiver.invoke(__block) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause1_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause1_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectClause1<kotlin.Any?>
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __self.run { __receiver.invoke<kotlin.Any?>(__block) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, `param`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?>
+    val __param = if (`param` == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(`param`) as kotlin.Any
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __self.run { __receiver.invoke<kotlin.Any?, kotlin.Any?>(__param, __block) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?>
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __self.run { __receiver.invoke<kotlin.Any?, kotlin.Any?>(__block) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "invoke")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, `receiver`: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectClause2<kotlin.Any?, kotlin.Any?>
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlin.Any? ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __self.run { __receiver.invoke<kotlin.Any?, kotlin.Any?>(__block) } }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectClause_clauseObject_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectClause_clauseObject_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectClause
+    val _result = run { __self.clauseObject }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectInstance_context_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectInstance_context_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>
+    val _result = run { __self.context }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__(self: kotlin.native.internal.NativePtr, disposableHandle: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>
+    val __disposableHandle = kotlin.native.internal.ref.dereferenceExternalRCRef(disposableHandle) as kotlinx.coroutines.DisposableHandle
+    val _result = run { __self.disposeOnCompletion(__disposableHandle) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, internalResult: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>
+    val __internalResult = if (internalResult == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(internalResult) as kotlin.Any
+    val _result = run { __self.selectInRegistrationPhase(__internalResult) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, clauseObject: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.selects.SelectInstance<kotlin.Any?>
+    val __clauseObject = kotlin.native.internal.ref.dereferenceExternalRCRef(clauseObject) as kotlin.Any
+    val __result = if (result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(result) as kotlin.Any
+    val _result = run { __self.trySelect(__clauseObject, __result) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_Swift_Int64_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_Swift_Int64_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, timeMillis: Long, block: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __timeMillis = timeMillis
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend {
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_selects_onTimeout<kotlin.Any?>(__timeMillis, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_ExportedKotlinPackages_kotlin_time_Duration_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+public fun kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_ExportedKotlinPackages_kotlin_time_Duration_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, timeout: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.selects.SelectBuilder<kotlin.Any?>
+    val __timeout = kotlin.native.internal.ref.dereferenceExternalRCRef(timeout) as kotlin.time.Duration
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend {
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val _result = run { __receiver.kotlinx_coroutines_selects_onTimeout<kotlin.Any?>(__timeout, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_select__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_selects_select__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__(builder: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __builder = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(builder);
+        { arg0: kotlinx.coroutines.selects.SelectBuilder<*> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.selects.select<kotlin.Any?>(__builder)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_selects_selectUnbiased__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_selects_selectUnbiased__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__(builder: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __builder = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(builder);
+        { arg0: kotlinx.coroutines.selects.SelectBuilder<*> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.selects.selectUnbiased<kotlin.Any?>(__builder)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_supervisorScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_supervisorScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.supervisorScope<kotlin.Any?>(__block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_suspendCancellableCoroutine__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuationU29202D_U20Swift_Void__")
+public fun kotlinx_coroutines_suspendCancellableCoroutine__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuationU29202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(block);
+        { arg0: kotlinx.coroutines.CancellableContinuation<*> ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.suspendCancellableCoroutine<kotlin.Any?>(__block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex__TypesOfArguments__Swift_Bool__")
+public fun kotlinx_coroutines_sync_Mutex__TypesOfArguments__Swift_Bool__(locked: Boolean): kotlin.native.internal.NativePtr {
+    val __locked = locked
+    val _result = run { kotlinx.coroutines.sync.Mutex(__locked) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+public fun kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Mutex
+    val __owner = kotlin.native.internal.ref.dereferenceExternalRCRef(owner) as kotlin.Any
+    val _result = run { __self.holdsLock(__owner) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex_isLocked_get")
+public fun kotlinx_coroutines_sync_Mutex_isLocked_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Mutex
+    val _result = run { __self.isLocked }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Mutex
+    val __owner = if (owner == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(owner) as kotlin.Any
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.lock(__owner)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex_onLock_get")
+@OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
+public fun kotlinx_coroutines_sync_Mutex_onLock_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Mutex
+    val _result = run { __self.onLock }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Mutex
+    val __owner = if (owner == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(owner) as kotlin.Any
+    val _result = run { __self.tryLock(__owner) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Mutex
+    val __owner = if (owner == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(owner) as kotlin.Any
+    val _result = run { __self.unlock(__owner) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Semaphore__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlinx_coroutines_sync_Semaphore__TypesOfArguments__Swift_Int32_Swift_Int32__(permits: Int, acquiredPermits: Int): kotlin.native.internal.NativePtr {
+    val __permits = permits
+    val __acquiredPermits = acquiredPermits
+    val _result = run { kotlinx.coroutines.sync.Semaphore(__permits, __acquiredPermits) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Semaphore_acquire")
+public fun kotlinx_coroutines_sync_Semaphore_acquire(self: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Semaphore
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.acquire()
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Semaphore_availablePermits_get")
+public fun kotlinx_coroutines_sync_Semaphore_availablePermits_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Semaphore
+    val _result = run { __self.availablePermits }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_Semaphore_tryAcquire")
+public fun kotlinx_coroutines_sync_Semaphore_tryAcquire(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.coroutines.sync.Semaphore
+    val _result = run { __self.tryAcquire() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_withLock__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Mutex_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_sync_withLock__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Mutex_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, owner: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.sync.Mutex
+    val __owner = if (owner == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(owner) as kotlin.Any
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->kotlin.native.internal.NativePtr>(action);
+        {
+            val _result = kotlinFun()
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_sync_withLock<kotlin.Any?>(__owner, __action)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_sync_withPermit__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Semaphore_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_sync_withPermit__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Semaphore_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.coroutines.sync.Semaphore
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->kotlin.native.internal.NativePtr>(action);
+        {
+            val _result = kotlinFun()
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __receiver.kotlinx_coroutines_sync_withPermit<kotlin.Any?>(__action)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_withContext__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_withContext__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(context: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __context = kotlin.native.internal.ref.dereferenceExternalRCRef(context) as kotlin.coroutines.CoroutineContext
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.withContext<kotlin.Any?>(__context, __block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_withTimeout__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_withTimeout__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeMillis: Long, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __timeMillis = timeMillis
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.withTimeout<kotlin.Any?>(__timeMillis, __block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_withTimeout__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_withTimeout__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeout: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __timeout = kotlin.native.internal.ref.dereferenceExternalRCRef(timeout) as kotlin.time.Duration
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.withTimeout<kotlin.Any?>(__timeout, __block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeMillis: Long, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __timeMillis = timeMillis
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.withTimeoutOrNull<kotlin.Any?>(__timeMillis, __block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeout: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr, continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __timeout = kotlin.native.internal.ref.dereferenceExternalRCRef(timeout) as kotlin.time.Duration
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
+        suspend { arg0: kotlinx.coroutines.CoroutineScope ->
+            suspendSwiftCoroutine { continuation: Function1<kotlin.Any?, Unit>, exception: Function1<kotlin.Throwable?, Unit>, cancellation: SwiftJob ->
+                val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+                val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+                val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+                val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+                val _result = kotlinFun(_arg0, _continuation, _exception, _cancellation)
+                run<Unit> { _result }
+            }
+        }
+    }
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(continuation);
+        { arg0: kotlin.Any? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.withTimeoutOrNull<kotlin.Any?>(__timeout, __block)
+    }
+}
+
+@ExportedBridge("kotlinx_coroutines_yield")
+public fun kotlinx_coroutines_yield(continuation: kotlin.native.internal.NativePtr, exception: kotlin.native.internal.NativePtr, cancellation: kotlin.native.internal.NativePtr): Unit {
+    val __continuation = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Boolean)->Boolean>(continuation);
+        { arg0: Unit ->
+            val _arg0 = run { arg0; true }
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __exception = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(exception);
+        { arg0: kotlin.Throwable? ->
+            val _arg0 = if (arg0 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        kotlinx.coroutines.yield()
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.swift
@@ -1,0 +1,9031 @@
+@_exported import ExportedKotlinPackages
+import KotlinRuntime
+import KotlinRuntimeSupport
+@_exported import KotlinCoroutineSupport
+import KotlinxAtomicFu
+@_implementationOnly import KotlinBridges_KotlinxCoroutinesCore
+@_spi(kotlin$ExperimentalStdlibApi) import KotlinStdlib
+
+public typealias intrinsics = ExportedKotlinPackages.kotlinx.coroutines.intrinsics
+public typealias channels = ExportedKotlinPackages.kotlinx.coroutines.channels
+public typealias flow = ExportedKotlinPackages.kotlinx.coroutines.flow
+public typealias selects = ExportedKotlinPackages.kotlinx.coroutines.selects
+public typealias `internal` = ExportedKotlinPackages.kotlinx.coroutines.`internal`
+public typealias sync = ExportedKotlinPackages.kotlinx.coroutines.sync
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.JobSupport")
+public typealias AbstractCoroutine = ExportedKotlinPackages.kotlinx.coroutines.AbstractCoroutine
+public typealias CancellableContinuation = ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+public typealias _CancellableContinuation = ExportedKotlinPackages.kotlinx.coroutines._CancellableContinuation
+public typealias __CancellableContinuation = ExportedKotlinPackages.kotlinx.coroutines.__CancellableContinuation
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias ChildHandle = ExportedKotlinPackages.kotlinx.coroutines.ChildHandle
+public typealias _ChildHandle = ExportedKotlinPackages.kotlinx.coroutines._ChildHandle
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias __ChildHandle = ExportedKotlinPackages.kotlinx.coroutines.__ChildHandle
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias ChildJob = ExportedKotlinPackages.kotlinx.coroutines.ChildJob
+public typealias _ChildJob = ExportedKotlinPackages.kotlinx.coroutines._ChildJob
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias __ChildJob = ExportedKotlinPackages.kotlinx.coroutines.__ChildJob
+public typealias CloseableCoroutineDispatcher = ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher
+public typealias CompletableDeferred = ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred
+public typealias _CompletableDeferred = ExportedKotlinPackages.kotlinx.coroutines._CompletableDeferred
+public typealias __CompletableDeferred = ExportedKotlinPackages.kotlinx.coroutines.__CompletableDeferred
+public typealias CompletableJob = ExportedKotlinPackages.kotlinx.coroutines.CompletableJob
+public typealias _CompletableJob = ExportedKotlinPackages.kotlinx.coroutines._CompletableJob
+public typealias __CompletableJob = ExportedKotlinPackages.kotlinx.coroutines.__CompletableJob
+@_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias CompletionHandlerException = ExportedKotlinPackages.kotlinx.coroutines.CompletionHandlerException
+public typealias CoroutineDispatcher = ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher
+public typealias CoroutineExceptionHandler = ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler
+public typealias _CoroutineExceptionHandler = ExportedKotlinPackages.kotlinx.coroutines._CoroutineExceptionHandler
+public typealias __CoroutineExceptionHandler = ExportedKotlinPackages.kotlinx.coroutines.__CoroutineExceptionHandler
+public typealias CoroutineName = ExportedKotlinPackages.kotlinx.coroutines.CoroutineName
+public typealias CoroutineScope = ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+public typealias _CoroutineScope = ExportedKotlinPackages.kotlinx.coroutines._CoroutineScope
+public typealias __CoroutineScope = ExportedKotlinPackages.kotlinx.coroutines.__CoroutineScope
+public typealias CoroutineStart = ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart
+public typealias Deferred = ExportedKotlinPackages.kotlinx.coroutines.Deferred
+public typealias _Deferred = ExportedKotlinPackages.kotlinx.coroutines._Deferred
+public typealias __Deferred = ExportedKotlinPackages.kotlinx.coroutines.__Deferred
+@_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias Delay = ExportedKotlinPackages.kotlinx.coroutines.Delay
+public typealias _Delay = ExportedKotlinPackages.kotlinx.coroutines._Delay
+@_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias __Delay = ExportedKotlinPackages.kotlinx.coroutines.__Delay
+public typealias Dispatchers = ExportedKotlinPackages.kotlinx.coroutines.Dispatchers
+public typealias DisposableHandle = ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+public typealias _DisposableHandle = ExportedKotlinPackages.kotlinx.coroutines._DisposableHandle
+public typealias __DisposableHandle = ExportedKotlinPackages.kotlinx.coroutines.__DisposableHandle
+@_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+public typealias GlobalScope = ExportedKotlinPackages.kotlinx.coroutines.GlobalScope
+public typealias Job = ExportedKotlinPackages.kotlinx.coroutines.Job
+public typealias _Job = ExportedKotlinPackages.kotlinx.coroutines._Job
+public typealias __Job = ExportedKotlinPackages.kotlinx.coroutines.__Job
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias JobSupport = ExportedKotlinPackages.kotlinx.coroutines.JobSupport
+public typealias MainCoroutineDispatcher = ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher
+public typealias NonCancellable = ExportedKotlinPackages.kotlinx.coroutines.NonCancellable
+@_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias NonDisposableHandle = ExportedKotlinPackages.kotlinx.coroutines.NonDisposableHandle
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias ParentJob = ExportedKotlinPackages.kotlinx.coroutines.ParentJob
+public typealias _ParentJob = ExportedKotlinPackages.kotlinx.coroutines._ParentJob
+@available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public typealias __ParentJob = ExportedKotlinPackages.kotlinx.coroutines.__ParentJob
+public typealias Runnable = ExportedKotlinPackages.kotlinx.coroutines.Runnable
+public typealias _Runnable = ExportedKotlinPackages.kotlinx.coroutines._Runnable
+public typealias __Runnable = ExportedKotlinPackages.kotlinx.coroutines.__Runnable
+@_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+public typealias TimeoutCancellationException = ExportedKotlinPackages.kotlinx.coroutines.TimeoutCancellationException
+public typealias CancellationException = ExportedKotlinPackages.kotlinx.coroutines.CancellationException
+public typealias CompletionHandler = ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+public final class _ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler_Key: KotlinRuntime.KotlinBase {
+    public static var shared: KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler_Key {
+        get {
+            return KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler_Key.__createClassWrapper(externalRCRef: kotlinx_coroutines_CoroutineExceptionHandler_Key_get())
+        }
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+    private init() {
+        fatalError()
+    }
+}
+public final class _ExportedKotlinPackages_kotlinx_coroutines_Job_Key: KotlinRuntime.KotlinBase {
+    public static var shared: KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_Job_Key {
+        get {
+            return KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_Job_Key.__createClassWrapper(externalRCRef: kotlinx_coroutines_Job_Key_get())
+        }
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+    private init() {
+        fatalError()
+    }
+}
+public final class _ExportedKotlinPackages_kotlinx_coroutines_channels_Channel_Factory: KotlinRuntime.KotlinBase {
+    public var BUFFERED: Swift.Int32 {
+        get {
+            return kotlinx_coroutines_channels_Channel_Factory_BUFFERED_get(self.__externalRCRef())
+        }
+    }
+    public var CONFLATED: Swift.Int32 {
+        get {
+            return kotlinx_coroutines_channels_Channel_Factory_CONFLATED_get(self.__externalRCRef())
+        }
+    }
+    public var DEFAULT_BUFFER_PROPERTY_NAME: Swift.String {
+        get {
+            return kotlinx_coroutines_channels_Channel_Factory_DEFAULT_BUFFER_PROPERTY_NAME_get(self.__externalRCRef())
+        }
+    }
+    public var RENDEZVOUS: Swift.Int32 {
+        get {
+            return kotlinx_coroutines_channels_Channel_Factory_RENDEZVOUS_get(self.__externalRCRef())
+        }
+    }
+    public var UNLIMITED: Swift.Int32 {
+        get {
+            return kotlinx_coroutines_channels_Channel_Factory_UNLIMITED_get(self.__externalRCRef())
+        }
+    }
+    public static var shared: KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_channels_Channel_Factory {
+        get {
+            return KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_channels_Channel_Factory.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_Channel_Factory_get())
+        }
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+    private init() {
+        fatalError()
+    }
+}
+public final class _ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion: KotlinRuntime.KotlinBase {
+    public var Eagerly: any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_SharingStarted_Companion_Eagerly_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted
+        }
+    }
+    public var Lazily: any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_SharingStarted_Companion_Lazily_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted
+        }
+    }
+    public static var shared: KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion {
+        get {
+            return KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion.__createClassWrapper(externalRCRef: kotlinx_coroutines_flow_SharingStarted_Companion_get())
+        }
+    }
+    public func WhileSubscribed(
+        stopTimeoutMillis: Swift.Int64,
+        replayExpirationMillis: Swift.Int64
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_SharingStarted_Companion_WhileSubscribed__TypesOfArguments__Swift_Int64_Swift_Int64__(self.__externalRCRef(), stopTimeoutMillis, replayExpirationMillis), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+    private init() {
+        fatalError()
+    }
+}
+public func cancellationException(
+    message: Swift.String?,
+    cause: ExportedKotlinPackages.kotlin.Throwable?
+) -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+    return ExportedKotlinPackages.kotlinx.coroutines.cancellationException(message: message, cause: cause)
+}
+public func completableDeferred(
+    value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred {
+    return ExportedKotlinPackages.kotlinx.coroutines.completableDeferred(value: value)
+}
+public func completableDeferred(
+    parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)?
+) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred {
+    return ExportedKotlinPackages.kotlinx.coroutines.completableDeferred(parent: parent)
+}
+public func coroutineExceptionHandler(
+    handler: @escaping (any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void
+) -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler {
+    return ExportedKotlinPackages.kotlinx.coroutines.coroutineExceptionHandler(handler: handler)
+}
+public func coroutineScope(
+    context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+) -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    return ExportedKotlinPackages.kotlinx.coroutines.coroutineScope(context: context)
+}
+public func job(
+    parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)?
+) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob {
+    return ExportedKotlinPackages.kotlinx.coroutines.job(parent: parent)
+}
+public func MainScope() -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    return ExportedKotlinPackages.kotlinx.coroutines.MainScope()
+}
+public func runnable(
+    block: @escaping () -> Swift.Void
+) -> any ExportedKotlinPackages.kotlinx.coroutines.Runnable {
+    return ExportedKotlinPackages.kotlinx.coroutines.runnable(block: block)
+}
+public func supervisorJob(
+    parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)?
+) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob {
+    return ExportedKotlinPackages.kotlinx.coroutines.supervisorJob(parent: parent)
+}
+public func awaitAll(
+    deferreds: any ExportedKotlinPackages.kotlinx.coroutines.Deferred...
+) async throws -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = kotlinx_coroutines_awaitAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Deferred__Vararg___(deferreds, {
+            let originalBlock: (Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = continuation
+            return { (arg0: Any) in
+                let _arg0: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = arg0 as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }(), {
+            let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }(), cancellation.__externalRCRef())
+    }
+}
+public func awaitCancellation() async throws -> Swift.Never {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.awaitCancellation()
+}
+public func coroutineScope(
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.coroutineScope(block: block)
+}
+public func currentCoroutineContext() async throws -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.currentCoroutineContext()
+}
+public func delay(
+    timeMillis: Swift.Int64
+) async throws -> Swift.Void {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.delay(timeMillis: timeMillis)
+}
+public func delay(
+    duration: ExportedKotlinPackages.kotlin.time.Duration
+) async throws -> Swift.Void {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.delay(duration: duration)
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi)
+public func handleCoroutineException(
+    context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+    exception: ExportedKotlinPackages.kotlin.Throwable
+) -> Swift.Void {
+    return ExportedKotlinPackages.kotlinx.coroutines.handleCoroutineException(context: context, exception: exception)
+}
+public func joinAll(
+    jobs: any ExportedKotlinPackages.kotlinx.coroutines.Job...
+) async throws -> Swift.Void {
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = kotlinx_coroutines_joinAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__Vararg___(jobs, {
+            let originalBlock: (Swift.Void) -> Swift.Void = continuation
+            return { (arg0: Swift.Bool) in
+                let _arg0: Swift.Void = { arg0; return () }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }(), {
+            let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }(), cancellation.__externalRCRef())
+    }
+}
+public func newFixedThreadPoolContext(
+    nThreads: Swift.Int32,
+    name: Swift.String
+) -> ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher {
+    return ExportedKotlinPackages.kotlinx.coroutines.newFixedThreadPoolContext(nThreads: nThreads, name: name)
+}
+@_spi(kotlinx$coroutines$DelicateCoroutinesApi) @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+public func newSingleThreadContext(
+    name: Swift.String
+) -> ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher {
+    return ExportedKotlinPackages.kotlinx.coroutines.newSingleThreadContext(name: name)
+}
+public func runBlocking(
+    context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return ExportedKotlinPackages.kotlinx.coroutines.runBlocking(context: context, block: block)
+}
+public func supervisorScope(
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.supervisorScope(block: block)
+}
+public func suspendCancellableCoroutine(
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation) -> Swift.Void
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.suspendCancellableCoroutine(block: block)
+}
+public func withContext(
+    context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.withContext(context: context, block: block)
+}
+public func withTimeout(
+    timeMillis: Swift.Int64,
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.withTimeout(timeMillis: timeMillis, block: block)
+}
+public func withTimeout(
+    timeout: ExportedKotlinPackages.kotlin.time.Duration,
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.withTimeout(timeout: timeout, block: block)
+}
+public func withTimeoutOrNull(
+    timeMillis: Swift.Int64,
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.withTimeoutOrNull(timeMillis: timeMillis, block: block)
+}
+public func withTimeoutOrNull(
+    timeout: ExportedKotlinPackages.kotlin.time.Duration,
+    block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.withTimeoutOrNull(timeout: timeout, block: block)
+}
+public func yield() async throws -> Swift.Void {
+    return try await ExportedKotlinPackages.kotlinx.coroutines.yield()
+}
+public func disposableHandle(
+    function: @escaping () -> Swift.Void
+) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+    return ExportedKotlinPackages.kotlinx.coroutines.disposableHandle(function: function)
+}
+extension ExportedKotlinPackages.kotlinx.coroutines {
+    public enum CoroutineStart: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {
+        case DEFAULT
+        case LAZY
+        case ATOMIC
+        case UNDISPATCHED
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public var isLazy: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_CoroutineStart_isLazy_get(self.__externalRCRef())
+            }
+        }
+        public var description: Swift.String {
+            get {
+                switch self {
+                case .DEFAULT: "DEFAULT"
+                case .LAZY: "LAZY"
+                case .ATOMIC: "ATOMIC"
+                case .UNDISPATCHED: "UNDISPATCHED"
+                default: fatalError()
+                }
+            }
+        }
+        public var rawValue: Swift.Int32 {
+            get {
+                switch self {
+                case .DEFAULT: 0
+                case .LAZY: 1
+                case .ATOMIC: 2
+                case .UNDISPATCHED: 3
+                default: fatalError()
+                }
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func callAsFunction(
+            block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            receiver: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            completion: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_CoroutineStart_invoke__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), receiver.map { it in it.__externalRCRef() } ?? nil, completion.__externalRCRef()); return () }()
+        }
+        public init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer!,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            switch kotlinx_coroutines_CoroutineStart_ordinal(__externalRCRefUnsafe) {
+            case 0: self = .DEFAULT
+            case 1: self = .LAZY
+            case 2: self = .ATOMIC
+            case 3: self = .UNDISPATCHED
+            default: fatalError()
+            }
+        }
+        public func __externalRCRef() -> Swift.UnsafeMutableRawPointer! {
+            return switch self {
+            case .DEFAULT: kotlinx_coroutines_CoroutineStart_DEFAULT()
+            case .LAZY: kotlinx_coroutines_CoroutineStart_LAZY()
+            case .ATOMIC: kotlinx_coroutines_CoroutineStart_ATOMIC()
+            case .UNDISPATCHED: kotlinx_coroutines_CoroutineStart_UNDISPATCHED()
+            default: fatalError()
+            }
+        }
+        public init?(
+            _ description: Swift.String
+        ) {
+            switch description {
+            case "DEFAULT": self = .DEFAULT
+            case "LAZY": self = .LAZY
+            case "ATOMIC": self = .ATOMIC
+            case "UNDISPATCHED": self = .UNDISPATCHED
+            default: return nil
+            }
+        }
+        public init?(
+            rawValue: Swift.Int32
+        ) {
+            guard 0..<4 ~= rawValue else { return nil }
+            self = CoroutineStart.allCases[Int(rawValue)]
+        }
+    }
+    public typealias CancellationException = ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException
+    public typealias CompletionHandler = (ExportedKotlinPackages.kotlin.Throwable?) -> Swift.Void
+    public protocol CancellableContinuation: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.coroutines.Continuation, ExportedKotlinPackages.kotlinx.coroutines._CancellableContinuation {
+        var isActive: Swift.Bool {
+            get
+        }
+        var isCancelled: Swift.Bool {
+            get
+        }
+        var isCompleted: Swift.Bool {
+            get
+        }
+        func cancel(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) -> Swift.Bool
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func completeResume(
+            token: any KotlinRuntimeSupport._KotlinBridgeable
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func initCancellability() -> Swift.Void
+        func invokeOnCancellation(
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        func resume(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func tryResume(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            idempotent: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func tryResume(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            idempotent: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func tryResumeWithException(
+            exception: ExportedKotlinPackages.kotlin.Throwable
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        func resumeUndispatched(
+            _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        func resumeUndispatchedWithException(
+            _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+            exception: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuation)
+    public protocol _CancellableContinuation: ExportedKotlinPackages.kotlin.coroutines._Continuation {
+    }
+    public protocol __CancellableContinuation: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlin.coroutines.__Continuation {
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol ChildHandle: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func childCancelled(
+            cause: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_ChildHandle)
+    public protocol _ChildHandle: ExportedKotlinPackages.kotlinx.coroutines._DisposableHandle {
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __ChildHandle: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__DisposableHandle {
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol ChildJob: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.Job {
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_ChildJob)
+    public protocol _ChildJob: ExportedKotlinPackages.kotlinx.coroutines._Job {
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __ChildJob: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__Job {
+    }
+    public protocol CompletableDeferred: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.Deferred, ExportedKotlinPackages.kotlinx.coroutines._CompletableDeferred {
+        func complete(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func completeExceptionally(
+            exception: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_CompletableDeferred)
+    public protocol _CompletableDeferred: ExportedKotlinPackages.kotlinx.coroutines._Deferred {
+    }
+    public protocol __CompletableDeferred: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__Deferred {
+    }
+    public protocol CompletableJob: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.Job, ExportedKotlinPackages.kotlinx.coroutines._CompletableJob {
+        func complete() -> Swift.Bool
+        func completeExceptionally(
+            exception: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_CompletableJob)
+    public protocol _CompletableJob: ExportedKotlinPackages.kotlinx.coroutines._Job {
+    }
+    public protocol __CompletableJob: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__Job {
+    }
+    public protocol CoroutineExceptionHandler: KotlinRuntime.KotlinBase, KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element, ExportedKotlinPackages.kotlinx.coroutines._CoroutineExceptionHandler {
+        func handleException(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            exception: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler)
+    public protocol _CoroutineExceptionHandler: KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    }
+    public protocol __CoroutineExceptionHandler: KotlinRuntimeSupport._KotlinBridgeable, KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    }
+    public protocol CoroutineScope: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines._CoroutineScope {
+        var coroutineContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            get
+        }
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope)
+    public protocol _CoroutineScope {
+    }
+    public protocol __CoroutineScope: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol Deferred: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.Job, ExportedKotlinPackages.kotlinx.coroutines._Deferred {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var onAwait: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        func `await`() async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        func getCompleted() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        func getCompletionExceptionOrNull() -> ExportedKotlinPackages.kotlin.Throwable?
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_Deferred)
+    public protocol _Deferred: ExportedKotlinPackages.kotlinx.coroutines._Job {
+    }
+    public protocol __Deferred: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__Job {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol Delay: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines._Delay {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func invokeOnTimeout(
+            timeMillis: Swift.Int64,
+            block: any ExportedKotlinPackages.kotlinx.coroutines.Runnable,
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_Delay)
+    public protocol _Delay {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __Delay: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol DisposableHandle: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines._DisposableHandle {
+        func dispose() -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle)
+    public protocol _DisposableHandle {
+    }
+    public protocol __DisposableHandle: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol Job: KotlinRuntime.KotlinBase, KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element, ExportedKotlinPackages.kotlinx.coroutines._Job {
+        var children: any ExportedKotlinPackages.kotlin.sequences.Sequence {
+            get
+        }
+        var isActive: Swift.Bool {
+            get
+        }
+        var isCancelled: Swift.Bool {
+            get
+        }
+        var isCompleted: Swift.Bool {
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var onJoin: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+            @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+            get
+        }
+        func cancel(
+            cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func getCancellationException() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func invokeOnCompletion(
+            onCancelling: Swift.Bool,
+            invokeImmediately: Swift.Bool,
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        func invokeOnCompletion(
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        func join() async throws -> Swift.Void
+        func start() -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_Job)
+    public protocol _Job: KotlinStdlib.__ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    }
+    public protocol __Job: KotlinRuntimeSupport._KotlinBridgeable, KotlinStdlib.___ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Element {
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol ParentJob: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.Job {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func getChildJobCancellationCause() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_ParentJob)
+    public protocol _ParentJob: ExportedKotlinPackages.kotlinx.coroutines._Job {
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __ParentJob: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__Job {
+    }
+    public protocol Runnable: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines._Runnable {
+        func run() -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_Runnable)
+    public protocol _Runnable {
+    }
+    public protocol __Runnable: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.JobSupport")
+    open class AbstractCoroutine: ExportedKotlinPackages.kotlinx.coroutines.JobSupport, ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope, ExportedKotlinPackages.kotlinx.coroutines.__CoroutineScope {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_AbstractCoroutine_context_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open var coroutineContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_AbstractCoroutine_coroutineContext_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open override var isActive: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_AbstractCoroutine_isActive_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func resumeWith(
+            result: ExportedKotlinPackages.kotlin.Result
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_AbstractCoroutine_resumeWith__TypesOfArguments__ExportedKotlinPackages_kotlin_Result__(self.__externalRCRef(), result.__externalRCRef()); return () }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func start(
+            start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+            receiver: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_AbstractCoroutine_start__TypesOfArguments__ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), start.__externalRCRef(), receiver.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }()); return () }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public init(
+            parentContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            initParentJob: Swift.Bool,
+            active: Swift.Bool
+        ) {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.AbstractCoroutine.self, "ExportedKotlinPackages.kotlinx.coroutines.AbstractCoroutine is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_AbstractCoroutine_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Bool_Swift_Bool__(__kt, parentContext.__externalRCRef(), initParentJob, active); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class CloseableCoroutineDispatcher: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+        open func close() -> Swift.Void {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher.self {
+                return { kotlinx_coroutines_CloseableCoroutineDispatcher_close(self.__externalRCRef()); return () }()
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher.close': a Swift subclass must override it and must not call super.")
+            }
+        }
+        public override init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher.self, "ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_CloseableCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public final class CompletionHandlerException: ExportedKotlinPackages.kotlin.RuntimeException {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public init(
+            message: Swift.String,
+            cause: ExportedKotlinPackages.kotlin.Throwable
+        ) {
+            let __kt = kotlinx_coroutines_CompletionHandlerException_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_CompletionHandlerException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String_ExportedKotlinPackages_kotlin_Throwable__(__kt, message, cause.__externalRCRef()); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class CoroutineDispatcher: ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement, ExportedKotlinPackages.kotlin.coroutines.ContinuationInterceptor, ExportedKotlinPackages.kotlin.coroutines.__ContinuationInterceptor {
+        @_spi(kotlin$ExperimentalStdlibApi)
+        public final class Key: ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextKey {
+            @_spi(kotlin$ExperimentalStdlibApi)
+            public static var shared: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.Key {
+                @_spi(kotlin$ExperimentalStdlibApi)
+                get {
+                    return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.Key.__createClassWrapper(externalRCRef: kotlinx_coroutines_CoroutineDispatcher_Key_get())
+                }
+            }
+            package override init(
+                __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+                options: KotlinRuntime.KotlinBaseConstructionOptions
+            ) {
+                super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+            }
+            private init() {
+                fatalError()
+            }
+        }
+        open func dispatch(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            block: any ExportedKotlinPackages.kotlinx.coroutines.Runnable
+        ) -> Swift.Void {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.self {
+                return { kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__(self.__externalRCRef(), context.__externalRCRef(), block.__externalRCRef()); return () }()
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.dispatch': a Swift subclass must override it and must not call super.")
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func dispatchYield(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            block: any ExportedKotlinPackages.kotlinx.coroutines.Runnable
+        ) -> Swift.Void {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.self {
+                return { kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable__(self.__externalRCRef(), context.__externalRCRef(), block.__externalRCRef()); return () }()
+            } else {
+                return { kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable___direct(self.__externalRCRef(), context.__externalRCRef(), block.__externalRCRef()); return () }()
+            }
+        }
+        public final func interceptContinuation(
+            continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        ) -> any ExportedKotlinPackages.kotlin.coroutines.Continuation {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_CoroutineDispatcher_interceptContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self.__externalRCRef(), continuation.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.Continuation.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        }
+        open func isDispatchNeeded(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        ) -> Swift.Bool {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.self {
+                return kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(self.__externalRCRef(), context.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(self.__externalRCRef(), context.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        open func limitedParallelism(
+            parallelism: Swift.Int32
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.self {
+                return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), parallelism))
+            } else {
+                return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct(self.__externalRCRef(), parallelism))
+            }
+        }
+        @available(*, unavailable, message: "Operator '+' on two CoroutineDispatcher objects is meaningless. CoroutineDispatcher is a coroutine context element and `+` is a set-sum operator for coroutine contexts. The dispatcher to the right of `+` just replaces the dispatcher to the left.")
+        public final func _plus(
+            other: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+            fatalError()
+        }
+        @available(*, unavailable, message: "Operator '+' on two CoroutineDispatcher objects is meaningless. CoroutineDispatcher is a coroutine context element and `+` is a set-sum operator for coroutine contexts. The dispatcher to the right of `+` just replaces the dispatcher to the left.")
+        public static func +(
+            this: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+            other: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+            fatalError()
+        }
+        public final func releaseInterceptedContinuation(
+            continuation: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_CoroutineDispatcher_releaseInterceptedContinuation__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__(self.__externalRCRef(), continuation.__externalRCRef()); return () }()
+        }
+        open func toString() -> Swift.String {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.self {
+                return kotlinx_coroutines_CoroutineDispatcher_toString(self.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_CoroutineDispatcher_toString_direct(self.__externalRCRef())
+            }
+        }
+        public init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.self, "ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_CoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    public final class CoroutineName: ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement {
+        public final class Key: KotlinRuntime.KotlinBase {
+            public static var shared: ExportedKotlinPackages.kotlinx.coroutines.CoroutineName.Key {
+                get {
+                    return ExportedKotlinPackages.kotlinx.coroutines.CoroutineName.Key.__createClassWrapper(externalRCRef: kotlinx_coroutines_CoroutineName_Key_get())
+                }
+            }
+            package override init(
+                __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+                options: KotlinRuntime.KotlinBaseConstructionOptions
+            ) {
+                super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+            }
+            private init() {
+                fatalError()
+            }
+        }
+        public var name: Swift.String {
+            get {
+                return kotlinx_coroutines_CoroutineName_name_get(self.__externalRCRef())
+            }
+        }
+        public func copy(
+            name: Swift.String
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.CoroutineName {
+            return ExportedKotlinPackages.kotlinx.coroutines.CoroutineName.__createClassWrapper(externalRCRef: kotlinx_coroutines_CoroutineName_copy__TypesOfArguments__Swift_String__(self.__externalRCRef(), name))
+        }
+        public func equals(
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            return kotlinx_coroutines_CoroutineName_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), other.map { it in it.__externalRCRef() } ?? nil)
+        }
+        public static func ==(
+            this: ExportedKotlinPackages.kotlinx.coroutines.CoroutineName,
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            this.equals(other: other)
+        }
+        public func hashCode() -> Swift.Int32 {
+            return kotlinx_coroutines_CoroutineName_hashCode(self.__externalRCRef())
+        }
+        public func toString() -> Swift.String {
+            return kotlinx_coroutines_CoroutineName_toString(self.__externalRCRef())
+        }
+        public init(
+            name: Swift.String
+        ) {
+            let __kt = kotlinx_coroutines_CoroutineName_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_CoroutineName_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String__(__kt, name); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    public final class Dispatchers: KotlinRuntime.KotlinBase {
+        public var Default: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_Dispatchers_Default_get(self.__externalRCRef()))
+            }
+        }
+        public var Main: ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher {
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_Dispatchers_Main_get(self.__externalRCRef()))
+            }
+        }
+        public var Unconfined: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_Dispatchers_Unconfined_get(self.__externalRCRef()))
+            }
+        }
+        public static var shared: ExportedKotlinPackages.kotlinx.coroutines.Dispatchers {
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.Dispatchers.__createClassWrapper(externalRCRef: kotlinx_coroutines_Dispatchers_get())
+            }
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        private init() {
+            fatalError()
+        }
+    }
+    @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+    public final class GlobalScope: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope, ExportedKotlinPackages.kotlinx.coroutines.__CoroutineScope {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        public var coroutineContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_GlobalScope_coroutineContext_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+            }
+        }
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        public static var shared: ExportedKotlinPackages.kotlinx.coroutines.GlobalScope {
+            @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.GlobalScope.__createClassWrapper(externalRCRef: kotlinx_coroutines_GlobalScope_get())
+            }
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        private init() {
+            fatalError()
+        }
+    }
+    @available(*, unavailable, message: "This is internal API and may be removed in the future releases") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    open class JobSupport: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.Job, ExportedKotlinPackages.kotlinx.coroutines.__Job, ExportedKotlinPackages.kotlinx.coroutines.ChildJob, ExportedKotlinPackages.kotlinx.coroutines.__ChildJob, ExportedKotlinPackages.kotlinx.coroutines.ParentJob, ExportedKotlinPackages.kotlinx.coroutines.__ParentJob {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var children: any ExportedKotlinPackages.kotlin.sequences.Sequence {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_JobSupport_children_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.sequences.Sequence.Type.self) as! any ExportedKotlinPackages.kotlin.sequences.Sequence
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open var isActive: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_JobSupport_isActive_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var isCancelled: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_JobSupport_isCancelled_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var isCompleted: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_JobSupport_isCompleted_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var isCompletedExceptionally: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_JobSupport_isCompletedExceptionally_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var key: any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_JobSupport_key_get(self.__externalRCRef()), conformsTo: KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key.Type.self) as! any KotlinStdlib._ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Key
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var onJoin: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_JobSupport_onJoin_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0
+            }
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi) @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+            @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi) @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return { switch kotlinx_coroutines_JobSupport_parent_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job; } }()
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildJob, ExportedKotlinPackages.kotlinx.coroutines.ChildHandle")
+        public final func attachChild(
+            child: any ExportedKotlinPackages.kotlinx.coroutines.ChildJob
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.ChildHandle {
+            fatalError()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func cancel(
+            cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_JobSupport_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func cancelCoroutine(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) -> Swift.Bool {
+            return kotlinx_coroutines_JobSupport_cancelCoroutine__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil)
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func cancelInternal(
+            cause: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_JobSupport_cancelInternal__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), cause.__externalRCRef()); return () }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func childCancelled(
+            cause: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Bool {
+            return kotlinx_coroutines_JobSupport_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), cause.__externalRCRef())
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func getCancellationException() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+            return ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: kotlinx_coroutines_JobSupport_getCancellationException(self.__externalRCRef()))
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func getChildJobCancellationCause() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+            return ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: kotlinx_coroutines_JobSupport_getChildJobCancellationCause(self.__externalRCRef()))
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func getCompletionExceptionOrNull() -> ExportedKotlinPackages.kotlin.Throwable? {
+            return { switch kotlinx_coroutines_JobSupport_getCompletionExceptionOrNull(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func invokeOnCompletion(
+            onCancelling: Swift.Bool,
+            invokeImmediately: Swift.Bool,
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), onCancelling, invokeImmediately, {
+                let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func invokeOnCompletion(
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_JobSupport_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func join() async throws -> Swift.Void {
+            try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_JobSupport_join(self.__externalRCRef(), {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ParentJob")
+        public final func parentCancelled(
+            parentJob: any ExportedKotlinPackages.kotlinx.coroutines.ParentJob
+        ) -> Swift.Void {
+            fatalError()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func start() -> Swift.Bool {
+            return kotlinx_coroutines_JobSupport_start(self.__externalRCRef())
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func toDebugString() -> Swift.String {
+            return kotlinx_coroutines_JobSupport_toDebugString(self.__externalRCRef())
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func toString() -> Swift.String {
+            return kotlinx_coroutines_JobSupport_toString(self.__externalRCRef())
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public init(
+            active: Swift.Bool
+        ) {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlinx.coroutines.JobSupport.self {
+                 __kt = kotlinx_coroutines_JobSupport_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_JobSupport_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(__kt, active); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class MainCoroutineDispatcher: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+        open var immediate: ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher {
+            get {
+                if Self.self == ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.self {
+                    return ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_MainCoroutineDispatcher_immediate_get(self.__externalRCRef()))
+                } else {
+                    fatalError("Cannot invoke the inherited implementation of abstract property 'ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.immediate': a Swift subclass must override it and must not call super.")
+                }
+            }
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        open override func limitedParallelism(
+            parallelism: Swift.Int32
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.self {
+                return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), parallelism))
+            } else {
+                return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32___direct(self.__externalRCRef(), parallelism))
+            }
+        }
+        open override func toString() -> Swift.String {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.self {
+                return kotlinx_coroutines_MainCoroutineDispatcher_toString(self.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_MainCoroutineDispatcher_toString_direct(self.__externalRCRef())
+            }
+        }
+        public override init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.self, "ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_MainCoroutineDispatcher_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    public final class NonCancellable: ExportedKotlinPackages.kotlin.coroutines.AbstractCoroutineContextElement, ExportedKotlinPackages.kotlinx.coroutines.Job, ExportedKotlinPackages.kotlinx.coroutines.__Job {
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public var children: any ExportedKotlinPackages.kotlin.sequences.Sequence {
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_NonCancellable_children_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.sequences.Sequence.Type.self) as! any ExportedKotlinPackages.kotlin.sequences.Sequence
+            }
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public var isActive: Swift.Bool {
+            get {
+                return kotlinx_coroutines_NonCancellable_isActive_get(self.__externalRCRef())
+            }
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public var isCancelled: Swift.Bool {
+            get {
+                return kotlinx_coroutines_NonCancellable_isCancelled_get(self.__externalRCRef())
+            }
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public var isCompleted: Swift.Bool {
+            get {
+                return kotlinx_coroutines_NonCancellable_isCompleted_get(self.__externalRCRef())
+            }
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public var onJoin: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_NonCancellable_onJoin_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0
+            }
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited") @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        public var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+            @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+            get {
+                return { switch kotlinx_coroutines_NonCancellable_parent_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job; } }()
+            }
+        }
+        public static var shared: ExportedKotlinPackages.kotlinx.coroutines.NonCancellable {
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.NonCancellable.__createClassWrapper(externalRCRef: kotlinx_coroutines_NonCancellable_get())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildJob, ExportedKotlinPackages.kotlinx.coroutines.ChildHandle")
+        public func attachChild(
+            child: any ExportedKotlinPackages.kotlinx.coroutines.ChildJob
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.ChildHandle {
+            fatalError()
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public func cancel(
+            cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_NonCancellable_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func getCancellationException() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+            return ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: kotlinx_coroutines_NonCancellable_getCancellationException(self.__externalRCRef()))
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func invokeOnCompletion(
+            onCancelling: Swift.Bool,
+            invokeImmediately: Swift.Bool,
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), onCancelling, invokeImmediately, {
+                let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public func invokeOnCompletion(
+            handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_NonCancellable_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public func join() async throws -> Swift.Void {
+            try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_NonCancellable_join(self.__externalRCRef(), {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+        }
+        @available(*, deprecated, message: "NonCancellable can be used only as an argument for 'withContext', direct usages of its API are prohibited")
+        public func start() -> Swift.Bool {
+            return kotlinx_coroutines_NonCancellable_start(self.__externalRCRef())
+        }
+        public func toString() -> Swift.String {
+            return kotlinx_coroutines_NonCancellable_toString(self.__externalRCRef())
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        private init() {
+            fatalError()
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public final class NonDisposableHandle: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle, ExportedKotlinPackages.kotlinx.coroutines.__DisposableHandle {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return { switch kotlinx_coroutines_NonDisposableHandle_parent_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job; } }()
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public static var shared: ExportedKotlinPackages.kotlinx.coroutines.NonDisposableHandle {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.NonDisposableHandle.__createClassWrapper(externalRCRef: kotlinx_coroutines_NonDisposableHandle_get())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func childCancelled(
+            cause: ExportedKotlinPackages.kotlin.Throwable
+        ) -> Swift.Bool {
+            return kotlinx_coroutines_NonDisposableHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), cause.__externalRCRef())
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func dispose() -> Swift.Void {
+            return { kotlinx_coroutines_NonDisposableHandle_dispose(self.__externalRCRef()); return () }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func toString() -> Swift.String {
+            return kotlinx_coroutines_NonDisposableHandle_toString(self.__externalRCRef())
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+        private init() {
+            fatalError()
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public final class TimeoutCancellationException: ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException {
+    }
+    public static func getIO(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.Dispatchers
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+        return ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_IO_get__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_Dispatchers__(receiver.__externalRCRef()))
+    }
+    public static func getIsActive(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.__externalRCRef())
+    }
+    public static func getIsActive(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(receiver.__externalRCRef())
+    }
+    public static func getJob(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Job {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_job_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    }
+    public static func cancellationException(
+        message: Swift.String?,
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+        return ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: kotlinx_coroutines_CancellationException__TypesOfArguments__Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(message ?? nil, cause.map { it in it.__externalRCRef() } ?? nil))
+    }
+    public static func completableDeferred(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(value.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred
+    }
+    public static func completableDeferred(
+        parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_CompletableDeferred__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(parent.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred
+    }
+    public static func coroutineExceptionHandler(
+        handler: @escaping (any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_CoroutineExceptionHandler__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U20ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void__({
+            let originalBlock: (any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void = handler
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+                let _arg1: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg1)
+                let _result = originalBlock(_arg0, _arg1)
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler
+    }
+    public static func coroutineScope(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_CoroutineScope__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    }
+    public static func job(
+        parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Job__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(parent.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableJob.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob
+    }
+    public static func MainScope() -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_MainScope(), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    }
+    public static func runnable(
+        block: @escaping () -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Runnable {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Runnable__TypesOfArguments__U2829202D_U20Swift_Void__({
+            let originalBlock: () -> Swift.Void = block
+            return {
+                let _result = originalBlock()
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Runnable.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Runnable
+    }
+    public static func supervisorJob(
+        parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_SupervisorJob__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job___(parent.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableJob.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob
+    }
+    public static func awaitAll(
+        deferreds: any ExportedKotlinPackages.kotlinx.coroutines.Deferred...
+    ) async throws -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_awaitAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Deferred__Vararg___(deferreds, {
+                let originalBlock: (Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = continuation
+                return { (arg0: Any) in
+                    let _arg0: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = arg0 as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func awaitCancellation() async throws -> Swift.Never {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_awaitCancellation({
+                let originalBlock: (Swift.Never) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Never = { arg0; fatalError() }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func coroutineScope(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_coroutineScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___({
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func currentCoroutineContext() async throws -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_currentCoroutineContext({
+                let originalBlock: (any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func delay(
+        timeMillis: Swift.Int64
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_delay__TypesOfArguments__Swift_Int64__(timeMillis, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func delay(
+        duration: ExportedKotlinPackages.kotlin.time.Duration
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_delay__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(duration.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func handleCoroutineException(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_handleCoroutineException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__(context.__externalRCRef(), exception.__externalRCRef()); return () }()
+    }
+    public static func joinAll(
+        jobs: any ExportedKotlinPackages.kotlinx.coroutines.Job...
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_joinAll__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__Vararg___(jobs, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func newFixedThreadPoolContext(
+        nThreads: Swift.Int32,
+        name: Swift.String
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher {
+        return ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_newFixedThreadPoolContext__TypesOfArguments__Swift_Int32_Swift_String__(nThreads, name))
+    }
+    @_spi(kotlinx$coroutines$DelicateCoroutinesApi) @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func newSingleThreadContext(
+        name: Swift.String
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher {
+        return ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_newSingleThreadContext__TypesOfArguments__Swift_String__(name))
+    }
+    public static func runBlocking(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_runBlocking__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(context.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public static func supervisorScope(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_supervisorScope__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___({
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func suspendCancellableCoroutine(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation) -> Swift.Void
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_suspendCancellableCoroutine__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuationU29202D_U20Swift_Void__({
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation) -> Swift.Void = block
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func withContext(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_withContext__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(context.__externalRCRef(), {
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func withTimeout(
+        timeMillis: Swift.Int64,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_withTimeout__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeMillis, {
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func withTimeout(
+        timeout: ExportedKotlinPackages.kotlin.time.Duration,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_withTimeout__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeout.__externalRCRef(), {
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func withTimeoutOrNull(
+        timeMillis: Swift.Int64,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__Swift_Int64_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeMillis, {
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func withTimeoutOrNull(
+        timeout: ExportedKotlinPackages.kotlin.time.Duration,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_withTimeoutOrNull__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(timeout.__externalRCRef(), {
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func yield() async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_yield({
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func async(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Deferred {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_async__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), context.__externalRCRef(), start.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Deferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Deferred
+    }
+    public static func cancel(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(receiver.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public static func cancel(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.Job,
+        message: Swift.String,
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(receiver.__externalRCRef(), message, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public static func cancel(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        message: Swift.String,
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_String_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(receiver.__externalRCRef(), message, cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public static func cancel(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_cancel__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(receiver.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public static func cancelAndJoin(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.Job
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_cancelAndJoin__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__(receiver.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func cancelChildren(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(receiver.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public static func cancelChildren(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.Job,
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_cancelChildren__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job_Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(receiver.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public static func completeWith(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred,
+        result: ExportedKotlinPackages.kotlin.Result
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_completeWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CompletableDeferred_ExportedKotlinPackages_kotlin_Result__(receiver.__externalRCRef(), result.__externalRCRef())
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func disposeOnCancellation(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation,
+        handle: any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_disposeOnCancellation__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CancellableContinuation_anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__(receiver.__externalRCRef(), handle.__externalRCRef()); return () }()
+    }
+    public static func ensureActive(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.__externalRCRef()); return () }()
+    }
+    public static func ensureActive(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.Job
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_Job__(receiver.__externalRCRef()); return () }()
+    }
+    public static func ensureActive(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_ensureActive__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(receiver.__externalRCRef()); return () }()
+    }
+    public static func invoke(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_invoke__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), {
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+                return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func launch(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Job {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_launch__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScopeU2920asyncU20throwsU202D_U20Swift_Void__(receiver.__externalRCRef(), context.__externalRCRef(), start.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    }
+    public static func newCoroutineContext(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        addedContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.__externalRCRef(), addedContext.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public static func newCoroutineContext(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_newCoroutineContext__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public static func plus(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_plus__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    }
+    public static func disposableHandle(
+        function: @escaping () -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_DisposableHandle__TypesOfArguments__U2829202D_U20Swift_Void__({
+            let originalBlock: () -> Swift.Void = function
+            return {
+                let _result = originalBlock()
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.intrinsics {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func startCoroutineCancellable(
+        _ receiver: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        completion: any ExportedKotlinPackages.kotlin.coroutines.Continuation
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_intrinsics_startCoroutineCancellable__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation__({
+            let originalBlock: () async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = receiver
+            return { (continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock()
+                }
+                return { _result; return true }()
+            }
+        }(), completion.__externalRCRef()); return () }()
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels {
+    public enum BufferOverflow: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {
+        case SUSPEND
+        case DROP_OLDEST
+        case DROP_LATEST
+        public var description: Swift.String {
+            get {
+                switch self {
+                case .SUSPEND: "SUSPEND"
+                case .DROP_OLDEST: "DROP_OLDEST"
+                case .DROP_LATEST: "DROP_LATEST"
+                default: fatalError()
+                }
+            }
+        }
+        public var rawValue: Swift.Int32 {
+            get {
+                switch self {
+                case .SUSPEND: 0
+                case .DROP_OLDEST: 1
+                case .DROP_LATEST: 2
+                default: fatalError()
+                }
+            }
+        }
+        public init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer!,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            switch kotlinx_coroutines_channels_BufferOverflow_ordinal(__externalRCRefUnsafe) {
+            case 0: self = .SUSPEND
+            case 1: self = .DROP_OLDEST
+            case 2: self = .DROP_LATEST
+            default: fatalError()
+            }
+        }
+        public func __externalRCRef() -> Swift.UnsafeMutableRawPointer! {
+            return switch self {
+            case .SUSPEND: kotlinx_coroutines_channels_BufferOverflow_SUSPEND()
+            case .DROP_OLDEST: kotlinx_coroutines_channels_BufferOverflow_DROP_OLDEST()
+            case .DROP_LATEST: kotlinx_coroutines_channels_BufferOverflow_DROP_LATEST()
+            default: fatalError()
+            }
+        }
+        public init?(
+            _ description: Swift.String
+        ) {
+            switch description {
+            case "SUSPEND": self = .SUSPEND
+            case "DROP_OLDEST": self = .DROP_OLDEST
+            case "DROP_LATEST": self = .DROP_LATEST
+            default: return nil
+            }
+        }
+        public init?(
+            rawValue: Swift.Int32
+        ) {
+            guard 0..<3 ~= rawValue else { return nil }
+            self = BufferOverflow.allCases[Int(rawValue)]
+        }
+    }
+    @available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public protocol BroadcastChannel: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel, ExportedKotlinPackages.kotlinx.coroutines.channels._BroadcastChannel {
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        func cancel(
+            cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        func openSubscription() -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_channels_BroadcastChannel)
+    public protocol _BroadcastChannel: ExportedKotlinPackages.kotlinx.coroutines.channels._SendChannel {
+    }
+    @available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public protocol __BroadcastChannel: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.channels.__SendChannel {
+    }
+    public protocol Channel: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel, ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel, ExportedKotlinPackages.kotlinx.coroutines.channels._Channel {
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_channels_Channel)
+    public protocol _Channel: ExportedKotlinPackages.kotlinx.coroutines.channels._SendChannel, ExportedKotlinPackages.kotlinx.coroutines.channels._ReceiveChannel {
+    }
+    public protocol __Channel: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.channels.__SendChannel, ExportedKotlinPackages.kotlinx.coroutines.channels.__ReceiveChannel {
+    }
+    public protocol ChannelIterator: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.channels._ChannelIterator {
+        func hasNext() async throws -> Swift.Bool
+        func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelIterator)
+    public protocol _ChannelIterator {
+    }
+    public protocol __ChannelIterator: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol ProducerScope: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope, ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel, ExportedKotlinPackages.kotlinx.coroutines.channels._ProducerScope {
+        var channel: any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel {
+            get
+        }
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScope)
+    public protocol _ProducerScope: ExportedKotlinPackages.kotlinx.coroutines._CoroutineScope, ExportedKotlinPackages.kotlinx.coroutines.channels._SendChannel {
+    }
+    public protocol __ProducerScope: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.__CoroutineScope, ExportedKotlinPackages.kotlinx.coroutines.channels.__SendChannel {
+    }
+    public protocol ReceiveChannel: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.channels._ReceiveChannel {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        var isClosedForReceive: Swift.Bool {
+            @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        var isEmpty: Swift.Bool {
+            @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var onReceive: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var onReceiveCatching: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        func cancel(
+            cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+        ) -> Swift.Void
+        func iterator() -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator
+        func receive() async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        func receiveCatching() async throws -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult
+        func tryReceive() -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel)
+    public protocol _ReceiveChannel {
+    }
+    public protocol __ReceiveChannel: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol SendChannel: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.channels._SendChannel {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        var isClosedForSend: Swift.Bool {
+            @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var onSend: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        func close(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) -> Swift.Bool
+        func invokeOnClose(
+            handler: @escaping (ExportedKotlinPackages.kotlin.Throwable?) -> Swift.Void
+        ) -> Swift.Void
+        func send(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) async throws -> Swift.Void
+        func trySend(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel)
+    public protocol _SendChannel {
+    }
+    public protocol __SendChannel: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public final class ChannelResult: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final class Companion: KotlinRuntime.KotlinBase {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            public static var shared: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.Companion {
+                @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+                get {
+                    return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.Companion.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_ChannelResult_Companion_get())
+                }
+            }
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            public func closed(
+                cause: ExportedKotlinPackages.kotlin.Throwable?
+            ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+                return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_ChannelResult_Companion_closed__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil))
+            }
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            public func failure() -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+                return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_ChannelResult_Companion_failure(self.__externalRCRef()))
+            }
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            public func success(
+                value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+            ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+                return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_ChannelResult_Companion_success__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil))
+            }
+            package override init(
+                __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+                options: KotlinRuntime.KotlinBaseConstructionOptions
+            ) {
+                super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+            }
+            private init() {
+                fatalError()
+            }
+        }
+        public var isClosed: Swift.Bool {
+            get {
+                return kotlinx_coroutines_channels_ChannelResult_isClosed_get(self.__externalRCRef())
+            }
+        }
+        public var isFailure: Swift.Bool {
+            get {
+                return kotlinx_coroutines_channels_ChannelResult_isFailure_get(self.__externalRCRef())
+            }
+        }
+        public var isSuccess: Swift.Bool {
+            get {
+                return kotlinx_coroutines_channels_ChannelResult_isSuccess_get(self.__externalRCRef())
+            }
+        }
+        public func equals(
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            return kotlinx_coroutines_channels_ChannelResult_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), other.map { it in it.__externalRCRef() } ?? nil)
+        }
+        public static func ==(
+            this: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult,
+            other: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            this.equals(other: other)
+        }
+        public func exceptionOrNull() -> ExportedKotlinPackages.kotlin.Throwable? {
+            return { switch kotlinx_coroutines_channels_ChannelResult_exceptionOrNull(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+        }
+        public func getOrNull() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlinx_coroutines_channels_ChannelResult_getOrNull(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func getOrThrow() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlinx_coroutines_channels_ChannelResult_getOrThrow(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        public func hashCode() -> Swift.Int32 {
+            return kotlinx_coroutines_channels_ChannelResult_hashCode(self.__externalRCRef())
+        }
+        public func toString() -> Swift.String {
+            return kotlinx_coroutines_channels_ChannelResult_toString(self.__externalRCRef())
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    public final class ClosedReceiveChannelException: ExportedKotlinPackages.kotlin.NoSuchElementException {
+        public override init(
+            message: Swift.String?
+        ) {
+            let __kt = kotlinx_coroutines_channels_ClosedReceiveChannelException_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_channels_ClosedReceiveChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    public final class ClosedSendChannelException: ExportedKotlinPackages.kotlin.IllegalStateException {
+        public override init(
+            message: Swift.String?
+        ) {
+            let __kt = kotlinx_coroutines_channels_ClosedSendChannelException_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_channels_ClosedSendChannelException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt, message ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @available(*, deprecated, message: "ConflatedBroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public final class ConflatedBroadcastChannel: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi) @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public var isClosedForSend: Swift.Bool {
+            @_spi(kotlinx$coroutines$DelicateCoroutinesApi) @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+            get {
+                return kotlinx_coroutines_channels_ConflatedBroadcastChannel_isClosedForSend_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public var onSend: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi) @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_ConflatedBroadcastChannel_onSend_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2
+            }
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+            get {
+                return { switch kotlinx_coroutines_channels_ConflatedBroadcastChannel_value_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+            }
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public var valueOrNull: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+            get {
+                return { switch kotlinx_coroutines_channels_ConflatedBroadcastChannel_valueOrNull_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+            }
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func cancel(
+            cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_channels_ConflatedBroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func close(
+            cause: ExportedKotlinPackages.kotlin.Throwable?
+        ) -> Swift.Bool {
+            return kotlinx_coroutines_channels_ConflatedBroadcastChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil)
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func invokeOnClose(
+            handler: @escaping (ExportedKotlinPackages.kotlin.Throwable?) -> Swift.Void
+        ) -> Swift.Void {
+            return { kotlinx_coroutines_channels_ConflatedBroadcastChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }()); return () }()
+        }
+        @available(*, unavailable, message: "Deprecated in the favour of 'trySend' method. Replacement: trySend(element).isSuccess") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func offer(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool {
+            fatalError()
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func openSubscription() -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_ConflatedBroadcastChannel_openSubscription(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func send(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) async throws -> Swift.Void {
+            try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_channels_ConflatedBroadcastChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil, {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public func trySend(
+            element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+            return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_ConflatedBroadcastChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil))
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public init() {
+            let __kt = kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+        public init(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) {
+            let __kt = kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_channels_ConflatedBroadcastChannel_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(__kt, value.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and StateFlow, and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public static func broadcastChannel(
+        capacity: Swift.Int32
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_BroadcastChannel__TypesOfArguments__Swift_Int32__(capacity), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel
+    }
+    public static func channel(
+        capacity: Swift.Int32,
+        onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow,
+        onUndeliveredElement: (((any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Void)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.Channel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_Channel__TypesOfArguments__Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow_Swift_Optional_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void___(capacity, onBufferOverflow.__externalRCRef(), onUndeliveredElement.map { it in {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = it
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.Channel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.Channel
+    }
+    public static func awaitClose(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope,
+        block: @escaping () -> Swift.Void
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_awaitClose__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScope_U2829202D_U20Swift_Void__(receiver.__externalRCRef(), {
+                let originalBlock: () -> Swift.Void = block
+                return {
+                    let _result = originalBlock()
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public static func broadcast(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        capacity: Swift.Int32,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+        onCompletion: ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler?,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(receiver.__externalRCRef(), context.__externalRCRef(), capacity, start.__externalRCRef(), onCompletion.map { it in {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = it
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }() } ?? nil, {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel
+    }
+    @available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public static func broadcast(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel,
+        capacity: Swift.Int32,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_broadcast__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart__(receiver.__externalRCRef(), capacity, start.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel
+    }
+    @available(*, unavailable, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public static func consume(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        fatalError()
+    }
+    public static func consume(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_channels_consume__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannelU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+                let _result = originalBlock(_arg0)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @available(*, unavailable, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public static func consumeEach(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel,
+        action: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Void
+    ) async throws -> Swift.Void {
+        fatalError()
+    }
+    public static func consumeEach(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel,
+        action: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Void
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_consumeEach__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(receiver.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = action
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func getOrElse(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult,
+        onFailure: @escaping (ExportedKotlinPackages.kotlin.Throwable?) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_channels_getOrElse__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = onFailure
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public static func onClosed(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult,
+        action: @escaping (ExportedKotlinPackages.kotlin.Throwable?) -> Swift.Void
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_onClosed__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()))
+    }
+    public static func onFailure(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult,
+        action: @escaping (ExportedKotlinPackages.kotlin.Throwable?) -> Swift.Void
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_onFailure__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()))
+    }
+    public static func onSuccess(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult,
+        action: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Void
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_onSuccess__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()))
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func produce(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        capacity: Swift.Int32,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+        onCompletion: ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler?,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_CoroutineStart_Swift_Optional_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(receiver.__externalRCRef(), context.__externalRCRef(), capacity, start.__externalRCRef(), onCompletion.map { it in {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = it
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }() } ?? nil, {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func produce(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        capacity: Swift.Int32,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_produce__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__(receiver.__externalRCRef(), context.__externalRCRef(), capacity, {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    }
+    public static func toList(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    ) async throws -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_toList__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(receiver.__externalRCRef(), {
+                let originalBlock: (Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = continuation
+                return { (arg0: Any) in
+                    let _arg0: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = arg0 as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func trySendBlocking(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel,
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_trySendBlocking__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil))
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow {
+    public enum SharingCommand: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {
+        case START
+        case STOP
+        case STOP_AND_RESET_REPLAY_CACHE
+        public var description: Swift.String {
+            get {
+                switch self {
+                case .START: "START"
+                case .STOP: "STOP"
+                case .STOP_AND_RESET_REPLAY_CACHE: "STOP_AND_RESET_REPLAY_CACHE"
+                default: fatalError()
+                }
+            }
+        }
+        public var rawValue: Swift.Int32 {
+            get {
+                switch self {
+                case .START: 0
+                case .STOP: 1
+                case .STOP_AND_RESET_REPLAY_CACHE: 2
+                default: fatalError()
+                }
+            }
+        }
+        public init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer!,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            switch kotlinx_coroutines_flow_SharingCommand_ordinal(__externalRCRefUnsafe) {
+            case 0: self = .START
+            case 1: self = .STOP
+            case 2: self = .STOP_AND_RESET_REPLAY_CACHE
+            default: fatalError()
+            }
+        }
+        public func __externalRCRef() -> Swift.UnsafeMutableRawPointer! {
+            return switch self {
+            case .START: kotlinx_coroutines_flow_SharingCommand_START()
+            case .STOP: kotlinx_coroutines_flow_SharingCommand_STOP()
+            case .STOP_AND_RESET_REPLAY_CACHE: kotlinx_coroutines_flow_SharingCommand_STOP_AND_RESET_REPLAY_CACHE()
+            default: fatalError()
+            }
+        }
+        public init?(
+            _ description: Swift.String
+        ) {
+            switch description {
+            case "START": self = .START
+            case "STOP": self = .STOP
+            case "STOP_AND_RESET_REPLAY_CACHE": self = .STOP_AND_RESET_REPLAY_CACHE
+            default: return nil
+            }
+        }
+        public init?(
+            rawValue: Swift.Int32
+        ) {
+            guard 0..<3 ~= rawValue else { return nil }
+            self = SharingCommand.allCases[Int(rawValue)]
+        }
+    }
+    public protocol Flow: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow._Flow, KotlinCoroutineSupport.KotlinFlow {
+        func collect(
+            collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+        ) async throws -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_Flow)
+    public protocol _Flow {
+    }
+    public protocol __Flow: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol FlowCollector: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow._FlowCollector {
+        func emit(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) async throws -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector)
+    public protocol _FlowCollector {
+    }
+    public protocol __FlowCollector: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol MutableSharedFlow: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlinx.coroutines.flow._MutableSharedFlow, KotlinCoroutineSupport.KotlinMutableSharedFlow {
+        var subscriptionCount: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32> {
+            get
+        }
+        func emit(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) async throws -> Swift.Void
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        func resetReplayCache() -> Swift.Void
+        func tryEmit(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_MutableSharedFlow)
+    public protocol _MutableSharedFlow: ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow._FlowCollector {
+    }
+    public protocol __MutableSharedFlow: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.flow.__SharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__FlowCollector {
+    }
+    public protocol MutableStateFlow: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow._MutableStateFlow, KotlinCoroutineSupport.KotlinMutableStateFlow {
+        var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            get
+            set
+        }
+        func compareAndSet(
+            expect: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            update: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_MutableStateFlow)
+    public protocol _MutableStateFlow: ExportedKotlinPackages.kotlinx.coroutines.flow._StateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow._MutableSharedFlow {
+    }
+    public protocol __MutableStateFlow: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.flow.__StateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableSharedFlow {
+    }
+    public protocol SharedFlow: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow, KotlinCoroutineSupport.KotlinSharedFlow {
+        var replayCache: [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+            get
+        }
+        func collect(
+            collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+        ) async throws -> Swift.Never
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_SharedFlow)
+    public protocol _SharedFlow: ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
+    }
+    public protocol __SharedFlow: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.flow.__Flow {
+    }
+    public protocol SharingStarted: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow._SharingStarted {
+        func command(
+            subscriptionCount: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32>
+        ) -> any KotlinCoroutineSupport.KotlinTypedFlow<ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand>
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted)
+    public protocol _SharingStarted {
+    }
+    public protocol __SharingStarted: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol StateFlow: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow._StateFlow, KotlinCoroutineSupport.KotlinStateFlow {
+        var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            get
+        }
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_StateFlow)
+    public protocol _StateFlow: ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow {
+    }
+    public protocol __StateFlow: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.flow.__SharedFlow {
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    open class AbstractFlow: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        public final func collect(
+            collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+        ) async throws -> Swift.Void {
+            try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_flow_AbstractFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self.__externalRCRef(), collector.__externalRCRef(), {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        open func collectSafely(
+            collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+        ) async throws -> Swift.Void {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.flow.AbstractFlow.self {
+                try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self.__externalRCRef(), collector.__externalRCRef(), {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlinx.coroutines.flow.AbstractFlow.collectSafely': a Swift subclass must override it and must not call super.")
+            }
+        }
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        public init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.flow.AbstractFlow.self, "ExportedKotlinPackages.kotlinx.coroutines.flow.AbstractFlow is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_flow_AbstractFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static var DEFAULT_CONCURRENCY: Swift.Int32 {
+        @_spi(kotlinx$coroutines$FlowPreview)
+        get {
+            return kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_get()
+        }
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static var DEFAULT_CONCURRENCY_PROPERTY_NAME: Swift.String {
+        @_spi(kotlinx$coroutines$FlowPreview)
+        get {
+            return kotlinx_coroutines_flow_DEFAULT_CONCURRENCY_PROPERTY_NAME_get()
+        }
+    }
+    public static func getCoroutineContext(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_coroutineContext_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    }
+    public static func getIsActive(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_flow_isActive_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(receiver.__externalRCRef())
+    }
+    public static func mutableSharedFlow(
+        replay: Swift.Int32,
+        extraBufferCapacity: Swift.Int32,
+        onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow
+    ) -> any KotlinCoroutineSupport.KotlinTypedMutableSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedMutableSharedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_MutableSharedFlow__TypesOfArguments__Swift_Int32_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(replay, extraBufferCapacity, onBufferOverflow.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func mutableStateFlow(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedMutableStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedMutableStateFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_MutableStateFlow__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(value.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func callbackFlow(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_callbackFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__({
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func channelFlow(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_channelFlow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ProducerScopeU2920asyncU20throwsU202D_U20Swift_Void__({
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combine(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow4: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow5: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), flow3.wrapped.__externalRCRef(), flow4.wrapped.__externalRCRef(), flow5.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, arg3: Swift.UnsafeMutableRawPointer?, arg4: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg3: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg3 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg4: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg4 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2, _arg3, _arg4)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combine(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow4: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), flow3.wrapped.__externalRCRef(), flow4.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, arg3: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg3: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg3 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2, _arg3)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combine(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), flow3.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combine(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combine__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combine(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combine__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), flow.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combineTransform(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow4: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow5: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), flow3.wrapped.__externalRCRef(), flow4.wrapped.__externalRCRef(), flow5.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, arg3: Swift.UnsafeMutableRawPointer?, arg4: Swift.UnsafeMutableRawPointer?, arg5: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg3: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg3 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg4: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg4 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg5: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg5 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combineTransform(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow4: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), flow3.wrapped.__externalRCRef(), flow4.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, arg3: Swift.UnsafeMutableRawPointer?, arg4: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg3: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg3 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg4: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg4 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2, _arg3, _arg4)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combineTransform(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), flow3.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, arg3: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg3: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg3 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2, _arg3)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combineTransform(
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combineTransform__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(flow.wrapped.__externalRCRef(), flow2.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func combineTransform(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_combineTransform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), flow.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg2: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg2 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func emptyFlow() -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_emptyFlow(), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func flow(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flow__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__({
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void = block
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func flowOf(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(value.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func flowOf(
+        elements: (any KotlinRuntimeSupport._KotlinBridgeable)?...
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flowOf__TypesOfArguments__Swift_Array_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Vararg___(elements.map { it in it as! NSObject? ?? NSNull() }), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func merge(
+        flows: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>...
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_merge__TypesOfArguments__Swift_Array_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Vararg___(flows), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func WhileSubscribed(
+        _ receiver: KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion,
+        stopTimeout: ExportedKotlinPackages.kotlin.time.Duration,
+        replayExpiration: ExportedKotlinPackages.kotlin.time.Duration
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_WhileSubscribed__TypesOfArgumentsE__KotlinxCoroutinesCore__ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion_ExportedKotlinPackages_kotlin_time_Duration_ExportedKotlinPackages_kotlin_time_Duration__(receiver.__externalRCRef(), stopTimeout.__externalRCRef(), replayExpiration.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted
+    }
+    public static func asFlow(
+        _ receiver: @escaping () -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___({
+            let originalBlock: () -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = receiver
+            return {
+                let _result = originalBlock()
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: ExportedKotlinPackages.kotlin.Array
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Array__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: ExportedKotlinPackages.kotlin.IntArray
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Int32> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Int32>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_IntArray__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, Swift.Int32.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: ExportedKotlinPackages.kotlin.LongArray
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Int64> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Int64>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_LongArray__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, Swift.Int64.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: any ExportedKotlinPackages.kotlin.collections.Iterable
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterable__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: any ExportedKotlinPackages.kotlin.collections.Iterator
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_collections_Iterator__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: Swift.ClosedRange<Swift.Int32>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Int32> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Int32>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int32___(kotlin_ranges_intRange_create_int_KotlinxCoroutinesCore(receiver.lowerBound, receiver.upperBound)), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, Swift.Int32.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: Swift.ClosedRange<Swift.Int64>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Int64> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Int64>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__Swift_ClosedRange_Swift_Int64___(kotlin_ranges_longRange_create_long_KotlinxCoroutinesCore(receiver.lowerBound, receiver.upperBound)), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, Swift.Int64.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: any ExportedKotlinPackages.kotlin.sequences.Sequence
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_sequences_Sequence__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func asFlow(
+        _ receiver: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asFlow__TypesOfArgumentsE__U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___({
+            let originalBlock: () async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = receiver
+            return { (continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock()
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "'BroadcastChannel' is obsolete and all corresponding operators are deprecated in the favour of StateFlow and SharedFlow") @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public static func asFlow(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func asSharedFlow(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedMutableSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedSharedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asSharedFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func asStateFlow(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedMutableStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_asStateFlow__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func buffer(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        capacity: Swift.Int32,
+        onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_buffer__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(receiver.wrapped.__externalRCRef(), capacity, onBufferOverflow.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Flow analogue of 'cache()' is 'shareIn' with unlimited replay and 'started = SharingStared.Lazily' argument'. Replacement: this.shareIn(scope, Int.MAX_VALUE, started = SharingStared.Lazily)")
+    public static func cache(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "cancel() is resolved into the extension of outer CoroutineScope which is likely to be an error.Use currentCoroutineContext().cancel() instead or specify the receiver of cancel() explicitly. Replacement: currentCoroutineContext().cancel(cause)")
+    public static func cancel(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector,
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        fatalError()
+    }
+    public static func cancellable(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_cancellable__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Applying 'cancellable' to a SharedFlow has no effect. See the SharedFlow documentation on Operator Fusion.. Replacement: this")
+    public static func cancellable(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func `catch`(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg1)
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, deprecated, message: "SharedFlow never completes, so this operator typically has not effect, it can only catch exceptions from 'onSubscribe' operator. Replacement: this")
+    public static func `catch`(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_catch__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg1)
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func collect(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_collect__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_Flow__(receiver.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func collectIndexed(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (Swift.Int32, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_collectIndexed__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Int32_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Int32, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = action
+                return { (arg0: Swift.Int32, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Int32 = arg0
+                    let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Void) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0, _arg1)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func collectLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_collectLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = action
+                return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Void) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, unavailable, message: "Flow analogue of 'combineLatest' is 'combine'. Replacement: combine(this, other, other2, other3, transform)")
+    public static func combineLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other4: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'combineLatest' is 'combine'. Replacement: combine(this, other, other2, other3, transform)")
+    public static func combineLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other3: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'combineLatest' is 'combine'. Replacement: combine(this, other, other2, transform)")
+    public static func combineLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other2: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'combineLatest' is 'combine'. Replacement: this.combine(other, transform)")
+    public static func combineLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'compose' is 'let'. Replacement: let(transformer)")
+    public static func compose(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transformer: @escaping (any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'concatMap' is 'flatMapConcat'. Replacement: flatMapConcat(mapper)")
+    public static func concatMap(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        mapper: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'concatWith' is 'onCompletion'. Use 'onCompletion { emit(value) }'. Replacement: onCompletion { emit(value) }")
+    public static func concatWith(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'concatWith' is 'onCompletion'. Use 'onCompletion { if (it == null) emitAll(other) }'. Replacement: onCompletion { if (it == null) emitAll(other) }")
+    public static func concatWith(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func conflate(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_conflate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Applying 'conflate' to StateFlow has no effect. See the StateFlow documentation on Operator Fusion.. Replacement: this")
+    public static func conflate(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func consumeAsFlow(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_consumeAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func count(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> Swift.Int32 {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Int32) -> Swift.Void = continuation
+                return { (arg0: Swift.Int32) in
+                    let _arg0: Swift.Int32 = arg0
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func count(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) async throws -> Swift.Int32 {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+                return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Bool) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Int32) -> Swift.Void = continuation
+                return { (arg0: Swift.Int32) in
+                    let _arg0: Swift.Int32 = arg0
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, deprecated, message: "SharedFlow never completes, so this terminal operation never completes.")
+    public static func count(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> Swift.Int32 {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_count__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Int32) -> Swift.Void = continuation
+                return { (arg0: Swift.Int32) in
+                    let _arg0: Swift.Int32 = arg0
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func debounce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeoutMillis: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Int64
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Int64__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Int64 = timeoutMillis
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func debounce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeout: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> ExportedKotlinPackages.kotlin.time.Duration
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20ExportedKotlinPackages_kotlin_time_Duration__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> ExportedKotlinPackages.kotlin.time.Duration = timeout
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result.__externalRCRef()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func debounce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeoutMillis: Swift.Int64
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__(receiver.wrapped.__externalRCRef(), timeoutMillis), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func debounce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeout: ExportedKotlinPackages.kotlin.time.Duration
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_debounce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(receiver.wrapped.__externalRCRef(), timeout.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Use 'onEach { delay(timeMillis) }'. Replacement: onEach { delay(timeMillis) }")
+    public static func delayEach(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeMillis: Swift.Int64
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Use 'onStart { delay(timeMillis) }'. Replacement: onStart { delay(timeMillis) }")
+    public static func delayFlow(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeMillis: Swift.Int64
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func distinctUntilChanged(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func distinctUntilChanged(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        areEquivalent: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_distinctUntilChanged__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Bool = areEquivalent
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0, _arg1)
+                return _result
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Applying 'distinctUntilChanged' to StateFlow has no effect. See the StateFlow documentation on Operator Fusion.. Replacement: this")
+    public static func distinctUntilChanged(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func distinctUntilChangedBy(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        keySelector: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_distinctUntilChangedBy__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = keySelector
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func drop(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        count: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_drop__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__(receiver.wrapped.__externalRCRef(), count), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func dropWhile(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_dropWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func emitAll(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector,
+        channel: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(receiver.__externalRCRef(), channel.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func emitAll(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector,
+        flow: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_emitAll__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.__externalRCRef(), flow.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func filter(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_filter__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Declaration uses unsupported types")
+    public static func filterIsInstance(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow,
+        klass: Swift.Never
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinRuntimeSupport._KotlinBridgeable> {
+        fatalError()
+    }
+    public static func filterNot(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_filterNot__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func filterNotNull(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinRuntimeSupport._KotlinBridgeable> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<any KotlinRuntimeSupport._KotlinBridgeable>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_filterNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func first(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func first(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_first__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+                return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Bool) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func firstOrNull(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func firstOrNull(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_firstOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+                return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Bool) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, unavailable, message: "Flow analogue is 'flatMapConcat'. Replacement: flatMapConcat(mapper)")
+    public static func flatMap(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        mapper: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func flatMapConcat(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flatMapConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(pointerToBlock.__externalRCRef()!, _1.wrapped.__externalRCRef()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func flatMapLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flatMapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(pointerToBlock.__externalRCRef()!, _1.wrapped.__externalRCRef()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func flatMapMerge(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        concurrency: Swift.Int32,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flatMapMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), concurrency, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(pointerToBlock.__externalRCRef()!, _1.wrapped.__externalRCRef()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Flow analogue of 'flatten' is 'flattenConcat'. Replacement: flattenConcat()")
+    public static func flatten(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func flattenConcat(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flattenConcat__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func flattenMerge(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>>,
+        concurrency: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flattenMerge__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____Swift_Int32__(receiver.wrapped.__externalRCRef(), concurrency), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func flowOn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_flowOn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(receiver.wrapped.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Applying 'flowOn' to SharedFlow has no effect. See the SharedFlow documentation on Operator Fusion.. Replacement: this")
+    public static func flowOn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func fold(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_fold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), initial.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+                return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0, _arg1)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, unavailable, message: "Flow analogue of 'forEach' is 'collect'. Replacement: collect(action)")
+    public static func forEach(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> Swift.Void {
+        fatalError()
+    }
+    public static func getAndUpdate(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedMutableStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        function: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_flow_getAndUpdate__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = function
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public static func last(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_last__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func lastOrNull(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_lastOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func launchIn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        scope: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Job {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_launchIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(receiver.wrapped.__externalRCRef(), scope.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    }
+    public static func map(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_map__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func mapLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_mapLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func mapNotNull(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinRuntimeSupport._KotlinBridgeable> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<any KotlinRuntimeSupport._KotlinBridgeable>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_mapNotNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Flow analogue of 'merge' is 'flattenConcat'. Replacement: flattenConcat()")
+    public static func merge(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Collect flow in the desired context instead")
+    public static func observeOn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func onCompletion(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_onCompletion__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg1 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func onEach(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_onEach__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func onEmpty(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_onEmpty__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { emitAll(fallback) }'. Replacement: catch { emitAll(fallback) }")
+    public static func onErrorResume(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        fallback: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { emitAll(fallback) }'. Replacement: catch { emitAll(fallback) }")
+    public static func onErrorResumeNext(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        fallback: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { emit(fallback) }'. Replacement: catch { emit(fallback) }")
+    public static func onErrorReturn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        fallback: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'onErrorXxx' is 'catch'. Use 'catch { e -> if (predicate(e)) emit(fallback) else throw e }'. Replacement: catch { e -> if (predicate(e)) emit(fallback) else throw e }")
+    public static func onErrorReturn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        fallback: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        predicate: @escaping (ExportedKotlinPackages.kotlin.Throwable) -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func onStart(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_onStart__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func onSubscription(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        action: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedSharedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_onSubscription__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollectorU2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector) async throws -> Swift.Void = action
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func produceIn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        scope: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_produceIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(receiver.wrapped.__externalRCRef(), scope.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    }
+    @available(*, unavailable, message: """
+Flow analogue of 'publish()' is 'shareIn'.
+publish().connect() is the default strategy (no extra call is needed),
+publish().autoConnect() translates to 'started = SharingStared.Lazily' argument,
+publish().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.. Replacement: this.shareIn(scope, 0)
+""")
+    public static func publish(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: """
+Flow analogue of 'publish(bufferSize)' is 'buffer' followed by 'shareIn'.
+publish().connect() is the default strategy (no extra call is needed),
+publish().autoConnect() translates to 'started = SharingStared.Lazily' argument,
+publish().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.. Replacement: this.buffer(bufferSize).shareIn(scope, 0)
+""")
+    public static func publish(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        bufferSize: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Collect flow in the desired context instead")
+    public static func publishOn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func receiveAsFlow(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_receiveAsFlow__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_ReceiveChannel__(receiver.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func reduce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_reduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+                return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                    }()
+                    let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                        return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                    }()
+                    let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                    let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                        try await originalBlock(_arg0, _arg1)
+                    }
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, unavailable, message: """
+Flow analogue of 'replay()' is 'shareIn' with unlimited replay.
+replay().connect() is the default strategy (no extra call is needed),
+replay().autoConnect() translates to 'started = SharingStared.Lazily' argument,
+replay().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.. Replacement: this.shareIn(scope, Int.MAX_VALUE)
+""")
+    public static func replay(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: """
+Flow analogue of 'replay(bufferSize)' is 'shareIn' with the specified replay parameter.
+replay().connect() is the default strategy (no extra call is needed),
+replay().autoConnect() translates to 'started = SharingStared.Lazily' argument,
+replay().refCount() translates to 'started = SharingStared.WhileSubscribed()' argument.. Replacement: this.shareIn(scope, bufferSize)
+""")
+    public static func replay(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        bufferSize: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func retry(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        retries: Swift.Int64,
+        predicate: @escaping (ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), retries, {
+            let originalBlock: (ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg0)
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, deprecated, message: "SharedFlow never completes, so this operator has no effect.. Replacement: this")
+    public static func retry(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        retries: Swift.Int64,
+        predicate: @escaping (ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_retry__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64_U28ExportedKotlinPackages_kotlin_ThrowableU2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), retries, {
+            let originalBlock: (ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg0)
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func retryWhen(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable, Swift.Int64) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable, Swift.Int64) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer, arg2: Swift.Int64, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg1)
+                let _arg2: Swift.Int64 = arg2
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, deprecated, message: "SharedFlow never completes, so this operator has no effect.. Replacement: this")
+    public static func retryWhen(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable, Swift.Int64) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_retryWhen__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20ExportedKotlinPackages_kotlin_Throwable_U20Swift_Int64U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlin.Throwable, Swift.Int64) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer, arg2: Swift.Int64, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg1)
+                let _arg2: Swift.Int64 = arg2
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1, _arg2)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func runningFold(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_runningFold__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), initial.map { it in it.__externalRCRef() } ?? nil, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func runningReduce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_runningReduce__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func sample(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        periodMillis: Swift.Int64
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int64__(receiver.wrapped.__externalRCRef(), periodMillis), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func sample(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        period: ExportedKotlinPackages.kotlin.time.Duration
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_sample__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(receiver.wrapped.__externalRCRef(), period.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func scan(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_scan__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), initial.map { it in it.__externalRCRef() } ?? nil, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = operation
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Flow has less verbose 'scan' shortcut. Replacement: scan(initial, operation)")
+    public static func scanFold(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        initial: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "'scanReduce' was renamed to 'runningReduce' to be consistent with Kotlin standard library. Replacement: runningReduce(operation)")
+    public static func scanReduce(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        operation: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func shareIn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        scope: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        started: any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted,
+        replay: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedSharedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_shareIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Int32__(receiver.wrapped.__externalRCRef(), scope.__externalRCRef(), started.__externalRCRef(), replay), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func single(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_single__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func singleOrNull(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_singleOrNull__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, unavailable, message: "Flow analogue of 'skip' is 'drop'. Replacement: drop(count)")
+    public static func skip(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        count: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'startWith' is 'onStart'. Use 'onStart { emit(value) }'. Replacement: onStart { emit(value) }")
+    public static func startWith(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogue of 'startWith' is 'onStart'. Use 'onStart { emitAll(other) }'. Replacement: onStart { emitAll(other) }")
+    public static func startWith(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func stateIn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        scope: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    ) async throws -> any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(receiver.wrapped.__externalRCRef(), scope.__externalRCRef(), {
+                let originalBlock: (any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func stateIn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        scope: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope,
+        started: any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted,
+        initialValue: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_stateIn__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope_anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), scope.__externalRCRef(), started.__externalRCRef(), initialValue.map { it in it.__externalRCRef() } ?? nil), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @available(*, unavailable, message: "Use 'launchIn' with 'onEach', 'onCompletion' and 'catch' instead")
+    public static func subscribe(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> Swift.Void {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Use 'launchIn' with 'onEach', 'onCompletion' and 'catch' instead")
+    public static func subscribe(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        onEach: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> Swift.Void {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Use 'launchIn' with 'onEach', 'onCompletion' and 'catch' instead")
+    public static func subscribe(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        onEach: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void,
+        onError: @escaping (ExportedKotlinPackages.kotlin.Throwable) async throws -> Swift.Void
+    ) -> Swift.Void {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Use 'flowOn' instead")
+    public static func subscribeOn(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Flow analogues of 'switchMap' are 'transformLatest', 'flatMapLatest' and 'mapLatest'. Replacement: this.flatMapLatest(transform)")
+    public static func switchMap(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        fatalError()
+    }
+    public static func take(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        count: Swift.Int32
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_take__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___Swift_Int32__(receiver.wrapped.__externalRCRef(), count), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func takeWhile(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_takeWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = predicate
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$FlowPreview)
+    public static func timeout(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        timeout: ExportedKotlinPackages.kotlin.time.Duration
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_timeout__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___ExportedKotlinPackages_kotlin_time_Duration__(receiver.wrapped.__externalRCRef(), timeout.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func toCollection(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        destination: any ExportedKotlinPackages.kotlin.collections.MutableCollection
+    ) async throws -> any ExportedKotlinPackages.kotlin.collections.MutableCollection {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toCollection__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableCollection__(receiver.wrapped.__externalRCRef(), destination.__externalRCRef(), {
+                let originalBlock: (any ExportedKotlinPackages.kotlin.collections.MutableCollection) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlin.collections.MutableCollection = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlin.collections.MutableCollection.Type.self) as! any ExportedKotlinPackages.kotlin.collections.MutableCollection
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func toList(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        destination: any ExportedKotlinPackages.kotlin.collections.MutableList
+    ) async throws -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__(receiver.wrapped.__externalRCRef(), destination.__externalRCRef(), {
+                let originalBlock: (Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = continuation
+                return { (arg0: Any) in
+                    let _arg0: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = arg0 as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, deprecated, message: "SharedFlow never completes, so this terminal operation never completes.")
+    public static func toList(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>) -> Swift.Void = continuation
+                return { (arg0: Any) in
+                    let _arg0: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = arg0 as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func toList(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        destination: any ExportedKotlinPackages.kotlin.collections.MutableList
+    ) async throws -> Swift.Never {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toList__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableList__(receiver.wrapped.__externalRCRef(), destination.__externalRCRef(), {
+                let originalBlock: (Swift.Never) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Never = { arg0; fatalError() }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func toSet(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        destination: any ExportedKotlinPackages.kotlin.collections.MutableSet
+    ) async throws -> Swift.Set<Swift.Optional<Swift.AnyHashable>> {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__(receiver.wrapped.__externalRCRef(), destination.__externalRCRef(), {
+                let originalBlock: (Swift.Set<Swift.Optional<Swift.AnyHashable>>) -> Swift.Void = continuation
+                return { (arg0: Any) in
+                    let _arg0: Swift.Set<Swift.Optional<Swift.AnyHashable>> = arg0 as! Swift.Set<Swift.Optional<Swift.AnyHashable>>
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @available(*, deprecated, message: "SharedFlow never completes, so this terminal operation never completes.")
+    public static func toSet(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) async throws -> Swift.Set<Swift.Optional<Swift.AnyHashable>> {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef(), {
+                let originalBlock: (Swift.Set<Swift.Optional<Swift.AnyHashable>>) -> Swift.Void = continuation
+                return { (arg0: Any) in
+                    let _arg0: Swift.Set<Swift.Optional<Swift.AnyHashable>> = arg0 as! Swift.Set<Swift.Optional<Swift.AnyHashable>>
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func toSet(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedSharedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        destination: any ExportedKotlinPackages.kotlin.collections.MutableSet
+    ) async throws -> Swift.Never {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_toSet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedSharedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20ExportedKotlinPackages_kotlin_collections_MutableSet__(receiver.wrapped.__externalRCRef(), destination.__externalRCRef(), {
+                let originalBlock: (Swift.Never) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Never = { arg0; fatalError() }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func transform(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_transform__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func transformLatest(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_transformLatest__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func transformWhile(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Bool
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_transformWhile__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Bool__(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Bool = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Bool) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func update(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedMutableStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        function: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_flow_update__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = function
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()); return () }()
+    }
+    public static func updateAndGet(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedMutableStateFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        function: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_flow_updateAndGet__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedMutableStateFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = function
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    public static func withIndex(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<ExportedKotlinPackages.kotlin.collections.IndexedValue> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<ExportedKotlinPackages.kotlin.collections.IndexedValue>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_withIndex__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____(receiver.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, ExportedKotlinPackages.kotlin.collections.IndexedValue.Type.self)
+    }
+    public static func zip(
+        _ receiver: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        other: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>,
+        transform: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?, (any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_zip__TypesOfArgumentsE__anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___anyU20KotlinCoroutineSupport_KotlinTypedFlow_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.wrapped.__externalRCRef(), other.wrapped.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>, Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = transform
+            return { (arg0: Swift.UnsafeMutableRawPointer?, arg1: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _arg1: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg1 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0, _arg1)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+    public static func flowCollector(
+        function: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_FlowCollector__TypesOfArguments__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Void__({
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Void = function
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Void) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+    }
+    public static func sharingStarted(
+        function: @escaping (any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32>) -> any KotlinCoroutineSupport.KotlinTypedFlow<ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand>
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_SharingStarted__TypesOfArguments__U28anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_U29202D_U20anyU20KotlinCoroutineSupport_KotlinTypedFlow_ExportedKotlinPackages_kotlinx_coroutines_flow_SharingCommand___({
+            let originalBlock: (any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32>) -> any KotlinCoroutineSupport.KotlinTypedFlow<ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand> = function
+            return { (arg0: Swift.UnsafeMutableRawPointer) in
+                let _arg0: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32> = KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Int32>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, Swift.Int32.Type.self)
+                let _result = originalBlock(_arg0)
+                return _result.wrapped.__externalRCRef()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public enum SelectClause_SealedType: KotlinRuntimeSupport.SealedType {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        case selectClause0(ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0_SealedType)
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        case selectClause1(ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1_SealedType)
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        case selectClause2(ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2_SealedType)
+        public var value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause {
+            get {
+                switch self {
+                case let .selectClause0(type): type.value
+                case let .selectClause1(type): type.value
+                case let .selectClause2(type): type.value
+                }
+            }
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public enum SelectClause0_SealedType: KotlinRuntimeSupport.SealedType {
+        case unknown(ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0_SealedType.Unknown)
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public struct Unknown: KotlinRuntimeSupport.SealedType {
+            public let value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0
+            init(
+                _ value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0
+            ) {
+                self.value = value
+            }
+        }
+        public var value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+            get {
+                switch self {
+                case let .unknown(type): type.value
+                }
+            }
+        }
+    }
+    public protocol SelectBuilder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.selects._SelectBuilder {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func invoke(
+            _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0,
+            block: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func invoke(
+            _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1,
+            block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func invoke(
+            _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2,
+            param: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func invoke(
+            _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2,
+            block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder)
+    public protocol _SelectBuilder {
+    }
+    public protocol __SelectBuilder: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol SelectClause: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var clauseObject: any KotlinRuntimeSupport._KotlinBridgeable {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause)
+    public protocol _SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __SelectClause: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol SelectClause0: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause, ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause0 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0_SealedType
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @_disfavoredOverload
+        func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause0)
+    public protocol _SelectClause0: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __SelectClause0: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol SelectClause1: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause, ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause1)
+    public protocol _SelectClause1: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __SelectClause1: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol SelectClause2: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause, ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause2 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2)
+    public protocol _SelectClause2: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __SelectClause2: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol SelectInstance: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.selects._SelectInstance {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func disposeOnCompletion(
+            disposableHandle: any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func selectInRegistrationPhase(
+            internalResult: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func trySelect(
+            clauseObject: any KotlinRuntimeSupport._KotlinBridgeable,
+            result: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_selects_SelectInstance)
+    public protocol _SelectInstance {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __SelectInstance: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public struct SelectClause1_SealedType: KotlinRuntimeSupport.SealedType {
+        public let value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1
+        init(
+            _ value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1
+        ) {
+            self.value = value
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public struct SelectClause2_SealedType: KotlinRuntimeSupport.SealedType {
+        public let value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2
+        init(
+            _ value: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2
+        ) {
+            self.value = value
+        }
+    }
+    public static func select(
+        builder: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder) -> Swift.Void
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_selects_select__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__({
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder) -> Swift.Void = builder
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func selectUnbiased(
+        builder: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder) -> Swift.Void
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_selects_selectUnbiased__TypesOfArguments__U28anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilderU29202D_U20Swift_Void__({
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder) -> Swift.Void = builder
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func onTimeout(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder,
+        timeMillis: Swift.Int64,
+        block: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_Swift_Int64_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), timeMillis, {
+            let originalBlock: () async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock()
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public static func onTimeout(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder,
+        timeout: ExportedKotlinPackages.kotlin.time.Duration,
+        block: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_onTimeout__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectBuilder_ExportedKotlinPackages_kotlin_time_Duration_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), timeout.__externalRCRef(), {
+            let originalBlock: () async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock()
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.`internal` {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public typealias SynchronizedObject = ExportedKotlinPackages.kotlinx.atomicfu.locks.SynchronizedObject
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol MainDispatcherFactory: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.`internal`._MainDispatcherFactory {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var loadPriority: Swift.Int32 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func createDispatcher(
+            allFactories: [any ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory]
+        ) -> ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func hintOnError() -> Swift.String?
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_internal_MainDispatcherFactory)
+    public protocol _MainDispatcherFactory {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __MainDispatcherFactory: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol ThreadSafeHeapNode: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.`internal`._ThreadSafeHeapNode {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var index: Swift.Int32 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            set
+        }
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_internal_ThreadSafeHeapNode)
+    public protocol _ThreadSafeHeapNode {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __ThreadSafeHeapNode: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    open class AtomicOp: ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open override var atomicOp: ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.self {
+                    return ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.__createClassWrapper(externalRCRef: kotlinx_coroutines_internal_AtomicOp_atomicOp_get(self.__externalRCRef()))
+                } else {
+                    return ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.__createClassWrapper(externalRCRef: kotlinx_coroutines_internal_AtomicOp_atomicOp_get_direct(self.__externalRCRef()))
+                }
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func complete(
+            affected: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+            failure: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.self {
+                return { kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), affected.map { it in it.__externalRCRef() } ?? nil, failure.map { it in it.__externalRCRef() } ?? nil); return () }()
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.complete': a Swift subclass must override it and must not call super.")
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final override func perform(
+            affected: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            return { switch kotlinx_coroutines_internal_AtomicOp_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), affected.map { it in it.__externalRCRef() } ?? nil) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func prepare(
+            affected: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.self {
+                return { switch kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), affected.map { it in it.__externalRCRef() } ?? nil) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.prepare': a Swift subclass must override it and must not call super.")
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public override init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.self, "ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_internal_AtomicOp_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    open class LockFreeLinkedListHead: ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var isEmpty: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_internal_LockFreeLinkedListHead_isEmpty_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open override var isRemoved: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListHead.self {
+                    return kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get(self.__externalRCRef())
+                } else {
+                    return kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get_direct(self.__externalRCRef())
+                }
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final func remove() -> Swift.Never {
+            return { kotlinx_coroutines_internal_LockFreeLinkedListHead_remove(self.__externalRCRef()); fatalError() }()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public override init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListHead.self {
+                 __kt = kotlinx_coroutines_internal_LockFreeLinkedListHead_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_internal_LockFreeLinkedListHead_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    open class LockFreeLinkedListNode: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open var isRemoved: Swift.Bool {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.self {
+                    return kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get(self.__externalRCRef())
+                } else {
+                    return kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get_direct(self.__externalRCRef())
+                }
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var next: any KotlinRuntimeSupport._KotlinBridgeable {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: kotlinx_coroutines_internal_LockFreeLinkedListNode_next_get(self.__externalRCRef()))
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Declaration uses unsupported types")
+        public final var nextNode: Swift.Never {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                fatalError()
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Declaration uses unsupported types")
+        public final var prevNode: Swift.Never {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                fatalError()
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Declaration uses unsupported types")
+        public final func addLast(
+            node: Swift.Never
+        ) -> Swift.Void {
+            fatalError()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Declaration uses unsupported types")
+        public final func addLastIf(
+            node: Swift.Never,
+            condition: @escaping () -> Swift.Bool
+        ) -> Swift.Bool {
+            fatalError()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Declaration uses unsupported types")
+        public final func addOneIfEmpty(
+            node: Swift.Never
+        ) -> Swift.Bool {
+            fatalError()
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func remove() -> Swift.Bool {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.self {
+                return kotlinx_coroutines_internal_LockFreeLinkedListNode_remove(self.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_internal_LockFreeLinkedListNode_remove_direct(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func toString() -> Swift.String {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.self {
+                return kotlinx_coroutines_internal_LockFreeLinkedListNode_toString(self.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_internal_LockFreeLinkedListNode_toString_direct(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public init() {
+             let __kt: Swift.UnsafeMutableRawPointer!
+             if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.self {
+                 __kt = kotlinx_coroutines_internal_LockFreeLinkedListNode_init_allocate()
+             } else {
+                 __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+             }
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_internal_LockFreeLinkedListNode_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    open class OpDescriptor: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open var atomicOp: ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp? {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.self {
+                    return { switch kotlinx_coroutines_internal_OpDescriptor_atomicOp_get(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.__createClassWrapper(externalRCRef: res); } }()
+                } else {
+                    fatalError("Cannot invoke the inherited implementation of abstract property 'ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.atomicOp': a Swift subclass must override it and must not call super.")
+                }
+            }
+        }
+        open func perform(
+            affected: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.self {
+                return { switch kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), affected.map { it in it.__externalRCRef() } ?? nil) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+            } else {
+                fatalError("Cannot invoke the inherited implementation of abstract member 'ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.perform': a Swift subclass must override it and must not call super.")
+            }
+        }
+        open func toString() -> Swift.String {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.self {
+                return kotlinx_coroutines_internal_OpDescriptor_toString(self.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_internal_OpDescriptor_toString_direct(self.__externalRCRef())
+            }
+        }
+        public init() {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.self, "ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_internal_OpDescriptor_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func synchronized(
+        lock: ExportedKotlinPackages.kotlinx.coroutines.`internal`.SynchronizedObject,
+        block: @escaping () -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_internal_synchronized__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(lock.__externalRCRef(), {
+            let originalBlock: () -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return {
+                let _result = originalBlock()
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func synchronizedImpl(
+        lock: ExportedKotlinPackages.kotlinx.coroutines.`internal`.SynchronizedObject,
+        block: @escaping () -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_internal_synchronizedImpl__TypesOfArguments__ExportedKotlinPackages_kotlinx_atomicfu_locks_SynchronizedObject_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(lock.__externalRCRef(), {
+            let originalBlock: () -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return {
+                let _result = originalBlock()
+                return _result.map { it in it.__externalRCRef() } ?? nil
+            }
+        }()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public static func resumeCancellableWith(
+        _ receiver: any ExportedKotlinPackages.kotlin.coroutines.Continuation,
+        result: ExportedKotlinPackages.kotlin.Result,
+        onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_internal_resumeCancellableWith__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlin_coroutines_Continuation_ExportedKotlinPackages_kotlin_Result_Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(receiver.__externalRCRef(), result.__externalRCRef(), onCancellation.map { it in {
+            let originalBlock: (ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void = it
+            return { (arg0: Swift.UnsafeMutableRawPointer) in
+                let _arg0: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg0)
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }() } ?? nil); return () }()
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.sync {
+    public protocol Mutex: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.sync._Mutex {
+        var isLocked: Swift.Bool {
+            get
+        }
+        @available(*, deprecated, message: "Mutex.onLock deprecated without replacement. For additional details please refer to #2794") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        var onLock: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get
+        }
+        func holdsLock(
+            owner: any KotlinRuntimeSupport._KotlinBridgeable
+        ) -> Swift.Bool
+        func lock(
+            owner: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) async throws -> Swift.Void
+        func tryLock(
+            owner: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Bool
+        func unlock(
+            owner: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) -> Swift.Void
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_sync_Mutex)
+    public protocol _Mutex {
+    }
+    public protocol __Mutex: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol Semaphore: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.sync._Semaphore {
+        var availablePermits: Swift.Int32 {
+            get
+        }
+        func acquire() async throws -> Swift.Void
+        func tryAcquire() -> Swift.Bool
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_sync_Semaphore)
+    public protocol _Semaphore {
+    }
+    public protocol __Semaphore: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public static func mutex(
+        locked: Swift.Bool
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_sync_Mutex__TypesOfArguments__Swift_Bool__(locked), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    }
+    public static func semaphore(
+        permits: Swift.Int32,
+        acquiredPermits: Swift.Int32
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_sync_Semaphore__TypesOfArguments__Swift_Int32_Swift_Int32__(permits, acquiredPermits), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore
+    }
+    public static func withLock(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex,
+        owner: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        action: @escaping () -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_sync_withLock__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Mutex_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), owner.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: () -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
+                return {
+                    let _result = originalBlock()
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public static func withPermit(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore,
+        action: @escaping () -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_sync_withPermit__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_sync_Semaphore_U2829202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), {
+                let originalBlock: () -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
+                return {
+                    let _result = originalBlock()
+                    return _result.map { it in it.__externalRCRef() } ?? nil
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.`internal` {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol FusibleFlow: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`._FusibleFlow {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        func fuse(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            capacity: Swift.Int32,
+            onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow
+        ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+    }
+    @objc(_ExportedKotlinPackages_kotlinx_coroutines_flow_internal_FusibleFlow)
+    public protocol _FusibleFlow: ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public protocol __FusibleFlow: KotlinRuntimeSupport._KotlinBridgeable, ExportedKotlinPackages.kotlinx.coroutines.flow.__Flow {
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    open class ChannelFlow: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var capacity: Swift.Int32 {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return kotlinx_coroutines_flow_internal_ChannelFlow_capacity_get(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_internal_ChannelFlow_context_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public final var onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow {
+            @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+            get {
+                return ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow(__externalRCRefUnsafe: kotlinx_coroutines_flow_internal_ChannelFlow_onBufferOverflow_get(self.__externalRCRef()), options: .asBestFittingWrapper)
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func collect(
+            collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+        ) async throws -> Swift.Void {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.self {
+                try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self.__externalRCRef(), collector.__externalRCRef(), {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+            } else {
+                try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector___direct(self.__externalRCRef(), collector.__externalRCRef(), {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func dropChannelOperators() -> (any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>)? {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.self {
+                return { switch kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators(self.__externalRCRef()) { case nil: .none; case let res?: KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self); } }()
+            } else {
+                return { switch kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators_direct(self.__externalRCRef()) { case nil: .none; case let res?: KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self); } }()
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func fuse(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            capacity: Swift.Int32,
+            onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow
+        ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.self {
+                return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(self.__externalRCRef(), context.__externalRCRef(), capacity, onBufferOverflow.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+            } else {
+                return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow___direct(self.__externalRCRef(), context.__externalRCRef(), capacity, onBufferOverflow.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func produceImpl(
+            scope: any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+        ) -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.self {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope__(self.__externalRCRef(), scope.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+            } else {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope___direct(self.__externalRCRef(), scope.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        open func toString() -> Swift.String {
+            if Self.self == ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.self {
+                return kotlinx_coroutines_flow_internal_ChannelFlow_toString(self.__externalRCRef())
+            } else {
+                return kotlinx_coroutines_flow_internal_ChannelFlow_toString_direct(self.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public init(
+            context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+            capacity: Swift.Int32,
+            onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow
+        ) {
+            precondition(Self.self != ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.self, "ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow is an abstract class and cannot be instantiated directly")
+            let __kt = _kotlinAllocInstanceForSwiftSubclass(Self.self)
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_flow_internal_ChannelFlow_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(__kt, context.__externalRCRef(), capacity, onBufferOverflow.__externalRCRef()); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public final class SendingCollector: KotlinRuntime.KotlinBase {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public func emit(
+            value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+        ) async throws -> Swift.Void {
+            try await withKotlinContinuation { continuation, exception, cancellation in
+                let _: Bool = kotlinx_coroutines_flow_internal_SendingCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
+                    let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                    return { (arg0: Swift.Bool) in
+                        let _arg0: Swift.Void = { arg0; return () }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), {
+                    let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                    return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                        let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }(), cancellation.__externalRCRef())
+            }
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        public init(
+            channel: any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+        ) {
+            let __kt = kotlinx_coroutines_flow_internal_SendingCollector_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { kotlinx_coroutines_flow_internal_SendingCollector_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlinx_coroutines_channels_SendChannel__(__kt, channel.__externalRCRef()); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Dispatchers {
+    public var IO: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+        get {
+            let receiver = self
+            return ExportedKotlinPackages.kotlinx.coroutines.getIO(receiver)
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public var isActive: Swift.Bool {
+        get {
+            let receiver = self
+            return ExportedKotlinPackages.kotlinx.coroutines.getIsActive(receiver)
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public var isActive: Swift.Bool {
+        get {
+            let receiver = self
+            return ExportedKotlinPackages.kotlinx.coroutines.getIsActive(receiver)
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public var job: any ExportedKotlinPackages.kotlinx.coroutines.Job {
+        get {
+            let receiver = self
+            return ExportedKotlinPackages.kotlinx.coroutines.getJob(receiver)
+        }
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func async(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Deferred {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.async(receiver, context: context, start: start, block: block)
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public func cancel(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.cancel(receiver, cause: cause)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Job {
+    public func cancel(
+        message: Swift.String,
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.cancel(receiver, message: message, cause: cause)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func cancel(
+        message: Swift.String,
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.cancel(receiver, message: message, cause: cause)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func cancel(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.cancel(receiver, cause: cause)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Job {
+    public func cancelAndJoin() async throws -> Swift.Void {
+        let receiver = self
+        return try await ExportedKotlinPackages.kotlinx.coroutines.cancelAndJoin(receiver)
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public func cancelChildren(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.cancelChildren(receiver, cause: cause)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Job {
+    public func cancelChildren(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.cancelChildren(receiver, cause: cause)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred {
+    public func completeWith(
+        result: ExportedKotlinPackages.kotlin.Result
+    ) -> Swift.Bool {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.completeWith(receiver, result: result)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func disposeOnCancellation(
+        handle: any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    ) -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.disposeOnCancellation(receiver, handle: handle)
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public func ensureActive() -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.ensureActive(receiver)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Job {
+    public func ensureActive() -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.ensureActive(receiver)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func ensureActive() -> Swift.Void {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.ensureActive(receiver)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher {
+    public func invoke(
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        let receiver = self
+        return try await ExportedKotlinPackages.kotlinx.coroutines.invoke(receiver, block: block)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func launch(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        start: ExportedKotlinPackages.kotlinx.coroutines.CoroutineStart,
+        block: @escaping (any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope) async throws -> Swift.Void
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.Job {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.launch(receiver, context: context, start: start, block: block)
+    }
+}
+extension ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+    public func newCoroutineContext(
+        addedContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.newCoroutineContext(receiver, addedContext: addedContext)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func newCoroutineContext(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.newCoroutineContext(receiver, context: context)
+    }
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+    public func plus(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+        let receiver = self
+        return ExportedKotlinPackages.kotlinx.coroutines.plus(receiver, context: context)
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation where Self : ExportedKotlinPackages.kotlinx.coroutines.__CancellableContinuation {
+    public var isActive: Swift.Bool {
+        get {
+            return kotlinx_coroutines_CancellableContinuation_isActive_get(self.__externalRCRef())
+        }
+    }
+    public var isCancelled: Swift.Bool {
+        get {
+            return kotlinx_coroutines_CancellableContinuation_isCancelled_get(self.__externalRCRef())
+        }
+    }
+    public var isCompleted: Swift.Bool {
+        get {
+            return kotlinx_coroutines_CancellableContinuation_isCompleted_get(self.__externalRCRef())
+        }
+    }
+    public func cancel(
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil)
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func completeResume(
+        token: any KotlinRuntimeSupport._KotlinBridgeable
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self.__externalRCRef(), token.__externalRCRef()); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func initCancellability() -> Swift.Void {
+        return { kotlinx_coroutines_CancellableContinuation_initCancellability(self.__externalRCRef()); return () }()
+    }
+    public func invokeOnCancellation(
+        handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_CancellableContinuation_invokeOnCancellation__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resume(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_CancellableContinuation_resume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, onCancellation.map { it in {
+            let originalBlock: (ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void = it
+            return { (arg0: Swift.UnsafeMutableRawPointer) in
+                let _arg0: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg0)
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }() } ?? nil); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func tryResume(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        idempotent: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, idempotent.map { it in it.__externalRCRef() } ?? nil) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func tryResume(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        idempotent: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_U28ExportedKotlinPackages_kotlin_ThrowableU29202D_U20Swift_Void___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, idempotent.map { it in it.__externalRCRef() } ?? nil, onCancellation.map { it in {
+            let originalBlock: (ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void = it
+            return { (arg0: Swift.UnsafeMutableRawPointer) in
+                let _arg0: ExportedKotlinPackages.kotlin.Throwable = ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: arg0)
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }() } ?? nil) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func tryResumeWithException(
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), exception.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resumeUndispatched(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), receiver.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resumeUndispatchedWithException(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), receiver.__externalRCRef(), exception.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._CancellableContinuation {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation, ExportedKotlinPackages.kotlinx.coroutines.__CancellableContinuation where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._CancellableContinuation {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func completeResume(
+        token: any KotlinRuntimeSupport._KotlinBridgeable
+    ) -> Swift.Void {
+        fatalError("'completeResume' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func initCancellability() -> Swift.Void {
+        fatalError("'initCancellability' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resume(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+    ) -> Swift.Void {
+        fatalError("'resume' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func tryResume(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        idempotent: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        fatalError("'tryResume' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func tryResume(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        idempotent: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        onCancellation: ((ExportedKotlinPackages.kotlin.Throwable) -> Swift.Void)?
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        fatalError("'tryResume' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func tryResumeWithException(
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        fatalError("'tryResumeWithException' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resumeUndispatched(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        fatalError("'resumeUndispatched' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resumeUndispatchedWithException(
+        _ receiver: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher,
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Void {
+        fatalError("'resumeUndispatchedWithException' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildHandle") @_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.ChildHandle where Self : ExportedKotlinPackages.kotlinx.coroutines.__ChildHandle {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return { switch kotlinx_coroutines_ChildHandle_parent_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job; } }()
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func childCancelled(
+        cause: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_ChildHandle_childCancelled__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), cause.__externalRCRef())
+    }
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildHandle") @_documentation(visibility: internal)
+package extension KotlinRuntimeSupport._KotlinExistentialPenBox {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildHandle") @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.ChildHandle, ExportedKotlinPackages.kotlinx.coroutines.__ChildHandle where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._ChildHandle {
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildHandle")
+extension ExportedKotlinPackages.kotlinx.coroutines.ChildHandle {
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildJob") @_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.ChildJob where Self : ExportedKotlinPackages.kotlinx.coroutines.__ChildJob {
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildJob") @_documentation(visibility: internal)
+package extension KotlinRuntimeSupport._KotlinExistentialPenBox {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildJob") @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.ChildJob, ExportedKotlinPackages.kotlinx.coroutines.__ChildJob where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._ChildJob {
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ChildJob")
+extension ExportedKotlinPackages.kotlinx.coroutines.ChildJob {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred where Self : ExportedKotlinPackages.kotlinx.coroutines.__CompletableDeferred {
+    public func complete(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func completeExceptionally(
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), exception.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._CompletableDeferred {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred, ExportedKotlinPackages.kotlinx.coroutines.__CompletableDeferred where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._CompletableDeferred {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.CompletableJob where Self : ExportedKotlinPackages.kotlinx.coroutines.__CompletableJob {
+    public func complete() -> Swift.Bool {
+        return kotlinx_coroutines_CompletableJob_complete(self.__externalRCRef())
+    }
+    public func completeExceptionally(
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), exception.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._CompletableJob {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.CompletableJob, ExportedKotlinPackages.kotlinx.coroutines.__CompletableJob where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._CompletableJob {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CompletableJob {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler where Self : ExportedKotlinPackages.kotlinx.coroutines.__CoroutineExceptionHandler {
+    public func handleException(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        exception: ExportedKotlinPackages.kotlin.Throwable
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable__(self.__externalRCRef(), context.__externalRCRef(), exception.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._CoroutineExceptionHandler {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler, ExportedKotlinPackages.kotlinx.coroutines.__CoroutineExceptionHandler where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._CoroutineExceptionHandler {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler {
+    public typealias Key = KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_CoroutineExceptionHandler_Key
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope where Self : ExportedKotlinPackages.kotlinx.coroutines.__CoroutineScope {
+    public var coroutineContext: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_CoroutineScope_coroutineContext_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._CoroutineScope {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope, ExportedKotlinPackages.kotlinx.coroutines.__CoroutineScope where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._CoroutineScope {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.Deferred where Self : ExportedKotlinPackages.kotlinx.coroutines.__Deferred {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onAwait: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Deferred_onAwait_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1
+        }
+    }
+    public func `await`() async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_Deferred_await(self.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func getCompleted() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_Deferred_getCompleted(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func getCompletionExceptionOrNull() -> ExportedKotlinPackages.kotlin.Throwable? {
+        return { switch kotlinx_coroutines_Deferred_getCompletionExceptionOrNull(self.__externalRCRef()) { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._Deferred {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.Deferred, ExportedKotlinPackages.kotlinx.coroutines.__Deferred where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._Deferred {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Deferred {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onAwait: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            fatalError("'onAwait' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func getCompleted() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        fatalError("'getCompleted' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func getCompletionExceptionOrNull() -> ExportedKotlinPackages.kotlin.Throwable? {
+        fatalError("'getCompletionExceptionOrNull' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.Delay where Self : ExportedKotlinPackages.kotlinx.coroutines.__Delay {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invokeOnTimeout(
+        timeMillis: Swift.Int64,
+        block: any ExportedKotlinPackages.kotlinx.coroutines.Runnable,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext__(self.__externalRCRef(), timeMillis, block.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._Delay {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.Delay, ExportedKotlinPackages.kotlinx.coroutines.__Delay where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._Delay {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Delay {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invokeOnTimeout(
+        timeMillis: Swift.Int64,
+        block: any ExportedKotlinPackages.kotlinx.coroutines.Runnable,
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext___direct(self.__externalRCRef(), timeMillis, block.__externalRCRef(), context.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle where Self : ExportedKotlinPackages.kotlinx.coroutines.__DisposableHandle {
+    public func dispose() -> Swift.Void {
+        return { kotlinx_coroutines_DisposableHandle_dispose(self.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._DisposableHandle {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle, ExportedKotlinPackages.kotlinx.coroutines.__DisposableHandle where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._DisposableHandle {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.Job where Self : ExportedKotlinPackages.kotlinx.coroutines.__Job {
+    public var children: any ExportedKotlinPackages.kotlin.sequences.Sequence {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Job_children_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.sequences.Sequence.Type.self) as! any ExportedKotlinPackages.kotlin.sequences.Sequence
+        }
+    }
+    public var isActive: Swift.Bool {
+        get {
+            return kotlinx_coroutines_Job_isActive_get(self.__externalRCRef())
+        }
+    }
+    public var isCancelled: Swift.Bool {
+        get {
+            return kotlinx_coroutines_Job_isCancelled_get(self.__externalRCRef())
+        }
+    }
+    public var isCompleted: Swift.Bool {
+        get {
+            return kotlinx_coroutines_Job_isCompleted_get(self.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onJoin: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Job_onJoin_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        get {
+            return { switch kotlinx_coroutines_Job_parent_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job; } }()
+        }
+    }
+    public func cancel(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func getCancellationException() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+        return ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: kotlinx_coroutines_Job_getCancellationException(self.__externalRCRef()))
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invokeOnCompletion(
+        onCancelling: Swift.Bool,
+        invokeImmediately: Swift.Bool,
+        handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__Swift_Bool_Swift_Bool_U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), onCancelling, invokeImmediately, {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    }
+    public func invokeOnCompletion(
+        handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_Job_invokeOnCompletion__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    }
+    public func join() async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_Job_join(self.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func start() -> Swift.Bool {
+        return kotlinx_coroutines_Job_start(self.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._Job {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.Job, ExportedKotlinPackages.kotlinx.coroutines.__Job where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._Job {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Job {
+    public typealias Key = KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_Job_Key
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onJoin: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            fatalError("'onJoin' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public var parent: (any ExportedKotlinPackages.kotlinx.coroutines.Job)? {
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        get {
+            fatalError("'parent' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func getCancellationException() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+        fatalError("'getCancellationException' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invokeOnCompletion(
+        onCancelling: Swift.Bool,
+        invokeImmediately: Swift.Bool,
+        handler: @escaping ExportedKotlinPackages.kotlinx.coroutines.CompletionHandler
+    ) -> any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle {
+        fatalError("'invokeOnCompletion' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ParentJob") @_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.ParentJob where Self : ExportedKotlinPackages.kotlinx.coroutines.__ParentJob {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func getChildJobCancellationCause() -> ExportedKotlinPackages.kotlinx.coroutines.CancellationException {
+        return ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: kotlinx_coroutines_ParentJob_getChildJobCancellationCause(self.__externalRCRef()))
+    }
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ParentJob") @_documentation(visibility: internal)
+package extension KotlinRuntimeSupport._KotlinExistentialPenBox {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ParentJob") @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.ParentJob, ExportedKotlinPackages.kotlinx.coroutines.__ParentJob where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._ParentJob {
+}
+@available(*, unavailable, message: "Unavailable type(s): ExportedKotlinPackages.kotlinx.coroutines.ParentJob")
+extension ExportedKotlinPackages.kotlinx.coroutines.ParentJob {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.Runnable where Self : ExportedKotlinPackages.kotlinx.coroutines.__Runnable {
+    public func run() -> Swift.Void {
+        return { kotlinx_coroutines_Runnable_run(self.__externalRCRef()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines._Runnable {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.Runnable, ExportedKotlinPackages.kotlinx.coroutines.__Runnable where Wrapped : ExportedKotlinPackages.kotlinx.coroutines._Runnable {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.Runnable {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel where Self : ExportedKotlinPackages.kotlinx.coroutines.channels.__BroadcastChannel {
+    @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public func cancel(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    @_spi(kotlinx$coroutines$ObsoleteCoroutinesApi)
+    public func openSubscription() -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_BroadcastChannel_openSubscription(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.channels._BroadcastChannel {
+}
+@_spi(kotlinx$coroutines$ObsoleteCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel, ExportedKotlinPackages.kotlinx.coroutines.channels.__BroadcastChannel where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.channels._BroadcastChannel {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.Channel where Self : ExportedKotlinPackages.kotlinx.coroutines.channels.__Channel {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.channels._Channel {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.channels.Channel, ExportedKotlinPackages.kotlinx.coroutines.channels.__Channel where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.channels._Channel {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.Channel {
+    public typealias Factory = KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_channels_Channel_Factory
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator where Self : ExportedKotlinPackages.kotlinx.coroutines.channels.__ChannelIterator {
+    public func hasNext() async throws -> Swift.Bool {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_ChannelIterator_hasNext(self.__externalRCRef(), {
+                let originalBlock: (Swift.Bool) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Bool = arg0
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        return { switch kotlinx_coroutines_channels_ChannelIterator_next(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.channels._ChannelIterator {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator, ExportedKotlinPackages.kotlinx.coroutines.channels.__ChannelIterator where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.channels._ChannelIterator {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope where Self : ExportedKotlinPackages.kotlinx.coroutines.channels.__ProducerScope {
+    public var channel: any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel {
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_ProducerScope_channel_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.channels._ProducerScope {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope, ExportedKotlinPackages.kotlinx.coroutines.channels.__ProducerScope where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.channels._ProducerScope {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel where Self : ExportedKotlinPackages.kotlinx.coroutines.channels.__ReceiveChannel {
+    @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+    public var isClosedForReceive: Swift.Bool {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        get {
+            return kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get(self.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public var isEmpty: Swift.Bool {
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        get {
+            return kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get(self.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onReceive: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_ReceiveChannel_onReceive_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onReceiveCatching: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1
+        }
+    }
+    public func cancel(
+        cause: ExportedKotlinPackages.kotlinx.coroutines.CancellationException?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    public func iterator() -> any ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator {
+        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_ReceiveChannel_iterator(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator
+    }
+    public func receive() async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_ReceiveChannel_receive(self.__externalRCRef(), {
+                let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func receiveCatching() async throws -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_ReceiveChannel_receiveCatching(self.__externalRCRef(), {
+                let originalBlock: (ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult) -> Swift.Void = continuation
+                return { (arg0: Swift.UnsafeMutableRawPointer) in
+                    let _arg0: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult = ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: arg0)
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func tryReceive() -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_ReceiveChannel_tryReceive(self.__externalRCRef()))
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.channels._ReceiveChannel {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel, ExportedKotlinPackages.kotlinx.coroutines.channels.__ReceiveChannel where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.channels._ReceiveChannel {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel {
+    @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+    public var isClosedForReceive: Swift.Bool {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        get {
+            fatalError("'isClosedForReceive' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public var isEmpty: Swift.Bool {
+        @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+        get {
+            fatalError("'isEmpty' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onReceive: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            fatalError("'onReceive' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onReceiveCatching: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            fatalError("'onReceiveCatching' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel where Self : ExportedKotlinPackages.kotlinx.coroutines.channels.__SendChannel {
+    @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+    public var isClosedForSend: Swift.Bool {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        get {
+            return kotlinx_coroutines_channels_SendChannel_isClosedForSend_get(self.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onSend: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_channels_SendChannel_onSend_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2
+        }
+    }
+    public func close(
+        cause: ExportedKotlinPackages.kotlin.Throwable?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(self.__externalRCRef(), cause.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func invokeOnClose(
+        handler: @escaping (ExportedKotlinPackages.kotlin.Throwable?) -> Swift.Void
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_channels_SendChannel_invokeOnClose__TypesOfArguments__U28Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_U29202D_U20Swift_Void__(self.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<ExportedKotlinPackages.kotlin.Throwable>) -> Swift.Void = handler
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                let _arg0: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = { switch arg0 { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }()
+                let _result = originalBlock(_arg0)
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+    public func send(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func trySend(
+        element: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult {
+        return ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult.__createClassWrapper(externalRCRef: kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), element.map { it in it.__externalRCRef() } ?? nil))
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.channels._SendChannel {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel, ExportedKotlinPackages.kotlinx.coroutines.channels.__SendChannel where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.channels._SendChannel {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel {
+    @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+    public var isClosedForSend: Swift.Bool {
+        @_spi(kotlinx$coroutines$DelicateCoroutinesApi)
+        get {
+            fatalError("'isClosedForSend' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onSend: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            fatalError("'onSend' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.Flow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__Flow {
+    public func collect(
+        collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self.__externalRCRef(), collector.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, ExportedKotlinPackages.kotlinx.coroutines.flow.__Flow, KotlinCoroutineSupport.KotlinFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.Flow {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__FlowCollector {
+    public func emit(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._FlowCollector {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlinx.coroutines.flow.__FlowCollector where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._FlowCollector {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableSharedFlow {
+    public var subscriptionCount: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32> {
+        get {
+            return KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Int32>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, Swift.Int32.Type.self)
+        }
+    }
+    public func emit(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resetReplayCache() -> Swift.Void {
+        return { kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache(self.__externalRCRef()); return () }()
+    }
+    public func tryEmit(
+        value: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil)
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._MutableSharedFlow {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableSharedFlow, KotlinCoroutineSupport.KotlinMutableSharedFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._MutableSharedFlow {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow {
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resetReplayCache() -> Swift.Void {
+        fatalError("'resetReplayCache' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableStateFlow {
+    public var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        get {
+            return { switch kotlinx_coroutines_flow_MutableStateFlow_value_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+        set {
+            return { kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), newValue.map { it in it.__externalRCRef() } ?? nil); return () }()
+        }
+    }
+    public func compareAndSet(
+        expect: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        update: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), expect.map { it in it.__externalRCRef() } ?? nil, update.map { it in it.__externalRCRef() } ?? nil)
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._MutableStateFlow {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableStateFlow, KotlinCoroutineSupport.KotlinMutableStateFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._MutableStateFlow {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__SharedFlow {
+    public var replayCache: [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
+        get {
+            return kotlinx_coroutines_flow_SharedFlow_replayCache_get(self.__externalRCRef()) as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
+        }
+    }
+    public func collect(
+        collector: any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+    ) async throws -> Swift.Never {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector__(self.__externalRCRef(), collector.__externalRCRef(), {
+                let originalBlock: (Swift.Never) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Never = { arg0; fatalError() }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__SharedFlow, KotlinCoroutineSupport.KotlinSharedFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__SharingStarted {
+    public func command(
+        subscriptionCount: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32>
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32___(self.__externalRCRef(), subscriptionCount.wrapped.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand.Type.self)
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._SharingStarted {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted, ExportedKotlinPackages.kotlinx.coroutines.flow.__SharingStarted where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._SharingStarted {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted {
+    public typealias Companion = KotlinxCoroutinesCore._ExportedKotlinPackages_kotlinx_coroutines_flow_SharingStarted_Companion
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__StateFlow {
+    public var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
+        get {
+            return { switch kotlinx_coroutines_flow_StateFlow_value_get(self.__externalRCRef()) { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._StateFlow {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__StateFlow, KotlinCoroutineSupport.KotlinStateFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._StateFlow {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.FusibleFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.__FusibleFlow {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func fuse(
+        context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext,
+        capacity: Swift.Int32,
+        onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow
+    ) -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> {
+        return KotlinCoroutineSupport._KotlinTypedFlowImpl<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow__(self.__externalRCRef(), context.__externalRCRef(), capacity, onBufferOverflow.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinRuntimeSupport._KotlinBridgeable.Type.self)
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`._FusibleFlow {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.FusibleFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.__FusibleFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`._FusibleFlow {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.FusibleFlow {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder where Self : ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectBuilder {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0,
+        block: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause0_U282920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), receiver.__externalRCRef(), {
+            let originalBlock: () async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock()
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1,
+        block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause1_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2,
+        param: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), receiver.__externalRCRef(), param.map { it in it.__externalRCRef() } ?? nil, {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2,
+        block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectBuilder {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectBuilder where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.selects._SelectBuilder {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectBuilder {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0,
+        block: @escaping () async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        fatalError("'invoke' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1,
+        block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        fatalError("'invoke' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2,
+        param: (any KotlinRuntimeSupport._KotlinBridgeable)?,
+        block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        fatalError("'invoke' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func invoke(
+        _ receiver: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2,
+        block: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectBuilder_invoke__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_coroutines_selects_SelectClause2_U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U2920asyncU20throwsU202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self.__externalRCRef(), receiver.__externalRCRef(), {
+            let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) async throws -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
+            return { (arg0: Swift.UnsafeMutableRawPointer?, continuation: Swift.UnsafeMutableRawPointer, exception: Swift.UnsafeMutableRawPointer, cancellation: Swift.UnsafeMutableRawPointer) in
+                let _arg0: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = { switch arg0 { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
+                let _continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+                }()
+                let _exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+                    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+                    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+                }()
+                let _cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+                let _result = withKotlinTask(_continuation, _exception, _cancellation){
+                    try await originalBlock(_arg0)
+                }
+                return { _result; return true }()
+            }
+        }()); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause where Self : ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var clauseObject: any KotlinRuntimeSupport._KotlinBridgeable {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: kotlinx_coroutines_selects_SelectClause_clauseObject_get(self.__externalRCRef()))
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType {
+        fatalError("must implement sealedType in subclass")
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 where Self : ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause0 {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0_SealedType {
+        .unknown(.init(self))
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause0 {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause0 where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause0 {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi) @_disfavoredOverload
+    public func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType {
+        .selectClause0(sealedType())
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 where Self : ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause1 {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause1 {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause1 where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause1 {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType {
+        .selectClause1(.init(self))
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 where Self : ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause2 {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause2 {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectClause2 where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.selects._SelectClause2 {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func sealedType() -> ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause_SealedType {
+        .selectClause2(.init(self))
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance where Self : ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectInstance {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var context: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_selects_SelectInstance_context_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func disposeOnCompletion(
+        disposableHandle: any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle__(self.__externalRCRef(), disposableHandle.__externalRCRef()); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func selectInRegistrationPhase(
+        internalResult: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), internalResult.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func trySelect(
+        clauseObject: any KotlinRuntimeSupport._KotlinBridgeable,
+        result: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), clauseObject.__externalRCRef(), result.map { it in it.__externalRCRef() } ?? nil)
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.selects._SelectInstance {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance, ExportedKotlinPackages.kotlinx.coroutines.selects.__SelectInstance where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.selects._SelectInstance {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory where Self : ExportedKotlinPackages.kotlinx.coroutines.`internal`.__MainDispatcherFactory {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var loadPriority: Swift.Int32 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get(self.__externalRCRef())
+        }
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func createDispatcher(
+        allFactories: [any ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory]
+    ) -> ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher {
+        return ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.__createClassWrapper(externalRCRef: kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory___(self.__externalRCRef(), allFactories))
+    }
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func hintOnError() -> Swift.String? {
+        return kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError(self.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.`internal`._MainDispatcherFactory {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory, ExportedKotlinPackages.kotlinx.coroutines.`internal`.__MainDispatcherFactory where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.`internal`._MainDispatcherFactory {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public func hintOnError() -> Swift.String? {
+        return kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError_direct(self.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode where Self : ExportedKotlinPackages.kotlinx.coroutines.`internal`.__ThreadSafeHeapNode {
+    @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var index: Swift.Int32 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get(self.__externalRCRef())
+        }
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        set {
+            return { kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), newValue); return () }()
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.`internal`._ThreadSafeHeapNode {
+}
+@_spi(kotlinx$coroutines$InternalCoroutinesApi) @_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode, ExportedKotlinPackages.kotlinx.coroutines.`internal`.__ThreadSafeHeapNode where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.`internal`._ThreadSafeHeapNode {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode {
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex where Self : ExportedKotlinPackages.kotlinx.coroutines.sync.__Mutex {
+    public var isLocked: Swift.Bool {
+        get {
+            return kotlinx_coroutines_sync_Mutex_isLocked_get(self.__externalRCRef())
+        }
+    }
+    @available(*, deprecated, message: "Mutex.onLock deprecated without replacement. For additional details please refer to #2794") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onLock: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_sync_Mutex_onLock_get(self.__externalRCRef()), conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2
+        }
+    }
+    public func holdsLock(
+        owner: any KotlinRuntimeSupport._KotlinBridgeable
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self.__externalRCRef(), owner.__externalRCRef())
+    }
+    public func lock(
+        owner: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), owner.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func tryLock(
+        owner: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Bool {
+        return kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), owner.map { it in it.__externalRCRef() } ?? nil)
+    }
+    public func unlock(
+        owner: (any KotlinRuntimeSupport._KotlinBridgeable)?
+    ) -> Swift.Void {
+        return { kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), owner.map { it in it.__externalRCRef() } ?? nil); return () }()
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.sync._Mutex {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex, ExportedKotlinPackages.kotlinx.coroutines.sync.__Mutex where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.sync._Mutex {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex {
+    @available(*, deprecated, message: "Mutex.onLock deprecated without replacement. For additional details please refer to #2794") @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+    public var onLock: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 {
+        @_spi(kotlinx$coroutines$InternalCoroutinesApi)
+        get {
+            fatalError("'onLock' is an @_spi requirement that must be implemented by Swift conformers")
+        }
+    }
+}
+@_documentation(visibility: internal)
+extension ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore where Self : ExportedKotlinPackages.kotlinx.coroutines.sync.__Semaphore {
+    public var availablePermits: Swift.Int32 {
+        get {
+            return kotlinx_coroutines_sync_Semaphore_availablePermits_get(self.__externalRCRef())
+        }
+    }
+    public func acquire() async throws -> Swift.Void {
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_sync_Semaphore_acquire(self.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in
+                    let _arg0: Swift.Void = { arg0; return () }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), {
+                let originalBlock: (Swift.Optional<Swift.Error>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in
+                    let _arg0: Swift.Optional<Swift.Error> = { switch arg0 { case nil: .none; case let res?: KotlinRuntimeSupport.swiftError(fromKotlinThrowable: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res)!); } }()
+                    let _result = originalBlock(_arg0)
+                    return { _result; return true }()
+                }
+            }(), cancellation.__externalRCRef())
+        }
+    }
+    public func tryAcquire() -> Swift.Bool {
+        return kotlinx_coroutines_sync_Semaphore_tryAcquire(self.__externalRCRef())
+    }
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.sync._Semaphore {
+}
+@_documentation(visibility: internal)
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore, ExportedKotlinPackages.kotlinx.coroutines.sync.__Semaphore where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.sync._Semaphore {
+}
+extension ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore {
+}
+@_cdecl("kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ cause: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Bool = _self.cancel(cause: { switch cause { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_completeResume__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ token: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Void = _self.completeResume(token: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: token))
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_initCancellability__reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_initCancellability__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Void = _self.initCancellability()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_isActive_get__reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_isActive_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Bool = _self.isActive
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_isCancelled_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Bool = _self.isCancelled
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_isCompleted_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Bool = _self.isCompleted
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_resumeUndispatchedWithException__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ receiver: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Void = _self.resumeUndispatchedWithException(ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: receiver), exception: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: exception))
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_resumeUndispatched__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_coroutines_CoroutineDispatcher_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ receiver: Swift.UnsafeMutableRawPointer, _ value: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Void = _self.resumeUndispatched(ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: receiver), value: { switch value { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_tryResumeWithException__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.tryResumeWithException(exception: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: exception))
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_CancellableContinuation_tryResume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ value: Swift.UnsafeMutableRawPointer?, _ idempotent: Swift.UnsafeMutableRawPointer?) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CancellableContinuation
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.tryResume(value: { switch value { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }(), idempotent: { switch idempotent { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse_swift")
+package func kotlinx_coroutines_CloseableCoroutineDispatcher_close__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.CloseableCoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Void = _self.close()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+package func kotlinx_coroutines_CompletableDeferred_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred
+    let _result: Swift.Bool = _self.completeExceptionally(exception: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: exception))
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_CompletableDeferred_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ value: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableDeferred
+    let _result: Swift.Bool = _self.complete(value: { switch value { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+package func kotlinx_coroutines_CompletableJob_completeExceptionally__TypesOfArguments__ExportedKotlinPackages_kotlin_Throwable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableJob.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob
+    let _result: Swift.Bool = _self.completeExceptionally(exception: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: exception))
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CompletableJob_complete__reverse_swift")
+package func kotlinx_coroutines_CompletableJob_complete__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CompletableJob.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CompletableJob
+    let _result: Swift.Bool = _self.complete()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift")
+package func kotlinx_coroutines_CoroutineDispatcher_dispatchYield__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer, _ block: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Void = _self.dispatchYield(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, block: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: block, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Runnable.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Runnable)
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift")
+package func kotlinx_coroutines_CoroutineDispatcher_dispatch__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer, _ block: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Void = _self.dispatch(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, block: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: block, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Runnable.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Runnable)
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift")
+package func kotlinx_coroutines_CoroutineDispatcher_isDispatchNeeded__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Bool = _self.isDispatchNeeded(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext)
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlinx_coroutines_CoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ parallelism: Swift.Int32) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher = _self.limitedParallelism(parallelism: parallelism)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineDispatcher_toString__reverse_swift")
+package func kotlinx_coroutines_CoroutineDispatcher_toString__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.String = _self.toString()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse_swift")
+package func kotlinx_coroutines_CoroutineExceptionHandler_handleException__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_ExportedKotlinPackages_kotlin_Throwable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineExceptionHandler
+    let _result: Swift.Void = _self.handleException(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, exception: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: exception))
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse_swift")
+package func kotlinx_coroutines_CoroutineScope_coroutineContext_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self.coroutineContext
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_Deferred_await__reverse_swift")
+package func kotlinx_coroutines_Deferred_await__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Deferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Deferred
+    let __continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.await()
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_Deferred_getCompleted__reverse_swift")
+package func kotlinx_coroutines_Deferred_getCompleted__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Deferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Deferred
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.getCompleted()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse_swift")
+package func kotlinx_coroutines_Deferred_getCompletionExceptionOrNull__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Deferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Deferred
+    let _result: Swift.Optional<ExportedKotlinPackages.kotlin.Throwable> = _self.getCompletionExceptionOrNull()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_Deferred_onAwait_get__reverse_swift")
+package func kotlinx_coroutines_Deferred_onAwait_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Deferred.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Deferred
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 = _self.onAwait
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift")
+package func kotlinx_coroutines_Delay_invokeOnTimeout__TypesOfArguments__Swift_Int64_anyU20ExportedKotlinPackages_kotlinx_coroutines_Runnable_anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ timeMillis: Swift.Int64, _ block: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Delay.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Delay
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle = _self.invokeOnTimeout(timeMillis: timeMillis, block: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: block, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Runnable.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Runnable, context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_DisposableHandle_dispose__reverse_swift")
+package func kotlinx_coroutines_DisposableHandle_dispose__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle
+    let _result: Swift.Void = _self.dispose()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift")
+package func kotlinx_coroutines_Job_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ cause: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: Swift.Void = _self.cancel(cause: { switch cause { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_Job_children_get__reverse_swift")
+package func kotlinx_coroutines_Job_children_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: any ExportedKotlinPackages.kotlin.sequences.Sequence = _self.children
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_Job_getCancellationException__reverse_swift")
+package func kotlinx_coroutines_Job_getCancellationException__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException = _self.getCancellationException()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_Job_isActive_get__reverse_swift")
+package func kotlinx_coroutines_Job_isActive_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: Swift.Bool = _self.isActive
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_Job_isCancelled_get__reverse_swift")
+package func kotlinx_coroutines_Job_isCancelled_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: Swift.Bool = _self.isCancelled
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_Job_isCompleted_get__reverse_swift")
+package func kotlinx_coroutines_Job_isCompleted_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: Swift.Bool = _self.isCompleted
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_Job_join__reverse_swift")
+package func kotlinx_coroutines_Job_join__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.join()
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_Job_onJoin_get__reverse_swift")
+package func kotlinx_coroutines_Job_onJoin_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause0 = _self.onJoin
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_Job_parent_get__reverse_swift")
+package func kotlinx_coroutines_Job_parent_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: Swift.Optional<any ExportedKotlinPackages.kotlinx.coroutines.Job> = _self.parent
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_Job_start__reverse_swift")
+package func kotlinx_coroutines_Job_start__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Job.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Job
+    let _result: Swift.Bool = _self.start()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse_swift")
+package func kotlinx_coroutines_MainCoroutineDispatcher_immediate_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher = _self.immediate
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlinx_coroutines_MainCoroutineDispatcher_limitedParallelism__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ parallelism: Swift.Int32) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.CoroutineDispatcher = _self.limitedParallelism(parallelism: parallelism)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse_swift")
+package func kotlinx_coroutines_MainCoroutineDispatcher_toString__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.String = _self.toString()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_Runnable_run__reverse_swift")
+package func kotlinx_coroutines_Runnable_run__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.Runnable.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.Runnable
+    let _result: Swift.Void = _self.run()
+    return { _result; return true }()
+}
+
+@available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported")
+@_cdecl("kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift")
+package func kotlinx_coroutines_channels_BroadcastChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ cause: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel
+    let _result: Swift.Void = _self.cancel(cause: { switch cause { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@available(*, deprecated, message: "BroadcastChannel is deprecated in the favour of SharedFlow and is no longer supported")
+@_cdecl("kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse_swift")
+package func kotlinx_coroutines_channels_BroadcastChannel_openSubscription__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.BroadcastChannel
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel = _self.openSubscription()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse_swift")
+package func kotlinx_coroutines_channels_ChannelIterator_hasNext__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator
+    let __continuation: (Swift.Bool) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Bool__(pointerToBlock.__externalRCRef()!, _1); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.hasNext()
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_channels_ChannelIterator_next__reverse_swift")
+package func kotlinx_coroutines_channels_ChannelIterator_next__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.next()
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_channels_ProducerScope_channel_get__reverse_swift")
+package func kotlinx_coroutines_channels_ProducerScope_channel_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ProducerScope
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel = _self.channel
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_cancel__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_coroutines_cancellation_CancellationException_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ cause: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: Swift.Void = _self.cancel(cause: { switch cause { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.coroutines.cancellation.CancellationException.__createClassWrapper(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_isClosedForReceive_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: Swift.Bool = _self.isClosedForReceive
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_isEmpty_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: Swift.Bool = _self.isEmpty
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_iterator__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelIterator = _self.iterator()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_onReceiveCatching_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 = _self.onReceiveCatching
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_onReceive_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause1 = _self.onReceive
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_receiveCatching__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let __continuation: (ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_ExportedKotlinPackages_kotlinx_coroutines_channels_ChannelResult__(pointerToBlock.__externalRCRef()!, _1.__externalRCRef()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.receiveCatching()
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_receive__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_receive__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let __continuation: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(pointerToBlock.__externalRCRef()!, _1.map { it in it.__externalRCRef() } ?? nil); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.receive()
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse_swift")
+package func kotlinx_coroutines_channels_ReceiveChannel_tryReceive__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult = _self.tryReceive()
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift")
+package func kotlinx_coroutines_channels_SendChannel_close__TypesOfArguments__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ cause: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+    let _result: Swift.Bool = _self.close(cause: { switch cause { case nil: .none; case let res?: ExportedKotlinPackages.kotlin.Throwable.__createClassWrapper(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse_swift")
+package func kotlinx_coroutines_channels_SendChannel_isClosedForSend_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+    let _result: Swift.Bool = _self.isClosedForSend
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_channels_SendChannel_onSend_get__reverse_swift")
+package func kotlinx_coroutines_channels_SendChannel_onSend_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 = _self.onSend
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_channels_SendChannel_send__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.send(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_channels_SendChannel_trySend__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ element: Swift.UnsafeMutableRawPointer?) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.channels.SendChannel
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.channels.ChannelResult = _self.trySend(element: { switch element { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+package func kotlinx_coroutines_flow_AbstractFlow_collectSafely__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ collector: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.flow.AbstractFlow.__createClassWrapper(externalRCRef: `self`)!
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.collectSafely(collector: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: collector, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector)
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ value: Swift.UnsafeMutableRawPointer?, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.emit(value: { switch value { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+package func kotlinx_coroutines_flow_Flow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ collector: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.collect(collector: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: collector, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector)
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ value: Swift.UnsafeMutableRawPointer?, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.emit(value: { switch value { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift")
+package func kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow
+    let _result: Swift.Void = _self.resetReplayCache()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse_swift")
+package func kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow
+    let _result: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32> = _self.subscriptionCount
+    return _result.wrapped.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ value: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow
+    let _result: Swift.Bool = _self.tryEmit(value: { switch value { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ expect: Swift.UnsafeMutableRawPointer?, _ update: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow
+    let _result: Swift.Bool = _self.compareAndSet(expect: { switch expect { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }(), update: { switch update { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse_swift")
+package func kotlinx_coroutines_flow_MutableStateFlow_value_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.value
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_flow_MutableStateFlow_value_set__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ newValue: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow
+    let _result: Swift.Void = { _self.value = { switch newValue { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }() }()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+package func kotlinx_coroutines_flow_SharedFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ collector: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow
+    let __continuation: (Swift.Never) -> Swift.Void = {
+    let _ = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _ in fatalError() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.collect(collector: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: collector, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector)
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse_swift")
+package func kotlinx_coroutines_flow_SharedFlow_replayCache_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Any {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow
+    let _result: Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = _self.replayCache
+    return _result.map { it in it as! NSObject? ?? NSNull() }
+}
+
+@_cdecl("kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse_swift")
+package func kotlinx_coroutines_flow_SharingStarted_command__TypesOfArguments__anyU20KotlinCoroutineSupport_KotlinTypedStateFlow_Swift_Int32_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ subscriptionCount: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.SharingStarted
+    let _result: any KotlinCoroutineSupport.KotlinTypedFlow<ExportedKotlinPackages.kotlinx.coroutines.flow.SharingCommand> = _self.command(subscriptionCount: KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Int32>.create(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: subscriptionCount, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, Swift.Int32.Type.self))
+    return _result.wrapped.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_flow_StateFlow_value_get__reverse_swift")
+package func kotlinx_coroutines_flow_StateFlow_value_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.value
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift")
+package func kotlinx_coroutines_flow_internal_ChannelFlow_collect__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_flow_FlowCollector____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ collector: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.__createClassWrapper(externalRCRef: `self`)!
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.collect(collector: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: collector, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector)
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse_swift")
+package func kotlinx_coroutines_flow_internal_ChannelFlow_dropChannelOperators__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Optional<any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>> = _self.dropChannelOperators()
+    return _result.map { it in it.wrapped.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift")
+package func kotlinx_coroutines_flow_internal_ChannelFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer, _ capacity: Swift.Int32, _ onBufferOverflow: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.__createClassWrapper(externalRCRef: `self`)!
+    let _result: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = _self.fuse(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, capacity: capacity, onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow(__externalRCRefUnsafe: onBufferOverflow, options: .asBestFittingWrapper))
+    return _result.wrapped.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse_swift")
+package func kotlinx_coroutines_flow_internal_ChannelFlow_produceImpl__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_CoroutineScope____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ scope: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.__createClassWrapper(externalRCRef: `self`)!
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.channels.ReceiveChannel = _self.produceImpl(scope: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: scope, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.CoroutineScope)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse_swift")
+package func kotlinx_coroutines_flow_internal_ChannelFlow_toString__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.ChannelFlow.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.String = _self.toString()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift")
+package func kotlinx_coroutines_flow_internal_FusibleFlow_fuse__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_coroutines_CoroutineContext_Swift_Int32_ExportedKotlinPackages_kotlinx_coroutines_channels_BufferOverflow____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ context: Swift.UnsafeMutableRawPointer, _ capacity: Swift.Int32, _ onBufferOverflow: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.FusibleFlow.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.`internal`.FusibleFlow
+    let _result: any KotlinCoroutineSupport.KotlinTypedFlow<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>> = _self.fuse(context: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: context, conformsTo: ExportedKotlinPackages.kotlin.coroutines.CoroutineContext.Type.self) as! any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext, capacity: capacity, onBufferOverflow: ExportedKotlinPackages.kotlinx.coroutines.channels.BufferOverflow(__externalRCRefUnsafe: onBufferOverflow, options: .asBestFittingWrapper))
+    return _result.wrapped.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse_swift")
+package func kotlinx_coroutines_internal_AtomicOp_atomicOp_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.__createClassWrapper(externalRCRef: `self`)!
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp = _self.atomicOp
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_internal_AtomicOp_complete__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ affected: Swift.UnsafeMutableRawPointer?, _ failure: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Void = _self.complete(affected: { switch affected { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }(), failure: { switch failure { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_internal_AtomicOp_prepare__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ affected: Swift.UnsafeMutableRawPointer?) -> Swift.UnsafeMutableRawPointer? {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.prepare(affected: { switch affected { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse_swift")
+package func kotlinx_coroutines_internal_LockFreeLinkedListHead_isRemoved_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListHead.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Bool = _self.isRemoved
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse_swift")
+package func kotlinx_coroutines_internal_LockFreeLinkedListNode_isRemoved_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Bool = _self.isRemoved
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse_swift")
+package func kotlinx_coroutines_internal_LockFreeLinkedListNode_remove__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Bool = _self.remove()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse_swift")
+package func kotlinx_coroutines_internal_LockFreeLinkedListNode_toString__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.LockFreeLinkedListNode.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.String = _self.toString()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse_swift")
+package func kotlinx_coroutines_internal_MainDispatcherFactory_createDispatcher__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlinx_coroutines_U60internalU60_MainDispatcherFactory_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ allFactories: Any) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory
+    let _result: ExportedKotlinPackages.kotlinx.coroutines.MainCoroutineDispatcher = _self.createDispatcher(allFactories: allFactories as! Swift.Array<any ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory>)
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse_swift")
+package func kotlinx_coroutines_internal_MainDispatcherFactory_hintOnError__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String? {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory
+    let _result: Swift.Optional<Swift.String> = _self.hintOnError()
+    return _result ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse_swift")
+package func kotlinx_coroutines_internal_MainDispatcherFactory_loadPriority_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.`internal`.MainDispatcherFactory
+    let _result: Swift.Int32 = _self.loadPriority
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse_swift")
+package func kotlinx_coroutines_internal_OpDescriptor_atomicOp_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Optional<ExportedKotlinPackages.kotlinx.coroutines.`internal`.AtomicOp> = _self.atomicOp
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_internal_OpDescriptor_perform__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ affected: Swift.UnsafeMutableRawPointer?) -> Swift.UnsafeMutableRawPointer? {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = _self.perform(affected: { switch affected { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result.map { it in it.__externalRCRef() } ?? nil
+}
+
+@_cdecl("kotlinx_coroutines_internal_OpDescriptor_toString__reverse_swift")
+package func kotlinx_coroutines_internal_OpDescriptor_toString__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.String {
+    let _self = ExportedKotlinPackages.kotlinx.coroutines.`internal`.OpDescriptor.__createClassWrapper(externalRCRef: `self`)!
+    let _result: Swift.String = _self.toString()
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse_swift")
+package func kotlinx_coroutines_internal_ThreadSafeHeapNode_index_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode
+    let _result: Swift.Int32 = _self.index
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse_swift")
+package func kotlinx_coroutines_internal_ThreadSafeHeapNode_index_set__TypesOfArguments__Swift_Int32____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ newValue: Swift.Int32) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.`internal`.ThreadSafeHeapNode
+    let _result: Swift.Void = { _self.index = newValue }()
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse_swift")
+package func kotlinx_coroutines_selects_SelectClause_clauseObject_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause
+    let _result: any KotlinRuntimeSupport._KotlinBridgeable = _self.clauseObject
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_selects_SelectInstance_context_get__reverse_swift")
+package func kotlinx_coroutines_selects_SelectInstance_context_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance
+    let _result: any ExportedKotlinPackages.kotlin.coroutines.CoroutineContext = _self.context
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse_swift")
+package func kotlinx_coroutines_selects_SelectInstance_disposeOnCompletion__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_coroutines_DisposableHandle____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ disposableHandle: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance
+    let _result: Swift.Void = _self.disposeOnCompletion(disposableHandle: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: disposableHandle, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.DisposableHandle)
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_selects_SelectInstance_selectInRegistrationPhase__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ internalResult: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance
+    let _result: Swift.Void = _self.selectInRegistrationPhase(internalResult: { switch internalResult { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_selects_SelectInstance_trySelect__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ clauseObject: Swift.UnsafeMutableRawPointer, _ result: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectInstance
+    let _result: Swift.Bool = _self.trySelect(clauseObject: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: clauseObject), result: { switch result { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+package func kotlinx_coroutines_sync_Mutex_holdsLock__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ owner: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    let _result: Swift.Bool = _self.holdsLock(owner: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: owner))
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_sync_Mutex_isLocked_get__reverse_swift")
+package func kotlinx_coroutines_sync_Mutex_isLocked_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    let _result: Swift.Bool = _self.isLocked
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_sync_Mutex_lock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ owner: Swift.UnsafeMutableRawPointer?, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.lock(owner: { switch owner { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    }
+    return true
+}
+
+@available(*, deprecated, message: "Mutex.onLock deprecated without replacement. For additional details please refer to #2794")
+@_cdecl("kotlinx_coroutines_sync_Mutex_onLock_get__reverse_swift")
+package func kotlinx_coroutines_sync_Mutex_onLock_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    let _result: any ExportedKotlinPackages.kotlinx.coroutines.selects.SelectClause2 = _self.onLock
+    return _result.__externalRCRef()
+}
+
+@_cdecl("kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_sync_Mutex_tryLock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ owner: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    let _result: Swift.Bool = _self.tryLock(owner: { switch owner { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+package func kotlinx_coroutines_sync_Mutex_unlock__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ owner: Swift.UnsafeMutableRawPointer?) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Mutex
+    let _result: Swift.Void = _self.unlock(owner: { switch owner { case nil: .none; case let res?: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }())
+    return { _result; return true }()
+}
+
+@_cdecl("kotlinx_coroutines_sync_Semaphore_acquire__reverse_swift")
+package func kotlinx_coroutines_sync_Semaphore_acquire__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ continuation: Swift.UnsafeMutableRawPointer, _ exception: Swift.UnsafeMutableRawPointer, _ cancellation: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore
+    let __continuation: (Swift.Void) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: continuation, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__(pointerToBlock.__externalRCRef()!, { _1; return true }()); return () }() }
+}()
+    let __exception: (Swift.Optional<Swift.Error>) -> Swift.Void = {
+    let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: exception, options: .asBestFittingWrapper)!
+    return { _1 in return { KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_Error___(pointerToBlock.__externalRCRef()!, _1.map { it in KotlinRuntimeSupport.kotlinThrowableRCRef(for: it) } ?? nil); return () }() }
+}()
+    let __cancellation: KotlinCoroutineSupport.KotlinTask = KotlinCoroutineSupport.KotlinTask.__createClassWrapper(externalRCRef: cancellation)
+    withKotlinTask(__continuation, __exception, __cancellation) {
+        try await _self.acquire()
+    }
+    return true
+}
+
+@_cdecl("kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse_swift")
+package func kotlinx_coroutines_sync_Semaphore_availablePermits_get__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Int32 {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore
+    let _result: Swift.Int32 = _self.availablePermits
+    return _result
+}
+
+@_cdecl("kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse_swift")
+package func kotlinx_coroutines_sync_Semaphore_tryAcquire__reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`, conformsTo: ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore.Type.self) as! any ExportedKotlinPackages.kotlinx.coroutines.sync.Semaphore
+    let _result: Swift.Bool = _self.tryAcquire()
+    return _result
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.kt
@@ -1,0 +1,5010 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.ContextualSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO19KotlinSerializationE20ContextualSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.MissingFieldException::class, "22ExportedKotlinPackages7kotlinxO13serializationO19KotlinSerializationE21MissingFieldExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.PolymorphicSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO19KotlinSerializationE21PolymorphicSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.SealedClassSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO19KotlinSerializationE21SealedClassSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.SerializationException::class, "22ExportedKotlinPackages7kotlinxO13serializationO19KotlinSerializationE22SerializationExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.BinaryFormat::class, "_ExportedKotlinPackages_kotlinx_serialization_BinaryFormat")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.DeserializationStrategy::class, "_ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.KSerializer::class, "_ExportedKotlinPackages_kotlinx_serialization_KSerializer")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.SerialFormat::class, "_ExportedKotlinPackages_kotlinx_serialization_SerialFormat")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.SerializationStrategy::class, "_ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.StringFormat::class, "_ExportedKotlinPackages_kotlinx_serialization_StringFormat")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.AbstractCollectionSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE28AbstractCollectionSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.AbstractPolymorphicSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE29AbstractPolymorphicSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.MapLikeSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE17MapLikeSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.NamedValueDecoder::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE17NamedValueDecoderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.NamedValueEncoder::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE17NamedValueEncoderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.TaggedDecoder::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE13TaggedDecoderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.TaggedEncoder::class, "22ExportedKotlinPackages7kotlinxO13serializationO8internalO19KotlinSerializationE13TaggedEncoderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.internal.GeneratedSerializer::class, "_ExportedKotlinPackages_kotlinx_serialization_internal_GeneratedSerializer")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.builtins.LongAsStringSerializer::class, "22ExportedKotlinPackages7kotlinxO13serializationO8builtinsO19KotlinSerializationE22LongAsStringSerializerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE28ClassSerialDescriptorBuilderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PolymorphicKind::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE15PolymorphicKindC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PolymorphicKind.OPEN::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE15PolymorphicKindC4OPENC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PolymorphicKind.SEALED::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE15PolymorphicKindC6SEALEDC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.BOOLEAN::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC7BOOLEANC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.BYTE::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC4BYTEC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.CHAR::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC4CHARC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.DOUBLE::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC6DOUBLEC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.FLOAT::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC5FLOATC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.INT::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC3INTC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.LONG::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC4LONGC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.SHORT::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC5SHORTC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.PrimitiveKind.STRING::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13PrimitiveKindC6STRINGC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.SerialKind::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE10SerialKindC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.SerialKind.CONTEXTUAL::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE10SerialKindC10CONTEXTUALC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.SerialKind.ENUM::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE10SerialKindC4ENUMC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.StructureKind::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13StructureKindC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.StructureKind.CLASS::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13StructureKindC5CLASSC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.StructureKind.LIST::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13StructureKindC4LISTC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.StructureKind.MAP::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13StructureKindC3MAPC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.StructureKind.OBJECT::class, "22ExportedKotlinPackages7kotlinxO13serializationO11descriptorsO19KotlinSerializationE13StructureKindC6OBJECTC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.descriptors.SerialDescriptor::class, "_ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.AbstractDecoder::class, "22ExportedKotlinPackages7kotlinxO13serializationO8encodingO19KotlinSerializationE15AbstractDecoderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.AbstractEncoder::class, "22ExportedKotlinPackages7kotlinxO13serializationO8encodingO19KotlinSerializationE15AbstractEncoderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.ChunkedDecoder::class, "_ExportedKotlinPackages_kotlinx_serialization_encoding_ChunkedDecoder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.CompositeDecoder::class, "_ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.CompositeEncoder::class, "_ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.Decoder::class, "_ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.Encoder::class, "_ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.modules.PolymorphicModuleBuilder::class, "22ExportedKotlinPackages7kotlinxO13serializationO7modulesO19KotlinSerializationE24PolymorphicModuleBuilderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.modules.SerializersModule::class, "22ExportedKotlinPackages7kotlinxO13serializationO7modulesO19KotlinSerializationE17SerializersModuleC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.modules.SerializersModuleBuilder::class, "22ExportedKotlinPackages7kotlinxO13serializationO7modulesO19KotlinSerializationE24SerializersModuleBuilderC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.modules.SerializersModuleCollector::class, "_ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.serialization.encoding.CompositeDecoder.Companion::class, "19KotlinSerialization81_ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_CompanionC")
+
+import kotlin.native.internal.objc.BindReverseBridgeToMethod
+import kotlin.native.internal.ImportedBridge
+import kotlinx.cinterop.*
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+import kotlinx.serialization.builtins.serializer as kotlinx_serialization_builtins_serializer
+import kotlinx.serialization.decodeFromHexString as kotlinx_serialization_decodeFromHexString
+import kotlinx.serialization.descriptors.elementDescriptors as kotlinx_serialization_descriptors_elementDescriptors
+import kotlinx.serialization.descriptors.elementNames as kotlinx_serialization_descriptors_elementNames
+import kotlinx.serialization.descriptors.getContextualDescriptor as kotlinx_serialization_descriptors_getContextualDescriptor
+import kotlinx.serialization.descriptors.getPolymorphicDescriptors as kotlinx_serialization_descriptors_getPolymorphicDescriptors
+import kotlinx.serialization.descriptors.nullable as kotlinx_serialization_descriptors_nullable
+import kotlinx.serialization.encodeToHexString as kotlinx_serialization_encodeToHexString
+import kotlinx.serialization.encoding.decodeStructure as kotlinx_serialization_encoding_decodeStructure
+import kotlinx.serialization.encoding.encodeCollection as kotlinx_serialization_encoding_encodeCollection
+import kotlinx.serialization.encoding.encodeStructure as kotlinx_serialization_encoding_encodeStructure
+import kotlinx.serialization.findPolymorphicSerializer as kotlinx_serialization_findPolymorphicSerializer
+import kotlinx.serialization.modules.overwriteWith as kotlinx_serialization_modules_overwriteWith
+import kotlinx.serialization.modules.plus as kotlinx_serialization_modules_plus
+
+@ImportedBridge("kotlinx_serialization_BinaryFormat_decodeFromByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_ExportedKotlinPackages_kotlin_ByteArray____reverse_swift")
+internal external fun kotlinx_serialization_BinaryFormat_decodeFromByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_ExportedKotlinPackages_kotlin_ByteArray____reverse_swift(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, bytes: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.BinaryFormat::class, "decodeFromByteArray")
+public fun kotlinx_serialization_BinaryFormat_decodeFromByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_ExportedKotlinPackages_kotlin_ByteArray____reverse(self: kotlinx.serialization.BinaryFormat, deserializer: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>, bytes: kotlin.ByteArray): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __deserializer = kotlin.native.internal.ref.createRetainedExternalRCRef(deserializer)
+    val __bytes = kotlin.native.internal.ref.createRetainedExternalRCRef(bytes)
+    val _result = kotlinx_serialization_BinaryFormat_decodeFromByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_ExportedKotlinPackages_kotlin_ByteArray____reverse_swift(__self, __deserializer, __bytes)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_BinaryFormat_encodeToByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_BinaryFormat_encodeToByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.BinaryFormat::class, "encodeToByteArray")
+public fun kotlinx_serialization_BinaryFormat_encodeToByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.BinaryFormat, serializer: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, value: kotlin.Any?): kotlin.ByteArray {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __serializer = kotlin.native.internal.ref.createRetainedExternalRCRef(serializer)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_BinaryFormat_encodeToByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __serializer, __value)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.ByteArray
+}
+
+@ImportedBridge("kotlinx_serialization_DeserializationStrategy_descriptor_get__reverse_swift")
+internal external fun kotlinx_serialization_DeserializationStrategy_descriptor_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.DeserializationStrategy::class, "<get-descriptor>")
+public fun kotlinx_serialization_DeserializationStrategy_descriptor_get__reverse(self: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>): kotlinx.serialization.descriptors.SerialDescriptor {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_DeserializationStrategy_descriptor_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.descriptors.SerialDescriptor
+}
+
+@ImportedBridge("kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift")
+internal external fun kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.DeserializationStrategy::class, "deserialize")
+public fun kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse(self: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>, decoder: kotlinx.serialization.encoding.Decoder): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __decoder = kotlin.native.internal.ref.createRetainedExternalRCRef(decoder)
+    val _result = kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift(__self, __decoder)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_KSerializer_descriptor_get__reverse_swift")
+internal external fun kotlinx_serialization_KSerializer_descriptor_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.KSerializer::class, "<get-descriptor>")
+public fun kotlinx_serialization_KSerializer_descriptor_get__reverse(self: kotlinx.serialization.KSerializer<kotlin.Any?>): kotlinx.serialization.descriptors.SerialDescriptor {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_KSerializer_descriptor_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.descriptors.SerialDescriptor
+}
+
+@ImportedBridge("kotlinx_serialization_SerialFormat_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_SerialFormat_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.SerialFormat::class, "<get-serializersModule>")
+public fun kotlinx_serialization_SerialFormat_serializersModule_get__reverse(self: kotlinx.serialization.SerialFormat): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_SerialFormat_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_SerializationStrategy_descriptor_get__reverse_swift")
+internal external fun kotlinx_serialization_SerializationStrategy_descriptor_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.SerializationStrategy::class, "<get-descriptor>")
+public fun kotlinx_serialization_SerializationStrategy_descriptor_get__reverse(self: kotlinx.serialization.SerializationStrategy<kotlin.Any?>): kotlinx.serialization.descriptors.SerialDescriptor {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_SerializationStrategy_descriptor_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.descriptors.SerialDescriptor
+}
+
+@ImportedBridge("kotlinx_serialization_SerializationStrategy_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_SerializationStrategy_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.SerializationStrategy::class, "serialize")
+public fun kotlinx_serialization_SerializationStrategy_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, encoder: kotlinx.serialization.encoding.Encoder, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __encoder = kotlin.native.internal.ref.createRetainedExternalRCRef(encoder)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_SerializationStrategy_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __encoder, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_StringFormat_decodeFromString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String____reverse_swift")
+internal external fun kotlinx_serialization_StringFormat_decodeFromString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String____reverse_swift(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, string: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.StringFormat::class, "decodeFromString")
+public fun kotlinx_serialization_StringFormat_decodeFromString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String____reverse(self: kotlinx.serialization.StringFormat, deserializer: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>, string: kotlin.String): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __deserializer = kotlin.native.internal.ref.createRetainedExternalRCRef(deserializer)
+    val __string = string.objcPtr()
+    val _result = kotlinx_serialization_StringFormat_decodeFromString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String____reverse_swift(__self, __deserializer, __string)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_StringFormat_encodeToString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_StringFormat_encodeToString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.StringFormat::class, "encodeToString")
+public fun kotlinx_serialization_StringFormat_encodeToString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.StringFormat, serializer: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, value: kotlin.Any?): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __serializer = kotlin.native.internal.ref.createRetainedExternalRCRef(serializer)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_StringFormat_encodeToString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __serializer, __value)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_annotations_get__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_annotations_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "<get-annotations>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_annotations_get__reverse(self: kotlinx.serialization.descriptors.SerialDescriptor): kotlin.collections.List<kotlin.Annotation> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_annotations_get__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.collections.List<kotlin.Annotation>>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_elementsCount_get__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_elementsCount_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "<get-elementsCount>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_elementsCount_get__reverse(self: kotlinx.serialization.descriptors.SerialDescriptor): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_elementsCount_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementAnnotations__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_getElementAnnotations__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "getElementAnnotations")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementAnnotations__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlin.collections.List<kotlin.Annotation> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_getElementAnnotations__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return interpretObjCPointer<kotlin.collections.List<kotlin.Annotation>>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementDescriptor__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_getElementDescriptor__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "getElementDescriptor")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementDescriptor__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlinx.serialization.descriptors.SerialDescriptor {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_getElementDescriptor__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.descriptors.SerialDescriptor
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementIndex__TypesOfArguments__Swift_String____reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_getElementIndex__TypesOfArguments__Swift_String____reverse_swift(self: kotlin.native.internal.NativePtr, name: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "getElementIndex")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementIndex__TypesOfArguments__Swift_String____reverse(self: kotlinx.serialization.descriptors.SerialDescriptor, name: kotlin.String): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __name = name.objcPtr()
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_getElementIndex__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementName__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_getElementName__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "getElementName")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementName__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_getElementName__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isElementOptional__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_isElementOptional__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "isElementOptional")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isElementOptional__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_isElementOptional__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isInline_get__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_isInline_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "<get-isInline>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isInline_get__reverse(self: kotlinx.serialization.descriptors.SerialDescriptor): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_isInline_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "<get-isNullable>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get__reverse(self: kotlinx.serialization.descriptors.SerialDescriptor): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_kind_get__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_kind_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "<get-kind>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_kind_get__reverse(self: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.descriptors.SerialKind {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_kind_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.descriptors.SerialKind
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_serialName_get__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialDescriptor_serialName_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialDescriptor::class, "<get-serialName>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_serialName_get__reverse(self: kotlinx.serialization.descriptors.SerialDescriptor): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialDescriptor_serialName_get__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialKind_hashCode__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialKind_hashCode__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialKind::class, "hashCode")
+public fun kotlinx_serialization_descriptors_SerialKind_hashCode__reverse(self: kotlinx.serialization.descriptors.SerialKind): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialKind_hashCode__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_descriptors_SerialKind_toString__reverse_swift")
+internal external fun kotlinx_serialization_descriptors_SerialKind_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.descriptors.SerialKind::class, "toString")
+public fun kotlinx_serialization_descriptors_SerialKind_toString__reverse(self: kotlinx.serialization.descriptors.SerialKind): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_descriptors_SerialKind_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "beginStructure")
+public fun kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.CompositeDecoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeDecoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeBoolean")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeByte__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeByte__reverse_swift(self: kotlin.native.internal.NativePtr): Byte
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeByte")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeByte__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Byte {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeByte__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeChar__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeChar__reverse_swift(self: kotlin.native.internal.NativePtr): Char
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeChar")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeChar__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Char {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeChar__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeDouble__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeDouble__reverse_swift(self: kotlin.native.internal.NativePtr): Double
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeDouble")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeDouble__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Double {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeDouble__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeEnum")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, enumDescriptor: kotlinx.serialization.descriptors.SerialDescriptor): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __enumDescriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(enumDescriptor)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __enumDescriptor)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeFloat__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeFloat__reverse_swift(self: kotlin.native.internal.NativePtr): Float
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeFloat")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeFloat__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Float {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeFloat__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeInlineElement")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlinx.serialization.encoding.Decoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Decoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeInline")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.Decoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Decoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInt__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeInt__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeInt")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInt__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeInt__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeLong__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeLong__reverse_swift(self: kotlin.native.internal.NativePtr): Long
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeLong")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeLong__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Long {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeLong__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeNotNullMark")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeNull__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeNull__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeNull")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeNull__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Nothing? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeNull__reverse_swift(__self)
+    return run { _result; null }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeSerializableElement")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, deserializer: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>, previousValue: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val __deserializer = kotlin.native.internal.ref.createRetainedExternalRCRef(deserializer)
+    val __previousValue = if (previousValue == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(previousValue)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __descriptor, index, __deserializer, __previousValue)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeSerializableValue")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, deserializer: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>, previousValue: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __deserializer = kotlin.native.internal.ref.createRetainedExternalRCRef(deserializer)
+    val __previousValue = if (previousValue == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(previousValue)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __deserializer, __previousValue)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeShort__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeShort__reverse_swift(self: kotlin.native.internal.NativePtr): Short
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeShort")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeShort__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): Short {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeShort__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeString__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeString")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeString__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeValue__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_decodeValue__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "decodeValue")
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeValue__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): kotlin.Any {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_decodeValue__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "endStructure")
+public fun kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractDecoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractDecoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractDecoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_encoding_AbstractDecoder_serializersModule_get__reverse(self: kotlinx.serialization.encoding.AbstractDecoder): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractDecoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "beginStructure")
+public fun kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.CompositeEncoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeEncoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse_swift(self: kotlin.native.internal.NativePtr, value: Boolean): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeBoolean")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Boolean): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8____reverse_swift(self: kotlin.native.internal.NativePtr, value: Byte): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeByte")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Byte): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift(self: kotlin.native.internal.NativePtr, value: Char): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeChar")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Char): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double____reverse_swift(self: kotlin.native.internal.NativePtr, value: Double): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeDouble")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Double): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeElement")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr, index: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeEnum")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, enumDescriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __enumDescriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(enumDescriptor)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __enumDescriptor, index)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float____reverse_swift(self: kotlin.native.internal.NativePtr, value: Float): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeFloat")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Float): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeInline")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.Encoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Encoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, value: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeInt")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Int): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64____reverse_swift(self: kotlin.native.internal.NativePtr, value: Long): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeLong")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Long): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeNull__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeNull__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeNull")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeNull__reverse(self: kotlinx.serialization.encoding.AbstractEncoder): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeNull__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeSerializableElement")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, serializer: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val __serializer = kotlin.native.internal.ref.createRetainedExternalRCRef(serializer)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __descriptor, index, __serializer, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16____reverse_swift(self: kotlin.native.internal.NativePtr, value: Short): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeShort")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: Short): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeString")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: kotlin.String): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = value.objcPtr()
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String____reverse_swift(__self, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "encodeValue")
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, value: kotlin.Any): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(__self, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "endStructure")
+public fun kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.AbstractEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_AbstractEncoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_encoding_AbstractEncoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.AbstractEncoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_encoding_AbstractEncoder_serializersModule_get__reverse(self: kotlinx.serialization.encoding.AbstractEncoder): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_AbstractEncoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeBooleanElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Byte
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeByteElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Byte {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Char
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeCharElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Char {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeCollectionSize")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Double
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeDoubleElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Double {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeElementIndex__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeElementIndex__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeElementIndex")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeElementIndex__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeElementIndex__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Float
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeFloatElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Float {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeInlineElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlinx.serialization.encoding.Decoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Decoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeIntElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Long
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeLongElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Long {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially__reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeSequentially")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially__reverse(self: kotlinx.serialization.encoding.CompositeDecoder): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeSerializableElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, deserializer: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>, previousValue: kotlin.Any?): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val __deserializer = kotlin.native.internal.ref.createRetainedExternalRCRef(deserializer)
+    val __previousValue = if (previousValue == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(previousValue)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __descriptor, index, __deserializer, __previousValue)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Short
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeShortElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Short {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "decodeStringElement")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "endStructure")
+public fun kotlinx_serialization_encoding_CompositeDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.CompositeDecoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeDecoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get__reverse(self: kotlinx.serialization.encoding.CompositeDecoder): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Boolean): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeBooleanElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Boolean): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Byte): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeByteElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Byte): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Char): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeCharElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Char): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Double): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeDoubleElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Double): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Float): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeFloatElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Float): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeInlineElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): kotlinx.serialization.encoding.Encoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Encoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeIntElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Int): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Long): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeLongElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Long): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeSerializableElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, serializer: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val __serializer = kotlin.native.internal.ref.createRetainedExternalRCRef(serializer)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __descriptor, index, __serializer, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Short): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeShortElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: Short): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16____reverse_swift(__self, __descriptor, index, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "encodeStringElement")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, value: kotlin.String): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val __value = value.objcPtr()
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String____reverse_swift(__self, __descriptor, index, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "endStructure")
+public fun kotlinx_serialization_encoding_CompositeEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get__reverse(self: kotlinx.serialization.encoding.CompositeEncoder): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.CompositeEncoder::class, "shouldEncodeElementDefault")
+public fun kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.CompositeEncoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, index)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "beginStructure")
+public fun kotlinx_serialization_encoding_Decoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.Decoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.CompositeDecoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_Decoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeDecoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeBoolean__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeBoolean__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeBoolean")
+public fun kotlinx_serialization_encoding_Decoder_decodeBoolean__reverse(self: kotlinx.serialization.encoding.Decoder): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeBoolean__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeByte__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeByte__reverse_swift(self: kotlin.native.internal.NativePtr): Byte
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeByte")
+public fun kotlinx_serialization_encoding_Decoder_decodeByte__reverse(self: kotlinx.serialization.encoding.Decoder): Byte {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeByte__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeChar__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeChar__reverse_swift(self: kotlin.native.internal.NativePtr): Char
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeChar")
+public fun kotlinx_serialization_encoding_Decoder_decodeChar__reverse(self: kotlinx.serialization.encoding.Decoder): Char {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeChar__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeDouble__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeDouble__reverse_swift(self: kotlin.native.internal.NativePtr): Double
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeDouble")
+public fun kotlinx_serialization_encoding_Decoder_decodeDouble__reverse(self: kotlinx.serialization.encoding.Decoder): Double {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeDouble__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeEnum")
+public fun kotlinx_serialization_encoding_Decoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.Decoder, enumDescriptor: kotlinx.serialization.descriptors.SerialDescriptor): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __enumDescriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(enumDescriptor)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __enumDescriptor)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeFloat__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeFloat__reverse_swift(self: kotlin.native.internal.NativePtr): Float
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeFloat")
+public fun kotlinx_serialization_encoding_Decoder_decodeFloat__reverse(self: kotlinx.serialization.encoding.Decoder): Float {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeFloat__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeInline")
+public fun kotlinx_serialization_encoding_Decoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.Decoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.Decoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Decoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeInt__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeInt__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeInt")
+public fun kotlinx_serialization_encoding_Decoder_decodeInt__reverse(self: kotlinx.serialization.encoding.Decoder): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeInt__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeLong__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeLong__reverse_swift(self: kotlin.native.internal.NativePtr): Long
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeLong")
+public fun kotlinx_serialization_encoding_Decoder_decodeLong__reverse(self: kotlinx.serialization.encoding.Decoder): Long {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeLong__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeNotNullMark__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeNotNullMark__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeNotNullMark")
+public fun kotlinx_serialization_encoding_Decoder_decodeNotNullMark__reverse(self: kotlinx.serialization.encoding.Decoder): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeNotNullMark__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeNull__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeNull__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeNull")
+public fun kotlinx_serialization_encoding_Decoder_decodeNull__reverse(self: kotlinx.serialization.encoding.Decoder): Nothing? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeNull__reverse_swift(__self)
+    return run { _result; null }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy____reverse_swift(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeSerializableValue")
+public fun kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy____reverse(self: kotlinx.serialization.encoding.Decoder, deserializer: kotlinx.serialization.DeserializationStrategy<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __deserializer = kotlin.native.internal.ref.createRetainedExternalRCRef(deserializer)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy____reverse_swift(__self, __deserializer)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeShort__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeShort__reverse_swift(self: kotlin.native.internal.NativePtr): Short
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeShort")
+public fun kotlinx_serialization_encoding_Decoder_decodeShort__reverse(self: kotlinx.serialization.encoding.Decoder): Short {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeShort__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_decodeString__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_decodeString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "decodeString")
+public fun kotlinx_serialization_encoding_Decoder_decodeString__reverse(self: kotlinx.serialization.encoding.Decoder): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_decodeString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Decoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Decoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Decoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_encoding_Decoder_serializersModule_get__reverse(self: kotlinx.serialization.encoding.Decoder): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Decoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, collectionSize: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "beginCollection")
+public fun kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.Encoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, collectionSize: Int): kotlinx.serialization.encoding.CompositeEncoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __descriptor, collectionSize)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeEncoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "beginStructure")
+public fun kotlinx_serialization_encoding_Encoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.Encoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.CompositeEncoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_Encoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeEncoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse_swift(self: kotlin.native.internal.NativePtr, value: Boolean): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeBoolean")
+public fun kotlinx_serialization_encoding_Encoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse(self: kotlinx.serialization.encoding.Encoder, value: Boolean): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeBoolean__TypesOfArguments__Swift_Bool____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeByte__TypesOfArguments__Swift_Int8____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeByte__TypesOfArguments__Swift_Int8____reverse_swift(self: kotlin.native.internal.NativePtr, value: Byte): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeByte")
+public fun kotlinx_serialization_encoding_Encoder_encodeByte__TypesOfArguments__Swift_Int8____reverse(self: kotlinx.serialization.encoding.Encoder, value: Byte): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeByte__TypesOfArguments__Swift_Int8____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift(self: kotlin.native.internal.NativePtr, value: Char): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeChar")
+public fun kotlinx_serialization_encoding_Encoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse(self: kotlinx.serialization.encoding.Encoder, value: Char): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeDouble__TypesOfArguments__Swift_Double____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeDouble__TypesOfArguments__Swift_Double____reverse_swift(self: kotlin.native.internal.NativePtr, value: Double): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeDouble")
+public fun kotlinx_serialization_encoding_Encoder_encodeDouble__TypesOfArguments__Swift_Double____reverse(self: kotlinx.serialization.encoding.Encoder, value: Double): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeDouble__TypesOfArguments__Swift_Double____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr, index: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeEnum")
+public fun kotlinx_serialization_encoding_Encoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse(self: kotlinx.serialization.encoding.Encoder, enumDescriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __enumDescriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(enumDescriptor)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32____reverse_swift(__self, __enumDescriptor, index)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeFloat__TypesOfArguments__Swift_Float____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeFloat__TypesOfArguments__Swift_Float____reverse_swift(self: kotlin.native.internal.NativePtr, value: Float): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeFloat")
+public fun kotlinx_serialization_encoding_Encoder_encodeFloat__TypesOfArguments__Swift_Float____reverse(self: kotlinx.serialization.encoding.Encoder, value: Float): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeFloat__TypesOfArguments__Swift_Float____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeInline")
+public fun kotlinx_serialization_encoding_Encoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.encoding.Encoder, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.Encoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Encoder
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeInt__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeInt__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, value: Int): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeInt")
+public fun kotlinx_serialization_encoding_Encoder_encodeInt__TypesOfArguments__Swift_Int32____reverse(self: kotlinx.serialization.encoding.Encoder, value: Int): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeInt__TypesOfArguments__Swift_Int32____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeLong__TypesOfArguments__Swift_Int64____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeLong__TypesOfArguments__Swift_Int64____reverse_swift(self: kotlin.native.internal.NativePtr, value: Long): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeLong")
+public fun kotlinx_serialization_encoding_Encoder_encodeLong__TypesOfArguments__Swift_Int64____reverse(self: kotlinx.serialization.encoding.Encoder, value: Long): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeLong__TypesOfArguments__Swift_Int64____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeNotNullMark__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeNotNullMark__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeNotNullMark")
+public fun kotlinx_serialization_encoding_Encoder_encodeNotNullMark__reverse(self: kotlinx.serialization.encoding.Encoder): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeNotNullMark__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeNull__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeNull__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeNull")
+public fun kotlinx_serialization_encoding_Encoder_encodeNull__reverse(self: kotlinx.serialization.encoding.Encoder): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeNull__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeSerializableValue")
+public fun kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.encoding.Encoder, serializer: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __serializer = kotlin.native.internal.ref.createRetainedExternalRCRef(serializer)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __serializer, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeShort__TypesOfArguments__Swift_Int16____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeShort__TypesOfArguments__Swift_Int16____reverse_swift(self: kotlin.native.internal.NativePtr, value: Short): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeShort")
+public fun kotlinx_serialization_encoding_Encoder_encodeShort__TypesOfArguments__Swift_Int16____reverse(self: kotlinx.serialization.encoding.Encoder, value: Short): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_encodeShort__TypesOfArguments__Swift_Int16____reverse_swift(__self, value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_encodeString__TypesOfArguments__Swift_String____reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_encodeString__TypesOfArguments__Swift_String____reverse_swift(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "encodeString")
+public fun kotlinx_serialization_encoding_Encoder_encodeString__TypesOfArguments__Swift_String____reverse(self: kotlinx.serialization.encoding.Encoder, value: kotlin.String): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __value = value.objcPtr()
+    val _result = kotlinx_serialization_encoding_Encoder_encodeString__TypesOfArguments__Swift_String____reverse_swift(__self, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_encoding_Encoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_encoding_Encoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.encoding.Encoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_encoding_Encoder_serializersModule_get__reverse(self: kotlinx.serialization.encoding.Encoder): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_encoding_Encoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift")
+internal external fun kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.AbstractCollectionSerializer::class, "deserialize")
+public fun kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse(self: kotlinx.serialization.internal.AbstractCollectionSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>, decoder: kotlinx.serialization.encoding.Decoder): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __decoder = kotlin.native.internal.ref.createRetainedExternalRCRef(decoder)
+    val _result = kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift(__self, __decoder)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlinx_serialization_internal_AbstractCollectionSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_internal_AbstractCollectionSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.AbstractCollectionSerializer::class, "serialize")
+public fun kotlinx_serialization_internal_AbstractCollectionSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.internal.AbstractCollectionSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>, encoder: kotlinx.serialization.encoding.Encoder, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __encoder = kotlin.native.internal.ref.createRetainedExternalRCRef(encoder)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_internal_AbstractCollectionSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __encoder, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String_____reverse_swift")
+internal external fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String_____reverse_swift(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr, klassName: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.AbstractPolymorphicSerializer::class, "findPolymorphicSerializerOrNull")
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String_____reverse(self: kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>, decoder: kotlinx.serialization.encoding.CompositeDecoder, klassName: kotlin.String?): kotlinx.serialization.DeserializationStrategy<*>? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __decoder = kotlin.native.internal.ref.createRetainedExternalRCRef(decoder)
+    val __klassName = if (klassName == null) kotlin.native.internal.NativePtr.NULL else klassName.objcPtr()
+    val _result = kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String_____reverse_swift(__self, __decoder, __klassName)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+internal external fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.AbstractPolymorphicSerializer::class, "findPolymorphicSerializerOrNull")
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse(self: kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>, encoder: kotlinx.serialization.encoding.Encoder, value: kotlin.Any): kotlinx.serialization.SerializationStrategy<*>? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __encoder = kotlin.native.internal.ref.createRetainedExternalRCRef(encoder)
+    val __value = kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(__self, __encoder, __value)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_serialization_internal_GeneratedSerializer_childSerializers__reverse_swift")
+internal external fun kotlinx_serialization_internal_GeneratedSerializer_childSerializers__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.GeneratedSerializer::class, "childSerializers")
+public fun kotlinx_serialization_internal_GeneratedSerializer_childSerializers__reverse(self: kotlinx.serialization.internal.GeneratedSerializer<kotlin.Any?>): kotlin.Array<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_GeneratedSerializer_childSerializers__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Array<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers__reverse_swift")
+internal external fun kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.GeneratedSerializer::class, "typeParametersSerializers")
+public fun kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers__reverse(self: kotlinx.serialization.internal.GeneratedSerializer<kotlin.Any?>): kotlin.Array<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Array<kotlin.Any?>
+}
+
+@ImportedBridge("kotlinx_serialization_internal_MapLikeSerializer_descriptor_get__reverse_swift")
+internal external fun kotlinx_serialization_internal_MapLikeSerializer_descriptor_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.MapLikeSerializer::class, "<get-descriptor>")
+public fun kotlinx_serialization_internal_MapLikeSerializer_descriptor_get__reverse(self: kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>): kotlinx.serialization.descriptors.SerialDescriptor {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_MapLikeSerializer_descriptor_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.descriptors.SerialDescriptor
+}
+
+@ImportedBridge("kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.MapLikeSerializer::class, "serialize")
+public fun kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>, encoder: kotlinx.serialization.encoding.Encoder, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __encoder = kotlin.native.internal.ref.createRetainedExternalRCRef(encoder)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __encoder, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedDecoder::class, "beginStructure")
+public fun kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.CompositeDecoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeDecoder
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedDecoder::class, "decodeInline")
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.Decoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Decoder
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark__reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedDecoder::class, "decodeNotNullMark")
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark__reverse(self: kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedDecoder::class, "endStructure")
+public fun kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedDecoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedDecoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedDecoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_internal_TaggedDecoder_serializersModule_get__reverse(self: kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_TaggedDecoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedEncoder::class, "beginStructure")
+public fun kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.CompositeEncoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.CompositeEncoder
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedEncoder::class, "encodeInline")
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse(self: kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>, descriptor: kotlinx.serialization.descriptors.SerialDescriptor): kotlinx.serialization.encoding.Encoder {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val _result = kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor____reverse_swift(__self, __descriptor)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.encoding.Encoder
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark__reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedEncoder::class, "encodeNotNullMark")
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark__reverse(self: kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeNull__reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedEncoder_encodeNull__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedEncoder::class, "encodeNull")
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeNull__reverse(self: kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_TaggedEncoder_encodeNull__reverse_swift(__self)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedEncoder::class, "encodeSerializableElement")
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>, descriptor: kotlinx.serialization.descriptors.SerialDescriptor, index: Int, serializer: kotlinx.serialization.SerializationStrategy<kotlin.Any?>, value: kotlin.Any?): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __descriptor = kotlin.native.internal.ref.createRetainedExternalRCRef(descriptor)
+    val __serializer = kotlin.native.internal.ref.createRetainedExternalRCRef(serializer)
+    val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+    val _result = kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __descriptor, index, __serializer, __value)
+    return run<Unit> { _result }
+}
+
+@ImportedBridge("kotlinx_serialization_internal_TaggedEncoder_serializersModule_get__reverse_swift")
+internal external fun kotlinx_serialization_internal_TaggedEncoder_serializersModule_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlinx.serialization.internal.TaggedEncoder::class, "<get-serializersModule>")
+public fun kotlinx_serialization_internal_TaggedEncoder_serializersModule_get__reverse(self: kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>): kotlinx.serialization.modules.SerializersModule {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlinx_serialization_internal_TaggedEncoder_serializersModule_get__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.serialization.modules.SerializersModule
+}
+
+@ImportedBridge("kotlinx_serialization_modules_SerializersModule_dumpTo__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector____reverse_swift")
+internal external fun kotlinx_serialization_modules_SerializersModule_dumpTo__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector____reverse_swift(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlinx.serialization.modules.SerializersModule::class, "dumpTo")
+public fun kotlinx_serialization_modules_SerializersModule_dumpTo__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector____reverse(self: kotlinx.serialization.modules.SerializersModule, collector: kotlinx.serialization.modules.SerializersModuleCollector): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __collector = kotlin.native.internal.ref.createRetainedExternalRCRef(collector)
+    val _result = kotlinx_serialization_modules_SerializersModule_dumpTo__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector____reverse_swift(__self, __collector)
+    return run<Unit> { _result }
+}
+
+@ExportedBridge("kotlinx_serialization_BinaryFormat_decodeFromByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_ExportedKotlinPackages_kotlin_ByteArray__")
+public fun kotlinx_serialization_BinaryFormat_decodeFromByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_ExportedKotlinPackages_kotlin_ByteArray__(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, bytes: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.BinaryFormat
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __bytes = kotlin.native.internal.ref.dereferenceExternalRCRef(bytes) as kotlin.ByteArray
+    val _result = run { __self.decodeFromByteArray<kotlin.Any?>(__deserializer, __bytes) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_BinaryFormat_encodeToByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_BinaryFormat_encodeToByteArray__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.BinaryFormat
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeToByteArray<kotlin.Any?>(__serializer, __value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_ContextualSerializer_descriptor_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_ContextualSerializer_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.ContextualSerializer<kotlin.Any>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_ContextualSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_ContextualSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.ContextualSerializer<kotlin.Any>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.deserialize(__decoder) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_ContextualSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_ContextualSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.ContextualSerializer<kotlin.Any>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_DeserializationStrategy_descriptor_get")
+public fun kotlinx_serialization_DeserializationStrategy_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__")
+public fun kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.deserialize(__decoder) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_KSerializer_descriptor_get")
+public fun kotlinx_serialization_KSerializer_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_MissingFieldException_init_allocate")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_MissingFieldException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.serialization.MissingFieldException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_MissingFieldException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Array_Swift_String__Swift_String__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_MissingFieldException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Array_Swift_String__Swift_String__(__kt: kotlin.native.internal.NativePtr, missingFields: kotlin.native.internal.NativePtr, serialName: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __missingFields = interpretObjCPointer<kotlin.collections.List<kotlin.String>>(missingFields)
+    val __serialName = interpretObjCPointer<kotlin.String>(serialName)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.MissingFieldException(__missingFields, __serialName)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_MissingFieldException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String_Swift_String__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_MissingFieldException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_String_Swift_String__(__kt: kotlin.native.internal.NativePtr, missingField: kotlin.native.internal.NativePtr, serialName: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __missingField = interpretObjCPointer<kotlin.String>(missingField)
+    val __serialName = interpretObjCPointer<kotlin.String>(serialName)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.MissingFieldException(__missingField, __serialName)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_MissingFieldException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Array_Swift_String__Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_MissingFieldException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Array_Swift_String__Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, missingFields: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __missingFields = interpretObjCPointer<kotlin.collections.List<kotlin.String>>(missingFields)
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.MissingFieldException(__missingFields, __message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_MissingFieldException_missingFields_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_MissingFieldException_missingFields_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.MissingFieldException
+    val _result = run { __self.missingFields }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_PolymorphicSerializer_descriptor_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_PolymorphicSerializer_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.PolymorphicSerializer<kotlin.Any>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_PolymorphicSerializer_toString")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_PolymorphicSerializer_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.PolymorphicSerializer<kotlin.Any>
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_SealedClassSerializer_descriptor_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_SealedClassSerializer_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.SealedClassSerializer<kotlin.Any>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_SealedClassSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_SealedClassSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String___(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr, klassName: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.SealedClassSerializer<kotlin.Any>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.CompositeDecoder
+    val __klassName = if (klassName == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(klassName)
+    val _result = run { __self.findPolymorphicSerializerOrNull(__decoder, __klassName) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_SealedClassSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_SealedClassSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.SealedClassSerializer<kotlin.Any>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.findPolymorphicSerializerOrNull(__encoder, __value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_SerialFormat_serializersModule_get")
+public fun kotlinx_serialization_SerialFormat_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.SerialFormat
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationException_init_allocate")
+public fun kotlinx_serialization_SerializationException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlinx.serialization.SerializationException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.SerializationException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.SerializationException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.SerializationException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlinx_serialization_SerializationException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.SerializationException(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationStrategy_descriptor_get")
+public fun kotlinx_serialization_SerializationStrategy_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_SerializationStrategy_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_SerializationStrategy_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_StringFormat_decodeFromString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String__")
+public fun kotlinx_serialization_StringFormat_decodeFromString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String__(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, string: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.StringFormat
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __string = interpretObjCPointer<kotlin.String>(string)
+    val _result = run { __self.decodeFromString<kotlin.Any?>(__deserializer, __string) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_StringFormat_encodeToString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_StringFormat_encodeToString__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.StringFormat
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeToString<kotlin.Any?>(__serializer, __value) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_BooleanArraySerializer")
+public fun kotlinx_serialization_builtins_BooleanArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.BooleanArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_ByteArraySerializer")
+public fun kotlinx_serialization_builtins_ByteArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.ByteArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_CharArraySerializer")
+public fun kotlinx_serialization_builtins_CharArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.CharArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_DoubleArraySerializer")
+public fun kotlinx_serialization_builtins_DoubleArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.DoubleArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_FloatArraySerializer")
+public fun kotlinx_serialization_builtins_FloatArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.FloatArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_IntArraySerializer")
+public fun kotlinx_serialization_builtins_IntArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.IntArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_ListSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+public fun kotlinx_serialization_builtins_ListSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(elementSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __elementSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(elementSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.builtins.ListSerializer<kotlin.Any?>(__elementSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_LongArraySerializer")
+public fun kotlinx_serialization_builtins_LongArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.LongArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_LongAsStringSerializer_descriptor_get")
+public fun kotlinx_serialization_builtins_LongAsStringSerializer_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.builtins.LongAsStringSerializer
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_LongAsStringSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__")
+public fun kotlinx_serialization_builtins_LongAsStringSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.builtins.LongAsStringSerializer
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.deserialize(__decoder) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_LongAsStringSerializer_get")
+public fun kotlinx_serialization_builtins_LongAsStringSerializer_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.LongAsStringSerializer }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_LongAsStringSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Int64__")
+public fun kotlinx_serialization_builtins_LongAsStringSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Int64__(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.builtins.LongAsStringSerializer
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_MapEntrySerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+public fun kotlinx_serialization_builtins_MapEntrySerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(keySerializer: kotlin.native.internal.NativePtr, valueSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __keySerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(keySerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val __valueSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(valueSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.builtins.MapEntrySerializer<kotlin.Any?, kotlin.Any?>(__keySerializer, __valueSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_MapSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+public fun kotlinx_serialization_builtins_MapSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(keySerializer: kotlin.native.internal.NativePtr, valueSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __keySerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(keySerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val __valueSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(valueSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.builtins.MapSerializer<kotlin.Any?, kotlin.Any?>(__keySerializer, __valueSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_NothingSerializer")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_builtins_NothingSerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.NothingSerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_PairSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+public fun kotlinx_serialization_builtins_PairSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(keySerializer: kotlin.native.internal.NativePtr, valueSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __keySerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(keySerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val __valueSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(valueSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.builtins.PairSerializer<kotlin.Any?, kotlin.Any?>(__keySerializer, __valueSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_SetSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+public fun kotlinx_serialization_builtins_SetSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(elementSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __elementSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(elementSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.builtins.SetSerializer<kotlin.Any?>(__elementSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_ShortArraySerializer")
+public fun kotlinx_serialization_builtins_ShortArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.ShortArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_TripleSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+public fun kotlinx_serialization_builtins_TripleSerializer__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(aSerializer: kotlin.native.internal.NativePtr, bSerializer: kotlin.native.internal.NativePtr, cSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __aSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(aSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val __bSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(bSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val __cSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(cSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.builtins.TripleSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>(__aSerializer, __bSerializer, __cSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_UByteArraySerializer")
+@OptIn(kotlin.ExperimentalUnsignedTypes::class, kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_builtins_UByteArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.UByteArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_UIntArraySerializer")
+@OptIn(kotlin.ExperimentalUnsignedTypes::class, kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_builtins_UIntArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.UIntArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_ULongArraySerializer")
+@OptIn(kotlin.ExperimentalUnsignedTypes::class, kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_builtins_ULongArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.ULongArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_UShortArraySerializer")
+@OptIn(kotlin.ExperimentalUnsignedTypes::class, kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_builtins_UShortArraySerializer(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.builtins.UShortArraySerializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Boolean_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Boolean_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Boolean.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Byte_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Byte_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Byte.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Char_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Char_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Char.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Double_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Double_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Double.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Float_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Float_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Float.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Int_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Int_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Int.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Long_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Long_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Long.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Short_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_Short_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.Short.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_String_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_String_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.String.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_UByte_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_UByte_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.UByte.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_UInt_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_UInt_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.UInt.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_ULong_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_ULong_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.ULong.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_UShort_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_UShort_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.UShort.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__Swift_Void__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__Swift_Void__(`receiver`: Boolean): kotlin.native.internal.NativePtr {
+    val __receiver = run<Unit> { `receiver` }
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_time_Duration_Companion__")
+public fun kotlinx_serialization_builtins_serializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlin_time_Duration_Companion__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlin.time.Duration.Companion
+    val _result = run { __receiver.kotlinx_serialization_builtins_serializer() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_decodeFromHexString__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_BinaryFormat_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String__")
+public fun kotlinx_serialization_decodeFromHexString__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_BinaryFormat_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_String__(`receiver`: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, hex: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.BinaryFormat
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __hex = interpretObjCPointer<kotlin.String>(hex)
+    val _result = run { __receiver.kotlinx_serialization_decodeFromHexString<kotlin.Any?>(__deserializer, __hex) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_annotations_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_annotations_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder
+    val _result = run { __self.annotations }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_annotations_set__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlin_Annotation___")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_annotations_set__TypesOfArguments__Swift_Array_anyU20ExportedKotlinPackages_kotlin_Annotation___(self: kotlin.native.internal.NativePtr, newValue: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder
+    val __newValue = interpretObjCPointer<kotlin.collections.List<kotlin.Annotation>>(newValue)
+    val _result = run { __self.annotations = __newValue }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_element__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Array_anyU20ExportedKotlinPackages_kotlin_Annotation__Swift_Bool__")
+public fun kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_element__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Array_anyU20ExportedKotlinPackages_kotlin_Annotation__Swift_Bool__(self: kotlin.native.internal.NativePtr, elementName: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, annotations: kotlin.native.internal.NativePtr, isOptional: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder
+    val __elementName = interpretObjCPointer<kotlin.String>(elementName)
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __annotations = interpretObjCPointer<kotlin.collections.List<kotlin.Annotation>>(annotations)
+    val __isOptional = isOptional
+    val _result = run { __self.element(__elementName, __descriptor, __annotations, __isOptional) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_serialName_get")
+public fun kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_serialName_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder
+    val _result = run { __self.serialName }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PolymorphicKind_OPEN_get")
+public fun kotlinx_serialization_descriptors_PolymorphicKind_OPEN_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PolymorphicKind.OPEN }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PolymorphicKind_SEALED_get")
+public fun kotlinx_serialization_descriptors_PolymorphicKind_SEALED_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PolymorphicKind.SEALED }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_BOOLEAN_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_BOOLEAN_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.BOOLEAN }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_BYTE_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_BYTE_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.BYTE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_CHAR_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_CHAR_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.CHAR }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_DOUBLE_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_DOUBLE_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.DOUBLE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_FLOAT_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_FLOAT_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.FLOAT }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_INT_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_INT_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.INT }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_LONG_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_LONG_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.LONG }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_SHORT_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_SHORT_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.SHORT }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveKind_STRING_get")
+public fun kotlinx_serialization_descriptors_PrimitiveKind_STRING_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveKind.STRING }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_PrimitiveSerialDescriptor__TypesOfArguments__Swift_String_ExportedKotlinPackages_kotlinx_serialization_descriptors_PrimitiveKind__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_PrimitiveSerialDescriptor__TypesOfArguments__Swift_String_ExportedKotlinPackages_kotlinx_serialization_descriptors_PrimitiveKind__(serialName: kotlin.native.internal.NativePtr, kind: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __serialName = interpretObjCPointer<kotlin.String>(serialName)
+    val __kind = kotlin.native.internal.ref.dereferenceExternalRCRef(kind) as kotlinx.serialization.descriptors.PrimitiveKind
+    val _result = run { kotlinx.serialization.descriptors.PrimitiveSerialDescriptor(__serialName, __kind) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(serialName: kotlin.native.internal.NativePtr, original: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __serialName = interpretObjCPointer<kotlin.String>(serialName)
+    val __original = kotlin.native.internal.ref.dereferenceExternalRCRef(original) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { kotlinx.serialization.descriptors.SerialDescriptor(__serialName, __original) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_annotations_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_annotations_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.annotations }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_annotations_get_direct", nonVirtualTargetMethod = "<get-annotations>")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_annotations_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.annotations }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_elementsCount_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_elementsCount_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.elementsCount }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementAnnotations__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementAnnotations__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.getElementAnnotations(__index) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementDescriptor__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementDescriptor__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.getElementDescriptor(__index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementIndex__TypesOfArguments__Swift_String__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementIndex__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, name: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __name = interpretObjCPointer<kotlin.String>(name)
+    val _result = run { __self.getElementIndex(__name) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_getElementName__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_getElementName__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.getElementName(__index) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isElementOptional__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isElementOptional__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.isElementOptional(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isInline_get")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isInline_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.isInline }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isInline_get_direct", nonVirtualTargetMethod = "<get-isInline>")
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isInline_get_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.isInline }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.isNullable }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get_direct", nonVirtualTargetMethod = "<get-isNullable>")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_isNullable_get_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.isNullable }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_kind_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_kind_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.kind }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialDescriptor_serialName_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialDescriptor_serialName_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.serialName }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialKind_CONTEXTUAL_get")
+public fun kotlinx_serialization_descriptors_SerialKind_CONTEXTUAL_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.SerialKind.CONTEXTUAL }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialKind_ENUM_get")
+public fun kotlinx_serialization_descriptors_SerialKind_ENUM_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.SerialKind.ENUM }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialKind_hashCode")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialKind_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialKind
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialKind_hashCode_direct", nonVirtualTargetMethod = "hashCode")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialKind_hashCode_direct(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialKind
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialKind_toString")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialKind_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialKind
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_SerialKind_toString_direct", nonVirtualTargetMethod = "toString")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_SerialKind_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.descriptors.SerialKind
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_StructureKind_CLASS_get")
+public fun kotlinx_serialization_descriptors_StructureKind_CLASS_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.StructureKind.CLASS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_StructureKind_LIST_get")
+public fun kotlinx_serialization_descriptors_StructureKind_LIST_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.StructureKind.LIST }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_StructureKind_MAP_get")
+public fun kotlinx_serialization_descriptors_StructureKind_MAP_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.StructureKind.MAP }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_StructureKind_OBJECT_get")
+public fun kotlinx_serialization_descriptors_StructureKind_OBJECT_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.descriptors.StructureKind.OBJECT }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_buildClassSerialDescriptor__TypesOfArguments__Swift_String_Swift_Array_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__Vararg__U28ExportedKotlinPackages_kotlinx_serialization_descriptors_ClassSerialDescriptorBuilderU29202D_U20Swift_Void__")
+public fun kotlinx_serialization_descriptors_buildClassSerialDescriptor__TypesOfArguments__Swift_String_Swift_Array_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__Vararg__U28ExportedKotlinPackages_kotlinx_serialization_descriptors_ClassSerialDescriptorBuilderU29202D_U20Swift_Void__(serialName: kotlin.native.internal.NativePtr, typeParameters: kotlin.native.internal.NativePtr, builderAction: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __serialName = interpretObjCPointer<kotlin.String>(serialName)
+    val __typeParameters = interpretObjCPointer<kotlin.collections.List<kotlinx.serialization.descriptors.SerialDescriptor>>(typeParameters).toTypedArray()
+    val __builderAction = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(builderAction);
+        { arg0: kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.serialization.descriptors.buildClassSerialDescriptor(__serialName, *__typeParameters, builderAction = __builderAction) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_buildSerialDescriptor__TypesOfArguments__Swift_String_ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialKind_Swift_Array_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__Vararg__U28ExportedKotlinPackages_kotlinx_serialization_descriptors_ClassSerialDescriptorBuilderU29202D_U20Swift_Void__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_buildSerialDescriptor__TypesOfArguments__Swift_String_ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialKind_Swift_Array_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__Vararg__U28ExportedKotlinPackages_kotlinx_serialization_descriptors_ClassSerialDescriptorBuilderU29202D_U20Swift_Void__(serialName: kotlin.native.internal.NativePtr, kind: kotlin.native.internal.NativePtr, typeParameters: kotlin.native.internal.NativePtr, builder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __serialName = interpretObjCPointer<kotlin.String>(serialName)
+    val __kind = kotlin.native.internal.ref.dereferenceExternalRCRef(kind) as kotlinx.serialization.descriptors.SerialKind
+    val __typeParameters = interpretObjCPointer<kotlin.collections.List<kotlinx.serialization.descriptors.SerialDescriptor>>(typeParameters).toTypedArray()
+    val __builder = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(builder);
+        { arg0: kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.serialization.descriptors.buildSerialDescriptor(__serialName, __kind, *__typeParameters, builder = __builder) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_elementDescriptors_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_elementDescriptors_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __receiver.kotlinx_serialization_descriptors_elementDescriptors }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_elementNames_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_elementNames_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __receiver.kotlinx_serialization_descriptors_elementNames }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_getContextualDescriptor__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_getContextualDescriptor__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(`receiver`: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.modules.SerializersModule
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __receiver.kotlinx_serialization_descriptors_getContextualDescriptor(__descriptor) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_getPolymorphicDescriptors__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_getPolymorphicDescriptors__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(`receiver`: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.modules.SerializersModule
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __receiver.kotlinx_serialization_descriptors_getPolymorphicDescriptors(__descriptor) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_listSerialDescriptor__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_listSerialDescriptor__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(elementDescriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __elementDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(elementDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { kotlinx.serialization.descriptors.listSerialDescriptor(__elementDescriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_mapSerialDescriptor__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_mapSerialDescriptor__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(keyDescriptor: kotlin.native.internal.NativePtr, valueDescriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __keyDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(keyDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __valueDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(valueDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { kotlinx.serialization.descriptors.mapSerialDescriptor(__keyDescriptor, __valueDescriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_nullable_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_descriptors_nullable_get__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(`receiver`: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __receiver.kotlinx_serialization_descriptors_nullable }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_descriptors_setSerialDescriptor__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_descriptors_setSerialDescriptor__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(elementDescriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __elementDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(elementDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { kotlinx.serialization.descriptors.setSerialDescriptor(__elementDescriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encodeToHexString__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_BinaryFormat_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_encodeToHexString__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_BinaryFormat_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.BinaryFormat
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __receiver.kotlinx_serialization_encodeToHexString<kotlin.Any?>(__serializer, __value) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "beginStructure")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeBoolean() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeBooleanElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean_direct", nonVirtualTargetMethod = "decodeBoolean")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeBoolean_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeBoolean() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeByte")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeByte() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeByteElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeByte_direct", nonVirtualTargetMethod = "decodeByte")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeByte_direct(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeByte() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeChar")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeChar() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeCharElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeChar_direct", nonVirtualTargetMethod = "decodeChar")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeChar_direct(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeChar() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeDouble")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeDoubleElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeDouble_direct", nonVirtualTargetMethod = "decodeDouble")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeDouble_direct(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeEnum(__enumDescriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "decodeEnum")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeEnum(__enumDescriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeFloat")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeFloatElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeFloat_direct", nonVirtualTargetMethod = "decodeFloat")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeFloat_direct(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct", nonVirtualTargetMethod = "decodeInlineElement")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "decodeInline")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInt")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeInt() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeIntElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeInt_direct", nonVirtualTargetMethod = "decodeInt")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeInt_direct(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeInt() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeLong")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeLong() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeLongElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeLong_direct", nonVirtualTargetMethod = "decodeLong")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeLong_direct(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeLong() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeNotNullMark() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark_direct", nonVirtualTargetMethod = "decodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeNotNullMark_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeNotNullMark() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeNull(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeNull_direct", nonVirtualTargetMethod = "decodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeNull_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __previousValue = if (previousValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previousValue) as kotlin.Any
+    val _result = run { __self.decodeSerializableElement<kotlin.Any?>(__descriptor, __index, __deserializer, __previousValue) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "decodeSerializableElement")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __previousValue = if (previousValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previousValue) as kotlin.Any
+    val _result = run { __self.decodeSerializableElement<kotlin.Any?>(__descriptor, __index, __deserializer, __previousValue) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __previousValue = if (previousValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previousValue) as kotlin.Any
+    val _result = run { __self.decodeSerializableValue<kotlin.Any?>(__deserializer, __previousValue) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "decodeSerializableValue")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __previousValue = if (previousValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previousValue) as kotlin.Any
+    val _result = run { __self.decodeSerializableValue<kotlin.Any?>(__deserializer, __previousValue) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeShort")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeShort() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeShortElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeShort_direct", nonVirtualTargetMethod = "decodeShort")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeShort_direct(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeShort() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeString")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeStringElement(__descriptor, __index) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeString_direct", nonVirtualTargetMethod = "decodeString")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeValue")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeValue(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeValue() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_decodeValue_direct", nonVirtualTargetMethod = "decodeValue")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_decodeValue_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.decodeValue() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "endStructure")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.encoding.AbstractDecoder()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractDecoder_serializersModule_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractDecoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractDecoder
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "beginStructure")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeBoolean(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeBooleanElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool___direct", nonVirtualTargetMethod = "encodeBoolean")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeBoolean__TypesOfArguments__Swift_Bool___direct(self: kotlin.native.internal.NativePtr, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeBoolean(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeByte(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeByteElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8___direct", nonVirtualTargetMethod = "encodeByte")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeByte__TypesOfArguments__Swift_Int8___direct(self: kotlin.native.internal.NativePtr, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeByte(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeChar(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeCharElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit___direct", nonVirtualTargetMethod = "encodeChar")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit___direct(self: kotlin.native.internal.NativePtr, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeChar(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeDouble(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeDoubleElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double___direct", nonVirtualTargetMethod = "encodeDouble")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeDouble__TypesOfArguments__Swift_Double___direct(self: kotlin.native.internal.NativePtr, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeDouble(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct", nonVirtualTargetMethod = "encodeElement")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeEnum(__enumDescriptor, __index) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct", nonVirtualTargetMethod = "encodeEnum")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeEnum(__enumDescriptor, __index) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeFloat(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeFloatElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float___direct", nonVirtualTargetMethod = "encodeFloat")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeFloat__TypesOfArguments__Swift_Float___direct(self: kotlin.native.internal.NativePtr, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeFloat(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.encodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "encodeInline")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.encodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeInt(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeIntElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32___direct", nonVirtualTargetMethod = "encodeInt")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeInt__TypesOfArguments__Swift_Int32___direct(self: kotlin.native.internal.NativePtr, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeInt(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeLong(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeLongElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64___direct", nonVirtualTargetMethod = "encodeLong")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeLong__TypesOfArguments__Swift_Int64___direct(self: kotlin.native.internal.NativePtr, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeLong(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeNull(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val _result = run { __self.encodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeNull_direct", nonVirtualTargetMethod = "encodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeNull_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val _result = run { __self.encodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableElement<kotlin.Any?>(__descriptor, __index, __serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "encodeSerializableElement")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableElement<kotlin.Any?>(__descriptor, __index, __serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeShort(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeShortElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16___direct", nonVirtualTargetMethod = "encodeShort")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeShort__TypesOfArguments__Swift_Int16___direct(self: kotlin.native.internal.NativePtr, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = value
+    val _result = run { __self.encodeShort(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeString(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeStringElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String___direct", nonVirtualTargetMethod = "encodeString")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeString__TypesOfArguments__Swift_String___direct(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeString(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeValue(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable___direct", nonVirtualTargetMethod = "encodeValue")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_encodeValue__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable___direct(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeValue(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "endStructure")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.encoding.AbstractEncoder()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_AbstractEncoder_serializersModule_get")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_AbstractEncoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.AbstractEncoder
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_ChunkedDecoder_decodeStringChunked__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_ChunkedDecoder_decodeStringChunked__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, consumeChunk: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.ChunkedDecoder
+    val __consumeChunk = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(consumeChunk);
+        { arg0: kotlin.String ->
+            val _arg0 = arg0.objcPtr()
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.decodeStringChunked(__consumeChunk) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_Companion_DECODE_DONE_get")
+public fun kotlinx_serialization_encoding_CompositeDecoder_Companion_DECODE_DONE_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder.Companion
+    val _result = run { __self.DECODE_DONE }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_Companion_UNKNOWN_NAME_get")
+public fun kotlinx_serialization_encoding_CompositeDecoder_Companion_UNKNOWN_NAME_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder.Companion
+    val _result = run { __self.UNKNOWN_NAME }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_Companion_get")
+public fun kotlinx_serialization_encoding_CompositeDecoder_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.encoding.CompositeDecoder.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeBooleanElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeByteElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeCharElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeCollectionSize(__descriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "decodeCollectionSize")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeCollectionSize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeCollectionSize(__descriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeDoubleElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeElementIndex__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeElementIndex__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeElementIndex(__descriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeFloatElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeIntElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeLongElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val _result = run { __self.decodeSequentially() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially_direct", nonVirtualTargetMethod = "decodeSequentially")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeSequentially_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val _result = run { __self.decodeSequentially() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __previousValue = if (previousValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previousValue) as kotlin.Any
+    val _result = run { __self.decodeSerializableElement<kotlin.Any?>(__descriptor, __index, __deserializer, __previousValue) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeShortElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeStringElement(__descriptor, __index) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_CompositeDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get")
+public fun kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeDecoder
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeBooleanElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeByteElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeCharElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeDoubleElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeFloatElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeIntElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeLongElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableElement<kotlin.Any?>(__descriptor, __index, __serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeShortElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeStringElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_CompositeEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get")
+public fun kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.shouldEncodeElementDefault(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct", nonVirtualTargetMethod = "shouldEncodeElementDefault")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_CompositeEncoder_shouldEncodeElementDefault__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.CompositeEncoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.shouldEncodeElementDefault(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_Decoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeBoolean")
+public fun kotlinx_serialization_encoding_Decoder_decodeBoolean(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeBoolean() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeByte")
+public fun kotlinx_serialization_encoding_Decoder_decodeByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeByte() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeChar")
+public fun kotlinx_serialization_encoding_Decoder_decodeChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeChar() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeDouble")
+public fun kotlinx_serialization_encoding_Decoder_decodeDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_Decoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeEnum(__enumDescriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeFloat")
+public fun kotlinx_serialization_encoding_Decoder_decodeFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_Decoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeInt")
+public fun kotlinx_serialization_encoding_Decoder_decodeInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeInt() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeLong")
+public fun kotlinx_serialization_encoding_Decoder_decodeLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeLong() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_Decoder_decodeNotNullMark(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeNotNullMark() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_Decoder_decodeNull(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy__")
+public fun kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy__(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val _result = run { __self.decodeSerializableValue<kotlin.Any?>(__deserializer) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy___direct", nonVirtualTargetMethod = "decodeSerializableValue")
+public fun kotlinx_serialization_encoding_Decoder_decodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy___direct(self: kotlin.native.internal.NativePtr, deserializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val _result = run { __self.decodeSerializableValue<kotlin.Any?>(__deserializer) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeShort")
+public fun kotlinx_serialization_encoding_Decoder_decodeShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeShort() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_decodeString")
+public fun kotlinx_serialization_encoding_Decoder_decodeString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.decodeString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Decoder_serializersModule_get")
+public fun kotlinx_serialization_encoding_Decoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, collectionSize: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __collectionSize = collectionSize
+    val _result = run { __self.beginCollection(__descriptor, __collectionSize) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct", nonVirtualTargetMethod = "beginCollection")
+public fun kotlinx_serialization_encoding_Encoder_beginCollection__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, collectionSize: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __collectionSize = collectionSize
+    val _result = run { __self.beginCollection(__descriptor, __collectionSize) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_Encoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeBoolean__TypesOfArguments__Swift_Bool__")
+public fun kotlinx_serialization_encoding_Encoder_encodeBoolean__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeBoolean(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeByte__TypesOfArguments__Swift_Int8__")
+public fun kotlinx_serialization_encoding_Encoder_encodeByte__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeByte(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlinx_serialization_encoding_Encoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeChar(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeDouble__TypesOfArguments__Swift_Double__")
+public fun kotlinx_serialization_encoding_Encoder_encodeDouble__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeDouble(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+public fun kotlinx_serialization_encoding_Encoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeEnum(__enumDescriptor, __index) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeFloat__TypesOfArguments__Swift_Float__")
+public fun kotlinx_serialization_encoding_Encoder_encodeFloat__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeFloat(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+public fun kotlinx_serialization_encoding_Encoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.encodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeInt__TypesOfArguments__Swift_Int32__")
+public fun kotlinx_serialization_encoding_Encoder_encodeInt__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeInt(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeLong__TypesOfArguments__Swift_Int64__")
+public fun kotlinx_serialization_encoding_Encoder_encodeLong__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeLong(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_Encoder_encodeNotNullMark(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val _result = run { __self.encodeNotNullMark() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeNotNullMark_direct", nonVirtualTargetMethod = "encodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_Encoder_encodeNotNullMark_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val _result = run { __self.encodeNotNullMark() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_encoding_Encoder_encodeNull(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val _result = run { __self.encodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableValue<kotlin.Any?>(__serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "encodeSerializableValue")
+public fun kotlinx_serialization_encoding_Encoder_encodeSerializableValue__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableValue<kotlin.Any?>(__serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeShort__TypesOfArguments__Swift_Int16__")
+public fun kotlinx_serialization_encoding_Encoder_encodeShort__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = value
+    val _result = run { __self.encodeShort(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_encodeString__TypesOfArguments__Swift_String__")
+public fun kotlinx_serialization_encoding_Encoder_encodeString__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeString(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_Encoder_serializersModule_get")
+public fun kotlinx_serialization_encoding_Encoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.encoding.Encoder
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_decodeStructure__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoderU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlinx_serialization_encoding_decodeStructure__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoderU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(`receiver`: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.encoding.Decoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->kotlin.native.internal.NativePtr>(block);
+        { arg0: kotlinx.serialization.encoding.CompositeDecoder ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __receiver.kotlinx_serialization_encoding_decodeStructure<kotlin.Any?>(__descriptor, __block) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_encodeCollection__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoderU29202D_U20Swift_Void__")
+public fun kotlinx_serialization_encoding_encodeCollection__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoderU29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, collectionSize: Int, block: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __collectionSize = collectionSize
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(block);
+        { arg0: kotlinx.serialization.encoding.CompositeEncoder ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_serialization_encoding_encodeCollection(__descriptor, __collectionSize, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_encodeCollection__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_anyU20ExportedKotlinPackages_kotlin_collections_Collection_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoder_U20Swift_Int32_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__")
+public fun kotlinx_serialization_encoding_encodeCollection__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_anyU20ExportedKotlinPackages_kotlin_collections_Collection_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoder_U20Swift_Int32_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, collection: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __collection = kotlin.native.internal.ref.dereferenceExternalRCRef(collection) as kotlin.collections.Collection<kotlin.Any?>
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, Int, kotlin.native.internal.NativePtr)->Boolean>(block);
+        { arg0: kotlinx.serialization.encoding.CompositeEncoder, arg1: Int, arg2: kotlin.Any? ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _arg1 = arg1
+            val _arg2 = if (arg2 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg2)
+            val _result = kotlinFun(_arg0, _arg1, _arg2)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_serialization_encoding_encodeCollection<kotlin.Any?>(__descriptor, __collection, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_encoding_encodeStructure__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoderU29202D_U20Swift_Void__")
+public fun kotlinx_serialization_encoding_encodeStructure__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoderU29202D_U20Swift_Void__(`receiver`: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): Boolean {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.encoding.Encoder
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(block);
+        { arg0: kotlinx.serialization.encoding.CompositeEncoder ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __receiver.kotlinx_serialization_encoding_encodeStructure(__descriptor, __block) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_findPolymorphicSerializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_U60internalU60_AbstractPolymorphicSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_findPolymorphicSerializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_U60internalU60_AbstractPolymorphicSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String___(`receiver`: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr, klassName: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.CompositeDecoder
+    val __klassName = if (klassName == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(klassName)
+    val _result = run { __receiver.kotlinx_serialization_findPolymorphicSerializer<kotlin.Any>(__decoder, __klassName) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_findPolymorphicSerializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_U60internalU60_AbstractPolymorphicSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_findPolymorphicSerializer__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_U60internalU60_AbstractPolymorphicSerializer_anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__(`receiver`: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __receiver.kotlinx_serialization_findPolymorphicSerializer<kotlin.Any>(__encoder, __value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractCollectionSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.deserialize(__decoder) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder___direct", nonVirtualTargetMethod = "deserialize")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractCollectionSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder___direct(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractCollectionSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.deserialize(__decoder) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractCollectionSerializer_merge__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractCollectionSerializer_merge__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr, previous: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractCollectionSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val __previous = if (previous == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previous) as kotlin.Any
+    val _result = run { __self.merge(__decoder, __previous) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractCollectionSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractCollectionSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractCollectionSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder__(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.Decoder
+    val _result = run { __self.deserialize(__decoder) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String___(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr, klassName: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.CompositeDecoder
+    val __klassName = if (klassName == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(klassName)
+    val _result = run { __self.findPolymorphicSerializerOrNull(__decoder, __klassName) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.findPolymorphicSerializerOrNull(__encoder, __value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String____direct", nonVirtualTargetMethod = "findPolymorphicSerializerOrNull")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Swift_Optional_Swift_String____direct(self: kotlin.native.internal.NativePtr, decoder: kotlin.native.internal.NativePtr, klassName: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __decoder = kotlin.native.internal.ref.dereferenceExternalRCRef(decoder) as kotlinx.serialization.encoding.CompositeDecoder
+    val __klassName = if (klassName == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(klassName)
+    val _result = run { __self.findPolymorphicSerializerOrNull(__decoder, __klassName) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable___direct", nonVirtualTargetMethod = "findPolymorphicSerializerOrNull")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_findPolymorphicSerializerOrNull__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable___direct(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.findPolymorphicSerializerOrNull(__encoder, __value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_AbstractPolymorphicSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_AbstractPolymorphicSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.AbstractPolymorphicSerializer<kotlin.Any>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_GeneratedSerializer_childSerializers")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_GeneratedSerializer_childSerializers(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.GeneratedSerializer<kotlin.Any?>
+    val _result = run { __self.childSerializers() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.GeneratedSerializer<kotlin.Any?>
+    val _result = run { __self.typeParametersSerializers() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers_direct", nonVirtualTargetMethod = "typeParametersSerializers")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_GeneratedSerializer_typeParametersSerializers_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.GeneratedSerializer<kotlin.Any?>
+    val _result = run { __self.typeParametersSerializers() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_InlinePrimitiveDescriptor__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_InlinePrimitiveDescriptor__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_KSerializer__(name: kotlin.native.internal.NativePtr, primitiveSerializer: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __name = interpretObjCPointer<kotlin.String>(name)
+    val __primitiveSerializer = kotlin.native.internal.ref.dereferenceExternalRCRef(primitiveSerializer) as kotlinx.serialization.KSerializer<kotlin.Any?>
+    val _result = run { kotlinx.serialization.`internal`.InlinePrimitiveDescriptor<kotlin.Any?>(__name, __primitiveSerializer) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_MapLikeSerializer_descriptor_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_MapLikeSerializer_descriptor_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>
+    val _result = run { __self.descriptor }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_MapLikeSerializer_keySerializer_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_MapLikeSerializer_keySerializer_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>
+    val _result = run { __self.keySerializer }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "serialize")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_MapLikeSerializer_serialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, encoder: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>
+    val __encoder = kotlin.native.internal.ref.dereferenceExternalRCRef(encoder) as kotlinx.serialization.encoding.Encoder
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.serialize(__encoder, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_MapLikeSerializer_valueSerializer_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_MapLikeSerializer_valueSerializer_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.MapLikeSerializer<kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.collections.MutableMap<kotlin.Any?, kotlin.Any?>>
+    val _result = run { __self.valueSerializer }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_NamedValueDecoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_NamedValueDecoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.internal.NamedValueDecoder()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_NamedValueEncoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_NamedValueEncoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.internal.NamedValueEncoder()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "beginStructure")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeBoolean")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeBoolean(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeBoolean() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeBooleanElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeByte")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeByte() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeByteElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeChar")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeChar() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeCharElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeDouble")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeDoubleElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeEnum(__enumDescriptor) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeFloat")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeFloatElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "decodeInline")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.decodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeInt")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeInt() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeIntElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeLong")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeLong() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeLongElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeNotNullMark() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark_direct", nonVirtualTargetMethod = "decodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeNotNullMark_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeNotNullMark() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeNull(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_DeserializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, deserializer: kotlin.native.internal.NativePtr, previousValue: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __deserializer = kotlin.native.internal.ref.dereferenceExternalRCRef(deserializer) as kotlinx.serialization.DeserializationStrategy<kotlin.Any?>
+    val __previousValue = if (previousValue == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(previousValue) as kotlin.Any
+    val _result = run { __self.decodeSerializableElement<kotlin.Any?>(__descriptor, __index, __deserializer, __previousValue) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeShort")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeShort() }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeShortElement(__descriptor, __index) }
+    return _result
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeString")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.decodeString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_decodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.decodeStringElement(__descriptor, __index) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "endStructure")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_serializersModule_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedDecoder_serializersModule_get_direct", nonVirtualTargetMethod = "<get-serializersModule>")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedDecoder_serializersModule_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedDecoder<kotlin.Any?>
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "beginStructure")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_beginStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.beginStructure(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeBoolean__TypesOfArguments__Swift_Bool__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeBoolean__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeBoolean(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeBooleanElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Bool__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeBooleanElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeByte__TypesOfArguments__Swift_Int8__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeByte__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeByte(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeByteElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int8__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeByteElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeChar__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeChar(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeCharElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeCharElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeDouble__TypesOfArguments__Swift_Double__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeDouble__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeDouble(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeDoubleElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Double__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Double): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeDoubleElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeEnum__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, enumDescriptor: kotlin.native.internal.NativePtr, index: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __enumDescriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(enumDescriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeEnum(__enumDescriptor, __index) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeFloat__TypesOfArguments__Swift_Float__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeFloat__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeFloat(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeFloatElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Float__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Float): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeFloatElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.encodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeInlineElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val _result = run { __self.encodeInlineElement(__descriptor, __index) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct", nonVirtualTargetMethod = "encodeInline")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeInline__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor___direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.encodeInline(__descriptor) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeInt__TypesOfArguments__Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeInt__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeInt(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeIntElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeIntElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeLong__TypesOfArguments__Swift_Int64__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeLong__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeLong(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeLongElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int64__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Long): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeLongElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val _result = run { __self.encodeNotNullMark() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark_direct", nonVirtualTargetMethod = "encodeNotNullMark")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeNotNullMark_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val _result = run { __self.encodeNotNullMark() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeNull(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val _result = run { __self.encodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeNull_direct", nonVirtualTargetMethod = "encodeNull")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeNull_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val _result = run { __self.encodeNull() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableElement<kotlin.Any?>(__descriptor, __index, __serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "encodeSerializableElement")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeSerializableElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_SerializationStrategy_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, serializer: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __serializer = kotlin.native.internal.ref.dereferenceExternalRCRef(serializer) as kotlinx.serialization.SerializationStrategy<kotlin.Any?>
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.encodeSerializableElement<kotlin.Any?>(__descriptor, __index, __serializer, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeShort__TypesOfArguments__Swift_Int16__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeShort__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = value
+    val _result = run { __self.encodeShort(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeShortElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_Int16__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: Short): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = value
+    val _result = run { __self.encodeShortElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeString__TypesOfArguments__Swift_String__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeString__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeString(__value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_encodeStringElement__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_Swift_String__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val __index = index
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.encodeStringElement(__descriptor, __index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_endStructure__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(self: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { __self.endStructure(__descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_serializersModule_get")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_serializersModule_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_TaggedEncoder_serializersModule_get_direct", nonVirtualTargetMethod = "<get-serializersModule>")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_TaggedEncoder_serializersModule_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.internal.TaggedEncoder<kotlin.Any?>
+    val _result = run { __self.serializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_internal_throwArrayMissingFieldException__TypesOfArguments__ExportedKotlinPackages_kotlin_IntArray_ExportedKotlinPackages_kotlin_IntArray_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_throwArrayMissingFieldException__TypesOfArguments__ExportedKotlinPackages_kotlin_IntArray_ExportedKotlinPackages_kotlin_IntArray_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(seenArray: kotlin.native.internal.NativePtr, goldenMaskArray: kotlin.native.internal.NativePtr, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __seenArray = kotlin.native.internal.ref.dereferenceExternalRCRef(seenArray) as kotlin.IntArray
+    val __goldenMaskArray = kotlin.native.internal.ref.dereferenceExternalRCRef(goldenMaskArray) as kotlin.IntArray
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { kotlinx.serialization.`internal`.throwArrayMissingFieldException(__seenArray, __goldenMaskArray, __descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_internal_throwMissingFieldException__TypesOfArguments__Swift_Int32_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__")
+@OptIn(kotlinx.serialization.InternalSerializationApi::class)
+public fun kotlinx_serialization_internal_throwMissingFieldException__TypesOfArguments__Swift_Int32_Swift_Int32_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__(seen: Int, goldenMask: Int, descriptor: kotlin.native.internal.NativePtr): Boolean {
+    val __seen = seen
+    val __goldenMask = goldenMask
+    val __descriptor = kotlin.native.internal.ref.dereferenceExternalRCRef(descriptor) as kotlinx.serialization.descriptors.SerialDescriptor
+    val _result = run { kotlinx.serialization.`internal`.throwMissingFieldException(__seen, __goldenMask, __descriptor) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_modules_EmptySerializersModule")
+public fun kotlinx_serialization_modules_EmptySerializersModule(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.modules.EmptySerializersModule() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_modules_EmptySerializersModule_get")
+public fun kotlinx_serialization_modules_EmptySerializersModule_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlinx.serialization.modules.EmptySerializersModule }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_modules_SerializersModule__TypesOfArguments__U28ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleBuilderU29202D_U20Swift_Void__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_modules_SerializersModule__TypesOfArguments__U28ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleBuilderU29202D_U20Swift_Void__(builderAction: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __builderAction = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(builderAction);
+        { arg0: kotlinx.serialization.modules.SerializersModuleBuilder ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { kotlinx.serialization.modules.SerializersModule(__builderAction) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_modules_SerializersModuleBuilder_include__TypesOfArguments__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_modules_SerializersModuleBuilder_include__TypesOfArguments__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule__(self: kotlin.native.internal.NativePtr, module: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.modules.SerializersModuleBuilder
+    val __module = kotlin.native.internal.ref.dereferenceExternalRCRef(module) as kotlinx.serialization.modules.SerializersModule
+    val _result = run { __self.include(__module) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_modules_SerializersModule_dumpTo__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector__")
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+public fun kotlinx_serialization_modules_SerializersModule_dumpTo__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleCollector__(self: kotlin.native.internal.NativePtr, collector: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlinx.serialization.modules.SerializersModule
+    val __collector = kotlin.native.internal.ref.dereferenceExternalRCRef(collector) as kotlinx.serialization.modules.SerializersModuleCollector
+    val _result = run { __self.dumpTo(__collector) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlinx_serialization_modules_overwriteWith__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule__")
+public fun kotlinx_serialization_modules_overwriteWith__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule__(`receiver`: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.modules.SerializersModule
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlinx.serialization.modules.SerializersModule
+    val _result = run { __receiver.kotlinx_serialization_modules_overwriteWith(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlinx_serialization_modules_plus__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule__")
+public fun kotlinx_serialization_modules_plus__TypesOfArgumentsE__ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule_ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModule__(`receiver`: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __receiver = kotlin.native.internal.ref.dereferenceExternalRCRef(`receiver`) as kotlinx.serialization.modules.SerializersModule
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlinx.serialization.modules.SerializersModule
+    val _result = run { __receiver.kotlinx_serialization_modules_plus(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -1,0 +1,7240 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Array::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE5ArrayC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Boolean.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE7BooleanC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Byte.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE4ByteC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ByteArray::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE9ByteArrayC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Char.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE4CharC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Double.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE6DoubleC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Exception::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE9ExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Float.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE5FloatC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.IllegalArgumentException::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE24IllegalArgumentExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Int.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE3IntC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.IntArray::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE8IntArrayC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Long.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE4LongC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Number::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE6NumberC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.RuntimeException::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE16RuntimeExceptionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Short.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE5ShortC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.String.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE6StringC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Throwable::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE9ThrowableC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.UByte.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE5UByteC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.UInt.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE4UIntC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ULong.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE5ULongC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.UShort.Companion::class, "22ExportedKotlinPackages6kotlinO12KotlinStdlibE6UShortC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.Annotation::class, "_ExportedKotlinPackages_kotlin_Annotation")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.CharSequence::class, "_ExportedKotlinPackages_kotlin_CharSequence")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.ByteIterator::class, "22ExportedKotlinPackages6kotlinO11collectionsO12KotlinStdlibE12ByteIteratorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.CharIterator::class, "22ExportedKotlinPackages6kotlinO11collectionsO12KotlinStdlibE12CharIteratorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.IntIterator::class, "22ExportedKotlinPackages6kotlinO11collectionsO12KotlinStdlibE11IntIteratorC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.Collection::class, "_ExportedKotlinPackages_kotlin_collections_Collection")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.Iterable::class, "_ExportedKotlinPackages_kotlin_collections_Iterable")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.collections.Iterator::class, "_ExportedKotlinPackages_kotlin_collections_Iterator")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.CharProgression::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE15CharProgressionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.CharProgression.Companion::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE15CharProgressionC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.CharRange::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE9CharRangeC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.CharRange.Companion::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE9CharRangeC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.UIntProgression::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE15UIntProgressionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.UIntProgression.Companion::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE15UIntProgressionC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.UIntRange::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE9UIntRangeC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.UIntRange.Companion::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE9UIntRangeC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.ULongProgression::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE16ULongProgressionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.ULongProgression.Companion::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE16ULongProgressionC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.ULongRange::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE10ULongRangeC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.ranges.ULongRange.Companion::class, "22ExportedKotlinPackages6kotlinO6rangesO12KotlinStdlibE10ULongRangeC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.time.Duration::class, "22ExportedKotlinPackages6kotlinO4timeO12KotlinStdlibE8DurationC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlin.time.Duration.Companion::class, "22ExportedKotlinPackages6kotlinO4timeO12KotlinStdlibE8DurationC9CompanionC")
+
+import kotlin.native.internal.objc.BindReverseBridgeToMethod
+import kotlin.native.internal.ImportedBridge
+import kotlinx.cinterop.*
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ImportedBridge("kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse_swift")
+internal external fun kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, index: Int): Char
+
+@BindReverseBridgeToMethod(kotlin.CharSequence::class, "get")
+public fun kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse(self: kotlin.CharSequence, index: Int): Char {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return _result
+}
+
+@ImportedBridge("kotlin_CharSequence_length_get__reverse_swift")
+internal external fun kotlin_CharSequence_length_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.CharSequence::class, "<get-length>")
+public fun kotlin_CharSequence_length_get__reverse(self: kotlin.CharSequence): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_CharSequence_length_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
+internal external fun kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(self: kotlin.native.internal.NativePtr, startIndex: Int, endIndex: Int): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.CharSequence::class, "subSequence")
+public fun kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse(self: kotlin.CharSequence, startIndex: Int, endIndex: Int): kotlin.CharSequence {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, startIndex, endIndex)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.CharSequence
+}
+
+@ImportedBridge("kotlin_Number_toByte__reverse_swift")
+internal external fun kotlin_Number_toByte__reverse_swift(self: kotlin.native.internal.NativePtr): Byte
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toByte")
+public fun kotlin_Number_toByte__reverse(self: kotlin.Number): Byte {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toByte__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Number_toChar__reverse_swift")
+internal external fun kotlin_Number_toChar__reverse_swift(self: kotlin.native.internal.NativePtr): Char
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toChar")
+public fun kotlin_Number_toChar__reverse(self: kotlin.Number): Char {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toChar__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Number_toDouble__reverse_swift")
+internal external fun kotlin_Number_toDouble__reverse_swift(self: kotlin.native.internal.NativePtr): Double
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toDouble")
+public fun kotlin_Number_toDouble__reverse(self: kotlin.Number): Double {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toDouble__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Number_toFloat__reverse_swift")
+internal external fun kotlin_Number_toFloat__reverse_swift(self: kotlin.native.internal.NativePtr): Float
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toFloat")
+public fun kotlin_Number_toFloat__reverse(self: kotlin.Number): Float {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toFloat__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Number_toInt__reverse_swift")
+internal external fun kotlin_Number_toInt__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toInt")
+public fun kotlin_Number_toInt__reverse(self: kotlin.Number): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toInt__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Number_toLong__reverse_swift")
+internal external fun kotlin_Number_toLong__reverse_swift(self: kotlin.native.internal.NativePtr): Long
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toLong")
+public fun kotlin_Number_toLong__reverse(self: kotlin.Number): Long {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toLong__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Number_toShort__reverse_swift")
+internal external fun kotlin_Number_toShort__reverse_swift(self: kotlin.native.internal.NativePtr): Short
+
+@BindReverseBridgeToMethod(kotlin.Number::class, "toShort")
+public fun kotlin_Number_toShort__reverse(self: kotlin.Number): Short {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Number_toShort__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_Throwable_cause_get__reverse_swift")
+internal external fun kotlin_Throwable_cause_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.Throwable::class, "<get-cause>")
+public fun kotlin_Throwable_cause_get__reverse(self: kotlin.Throwable): kotlin.Throwable? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Throwable_cause_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Throwable
+}
+
+@ImportedBridge("kotlin_Throwable_message_get__reverse_swift")
+internal external fun kotlin_Throwable_message_get__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.Throwable::class, "<get-message>")
+public fun kotlin_Throwable_message_get__reverse(self: kotlin.Throwable): kotlin.String? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Throwable_message_get__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlin_Throwable_toString__reverse_swift")
+internal external fun kotlin_Throwable_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.Throwable::class, "toString")
+public fun kotlin_Throwable_toString__reverse(self: kotlin.Throwable): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_Throwable_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlin_collections_ByteIterator_nextByte__reverse_swift")
+internal external fun kotlin_collections_ByteIterator_nextByte__reverse_swift(self: kotlin.native.internal.NativePtr): Byte
+
+@BindReverseBridgeToMethod(kotlin.collections.ByteIterator::class, "nextByte")
+public fun kotlin_collections_ByteIterator_nextByte__reverse(self: kotlin.collections.ByteIterator): Byte {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_ByteIterator_nextByte__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_CharIterator_nextChar__reverse_swift")
+internal external fun kotlin_collections_CharIterator_nextChar__reverse_swift(self: kotlin.native.internal.NativePtr): Char
+
+@BindReverseBridgeToMethod(kotlin.collections.CharIterator::class, "nextChar")
+public fun kotlin_collections_CharIterator_nextChar__reverse(self: kotlin.collections.CharIterator): Char {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_CharIterator_nextChar__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift")
+internal external fun kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "containsAll")
+public fun kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse(self: kotlin.collections.Collection<kotlin.Any?>, elements: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __elements = kotlin.native.internal.ref.createRetainedExternalRCRef(elements)
+    val _result = kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection____reverse_swift(__self, __elements)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "contains")
+public fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.Collection<kotlin.Any?>, element: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
+    val _result = kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_isEmpty__reverse_swift")
+internal external fun kotlin_collections_Collection_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "isEmpty")
+public fun kotlin_collections_Collection_isEmpty__reverse(self: kotlin.collections.Collection<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Collection_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Collection_iterator__reverse_swift")
+internal external fun kotlin_collections_Collection_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "iterator")
+public fun kotlin_collections_Collection_iterator__reverse(self: kotlin.collections.Collection<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Collection_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_Collection_size_get__reverse_swift")
+internal external fun kotlin_collections_Collection_size_get__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.Collection::class, "<get-size>")
+public fun kotlin_collections_Collection_size_get__reverse(self: kotlin.collections.Collection<kotlin.Any?>): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Collection_size_get__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_IntIterator_nextInt__reverse_swift")
+internal external fun kotlin_collections_IntIterator_nextInt__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.collections.IntIterator::class, "nextInt")
+public fun kotlin_collections_IntIterator_nextInt__reverse(self: kotlin.collections.IntIterator): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_IntIterator_nextInt__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Iterable_iterator__reverse_swift")
+internal external fun kotlin_collections_Iterable_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Iterable::class, "iterator")
+public fun kotlin_collections_Iterable_iterator__reverse(self: kotlin.collections.Iterable<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Iterable_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
+}
+
+@ImportedBridge("kotlin_collections_Iterator_hasNext__reverse_swift")
+internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
+public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
+internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
+public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+}
+
+@ImportedBridge("kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.ranges.CharProgression::class, "equals")
+public fun kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.ranges.CharProgression, other: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __other = if (other == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(other)
+    val _result = kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_CharProgression_hashCode__reverse_swift")
+internal external fun kotlin_ranges_CharProgression_hashCode__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.ranges.CharProgression::class, "hashCode")
+public fun kotlin_ranges_CharProgression_hashCode__reverse(self: kotlin.ranges.CharProgression): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_CharProgression_hashCode__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_CharProgression_isEmpty__reverse_swift")
+internal external fun kotlin_ranges_CharProgression_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.ranges.CharProgression::class, "isEmpty")
+public fun kotlin_ranges_CharProgression_isEmpty__reverse(self: kotlin.ranges.CharProgression): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_CharProgression_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_CharProgression_iterator__reverse_swift")
+internal external fun kotlin_ranges_CharProgression_iterator__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.ranges.CharProgression::class, "iterator")
+public fun kotlin_ranges_CharProgression_iterator__reverse(self: kotlin.ranges.CharProgression): kotlin.collections.CharIterator {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_CharProgression_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.CharIterator
+}
+
+@ImportedBridge("kotlin_ranges_CharProgression_toString__reverse_swift")
+internal external fun kotlin_ranges_CharProgression_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.ranges.CharProgression::class, "toString")
+public fun kotlin_ranges_CharProgression_toString__reverse(self: kotlin.ranges.CharProgression): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_CharProgression_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.ranges.UIntProgression::class, "equals")
+public fun kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.ranges.UIntProgression, other: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __other = if (other == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(other)
+    val _result = kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_UIntProgression_hashCode__reverse_swift")
+internal external fun kotlin_ranges_UIntProgression_hashCode__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.ranges.UIntProgression::class, "hashCode")
+public fun kotlin_ranges_UIntProgression_hashCode__reverse(self: kotlin.ranges.UIntProgression): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_UIntProgression_hashCode__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_UIntProgression_isEmpty__reverse_swift")
+internal external fun kotlin_ranges_UIntProgression_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.ranges.UIntProgression::class, "isEmpty")
+public fun kotlin_ranges_UIntProgression_isEmpty__reverse(self: kotlin.ranges.UIntProgression): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_UIntProgression_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_UIntProgression_toString__reverse_swift")
+internal external fun kotlin_ranges_UIntProgression_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.ranges.UIntProgression::class, "toString")
+public fun kotlin_ranges_UIntProgression_toString__reverse(self: kotlin.ranges.UIntProgression): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_UIntProgression_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ImportedBridge("kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
+internal external fun kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.ranges.ULongProgression::class, "equals")
+public fun kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.ranges.ULongProgression, other: kotlin.Any?): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __other = if (other == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(other)
+    val _result = kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_ULongProgression_hashCode__reverse_swift")
+internal external fun kotlin_ranges_ULongProgression_hashCode__reverse_swift(self: kotlin.native.internal.NativePtr): Int
+
+@BindReverseBridgeToMethod(kotlin.ranges.ULongProgression::class, "hashCode")
+public fun kotlin_ranges_ULongProgression_hashCode__reverse(self: kotlin.ranges.ULongProgression): Int {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_ULongProgression_hashCode__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_ULongProgression_isEmpty__reverse_swift")
+internal external fun kotlin_ranges_ULongProgression_isEmpty__reverse_swift(self: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(kotlin.ranges.ULongProgression::class, "isEmpty")
+public fun kotlin_ranges_ULongProgression_isEmpty__reverse(self: kotlin.ranges.ULongProgression): Boolean {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_ULongProgression_isEmpty__reverse_swift(__self)
+    return _result
+}
+
+@ImportedBridge("kotlin_ranges_ULongProgression_toString__reverse_swift")
+internal external fun kotlin_ranges_ULongProgression_toString__reverse_swift(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr
+
+@BindReverseBridgeToMethod(kotlin.ranges.ULongProgression::class, "toString")
+public fun kotlin_ranges_ULongProgression_toString__reverse(self: kotlin.ranges.ULongProgression): kotlin.String {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val _result = kotlin_ranges_ULongProgression_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
+}
+
+@ExportedBridge("kotlin_Array_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Array_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Array_iterator")
+public fun kotlin_Array_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Array_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Array_set__TypesOfArguments__Swift_Int32_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, index: Int, value: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val __index = index
+    val __value = if (value == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(value) as kotlin.Any
+    val _result = run { __self.`set`(__index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Array_size_get")
+public fun kotlin_Array_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Array<kotlin.Any?>
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_Companion_get")
+public fun kotlin_Boolean_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Boolean.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Boolean_and__TypesOfArguments__Swift_Bool__")
+public fun kotlin_Boolean_and__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, other: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_compareTo__TypesOfArguments__Swift_Bool__")
+public fun kotlin_Boolean_compareTo__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, other: Boolean): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Boolean_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_hashCode")
+public fun kotlin_Boolean_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_not")
+public fun kotlin_Boolean_not(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val _result = run { __self.not() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_or__TypesOfArguments__Swift_Bool__")
+public fun kotlin_Boolean_or__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, other: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Boolean_toString")
+public fun kotlin_Boolean_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Boolean_xor__TypesOfArguments__Swift_Bool__")
+public fun kotlin_Boolean_xor__TypesOfArguments__Swift_Bool__(self: kotlin.native.internal.NativePtr, other: Boolean): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Boolean
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ByteArray_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_ByteArray_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ByteArray
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ByteArray_iterator")
+public fun kotlin_ByteArray_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ByteArray
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ByteArray_set__TypesOfArguments__Swift_Int32_Swift_Int8__")
+public fun kotlin_ByteArray_set__TypesOfArguments__Swift_Int32_Swift_Int8__(self: kotlin.native.internal.NativePtr, index: Int, value: Byte): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ByteArray
+    val __index = index
+    val __value = value
+    val _result = run { __self.`set`(__index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_ByteArray_size_get")
+public fun kotlin_ByteArray_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ByteArray
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_Companion_MAX_VALUE_get")
+public fun kotlin_Byte_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_Companion_MIN_VALUE_get")
+public fun kotlin_Byte_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_Companion_SIZE_BITS_get")
+public fun kotlin_Byte_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_Companion_SIZE_BYTES_get")
+public fun kotlin_Byte_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_Companion_get")
+public fun kotlin_Byte_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Byte.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_compareTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_compareTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_compareTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_compareTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_compareTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_compareTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_compareTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_compareTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_compareTo__TypesOfArguments__Swift_Float__")
+public fun kotlin_Byte_compareTo__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_compareTo__TypesOfArguments__Swift_Double__")
+public fun kotlin_Byte_compareTo__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_dec")
+public fun kotlin_Byte_dec(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_div__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_div__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_div__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_div__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_div__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_div__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_div__TypesOfArguments__Swift_Float__")
+public fun kotlin_Byte_div__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_Byte_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Byte_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_hashCode")
+public fun kotlin_Byte_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_inc")
+public fun kotlin_Byte_inc(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_minus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_minus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_minus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_minus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_minus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_minus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_minus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Byte_minus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_minus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Byte_minus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_plus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_plus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_plus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_plus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_plus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_plus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_plus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Byte_plus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_plus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Byte_plus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_rangeTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_rangeUntil__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Byte_rem__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_rem__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_rem__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_rem__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_rem__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_rem__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_rem__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_rem__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_rem__TypesOfArguments__Swift_Float__")
+public fun kotlin_Byte_rem__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_rem__TypesOfArguments__Swift_Double__")
+public fun kotlin_Byte_rem__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_times__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Byte_times__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_times__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Byte_times__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Byte_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_times__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Byte_times__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_times__TypesOfArguments__Swift_Float__")
+public fun kotlin_Byte_times__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_Byte_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toByte")
+public fun kotlin_Byte_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toChar")
+public fun kotlin_Byte_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toDouble")
+public fun kotlin_Byte_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toFloat")
+public fun kotlin_Byte_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toInt")
+public fun kotlin_Byte_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toLong")
+public fun kotlin_Byte_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toShort")
+public fun kotlin_Byte_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_toString")
+public fun kotlin_Byte_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Byte_unaryMinus")
+public fun kotlin_Byte_unaryMinus(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.unaryMinus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Byte_unaryPlus")
+public fun kotlin_Byte_unaryPlus(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Byte
+    val _result = run { __self.unaryPlus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_CharSequence_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_CharSequence_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.CharSequence
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlin_CharSequence_length_get")
+public fun kotlin_CharSequence_length_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.CharSequence
+    val _result = run { __self.length }
+    return _result
+}
+
+@ExportedBridge("kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, startIndex: Int, endIndex: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.CharSequence
+    val __startIndex = startIndex
+    val __endIndex = endIndex
+    val _result = run { __self.subSequence(__startIndex, __endIndex) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Char_Companion_MAX_CODE_POINT_get")
+@OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+public fun kotlin_Char_Companion_MAX_CODE_POINT_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MAX_CODE_POINT }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MAX_HIGH_SURROGATE_get")
+public fun kotlin_Char_Companion_MAX_HIGH_SURROGATE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MAX_HIGH_SURROGATE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MAX_LOW_SURROGATE_get")
+public fun kotlin_Char_Companion_MAX_LOW_SURROGATE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MAX_LOW_SURROGATE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MAX_RADIX_get")
+public fun kotlin_Char_Companion_MAX_RADIX_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MAX_RADIX }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MAX_SURROGATE_get")
+public fun kotlin_Char_Companion_MAX_SURROGATE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MAX_SURROGATE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MAX_VALUE_get")
+public fun kotlin_Char_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_CODE_POINT_get")
+@OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+public fun kotlin_Char_Companion_MIN_CODE_POINT_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_CODE_POINT }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_HIGH_SURROGATE_get")
+public fun kotlin_Char_Companion_MIN_HIGH_SURROGATE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_HIGH_SURROGATE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_LOW_SURROGATE_get")
+public fun kotlin_Char_Companion_MIN_LOW_SURROGATE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_LOW_SURROGATE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_RADIX_get")
+public fun kotlin_Char_Companion_MIN_RADIX_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_RADIX }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_SUPPLEMENTARY_CODE_POINT_get")
+@OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+public fun kotlin_Char_Companion_MIN_SUPPLEMENTARY_CODE_POINT_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_SUPPLEMENTARY_CODE_POINT }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_SURROGATE_get")
+public fun kotlin_Char_Companion_MIN_SURROGATE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_SURROGATE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_MIN_VALUE_get")
+public fun kotlin_Char_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_SIZE_BITS_get")
+public fun kotlin_Char_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_SIZE_BYTES_get")
+public fun kotlin_Char_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_Companion_get")
+public fun kotlin_Char_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Char.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Char_compareTo__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlin_Char_compareTo__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, other: Char): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_dec")
+public fun kotlin_Char_dec(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Char_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_hashCode")
+public fun kotlin_Char_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_inc")
+public fun kotlin_Char_inc(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_minus__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlin_Char_minus__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, other: Char): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Char_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Char_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_rangeTo__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlin_Char_rangeTo__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, other: Char): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Char_rangeUntil__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlin_Char_rangeUntil__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, other: Char): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Char_toByte")
+public fun kotlin_Char_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toChar")
+public fun kotlin_Char_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toDouble")
+public fun kotlin_Char_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toFloat")
+public fun kotlin_Char_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toInt")
+public fun kotlin_Char_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toLong")
+public fun kotlin_Char_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toShort")
+public fun kotlin_Char_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Char_toString")
+public fun kotlin_Char_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Char
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Double_Companion_MAX_VALUE_get")
+public fun kotlin_Double_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_MIN_VALUE_get")
+public fun kotlin_Double_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_NEGATIVE_INFINITY_get")
+public fun kotlin_Double_Companion_NEGATIVE_INFINITY_get(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.NEGATIVE_INFINITY }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_NaN_get")
+public fun kotlin_Double_Companion_NaN_get(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.NaN }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_POSITIVE_INFINITY_get")
+public fun kotlin_Double_Companion_POSITIVE_INFINITY_get(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.POSITIVE_INFINITY }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_SIZE_BITS_get")
+public fun kotlin_Double_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_SIZE_BYTES_get")
+public fun kotlin_Double_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_Companion_get")
+public fun kotlin_Double_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Double.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Double_compareTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Double_compareTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_compareTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Double_compareTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_compareTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Double_compareTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_compareTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Double_compareTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_compareTo__TypesOfArguments__Swift_Float__")
+public fun kotlin_Double_compareTo__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_compareTo__TypesOfArguments__Swift_Double__")
+public fun kotlin_Double_compareTo__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_dec")
+public fun kotlin_Double_dec(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_div__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Double_div__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_div__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Double_div__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Double_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_div__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Double_div__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_div__TypesOfArguments__Swift_Float__")
+public fun kotlin_Double_div__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_Double_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Double_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_hashCode")
+public fun kotlin_Double_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_inc")
+public fun kotlin_Double_inc(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_minus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Double_minus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_minus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Double_minus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Double_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_minus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Double_minus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_minus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Double_minus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_minus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Double_minus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_plus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Double_plus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_plus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Double_plus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Double_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_plus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Double_plus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_plus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Double_plus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_plus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Double_plus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_rem__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Double_rem__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_rem__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Double_rem__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_rem__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Double_rem__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_rem__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Double_rem__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_rem__TypesOfArguments__Swift_Float__")
+public fun kotlin_Double_rem__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_rem__TypesOfArguments__Swift_Double__")
+public fun kotlin_Double_rem__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_times__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Double_times__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_times__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Double_times__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Double_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_times__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Double_times__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_times__TypesOfArguments__Swift_Float__")
+public fun kotlin_Double_times__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_Double_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toByte")
+public fun kotlin_Double_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toChar")
+public fun kotlin_Double_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toDouble")
+public fun kotlin_Double_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toFloat")
+public fun kotlin_Double_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toInt")
+public fun kotlin_Double_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toLong")
+public fun kotlin_Double_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toShort")
+public fun kotlin_Double_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_toString")
+public fun kotlin_Double_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Double_unaryMinus")
+public fun kotlin_Double_unaryMinus(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.unaryMinus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Double_unaryPlus")
+public fun kotlin_Double_unaryPlus(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Double
+    val _result = run { __self.unaryPlus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Exception_init_allocate")
+public fun kotlin_Exception_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.Exception>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Exception_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Exception(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Float_Companion_MAX_VALUE_get")
+public fun kotlin_Float_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_MIN_VALUE_get")
+public fun kotlin_Float_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_NEGATIVE_INFINITY_get")
+public fun kotlin_Float_Companion_NEGATIVE_INFINITY_get(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.NEGATIVE_INFINITY }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_NaN_get")
+public fun kotlin_Float_Companion_NaN_get(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.NaN }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_POSITIVE_INFINITY_get")
+public fun kotlin_Float_Companion_POSITIVE_INFINITY_get(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.POSITIVE_INFINITY }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_SIZE_BITS_get")
+public fun kotlin_Float_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_SIZE_BYTES_get")
+public fun kotlin_Float_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_Companion_get")
+public fun kotlin_Float_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Float.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Float_compareTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Float_compareTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_compareTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Float_compareTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_compareTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Float_compareTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_compareTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Float_compareTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_compareTo__TypesOfArguments__Swift_Float__")
+public fun kotlin_Float_compareTo__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_compareTo__TypesOfArguments__Swift_Double__")
+public fun kotlin_Float_compareTo__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_dec")
+public fun kotlin_Float_dec(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_div__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Float_div__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_div__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Float_div__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Float_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_div__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Float_div__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_div__TypesOfArguments__Swift_Float__")
+public fun kotlin_Float_div__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_Float_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Float_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_hashCode")
+public fun kotlin_Float_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_inc")
+public fun kotlin_Float_inc(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_minus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Float_minus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_minus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Float_minus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Float_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_minus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Float_minus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_minus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Float_minus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_minus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Float_minus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_plus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Float_plus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_plus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Float_plus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Float_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_plus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Float_plus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_plus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Float_plus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_plus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Float_plus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_rem__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Float_rem__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_rem__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Float_rem__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_rem__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Float_rem__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_rem__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Float_rem__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_rem__TypesOfArguments__Swift_Float__")
+public fun kotlin_Float_rem__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_rem__TypesOfArguments__Swift_Double__")
+public fun kotlin_Float_rem__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_times__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Float_times__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_times__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Float_times__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Float_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_times__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Float_times__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_times__TypesOfArguments__Swift_Float__")
+public fun kotlin_Float_times__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_Float_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toByte")
+public fun kotlin_Float_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toChar")
+public fun kotlin_Float_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toDouble")
+public fun kotlin_Float_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toFloat")
+public fun kotlin_Float_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toInt")
+public fun kotlin_Float_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toLong")
+public fun kotlin_Float_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toShort")
+public fun kotlin_Float_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_toString")
+public fun kotlin_Float_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Float_unaryMinus")
+public fun kotlin_Float_unaryMinus(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.unaryMinus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Float_unaryPlus")
+public fun kotlin_Float_unaryPlus(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Float
+    val _result = run { __self.unaryPlus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_IllegalArgumentException_init_allocate")
+public fun kotlin_IllegalArgumentException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.IllegalArgumentException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalArgumentException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalArgumentException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalArgumentException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_IllegalArgumentException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.IllegalArgumentException(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IntArray_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_IntArray_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlin_IntArray_iterator")
+public fun kotlin_IntArray_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_IntArray_set__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlin_IntArray_set__TypesOfArguments__Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int, value: Int): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val __index = index
+    val __value = value
+    val _result = run { __self.`set`(__index, __value) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_IntArray_size_get")
+public fun kotlin_IntArray_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.IntArray
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_Companion_MAX_VALUE_get")
+public fun kotlin_Int_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_Companion_MIN_VALUE_get")
+public fun kotlin_Int_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_Companion_SIZE_BITS_get")
+public fun kotlin_Int_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_Companion_SIZE_BYTES_get")
+public fun kotlin_Int_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_Companion_get")
+public fun kotlin_Int_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Int.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_and__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_and__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_compareTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_compareTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_compareTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_compareTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_compareTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_compareTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_compareTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_compareTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_compareTo__TypesOfArguments__Swift_Float__")
+public fun kotlin_Int_compareTo__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_compareTo__TypesOfArguments__Swift_Double__")
+public fun kotlin_Int_compareTo__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_dec")
+public fun kotlin_Int_dec(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_div__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_div__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_div__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_div__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_div__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_div__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_div__TypesOfArguments__Swift_Float__")
+public fun kotlin_Int_div__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_Int_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Int_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_hashCode")
+public fun kotlin_Int_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_inc")
+public fun kotlin_Int_inc(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_inv")
+public fun kotlin_Int_inv(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.inv() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_minus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_minus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_minus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_minus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_minus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_minus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_minus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Int_minus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_minus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Int_minus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_or__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_or__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_plus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_plus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_plus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_plus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_plus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_plus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_plus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Int_plus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_plus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Int_plus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_rangeTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_rangeTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_rangeTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_rangeTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_rangeTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_rangeUntil__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Int_rem__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_rem__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_rem__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_rem__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_rem__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_rem__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_rem__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_rem__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_rem__TypesOfArguments__Swift_Float__")
+public fun kotlin_Int_rem__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_rem__TypesOfArguments__Swift_Double__")
+public fun kotlin_Int_rem__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_shl__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_shl__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __bitCount = bitCount
+    val _result = run { __self.shl(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_shr__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_shr__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __bitCount = bitCount
+    val _result = run { __self.shr(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_times__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Int_times__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_times__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Int_times__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_times__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Int_times__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_times__TypesOfArguments__Swift_Float__")
+public fun kotlin_Int_times__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_Int_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toByte")
+public fun kotlin_Int_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toChar")
+public fun kotlin_Int_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toDouble")
+public fun kotlin_Int_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toFloat")
+public fun kotlin_Int_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toInt")
+public fun kotlin_Int_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toLong")
+public fun kotlin_Int_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toShort")
+public fun kotlin_Int_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_toString")
+public fun kotlin_Int_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Int_unaryMinus")
+public fun kotlin_Int_unaryMinus(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.unaryMinus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_unaryPlus")
+public fun kotlin_Int_unaryPlus(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val _result = run { __self.unaryPlus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_ushr__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_ushr__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __bitCount = bitCount
+    val _result = run { __self.ushr(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Int_xor__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Int_xor__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Int
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_Companion_MAX_VALUE_get")
+public fun kotlin_Long_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_Companion_MIN_VALUE_get")
+public fun kotlin_Long_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_Companion_SIZE_BITS_get")
+public fun kotlin_Long_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_Companion_SIZE_BYTES_get")
+public fun kotlin_Long_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_Companion_get")
+public fun kotlin_Long_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Long.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_and__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_and__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_compareTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_compareTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_compareTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_compareTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_compareTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_compareTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_compareTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_compareTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_compareTo__TypesOfArguments__Swift_Float__")
+public fun kotlin_Long_compareTo__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_compareTo__TypesOfArguments__Swift_Double__")
+public fun kotlin_Long_compareTo__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_dec")
+public fun kotlin_Long_dec(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_div__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_div__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_div__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_div__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_div__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_div__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_div__TypesOfArguments__Swift_Float__")
+public fun kotlin_Long_div__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_Long_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Long_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_hashCode")
+public fun kotlin_Long_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_inc")
+public fun kotlin_Long_inc(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_inv")
+public fun kotlin_Long_inv(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.inv() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_minus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_minus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_minus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_minus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_minus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_minus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_minus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Long_minus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_minus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Long_minus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_or__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_or__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_plus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_plus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_plus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_plus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_plus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_plus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_plus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Long_plus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_plus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Long_plus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_rangeTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_rangeTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_rangeTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_rangeTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_rangeTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_rangeUntil__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Long_rem__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_rem__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_rem__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_rem__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_rem__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_rem__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_rem__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_rem__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_rem__TypesOfArguments__Swift_Float__")
+public fun kotlin_Long_rem__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_rem__TypesOfArguments__Swift_Double__")
+public fun kotlin_Long_rem__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_shl__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_shl__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __bitCount = bitCount
+    val _result = run { __self.shl(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_shr__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_shr__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __bitCount = bitCount
+    val _result = run { __self.shr(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_times__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Long_times__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_times__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Long_times__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_times__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_times__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_times__TypesOfArguments__Swift_Float__")
+public fun kotlin_Long_times__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_Long_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toByte")
+public fun kotlin_Long_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toChar")
+public fun kotlin_Long_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toDouble")
+public fun kotlin_Long_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toFloat")
+public fun kotlin_Long_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toInt")
+public fun kotlin_Long_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toLong")
+public fun kotlin_Long_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toShort")
+public fun kotlin_Long_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_toString")
+public fun kotlin_Long_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Long_unaryMinus")
+public fun kotlin_Long_unaryMinus(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.unaryMinus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_unaryPlus")
+public fun kotlin_Long_unaryPlus(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val _result = run { __self.unaryPlus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_ushr__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Long_ushr__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __bitCount = bitCount
+    val _result = run { __self.ushr(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Long_xor__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Long_xor__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Long
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_Number_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Number()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Number_toByte")
+public fun kotlin_Number_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toChar")
+public fun kotlin_Number_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toChar_direct", nonVirtualTargetMethod = "toChar")
+public fun kotlin_Number_toChar_direct(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toDouble")
+public fun kotlin_Number_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toFloat")
+public fun kotlin_Number_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toInt")
+public fun kotlin_Number_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toLong")
+public fun kotlin_Number_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Number_toShort")
+public fun kotlin_Number_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Number
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_allocate")
+public fun kotlin_RuntimeException_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.RuntimeException>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_RuntimeException_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.RuntimeException(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Short_Companion_MAX_VALUE_get")
+public fun kotlin_Short_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_Companion_MIN_VALUE_get")
+public fun kotlin_Short_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_Companion_SIZE_BITS_get")
+public fun kotlin_Short_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_Companion_SIZE_BYTES_get")
+public fun kotlin_Short_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_Companion_get")
+public fun kotlin_Short_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.Short.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_compareTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_compareTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_compareTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_compareTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_compareTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_compareTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_compareTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_compareTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_compareTo__TypesOfArguments__Swift_Float__")
+public fun kotlin_Short_compareTo__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_compareTo__TypesOfArguments__Swift_Double__")
+public fun kotlin_Short_compareTo__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_dec")
+public fun kotlin_Short_dec(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_div__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_div__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_div__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_div__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_div__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_div__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_div__TypesOfArguments__Swift_Float__")
+public fun kotlin_Short_div__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_Short_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_Short_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_hashCode")
+public fun kotlin_Short_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_inc")
+public fun kotlin_Short_inc(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_minus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_minus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_minus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_minus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_minus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_minus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_minus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_minus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_minus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Short_minus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_minus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Short_minus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_plus__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_plus__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_plus__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_plus__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_plus__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_plus__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_plus__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_plus__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_plus__TypesOfArguments__Swift_Float__")
+public fun kotlin_Short_plus__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_plus__TypesOfArguments__Swift_Double__")
+public fun kotlin_Short_plus__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_rangeTo__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_rangeTo__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeTo__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_rangeTo__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeTo__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_rangeTo__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeTo__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_rangeTo__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_rangeUntil__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Short_rem__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_rem__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_rem__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_rem__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_rem__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_rem__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_rem__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_rem__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_rem__TypesOfArguments__Swift_Float__")
+public fun kotlin_Short_rem__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_rem__TypesOfArguments__Swift_Double__")
+public fun kotlin_Short_rem__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_times__TypesOfArguments__Swift_Int8__")
+public fun kotlin_Short_times__TypesOfArguments__Swift_Int8__(self: kotlin.native.internal.NativePtr, other: Byte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_times__TypesOfArguments__Swift_Int16__")
+public fun kotlin_Short_times__TypesOfArguments__Swift_Int16__(self: kotlin.native.internal.NativePtr, other: Short): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_Short_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, other: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_times__TypesOfArguments__Swift_Int64__")
+public fun kotlin_Short_times__TypesOfArguments__Swift_Int64__(self: kotlin.native.internal.NativePtr, other: Long): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_times__TypesOfArguments__Swift_Float__")
+public fun kotlin_Short_times__TypesOfArguments__Swift_Float__(self: kotlin.native.internal.NativePtr, other: Float): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_Short_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, other: Double): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toByte")
+public fun kotlin_Short_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toChar")
+public fun kotlin_Short_toChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toDouble")
+public fun kotlin_Short_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toFloat")
+public fun kotlin_Short_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toInt")
+public fun kotlin_Short_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toLong")
+public fun kotlin_Short_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toShort")
+public fun kotlin_Short_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_toString")
+public fun kotlin_Short_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Short_unaryMinus")
+public fun kotlin_Short_unaryMinus(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.unaryMinus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_Short_unaryPlus")
+public fun kotlin_Short_unaryPlus(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Short
+    val _result = run { __self.unaryPlus() }
+    return _result
+}
+
+@ExportedBridge("kotlin_String_Companion_get")
+public fun kotlin_String_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.String.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_String_compareTo__TypesOfArguments__Swift_String__")
+public fun kotlin_String_compareTo__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val __other = interpretObjCPointer<kotlin.String>(other)
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_String_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_String_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_String_get__TypesOfArguments__Swift_Int32__")
+public fun kotlin_String_get__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, index: Int): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val __index = index
+    val _result = run { __self.`get`(__index) }
+    return _result
+}
+
+@ExportedBridge("kotlin_String_hashCode")
+public fun kotlin_String_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_String_init_allocate")
+public fun kotlin_String_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.String>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_String_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_String_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.String()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_String_length_get")
+public fun kotlin_String_length_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val _result = run { __self.length }
+    return _result
+}
+
+@ExportedBridge("kotlin_String_plus__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_String_plus__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.plus(__other) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_String_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32__")
+public fun kotlin_String_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32__(self: kotlin.native.internal.NativePtr, startIndex: Int, endIndex: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val __startIndex = startIndex
+    val __endIndex = endIndex
+    val _result = run { __self.subSequence(__startIndex, __endIndex) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_String_toString")
+public fun kotlin_String_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.String
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_cause_get")
+public fun kotlin_Throwable_cause_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.cause }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_cause_get_direct", nonVirtualTargetMethod = "<get-cause>")
+public fun kotlin_Throwable_cause_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.cause }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_getStackTrace")
+@OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+public fun kotlin_Throwable_getStackTrace(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.getStackTrace() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_init_allocate")
+public fun kotlin_Throwable_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.Throwable>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String__Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable(__message, __cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_Swift_String___(__kt: kotlin.native.internal.NativePtr, message: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __message = if (message == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<kotlin.String>(message)
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable(__message)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Optional_ExportedKotlinPackages_kotlin_Throwable___(__kt: kotlin.native.internal.NativePtr, cause: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __cause = if (cause == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(cause) as kotlin.Throwable
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable(__cause)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun kotlin_Throwable_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.Throwable()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_message_get")
+public fun kotlin_Throwable_message_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.message }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_message_get_direct", nonVirtualTargetMethod = "<get-message>")
+public fun kotlin_Throwable_message_get_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.message }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_printStackTrace")
+public fun kotlin_Throwable_printStackTrace(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.printStackTrace() }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_Throwable_toString")
+public fun kotlin_Throwable_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_Throwable_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlin_Throwable_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.Throwable
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_UByte_Companion_MAX_VALUE_get")
+public fun kotlin_UByte_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_Companion_MIN_VALUE_get")
+public fun kotlin_UByte_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_Companion_SIZE_BITS_get")
+public fun kotlin_UByte_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_Companion_SIZE_BYTES_get")
+public fun kotlin_UByte_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_Companion_get")
+public fun kotlin_UByte_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.UByte.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UByte_and__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_and__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_compareTo__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_dec")
+public fun kotlin_UByte_dec(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_div__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_div__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_div__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_div__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_div__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_div__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_div__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_div__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_UByte_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_floorDiv__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_hashCode")
+public fun kotlin_UByte_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_inc")
+public fun kotlin_UByte_inc(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_inv")
+public fun kotlin_UByte_inv(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.inv() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_minus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_minus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_minus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_minus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_minus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_minus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_minus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_minus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_mod__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_mod__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_mod__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_mod__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_mod__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_mod__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_mod__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_mod__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_or__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_or__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_plus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_plus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_plus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_plus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_plus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_plus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_plus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_plus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_rangeTo__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_rangeTo__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UByte_rangeUntil__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_rangeUntil__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UByte_rem__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_rem__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_rem__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_rem__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_rem__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_rem__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_rem__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_rem__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_times__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_times__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_times__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UByte_times__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_times__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UByte_times__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_times__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UByte_times__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toByte")
+public fun kotlin_UByte_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toDouble")
+public fun kotlin_UByte_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toFloat")
+public fun kotlin_UByte_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toInt")
+public fun kotlin_UByte_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toLong")
+public fun kotlin_UByte_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toShort")
+public fun kotlin_UByte_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toString")
+public fun kotlin_UByte_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_UByte_toUByte")
+public fun kotlin_UByte_toUByte(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toUByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toUInt")
+public fun kotlin_UByte_toUInt(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toUInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toULong")
+public fun kotlin_UByte_toULong(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toULong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_toUShort")
+public fun kotlin_UByte_toUShort(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val _result = run { __self.toUShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UByte_xor__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UByte_xor__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UByte
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_Companion_MAX_VALUE_get")
+public fun kotlin_UInt_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_Companion_MIN_VALUE_get")
+public fun kotlin_UInt_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_Companion_SIZE_BITS_get")
+public fun kotlin_UInt_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_Companion_SIZE_BYTES_get")
+public fun kotlin_UInt_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_Companion_get")
+public fun kotlin_UInt_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.UInt.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UInt_and__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_and__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_compareTo__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_dec")
+public fun kotlin_UInt_dec(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_div__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_div__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_div__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_div__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_div__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_div__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_div__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_div__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_UInt_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_floorDiv__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_hashCode")
+public fun kotlin_UInt_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_inc")
+public fun kotlin_UInt_inc(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_inv")
+public fun kotlin_UInt_inv(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.inv() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_minus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_minus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_minus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_minus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_minus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_minus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_minus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_minus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_mod__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_mod__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_mod__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_mod__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_mod__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_mod__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_mod__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_mod__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_or__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_or__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_plus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_plus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_plus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_plus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_plus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_plus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_plus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_plus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_rangeTo__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_rangeTo__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UInt_rangeUntil__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_rangeUntil__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UInt_rem__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_rem__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_rem__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_rem__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_rem__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_rem__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_rem__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_rem__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_shl__TypesOfArguments__Swift_Int32__")
+public fun kotlin_UInt_shl__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __bitCount = bitCount
+    val _result = run { __self.shl(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_shr__TypesOfArguments__Swift_Int32__")
+public fun kotlin_UInt_shr__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __bitCount = bitCount
+    val _result = run { __self.shr(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_times__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UInt_times__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_times__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UInt_times__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_times__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_times__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_times__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UInt_times__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toByte")
+public fun kotlin_UInt_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toDouble")
+public fun kotlin_UInt_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toFloat")
+public fun kotlin_UInt_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toInt")
+public fun kotlin_UInt_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toLong")
+public fun kotlin_UInt_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toShort")
+public fun kotlin_UInt_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toString")
+public fun kotlin_UInt_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_UInt_toUByte")
+public fun kotlin_UInt_toUByte(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toUByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toUInt")
+public fun kotlin_UInt_toUInt(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toUInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toULong")
+public fun kotlin_UInt_toULong(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toULong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_toUShort")
+public fun kotlin_UInt_toUShort(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val _result = run { __self.toUShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UInt_xor__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UInt_xor__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UInt
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_Companion_MAX_VALUE_get")
+public fun kotlin_ULong_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_Companion_MIN_VALUE_get")
+public fun kotlin_ULong_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_Companion_SIZE_BITS_get")
+public fun kotlin_ULong_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_Companion_SIZE_BYTES_get")
+public fun kotlin_ULong_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_Companion_get")
+public fun kotlin_ULong_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ULong.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ULong_and__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_and__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_compareTo__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_dec")
+public fun kotlin_ULong_dec(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_div__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_div__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_div__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_div__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_div__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_div__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_div__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_div__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ULong_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_floorDiv__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_hashCode")
+public fun kotlin_ULong_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_inc")
+public fun kotlin_ULong_inc(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_inv")
+public fun kotlin_ULong_inv(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.inv() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_minus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_minus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_minus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_minus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_minus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_minus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_minus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_minus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_mod__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_mod__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_mod__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_mod__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_mod__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_mod__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_mod__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_mod__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_or__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_or__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_plus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_plus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_plus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_plus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_plus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_plus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_plus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_plus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_rangeTo__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_rangeTo__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ULong_rangeUntil__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_rangeUntil__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ULong_rem__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_rem__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_rem__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_rem__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_rem__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_rem__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_rem__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_rem__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_shl__TypesOfArguments__Swift_Int32__")
+public fun kotlin_ULong_shl__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __bitCount = bitCount
+    val _result = run { __self.shl(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_shr__TypesOfArguments__Swift_Int32__")
+public fun kotlin_ULong_shr__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, bitCount: Int): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __bitCount = bitCount
+    val _result = run { __self.shr(__bitCount) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_times__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_ULong_times__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_times__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_ULong_times__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_times__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ULong_times__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_times__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_times__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toByte")
+public fun kotlin_ULong_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toDouble")
+public fun kotlin_ULong_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toFloat")
+public fun kotlin_ULong_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toInt")
+public fun kotlin_ULong_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toLong")
+public fun kotlin_ULong_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toShort")
+public fun kotlin_ULong_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toString")
+public fun kotlin_ULong_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ULong_toUByte")
+public fun kotlin_ULong_toUByte(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toUByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toUInt")
+public fun kotlin_ULong_toUInt(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toUInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toULong")
+public fun kotlin_ULong_toULong(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toULong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_toUShort")
+public fun kotlin_ULong_toUShort(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val _result = run { __self.toUShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ULong_xor__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ULong_xor__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ULong
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_Companion_MAX_VALUE_get")
+public fun kotlin_UShort_Companion_MAX_VALUE_get(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort.Companion
+    val _result = run { __self.MAX_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_Companion_MIN_VALUE_get")
+public fun kotlin_UShort_Companion_MIN_VALUE_get(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort.Companion
+    val _result = run { __self.MIN_VALUE }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_Companion_SIZE_BITS_get")
+public fun kotlin_UShort_Companion_SIZE_BITS_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort.Companion
+    val _result = run { __self.SIZE_BITS }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_Companion_SIZE_BYTES_get")
+public fun kotlin_UShort_Companion_SIZE_BYTES_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort.Companion
+    val _result = run { __self.SIZE_BYTES }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_Companion_get")
+public fun kotlin_UShort_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.UShort.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UShort_and__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_and__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.and(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_compareTo__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_dec")
+public fun kotlin_UShort_dec(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.dec() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_div__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_div__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_div__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_div__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_div__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_div__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_div__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_div__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_UShort_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_floorDiv__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.floorDiv(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_hashCode")
+public fun kotlin_UShort_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_inc")
+public fun kotlin_UShort_inc(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.inc() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_inv")
+public fun kotlin_UShort_inv(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.inv() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_minus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_minus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_minus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_minus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_minus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_minus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_minus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_minus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.minus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_mod__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_mod__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_mod__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_mod__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_mod__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_mod__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_mod__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_mod__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.mod(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_or__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_or__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.or(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_plus__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_plus__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_plus__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_plus__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_plus__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_plus__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_plus__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_plus__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.plus(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_rangeTo__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_rangeTo__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.rangeTo(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UShort_rangeUntil__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_rangeUntil__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.rangeUntil(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_UShort_rem__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_rem__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_rem__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_rem__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_rem__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_rem__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_rem__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_rem__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.rem(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_times__TypesOfArguments__Swift_UInt8__")
+public fun kotlin_UShort_times__TypesOfArguments__Swift_UInt8__(self: kotlin.native.internal.NativePtr, other: UByte): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_times__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_times__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_times__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_UShort_times__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, other: UInt): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_times__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_UShort_times__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, other: ULong): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.times(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toByte")
+public fun kotlin_UShort_toByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toDouble")
+public fun kotlin_UShort_toDouble(self: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toDouble() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toFloat")
+public fun kotlin_UShort_toFloat(self: kotlin.native.internal.NativePtr): Float {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toFloat() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toInt")
+public fun kotlin_UShort_toInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toLong")
+public fun kotlin_UShort_toLong(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toLong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toShort")
+public fun kotlin_UShort_toShort(self: kotlin.native.internal.NativePtr): Short {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toString")
+public fun kotlin_UShort_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_UShort_toUByte")
+public fun kotlin_UShort_toUByte(self: kotlin.native.internal.NativePtr): UByte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toUByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toUInt")
+public fun kotlin_UShort_toUInt(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toUInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toULong")
+public fun kotlin_UShort_toULong(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toULong() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_toUShort")
+public fun kotlin_UShort_toUShort(self: kotlin.native.internal.NativePtr): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val _result = run { __self.toUShort() }
+    return _result
+}
+
+@ExportedBridge("kotlin_UShort_xor__TypesOfArguments__Swift_UInt16__")
+public fun kotlin_UShort_xor__TypesOfArguments__Swift_UInt16__(self: kotlin.native.internal.NativePtr, other: UShort): UShort {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.UShort
+    val __other = other
+    val _result = run { __self.xor(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_ByteIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_collections_ByteIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.collections.ByteIterator()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_ByteIterator_next")
+public fun kotlin_collections_ByteIterator_next(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ByteIterator
+    val _result = run { __self.next() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_ByteIterator_nextByte")
+public fun kotlin_collections_ByteIterator_nextByte(self: kotlin.native.internal.NativePtr): Byte {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.ByteIterator
+    val _result = run { __self.nextByte() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_CharIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_collections_CharIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.collections.CharIterator()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_CharIterator_next")
+public fun kotlin_collections_CharIterator_next(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.CharIterator
+    val _result = run { __self.next() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_CharIterator_nextChar")
+public fun kotlin_collections_CharIterator_nextChar(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.CharIterator
+    val _result = run { __self.nextChar() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, element: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val __element = if (element == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(element) as kotlin.Any
+    val _result = run { __self.contains(__element) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__")
+public fun kotlin_collections_Collection_containsAll__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_collections_Collection__(self: kotlin.native.internal.NativePtr, elements: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val __elements = kotlin.native.internal.ref.dereferenceExternalRCRef(elements) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.containsAll(__elements) }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_isEmpty")
+public fun kotlin_collections_Collection_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Collection_iterator")
+public fun kotlin_collections_Collection_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_Collection_size_get")
+public fun kotlin_collections_Collection_size_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Collection<kotlin.Any?>
+    val _result = run { __self.size }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IntIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__", nonVirtualTargetMethod = "<init>")
+public fun kotlin_collections_IntIterator_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.collections.IntIterator()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_collections_IntIterator_next")
+public fun kotlin_collections_IntIterator_next(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IntIterator
+    val _result = run { __self.next() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_IntIterator_nextInt")
+public fun kotlin_collections_IntIterator_nextInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.IntIterator
+    val _result = run { __self.nextInt() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Iterable_iterator")
+public fun kotlin_collections_Iterable_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Iterable<kotlin.Any?>
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_collections_Iterator_hasNext")
+public fun kotlin_collections_Iterator_hasNext(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = run { __self.hasNext() }
+    return _result
+}
+
+@ExportedBridge("kotlin_collections_Iterator_next")
+public fun kotlin_collections_Iterator_next(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = run { __self.next() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_Companion_fromClosedRange__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit_Swift_Unicode_UTF16_CodeUnit_Swift_Int32__")
+public fun kotlin_ranges_CharProgression_Companion_fromClosedRange__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit_Swift_Unicode_UTF16_CodeUnit_Swift_Int32__(self: kotlin.native.internal.NativePtr, rangeStart: Char, rangeEnd: Char, step: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression.Companion
+    val __rangeStart = rangeStart
+    val __rangeEnd = rangeEnd
+    val __step = step
+    val _result = run { __self.fromClosedRange(__rangeStart, __rangeEnd, __step) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_Companion_get")
+public fun kotlin_ranges_CharProgression_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ranges.CharProgression.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "equals")
+public fun kotlin_ranges_CharProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_first_get")
+public fun kotlin_ranges_CharProgression_first_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.first }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_hashCode")
+public fun kotlin_ranges_CharProgression_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_hashCode_direct", nonVirtualTargetMethod = "hashCode")
+public fun kotlin_ranges_CharProgression_hashCode_direct(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_isEmpty")
+public fun kotlin_ranges_CharProgression_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_isEmpty_direct", nonVirtualTargetMethod = "isEmpty")
+public fun kotlin_ranges_CharProgression_isEmpty_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_iterator")
+public fun kotlin_ranges_CharProgression_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_iterator_direct", nonVirtualTargetMethod = "iterator")
+public fun kotlin_ranges_CharProgression_iterator_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_last_get")
+public fun kotlin_ranges_CharProgression_last_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.last }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_step_get")
+public fun kotlin_ranges_CharProgression_step_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.step }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_toString")
+public fun kotlin_ranges_CharProgression_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_CharProgression_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlin_ranges_CharProgression_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharProgression
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_Companion_EMPTY_get")
+public fun kotlin_ranges_CharRange_Companion_EMPTY_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange.Companion
+    val _result = run { __self.EMPTY }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_Companion_get")
+public fun kotlin_ranges_CharRange_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ranges.CharRange.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_contains__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlin_ranges_CharRange_contains__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit__(self: kotlin.native.internal.NativePtr, value: Char): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val __value = value
+    val _result = run { __self.contains(__value) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_endExclusive_get")
+public fun kotlin_ranges_CharRange_endExclusive_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val _result = run { __self.endExclusive }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_endInclusive_get")
+public fun kotlin_ranges_CharRange_endInclusive_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val _result = run { __self.endInclusive }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ranges_CharRange_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_hashCode")
+public fun kotlin_ranges_CharRange_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_init_allocate")
+public fun kotlin_ranges_CharRange_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.ranges.CharRange>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Unicode_UTF16_CodeUnit_Swift_Unicode_UTF16_CodeUnit__")
+public fun kotlin_ranges_CharRange_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Unicode_UTF16_CodeUnit_Swift_Unicode_UTF16_CodeUnit__(__kt: kotlin.native.internal.NativePtr, start: Char, endInclusive: Char): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __start = start
+    val __endInclusive = endInclusive
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.ranges.CharRange(__start, __endInclusive)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_isEmpty")
+public fun kotlin_ranges_CharRange_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_start_get")
+public fun kotlin_ranges_CharRange_start_get(self: kotlin.native.internal.NativePtr): Char {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val _result = run { __self.start }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_CharRange_toString")
+public fun kotlin_ranges_CharRange_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.CharRange
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_Companion_fromClosedRange__TypesOfArguments__Swift_UInt32_Swift_UInt32_Swift_Int32__")
+public fun kotlin_ranges_UIntProgression_Companion_fromClosedRange__TypesOfArguments__Swift_UInt32_Swift_UInt32_Swift_Int32__(self: kotlin.native.internal.NativePtr, rangeStart: UInt, rangeEnd: UInt, step: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression.Companion
+    val __rangeStart = rangeStart
+    val __rangeEnd = rangeEnd
+    val __step = step
+    val _result = run { __self.fromClosedRange(__rangeStart, __rangeEnd, __step) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_Companion_get")
+public fun kotlin_ranges_UIntProgression_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ranges.UIntProgression.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "equals")
+public fun kotlin_ranges_UIntProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_first_get")
+public fun kotlin_ranges_UIntProgression_first_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.first }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_hashCode")
+public fun kotlin_ranges_UIntProgression_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_hashCode_direct", nonVirtualTargetMethod = "hashCode")
+public fun kotlin_ranges_UIntProgression_hashCode_direct(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_isEmpty")
+public fun kotlin_ranges_UIntProgression_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_isEmpty_direct", nonVirtualTargetMethod = "isEmpty")
+public fun kotlin_ranges_UIntProgression_isEmpty_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_iterator")
+public fun kotlin_ranges_UIntProgression_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_last_get")
+public fun kotlin_ranges_UIntProgression_last_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.last }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_step_get")
+public fun kotlin_ranges_UIntProgression_step_get(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.step }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_toString")
+public fun kotlin_ranges_UIntProgression_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_UIntProgression_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlin_ranges_UIntProgression_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntProgression
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_Companion_EMPTY_get")
+public fun kotlin_ranges_UIntRange_Companion_EMPTY_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange.Companion
+    val _result = run { __self.EMPTY }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_Companion_get")
+public fun kotlin_ranges_UIntRange_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ranges.UIntRange.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_contains__TypesOfArguments__Swift_UInt32__")
+public fun kotlin_ranges_UIntRange_contains__TypesOfArguments__Swift_UInt32__(self: kotlin.native.internal.NativePtr, value: UInt): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val __value = value
+    val _result = run { __self.contains(__value) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_endExclusive_get")
+public fun kotlin_ranges_UIntRange_endExclusive_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val _result = run { __self.endExclusive }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_endInclusive_get")
+public fun kotlin_ranges_UIntRange_endInclusive_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val _result = run { __self.endInclusive }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ranges_UIntRange_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_hashCode")
+public fun kotlin_ranges_UIntRange_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_init_allocate")
+public fun kotlin_ranges_UIntRange_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.ranges.UIntRange>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_UInt32_Swift_UInt32__")
+public fun kotlin_ranges_UIntRange_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_UInt32_Swift_UInt32__(__kt: kotlin.native.internal.NativePtr, start: UInt, endInclusive: UInt): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __start = start
+    val __endInclusive = endInclusive
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.ranges.UIntRange(__start, __endInclusive)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_isEmpty")
+public fun kotlin_ranges_UIntRange_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_start_get")
+public fun kotlin_ranges_UIntRange_start_get(self: kotlin.native.internal.NativePtr): UInt {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val _result = run { __self.start }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_UIntRange_toString")
+public fun kotlin_ranges_UIntRange_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.UIntRange
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_Companion_fromClosedRange__TypesOfArguments__Swift_UInt64_Swift_UInt64_Swift_Int64__")
+public fun kotlin_ranges_ULongProgression_Companion_fromClosedRange__TypesOfArguments__Swift_UInt64_Swift_UInt64_Swift_Int64__(self: kotlin.native.internal.NativePtr, rangeStart: ULong, rangeEnd: ULong, step: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression.Companion
+    val __rangeStart = rangeStart
+    val __rangeEnd = rangeEnd
+    val __step = step
+    val _result = run { __self.fromClosedRange(__rangeStart, __rangeEnd, __step) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_Companion_get")
+public fun kotlin_ranges_ULongProgression_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ranges.ULongProgression.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct", nonVirtualTargetMethod = "equals")
+public fun kotlin_ranges_ULongProgression_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable____direct(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_first_get")
+public fun kotlin_ranges_ULongProgression_first_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.first }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_hashCode")
+public fun kotlin_ranges_ULongProgression_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_hashCode_direct", nonVirtualTargetMethod = "hashCode")
+public fun kotlin_ranges_ULongProgression_hashCode_direct(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_isEmpty")
+public fun kotlin_ranges_ULongProgression_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_isEmpty_direct", nonVirtualTargetMethod = "isEmpty")
+public fun kotlin_ranges_ULongProgression_isEmpty_direct(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_iterator")
+public fun kotlin_ranges_ULongProgression_iterator(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.iterator() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_last_get")
+public fun kotlin_ranges_ULongProgression_last_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.last }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_step_get")
+public fun kotlin_ranges_ULongProgression_step_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.step }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_toString")
+public fun kotlin_ranges_ULongProgression_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_ULongProgression_toString_direct", nonVirtualTargetMethod = "toString")
+public fun kotlin_ranges_ULongProgression_toString_direct(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongProgression
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_Companion_EMPTY_get")
+public fun kotlin_ranges_ULongRange_Companion_EMPTY_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange.Companion
+    val _result = run { __self.EMPTY }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_Companion_get")
+public fun kotlin_ranges_ULongRange_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.ranges.ULongRange.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_contains__TypesOfArguments__Swift_UInt64__")
+public fun kotlin_ranges_ULongRange_contains__TypesOfArguments__Swift_UInt64__(self: kotlin.native.internal.NativePtr, value: ULong): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val __value = value
+    val _result = run { __self.contains(__value) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_endExclusive_get")
+public fun kotlin_ranges_ULongRange_endExclusive_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val _result = run { __self.endExclusive }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_endInclusive_get")
+public fun kotlin_ranges_ULongRange_endInclusive_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val _result = run { __self.endInclusive }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_ranges_ULongRange_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_hashCode")
+public fun kotlin_ranges_ULongRange_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_init_allocate")
+public fun kotlin_ranges_ULongRange_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<kotlin.ranges.ULongRange>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_UInt64_Swift_UInt64__")
+public fun kotlin_ranges_ULongRange_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_UInt64_Swift_UInt64__(__kt: kotlin.native.internal.NativePtr, start: ULong, endInclusive: ULong): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val __start = start
+    val __endInclusive = endInclusive
+    val _result = run { kotlin.native.internal.initInstance(____kt, kotlin.ranges.ULongRange(__start, __endInclusive)) }
+    return run { _result; true }
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_isEmpty")
+public fun kotlin_ranges_ULongRange_isEmpty(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val _result = run { __self.isEmpty() }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_start_get")
+public fun kotlin_ranges_ULongRange_start_get(self: kotlin.native.internal.NativePtr): ULong {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val _result = run { __self.start }
+    return _result
+}
+
+@ExportedBridge("kotlin_ranges_ULongRange_toString")
+public fun kotlin_ranges_ULongRange_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.ranges.ULongRange
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_ranges_intRange_create_int_KotlinStdlib")
+fun kotlin_ranges_intRange_create_int_KotlinStdlib(start: Int, end: Int): kotlin.native.internal.NativePtr {
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(start .. end)
+}
+
+@ExportedBridge("kotlin_ranges_intRange_getEndInclusive_int_KotlinStdlib")
+fun kotlin_ranges_intRange_getEndInclusive_int_KotlinStdlib(nativePtr: kotlin.native.internal.NativePtr): Int {
+    val intRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as IntRange
+    return intRange.endInclusive
+}
+
+@ExportedBridge("kotlin_ranges_intRange_getStart_int_KotlinStdlib")
+fun kotlin_ranges_intRange_getStart_int_KotlinStdlib(nativePtr: kotlin.native.internal.NativePtr): Int {
+    val intRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as IntRange
+    return intRange.start
+}
+
+@ExportedBridge("kotlin_ranges_longRange_create_long_KotlinStdlib")
+fun kotlin_ranges_longRange_create_long_KotlinStdlib(start: Long, end: Long): kotlin.native.internal.NativePtr {
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(start .. end)
+}
+
+@ExportedBridge("kotlin_ranges_longRange_getEndInclusive_long_KotlinStdlib")
+fun kotlin_ranges_longRange_getEndInclusive_long_KotlinStdlib(nativePtr: kotlin.native.internal.NativePtr): Long {
+    val longRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as LongRange
+    return longRange.endInclusive
+}
+
+@ExportedBridge("kotlin_ranges_longRange_getStart_long_KotlinStdlib")
+fun kotlin_ranges_longRange_getStart_long_KotlinStdlib(nativePtr: kotlin.native.internal.NativePtr): Long {
+    val longRange = kotlin.native.internal.ref.dereferenceExternalRCRef(nativePtr) as LongRange
+    return longRange.start
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_DAYS")
+public fun kotlin_time_DurationUnit_DAYS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.DAYS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_HOURS")
+public fun kotlin_time_DurationUnit_HOURS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.HOURS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_MICROSECONDS")
+public fun kotlin_time_DurationUnit_MICROSECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.MICROSECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_MILLISECONDS")
+public fun kotlin_time_DurationUnit_MILLISECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.MILLISECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_MINUTES")
+public fun kotlin_time_DurationUnit_MINUTES(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.MINUTES }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_NANOSECONDS")
+public fun kotlin_time_DurationUnit_NANOSECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.NANOSECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_SECONDS")
+public fun kotlin_time_DurationUnit_SECONDS(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.DurationUnit.SECONDS }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_DurationUnit_ordinal")
+public fun kotlin_time_DurationUnit_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.DurationUnit
+    val _result = run { __self.ordinal }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_INFINITE_get")
+public fun kotlin_time_Duration_Companion_INFINITE_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val _result = run { __self.INFINITE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_ZERO_get")
+public fun kotlin_time_Duration_Companion_ZERO_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val _result = run { __self.ZERO }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_convert__TypesOfArguments__Swift_Double_ExportedKotlinPackages_kotlin_time_DurationUnit_ExportedKotlinPackages_kotlin_time_DurationUnit__")
+@OptIn(kotlin.time.ExperimentalTime::class)
+public fun kotlin_time_Duration_Companion_convert__TypesOfArguments__Swift_Double_ExportedKotlinPackages_kotlin_time_DurationUnit_ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, value: Double, sourceUnit: kotlin.native.internal.NativePtr, targetUnit: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = value
+    val __sourceUnit = kotlin.native.internal.ref.dereferenceExternalRCRef(sourceUnit) as kotlin.time.DurationUnit
+    val __targetUnit = kotlin.native.internal.ref.dereferenceExternalRCRef(targetUnit) as kotlin.time.DurationUnit
+    val _result = run { __self.convert(__value, __sourceUnit, __targetUnit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.days } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.days } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_days_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.days } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_get")
+public fun kotlin_time_Duration_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.time.Duration.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.hours } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.hours } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_hours_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.hours } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.microseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.microseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_microseconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.microseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.milliseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.milliseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_milliseconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.milliseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.minutes } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.minutes } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_minutes_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.minutes } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.nanoseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.nanoseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_nanoseconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.nanoseconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parse__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parse__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parse(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parseIsoString__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parseIsoString__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parseIsoString(__value) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parseIsoStringOrNull__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parseIsoStringOrNull__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parseIsoStringOrNull(__value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_parseOrNull__TypesOfArguments__Swift_String__")
+public fun kotlin_time_Duration_Companion_parseOrNull__TypesOfArguments__Swift_String__(self: kotlin.native.internal.NativePtr, value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __value = interpretObjCPointer<kotlin.String>(value)
+    val _result = run { __self.parseOrNull(__value) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int32__")
+public fun kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int32__(self: kotlin.native.internal.NativePtr, `receiver`: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.seconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int64__")
+public fun kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Int64__(self: kotlin.native.internal.NativePtr, `receiver`: Long): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.seconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Double__")
+public fun kotlin_time_Duration_Companion_seconds_get__TypesOfArgumentsE__Swift_Double__(self: kotlin.native.internal.NativePtr, `receiver`: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration.Companion
+    val __receiver = `receiver`
+    val _result = run { __self.run { __receiver.seconds } }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_absoluteValue_get")
+public fun kotlin_time_Duration_absoluteValue_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.absoluteValue }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_compareTo__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_compareTo__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.compareTo(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_div__TypesOfArguments__Swift_Int32__")
+public fun kotlin_time_Duration_div__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, scale: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.div(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_div__TypesOfArguments__Swift_Double__")
+public fun kotlin_time_Duration_div__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, scale: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.div(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_div__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_div__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.div(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = if (other == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.Any
+    val _result = run { __self.equals(__other) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_hashCode")
+public fun kotlin_time_Duration_hashCode(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.hashCode() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeDays_get")
+public fun kotlin_time_Duration_inWholeDays_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeDays }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeHours_get")
+public fun kotlin_time_Duration_inWholeHours_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeHours }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeMicroseconds_get")
+public fun kotlin_time_Duration_inWholeMicroseconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeMicroseconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeMilliseconds_get")
+public fun kotlin_time_Duration_inWholeMilliseconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeMilliseconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeMinutes_get")
+public fun kotlin_time_Duration_inWholeMinutes_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeMinutes }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeNanoseconds_get")
+public fun kotlin_time_Duration_inWholeNanoseconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeNanoseconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_inWholeSeconds_get")
+public fun kotlin_time_Duration_inWholeSeconds_get(self: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.inWholeSeconds }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isFinite")
+public fun kotlin_time_Duration_isFinite(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isFinite() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isInfinite")
+public fun kotlin_time_Duration_isInfinite(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isInfinite() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isNegative")
+public fun kotlin_time_Duration_isNegative(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isNegative() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_isPositive")
+public fun kotlin_time_Duration_isPositive(self: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.isPositive() }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_minus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_minus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.minus(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_plus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__")
+public fun kotlin_time_Duration_plus__TypesOfArguments__ExportedKotlinPackages_kotlin_time_Duration__(self: kotlin.native.internal.NativePtr, other: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __other = kotlin.native.internal.ref.dereferenceExternalRCRef(other) as kotlin.time.Duration
+    val _result = run { __self.plus(__other) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_times__TypesOfArguments__Swift_Int32__")
+public fun kotlin_time_Duration_times__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, scale: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.times(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_times__TypesOfArguments__Swift_Double__")
+public fun kotlin_time_Duration_times__TypesOfArguments__Swift_Double__(self: kotlin.native.internal.NativePtr, scale: Double): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __scale = scale
+    val _result = run { __self.times(__scale) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int, Int, Int, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int, arg2: Int, arg3: Int, arg4: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _arg2 = arg2
+            val _arg3 = arg3
+            val _arg4 = arg4
+            val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3, _arg4)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int, Int, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int, arg2: Int, arg3: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _arg2 = arg2
+            val _arg3 = arg3
+            val _result = kotlinFun(_arg0, _arg1, _arg2, _arg3)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int, arg2: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _arg2 = arg2
+            val _result = kotlinFun(_arg0, _arg1, _arg2)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
+public fun kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self: kotlin.native.internal.NativePtr, action: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __action = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(Long, Int)->kotlin.native.internal.NativePtr>(action);
+        { arg0: Long, arg1: Int ->
+            val _arg0 = arg0
+            val _arg1 = arg1
+            val _result = kotlinFun(_arg0, _arg1)
+            if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
+        }
+    }
+    val _result = run { __self.toComponents<kotlin.Any?>(__action) }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("kotlin_time_Duration_toDouble__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__")
+public fun kotlin_time_Duration_toDouble__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr): Double {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val _result = run { __self.toDouble(__unit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_toInt__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__")
+public fun kotlin_time_Duration_toInt__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val _result = run { __self.toInt(__unit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_toIsoString")
+public fun kotlin_time_Duration_toIsoString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.toIsoString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_time_Duration_toLong__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__")
+public fun kotlin_time_Duration_toLong__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr): Long {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val _result = run { __self.toLong(__unit) }
+    return _result
+}
+
+@ExportedBridge("kotlin_time_Duration_toString")
+public fun kotlin_time_Duration_toString(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.toString() }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_time_Duration_toString__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit_Swift_Int32__")
+public fun kotlin_time_Duration_toString__TypesOfArguments__ExportedKotlinPackages_kotlin_time_DurationUnit_Swift_Int32__(self: kotlin.native.internal.NativePtr, unit: kotlin.native.internal.NativePtr, decimals: Int): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val __unit = kotlin.native.internal.ref.dereferenceExternalRCRef(unit) as kotlin.time.DurationUnit
+    val __decimals = decimals
+    val _result = run { __self.toString(__unit, __decimals) }
+    return _result.objcPtr()
+}
+
+@ExportedBridge("kotlin_time_Duration_unaryMinus")
+public fun kotlin_time_Duration_unaryMinus(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as kotlin.time.Duration
+    val _result = run { __self.unaryMinus() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/testLibraryA_full_dump/golden_result/testLibraryA/testLibraryA.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/testLibraryA_full_dump/golden_result/testLibraryA/testLibraryA.kt
@@ -1,0 +1,45 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(org.jetbrains.a.MyLibraryA::class, "22ExportedKotlinPackages3orgO9jetbrainsO1aO12testLibraryAE10MyLibraryAC")
+
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("org_jetbrains_a_MyLibraryA_init_allocate")
+public fun org_jetbrains_a_MyLibraryA_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<org.jetbrains.a.MyLibraryA>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_jetbrains_a_MyLibraryA_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun org_jetbrains_a_MyLibraryA_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, org.jetbrains.a.MyLibraryA()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("org_jetbrains_a_MyLibraryA_returnInt")
+public fun org_jetbrains_a_MyLibraryA_returnInt(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as org.jetbrains.a.MyLibraryA
+    val _result = run { __self.returnInt() }
+    return _result
+}
+
+@ExportedBridge("org_jetbrains_a_MyLibraryA_returnMe")
+public fun org_jetbrains_a_MyLibraryA_returnMe(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as org.jetbrains.a.MyLibraryA
+    val _result = run { __self.returnMe() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_jetbrains_a_topLevelFunction")
+public fun org_jetbrains_a_topLevelFunction(): Int {
+    val _result = run { org.jetbrains.a.topLevelFunction() }
+    return _result
+}
+
+@ExportedBridge("org_jetbrains_a_topLevelProperty_get")
+public fun org_jetbrains_a_topLevelProperty_get(): Int {
+    val _result = run { org.jetbrains.a.topLevelProperty }
+    return _result
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectTest.kt
@@ -10,6 +10,9 @@ import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestModule
 import org.jetbrains.kotlin.konan.test.blackbox.support.util.mapToSet
 import org.jetbrains.kotlin.konan.test.testLibraryAKlibFile
+import org.jetbrains.kotlin.konan.test.testLibraryAtomicFuCinteropInteropKlibFile
+import org.jetbrains.kotlin.konan.test.testLibraryAtomicFuKlibFile
+import org.jetbrains.kotlin.konan.test.testLibraryKotlinxCoroutinesKlibFile
 import org.jetbrains.kotlin.konan.test.testLibraryKotlinxSerializationCoreKlibFile
 import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
@@ -41,6 +44,32 @@ abstract class AbstractExternalProjectTest : AbstractSwiftExportTest() {
             "kotlinx.serialization",
         )
         runTest(klibSettings, "kotlinx-serialization-core")
+    }
+
+    @Test
+    fun `kotlinx-coroutines-core`() {
+        minOSVersion = "15.0"
+        val atomicFuCinterop = KlibExportSettings(
+            testLibraryAtomicFuCinteropInteropKlibFile,
+            targets.testTarget,
+            "KotlinxAtomicFuCinterop",
+            "kotlinx.atomicfu",
+        )
+        val atomicFu = KlibExportSettings(
+            testLibraryAtomicFuKlibFile,
+            targets.testTarget,
+            "KotlinxAtomicFu",
+            "kotlinx.atomicfu",
+            setOf(atomicFuCinterop),
+        )
+        val coroutines = KlibExportSettings(
+            testLibraryKotlinxCoroutinesKlibFile,
+            targets.testTarget,
+            "KotlinxCoroutinesCore",
+            "kotlinx.coroutines",
+            setOf(atomicFu, atomicFuCinterop)
+        )
+        runTest(coroutines, "kotlinx-coroutines-core")
     }
 
     private val tmpdir = FileUtil.createTempDirectory("SwiftExportIntegrationTests", null, false)

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectTest.kt
@@ -7,8 +7,8 @@ package org.jetbrains.kotlin.swiftexport.standalone.test
 
 import com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
-import org.jetbrains.kotlin.konan.test.blackbox.support.TestCase
-import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestModule
+import org.jetbrains.kotlin.konan.test.blackbox.support.util.mapToSet
 import org.jetbrains.kotlin.konan.test.testLibraryAKlibFile
 import org.jetbrains.kotlin.konan.test.testLibraryKotlinxSerializationCoreKlibFile
 import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
@@ -20,19 +20,7 @@ import java.io.File
 
 // Uses external project klibs prebuilt for macos_arm64 only on the CI agents.
 @EnabledOnNativeTargets(targets = ["macos_arm64"])
-abstract class AbstractExternalProjectGenerationTest : AbstractSwiftExportWithBinaryCompilationTest(), SwiftExportValidator {
-
-    private val tmpdir = FileUtil.createTempDirectory("SwiftExportIntegrationTests", null, false)
-
-    override fun runCompiledTest(
-        testPathFull: File,
-        testCase: TestCase,
-        swiftExportOutputs: Set<SwiftExportModule>,
-        swiftModules: Set<TestCompilationArtifact.Swift.Module>,
-        kotlinBinaryLibrary: TestCompilationArtifact.BinaryLibrary,
-    ) {
-        validateSwiftExportOutput(testPathFull, swiftExportOutputs)
-    }
+abstract class AbstractExternalProjectTest : AbstractSwiftExportTest() {
 
     @Test
     fun `full export of testLibraryA`() {
@@ -41,7 +29,7 @@ abstract class AbstractExternalProjectGenerationTest : AbstractSwiftExportWithBi
             targets.testTarget,
             "testLibraryA",
         )
-        validateFullLibraryDump(klibSettings, "testLibraryA_full_dump")
+        runTest(klibSettings, "testLibraryA_full_dump")
     }
 
     @Test
@@ -52,22 +40,47 @@ abstract class AbstractExternalProjectGenerationTest : AbstractSwiftExportWithBi
             "KotlinSerialization",
             "kotlinx.serialization",
         )
-        validateFullLibraryDump(klibSettings, "kotlinx-serialization-core")
+        runTest(klibSettings, "kotlinx-serialization-core")
     }
 
-    private fun validateFullLibraryDump(
+    private val tmpdir = FileUtil.createTempDirectory("SwiftExportIntegrationTests", null, false)
+
+    private fun runTest(
         klib: KlibExportSettings,
         goldenData: String,
-        validateKotlinBridge: Boolean = false,
     ) {
+        val klibs = mutableSetOf<KlibExportSettings>()
+        fun collectKlibs(klib: KlibExportSettings) {
+            klibs.add(klib)
+            klib.dependencies.forEach(::collectKlibs)
+        }
+        collectKlibs(klib)
+
+        val testPathFull = testDataDir.resolve(goldenData)
         val config = klib.createConfig(outputPath = tmpdir.toPath().resolve(klib.swiftModuleName))
-        val inputModule = klib.createInputModule(
-            SwiftModuleConfig(rootPackage = klib.rootPackage, exportMode = SwiftModuleExportMode.Full)
-        )
-        val result = runSwiftExport(setOf(inputModule), config).getOrThrow()
-        validateSwiftExportOutput(testDataDir.resolve(goldenData), result, validateKotlinBridge)
+        val modules = klibs.mapToSet {
+            val exportMode = if (it == klib) SwiftModuleExportMode.Full else SwiftModuleExportMode.Transitive
+            val config = SwiftModuleConfig(rootPackage = it.rootPackage, exportMode = exportMode)
+            it.createInputModule(config)
+        }
+
+        val swiftExportOutputs = runSwiftExport(modules, config).getOrThrow()
+
+        val testModules = mutableMapOf<KlibExportSettings, TestModule.Given>()
+        fun createTestModule(klib: KlibExportSettings): TestModule.Given = testModules.getOrPut(klib) {
+            val dependencies = klib.dependencies.mapToSet(::createTestModule)
+            TestModule.Given(klib.path.toFile(), dependencies)
+        }
+        createTestModule(klib)
+
+        runTest(testModules.values.toSet(), testPathFull, swiftExportOutputs)
     }
 
+    protected abstract fun runTest(
+        modules: Set<TestModule.Given>,
+        testPathFull: File,
+        swiftExportOutputs: Set<SwiftExportModule>,
+    )
 }
 
 private val testDataDir = ForTestCompileRuntime.transformTestDataPath("native/swift/swift-export-standalone-integration-tests/external/testData/generation")

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectWithBinaryCompilationTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectWithBinaryCompilationTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.swiftexport.standalone.test
+
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestCase
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestModule
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult.Companion.assertSuccess
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.BinaryLibraryKind
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
+import org.jetbrains.kotlin.konan.test.blackbox.support.util.flatMapToSet
+import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+abstract class AbstractExternalProjectWithBinaryCompilationTest : AbstractExternalProjectTest(), SwiftExportValidator {
+
+    @BeforeEach
+    fun checkHost() {
+        // Swift export compilation/execution requires an Apple host (swiftc/Xcode). The *target* gate
+        // lives in @EnabledOnNativeTargets on this class (see AbstractSwiftExportTest.assumeTestTargetEnabled).
+        Assumptions.assumeTrue(testRunSettings.get<KotlinNativeTargets>().hostTarget.family.isAppleFamily)
+    }
+
+    override fun runTest(
+        modules: Set<TestModule.Given>,
+        testPathFull: File,
+        swiftExportOutputs: Set<SwiftExportModule>,
+    ) {
+        val kotlinBridgeFiles = swiftExportOutputs.filterIsInstance<SwiftExportModule.BridgesToKotlin>().map {
+            it.files.kotlinBridges.toFile()
+        }
+        val testCase = generateSwiftExportTestCase(
+            testPathFull = testPathFull,
+            sources = kotlinBridgeFiles,
+            dependencies = modules,
+        )
+
+        val kotlinBinaryLibrary = testCompilationFactory.testCaseToBinaryLibrary(
+            testCase, testRunSettings,
+            kind = BinaryLibraryKind.STATIC,
+        ).result.assertSuccess().resultingArtifact
+
+        val swiftModules = swiftExportOutputs.flatMapToSet { it.compile(testPathFull, swiftExportOutputs) }
+        runCompiledTest(testPathFull, testCase, swiftExportOutputs, swiftModules, kotlinBinaryLibrary)
+    }
+
+    protected open fun runCompiledTest(
+        testPathFull: File,
+        testCase: TestCase,
+        swiftExportOutputs: Set<SwiftExportModule>,
+        swiftModules: Set<TestCompilationArtifact.Swift.Module>,
+        kotlinBinaryLibrary: TestCompilationArtifact.BinaryLibrary,
+    ) {
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectWithResultValidationTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectWithResultValidationTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.swiftexport.standalone.test
+
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestModule
+import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
+import java.io.File
+
+abstract class AbstractExternalProjectWithResultValidationTest : AbstractExternalProjectTest(), SwiftExportValidator {
+    override fun runTest(
+        modules: Set<TestModule.Given>,
+        testPathFull: File,
+        swiftExportOutputs: Set<SwiftExportModule>,
+    ) {
+        validateSwiftExportOutput(testPathFull, swiftExportOutputs)
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/TestUtils.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/TestUtils.kt
@@ -17,6 +17,7 @@ internal data class KlibExportSettings(
     val konanTarget: KonanTarget,
     val swiftModuleName: String,
     val rootPackage: String? = null,
+    val dependencies: Set<KlibExportSettings> = emptySet(),
 )
 
 internal fun KlibExportSettings.createConfig(outputPath: Path): SwiftExportConfig {


### PR DESCRIPTION
This also enables golden data validation for the Kotlin bridges and adds kotlinx-coroutines-core as an external project.

^[KT-87796](https://youtrack.jetbrains.com/issue/KT-87796) Fixed
^[KT-86510](https://youtrack.jetbrains.com/issue/KT-86510) Fixed