### PR TITLE
Filter out tests with non latest gradle version for code coverage

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-api/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("gradle-plugin-api-reference")
     id("generated-sources")
+    id("kgp-jacoco-instrumenter")
 }
 
 pluginApiReference {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -529,6 +529,11 @@ tasks.withType<Test>().configureEach {
     // (e.g. .../configuration-cache-report.html) during test runs.
     systemProperty("junit.jupiter.tempdir.cleanup.mode.default", "on_success")
 
+    if (kotlinBuildProperties.isTeamcityBuild.get() && kotlinBuildProperties.kgpTestCoverageEnabled.get()) {
+        // to avoid running all tests twice, use only latest gradle version
+        systemProperty("gradle.integration.tests.gradle.version.filter", gradleVersions.last())
+    }
+
     testLogging {
         // set options for log level LIFECYCLE
         events("started", "passed", "skipped", "failed", "standardOut")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     id("android-sdk-provisioner")
     id("gradle-plugin-published-compiler-dependency-configuration") // the test compilation's output is injected into test project's build classpath for the buildscript injection
     id("kotlin-git.gradle-build-conventions.file-leak-detector-downloader")
+    id("kgp-jacoco-agent-setup")
 }
 
 testsJar()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -565,3 +565,10 @@ tasks.withType<Test>().configureEach {
 }
 
 excludeGradleEmbeddedStdlibFromTestTasksRuntimeClasspath()
+
+registerKgpTestCoverageDataVariant(
+    configurationName = "integrationTestCoverageDataElements",
+    suiteName = "integrationTest",
+    execFile = layout.buildDirectory.file("jacoco/coverage.exec"),
+    testTask = tasks.named("kgpAllParallelTests"),
+)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
@@ -788,6 +788,23 @@ private fun collectGradleJvmOptions(
     if (addHeapDumpOptions) {
         addAll(heapDumpJvmOptions())
     }
+
+    addJacocoAgentIfEnabled()
+}
+
+private fun MutableList<String>.addJacocoAgentIfEnabled() {
+    val testCoverageEnabled = System.getProperty("kgp.jacoco.enabled").toBoolean()
+    if (!testCoverageEnabled) return
+
+    val jacocoRuntimeJar = System.getProperty("jacocoRuntimeJar") ?: return
+    val jacocoDestFile = System.getProperty("jacocoDestFile") ?: return
+
+    // Offline instrumentation: probes are already embedded in bytecode.
+    // Add JaCoCo runtime to boot classpath so probes can reach it from any classloader.
+    add("-Xbootclasspath/a:$jacocoRuntimeJar")
+    add("-Djacoco-agent.destfile=${jacocoDestFile}")
+    add("-Djacoco-agent.append=true")
+    add("-Djacoco-agent.output=file")
 }
 
 private fun collectKotlinJvmArgs(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
@@ -805,6 +805,9 @@ private fun MutableList<String>.addJacocoAgentIfEnabled() {
     add("-Djacoco-agent.destfile=${jacocoDestFile}")
     add("-Djacoco-agent.append=true")
     add("-Djacoco-agent.output=file")
+    // with instrumentation tests consume more memory and after reducing gradle daemon memory limit in 441ff40a it brought OOM
+    // this increase the limit as it was before
+    add("-Xmx1024m")
 }
 
 private fun collectKotlinJvmArgs(

--- a/libraries/tools/kotlin-gradle-plugin-test-coverage/README.md
+++ b/libraries/tools/kotlin-gradle-plugin-test-coverage/README.md
@@ -1,0 +1,60 @@
+# Test coverage collection in Kotlin Build Tools
+
+To collect test coverage in Kotlin Build Tools, we use [JaCoCo](https://www.jacoco.org/jacoco/). To measure coverage we replace the
+`kotlin-gradle-plugin` and `kotlin-gradle-plugin-api` JAR file with its instrumented version and run tests against it. For integration
+tests the JaCoCo agent is passed to the Gradle TestKit build JVMs; for functional tests the standard Gradle `jacoco` plugin attaches the
+agent to the test JVM, and the pre-instrumented classes report their coverage through it.
+
+Reports are aggregated using Gradle's
+[`jacoco-report-aggregation`](https://docs.gradle.org/current/userguide/jacoco_report_aggregation_plugin.html)
+plugin: the producer projects (`:kotlin-gradle-plugin`, `:kotlin-gradle-plugin-api`,
+`:kotlin-gradle-plugin-integration-tests`) expose coverage data, class dirs, and source dirs via outgoing configurations; the aggregator
+consumes them through `jacocoAggregation(project(...))`
+dependencies. No project reads another project's build directory directly, so this is compatible with Gradle Project Isolation and respects
+normal task-dependency and up-to-date semantics.
+
+In `:kotlin-gradle-plugin` the coverage-data variant (`coverageDataElementsForFunctionalTest`) is created automatically by the `jacoco` +
+`jvm-test-suite` plugin combination, since `functionalTest` is a `JvmTestSuite` there. `:kotlin-gradle-plugin-integration-tests` cannot
+model its tests as a single suite (one umbrella task spans several `Test` tasks sharing an exec file), so it registers an equivalent
+variant manually via `registerKgpTestCoverageDataVariant`.
+
+## How to collect coverage
+
+Test coverage collection is disabled by default. The reasons are performance and unnecessary instrumentation that could affect some tests. 
+To run tests with coverage, pass `kgp.jacoco.enabled=true`:
+
+```bash
+./gradlew :kotlin-gradle-plugin:functionalTest -Pkgp.jacoco.enabled=true
+```
+
+or
+
+```bash
+./gradlew :kotlin-gradle-plugin-integration-tests:kgpAllParallelTests -Pkgp.jacoco.enabled=true
+```
+
+Coverage data is written to `build/jacoco/` in each project with tests.
+
+> Note: when `kgp.jacoco.enabled=true`, the test tasks are configured with `ignoreFailures = true`,
+> so failing tests do not abort the build. This lets the dependent coverage report run on the
+> partial `.exec` data. The failures are still printed in the test output.
+
+## How to open coverage data locally
+
+You can open generated `.exec` coverage data with IntelliJ IDEA. It requires plugin *Code Coverage for Java*. IDEA shows coverage for all loaded modules in the Coverage Tool Window and
+renders per-file coverage percent in the Project view.
+
+## How to generate HTML/XML reports
+
+By default each report task auto-triggers the relevant tests via Gradle's dependency graph — running the report alone is enough:
+
+```bash
+./gradlew :kotlin-gradle-plugin-test-coverage:functionalCoverageReport -Pkgp.jacoco.enabled=true
+# triggers :kotlin-gradle-plugin:functionalTest
+
+./gradlew :kotlin-gradle-plugin-test-coverage:integrationCoverageReport -Pkgp.jacoco.enabled=true
+# triggers :kotlin-gradle-plugin-integration-tests:kgpAllParallelTests
+
+./gradlew :kotlin-gradle-plugin-test-coverage:combinedCoverageReport -Pkgp.jacoco.enabled=true
+# merges both
+```

--- a/libraries/tools/kotlin-gradle-plugin-test-coverage/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-test-coverage/build.gradle.kts
@@ -1,0 +1,68 @@
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
+plugins {
+    `jacoco-report-aggregation`
+}
+
+description = "Test Coverage report generation for KGP tests"
+
+val KGP_TEST_TASKS_GROUP = "Kotlin Gradle Plugin Verification"
+
+jacoco {
+    toolVersion = libs.versions.jacoco.get()
+}
+
+// `isTransitive = false` used to avoid having non-instrumented classes with zero coverage in reports
+// e.g., build-tools-api, konan.*, commonizer
+dependencies {
+    jacocoAggregation(project(":kotlin-gradle-plugin")) { isTransitive = false }
+    jacocoAggregation(project(":kotlin-gradle-plugin-api")) { isTransitive = false }
+    jacocoAggregation(project(":kotlin-gradle-plugin-integration-tests")) { isTransitive = false }
+}
+
+reporting {
+    reports {
+        register<JacocoCoverageReport>("functionalCoverageReport") {
+            testSuiteName = "functionalTest"
+        }
+        register<JacocoCoverageReport>("integrationCoverageReport") {
+            testSuiteName = "integrationTest"
+        }
+    }
+}
+
+// `jacoco-report-aggregation` has no match-all-suites option, so compose the combined report
+// manually from the per-suite tasks. Data still flows through the `jacocoAggregation` graph.
+val functionalReport = tasks.named<JacocoReport>("functionalCoverageReport")
+val integrationReport = tasks.named<JacocoReport>("integrationCoverageReport")
+
+tasks.register<JacocoReport>("combinedCoverageReport") {
+    group = KGP_TEST_TASKS_GROUP
+    description = "Aggregated HTML/XML coverage report for KGP functional + integration tests"
+
+    executionData.from(functionalReport.map { it.executionData })
+    executionData.from(integrationReport.map { it.executionData })
+    classDirectories.from(functionalReport.map { it.classDirectories })
+    sourceDirectories.from(functionalReport.map { it.sourceDirectories })
+
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+    }
+
+    onlyIf { executionData.files.any { it.exists() } }
+}
+
+// Default report set is HTML only; enable XML for the per-suite tasks too.
+listOf(functionalReport, integrationReport).forEach { reportTask ->
+    reportTask.configure {
+        group = KGP_TEST_TASKS_GROUP
+        reports {
+            html.required = true
+            xml.required = true
+            csv.required = false
+        }
+        onlyIf { executionData.files.any { it.exists() } }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("gradle-plugin-common-configuration")
     id("kotlin-git.gradle-build-conventions.binary-compatibility-extended")
     id("kotlin-git.gradle-build-conventions.kgp-npm-tooling-helper")
+    id("kgp-jacoco-instrumenter")
     id("android-sdk-provisioner")
     id("asm-deprecating-transformer")
     id("project-tests-convention")

--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -833,7 +833,7 @@ jacoco {
     toolVersion = libs.versions.jacoco.get()
 }
 
-val testCoverageEnabled = project.providers.gradleProperty("kgp.jacoco.enabled").orNull?.toBoolean() ?: false
+val testCoverageEnabled = kotlinBuildProperties.kgpTestCoverageEnabled.get()
 tasks.withType<Test>().configureEach {
     ignoreFailures = testCoverageEnabled
     extensions.configure<JacocoTaskExtension> {

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/README.md
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/README.md
@@ -1,0 +1,16 @@
+# kgp-jacoco-plugins
+
+Build conventions for collecting KGP test coverage with JaCoCo.
+See also [`kotlin-gradle-plugin-test-coverage/README.md`](../../../libraries/tools/kotlin-gradle-plugin-test-coverage/README.md)
+
+## `kgp-jacoco-instrumenter`
+
+Replaces the output of the `jar`/`embeddableJar` tasks with an offline-instrumented version produced by the JaCoCo CLI,
+so tests running against these jars collect coverage data
+Also adds the `common` source set to `mainSourceElements` so its sources appear in aggregated reports.
+
+## `kgp-jacoco-agent-setup`
+
+Set up JaCoCo agent for KGP integration tests that are using Gradle TestKit. 
+Passes the location of the JaCoCo agent runtime jar and the coverage output file (`build/jacoco/coverage.exec`)
+to test JVMs via the `jacocoRuntimeJar`/`jacocoDestFile` system properties.

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/build.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
+plugins {
+    `java-gradle-plugin`
+    `embedded-kotlin`
+    `kotlin-dsl`
+}
+
+description = "Plugins for KGP code coverage"
+
+kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+    compilerVersion = libs.versions.kotlin.`for`.gradle.plugins.compilation
+    jvmToolchain(17)
+}
+
+dependencies {
+    compileOnly(gradleApi())
+    compileOnly(gradleKotlinDsl())
+    api(project(":gradle-plugins-common"))
+    implementation(kotlinBuildHelpers())
+}
+
+project.configurations.named(org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME + "Main") {
+    resolutionStrategy {
+        eachDependency {
+            if (this.requested.group == "org.jetbrains.kotlin") useVersion(libs.versions.kotlin.`for`.gradle.plugins.compilation.get())
+        }
+    }
+}
+
+kotlin.compilerOptions.moduleName.value(project.name)

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/KgpCoverage.kt
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/KgpCoverage.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.TestSuiteName
+import org.gradle.api.attributes.VerificationType
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.named
+
+/**
+ * Registers a consumable outgoing configuration that exposes JaCoCo `.exec` files to
+ * `jacoco-report-aggregation` consumers.
+ */
+fun Project.registerKgpTestCoverageDataVariant(
+    configurationName: String,
+    suiteName: String,
+    execFile: Provider<RegularFile>,
+    testTask: TaskProvider<*>,
+) {
+    configurations.consumable(configurationName) {
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
+            attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.JACOCO_RESULTS))
+            attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, objects.named(suiteName))
+        }
+        outgoing.artifact(execFile) {
+            type = ArtifactTypeDefinition.BINARY_DATA_TYPE
+            builtBy(testTask)
+        }
+    }
+}

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-agent-setup.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-agent-setup.gradle.kts
@@ -31,6 +31,17 @@ tasks.withType<Test>().configureEach {
         inputs.files(jacocoAgentRuntimeResolver).withNormalizer(ClasspathNormalizer::class)
         outputs.upToDateWhen { jacocoDestFile.get().asFile.exists() }
 
+        // The test JVM itself also loads offline-instrumented KGP classes,
+        // so it needs the JaCoCo offline runtime too.
+        jvmArgumentProviders.add(CommandLineArgumentProvider {
+            listOf(
+                "-Xbootclasspath/a:${jacocoRuntimeJar.get().absolutePath}",
+                "-Djacoco-agent.destfile=${jacocoDestFile.get().asFile.absolutePath}",
+                "-Djacoco-agent.append=true",
+                "-Djacoco-agent.output=file",
+            )
+        })
+
         doFirst {
             // pass values to set up the classpath for integration tests to use offline instrumentation
             systemProperty("jacocoRuntimeJar", jacocoRuntimeJar.get().absolutePath)

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-agent-setup.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-agent-setup.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     jacocoAgentRuntime(jacocoAgentDependency.get()) { artifact { classifier = "runtime" } }
 }
 
-val kgpTestCoverageEnabled: Boolean = providers.gradleProperty("kgp.jacoco.enabled").orNull?.toBoolean() ?: false
+val kgpTestCoverageEnabled: Boolean = kotlinBuildProperties.kgpTestCoverageEnabled.get()
 
 tasks.withType<Test>().configureEach {
     systemProperty("kgp.jacoco.enabled", kgpTestCoverageEnabled)

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-agent-setup.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-agent-setup.gradle.kts
@@ -1,0 +1,40 @@
+import org.gradle.kotlin.dsl.withType
+
+val versionCatalog = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+val jacocoAgentDependency = versionCatalog.findLibrary("jacoco-agent").get()
+
+// Resolves the JaCoCo agent for TestKit subprocess instrumentation.
+val jacocoAgentRuntime = configurations.dependencyScope("jacocoAgentRuntime")
+val jacocoAgentRuntimeResolver = configurations.resolvable(jacocoAgentRuntime.name + "Resolver") {
+    extendsFrom(jacocoAgentRuntime)
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+    }
+}
+
+dependencies {
+    jacocoAgentRuntime(jacocoAgentDependency.get()) { artifact { classifier = "runtime" } }
+}
+
+val kgpTestCoverageEnabled: Boolean = providers.gradleProperty("kgp.jacoco.enabled").orNull?.toBoolean() ?: false
+
+tasks.withType<Test>().configureEach {
+    systemProperty("kgp.jacoco.enabled", kgpTestCoverageEnabled)
+    if (kgpTestCoverageEnabled) {
+
+        // Don't abort the build on test failures — the report still needs the partial `.exec`.
+        ignoreFailures = true
+
+        val jacocoRuntimeJar = jacocoAgentRuntimeResolver.map { it.incoming.files.singleFile }
+        val jacocoDestFile = layout.buildDirectory.file("jacoco/coverage.exec")
+
+        inputs.files(jacocoAgentRuntimeResolver).withNormalizer(ClasspathNormalizer::class)
+        outputs.upToDateWhen { jacocoDestFile.get().asFile.exists() }
+
+        doFirst {
+            // pass values to set up the classpath for integration tests to use offline instrumentation
+            systemProperty("jacocoRuntimeJar", jacocoRuntimeJar.get().absolutePath)
+            systemProperty("jacocoDestFile", jacocoDestFile.get().asFile.absolutePath)
+        }
+    }
+}

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-instrumenter.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-instrumenter.gradle.kts
@@ -38,9 +38,14 @@ if (kotlinBuildProperties.kgpTestCoverageEnabled.get()) {
         }
     }
 
+    // Final published jars: 'jar'/'embeddableJar' (main variant in kgp-api/kgp) plus the per-Gradle-version
+    // variant jars ('gradle96Jar', 'embeddableGradle96Jar', ...).
+    // Intentionally excludes intermediate ShadowJar tasks ('embeddableBaselineJar', 'embeddable*JarSpecific')
+    // to avoid instrumenting the same classes twice.
+    val instrumentedJarName = Regex("^(jar|embeddableJar|(embeddableG|g)radle\\d+Jar)$")
+
     tasks.withType<Jar>()
-        // different tasks used in kgp and kgp-api, but don't want to instrument gradle variants
-        .matching { it.name == "jar" || it.name == "embeddableJar" }
+        .matching { it.name.matches(instrumentedJarName) }
         .configureEach {
             val jacocoCli = jacocoCliClasspathResolver.map { it.incoming.files }
             inputs.files(jacocoCli)

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-instrumenter.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-instrumenter.gradle.kts
@@ -12,9 +12,6 @@ import org.gradle.kotlin.dsl.withType
 val versionCatalog = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
 val jacocoCliDependency = versionCatalog.findLibrary("jacoco-cli").get()
 
-val kgpTestCoverageEnabled: Boolean =
-    providers.gradleProperty("kgp.jacoco.enabled").orNull?.toBoolean() ?: false
-
 val jacocoCliClasspath = configurations.dependencyScope("jacocoCliClasspath")
 
 dependencies {
@@ -28,7 +25,7 @@ val jacocoCliClasspathResolver = configurations.resolvable(jacocoCliClasspath.na
     }
 }
 
-if (kgpTestCoverageEnabled) {
+if (kotlinBuildProperties.kgpTestCoverageEnabled.get()) {
     // `mainSourceElements` (consumed by jacoco-report-aggregation for source discovery) doesn't
     // include the `common` source set by default — add it so it shows up in reports.
     plugins.withId("java") {

--- a/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-instrumenter.gradle.kts
+++ b/repo/gradle-build-conventions/kgp-jacoco-plugins/src/main/kotlin/kgp-jacoco-instrumenter.gradle.kts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.kotlin.dsl.withType
+
+val versionCatalog = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+val jacocoCliDependency = versionCatalog.findLibrary("jacoco-cli").get()
+
+val kgpTestCoverageEnabled: Boolean =
+    providers.gradleProperty("kgp.jacoco.enabled").orNull?.toBoolean() ?: false
+
+val jacocoCliClasspath = configurations.dependencyScope("jacocoCliClasspath")
+
+dependencies {
+    jacocoCliClasspath(jacocoCliDependency.get())
+}
+
+val jacocoCliClasspathResolver = configurations.resolvable(jacocoCliClasspath.name + "Resolver") {
+    extendsFrom(jacocoCliClasspath)
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+    }
+}
+
+if (kgpTestCoverageEnabled) {
+    // `mainSourceElements` (consumed by jacoco-report-aggregation for source discovery) doesn't
+    // include the `common` source set by default — add it so it shows up in reports.
+    plugins.withId("java") {
+        configurations.findByName("mainSourceElements")?.let { mainSourceElements ->
+            sourceSets.findByName("common")?.allSource?.srcDirs?.forEach { srcDir ->
+                mainSourceElements.outgoing.artifact(srcDir) {
+                    type = ArtifactTypeDefinition.DIRECTORY_TYPE
+                }
+            }
+        }
+    }
+
+    tasks.withType<Jar>()
+        // different tasks used in kgp and kgp-api, but don't want to instrument gradle variants
+        .matching { it.name == "jar" || it.name == "embeddableJar" }
+        .configureEach {
+            val jacocoCli = jacocoCliClasspathResolver.map { it.incoming.files }
+            inputs.files(jacocoCli)
+                .withNormalizer(ClasspathNormalizer::class)
+
+            val execOps = serviceOf<ExecOperations>()
+            val fs = serviceOf<FileSystemOperations>()
+
+            val jacocoInstrumentOutputDir = temporaryDir.resolve("jacoco-instrument")
+
+            doLast {
+                val archiveFileName = archiveFileName.get()
+                val actualOutputFile = archiveFile.get().asFile
+
+                fs.delete { delete(jacocoInstrumentOutputDir) }
+                jacocoInstrumentOutputDir.mkdirs()
+
+                execOps.javaexec {
+                    mainClass.set("org.jacoco.cli.internal.Main")
+                    classpath(jacocoCli)
+                    args(
+                        "instrument",
+                        actualOutputFile.absolutePath,
+                        "--dest",
+                        jacocoInstrumentOutputDir,
+                    )
+                }
+
+                fs.copy {
+                    from(jacocoInstrumentOutputDir.resolve(archiveFileName))
+                    into(destinationDirectory)
+                }
+            }
+        }
+}

--- a/repo/gradle-build-conventions/settings.gradle.kts
+++ b/repo/gradle-build-conventions/settings.gradle.kts
@@ -70,6 +70,7 @@ include(":binary-compatibility-extended")
 include(":gradle-plugins-documentation")
 include(":gradle-plugins-common")
 include(":kgp-npm-tooling-helper")
+include(":kgp-jacoco-plugins")
 include(":d8-configuration")
 // TODO: uncomment after bootstrap
 // include(":swc-configuration")

--- a/repo/kotlin-build-helpers/src/BuildProperties.kt
+++ b/repo/kotlin-build-helpers/src/BuildProperties.kt
@@ -148,6 +148,8 @@ class KotlinBuildProperties internal constructor(
 
     val jarCompression: Boolean get() = booleanProperty("kotlin.build.jar.compression", isTeamcityBuild).get()
 
+    val kgpTestCoverageEnabled: Provider<Boolean> = booleanProperty("kgp.jacoco.enabled", false)
+
     private fun Provider<String>.toBoolean(defaultValue: Boolean = false): Provider<Boolean> = map {
         if (it.isEmpty()) return@map true // has property without value means 'true'
         return@map it.trim().toBoolean()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -396,6 +396,7 @@ include(
     ":kotlin-gradle-plugin-test-utils-embeddable",
     ":kotlin-gradle-plugin-integration-tests",
     ":kotlin-gradle-plugins-bom",
+    ":kotlin-gradle-plugin-test-coverage",
     ":kotlin-privacy-manifests-plugin",
     ":compiler:build-tools:kotlin-build-statistics",
     ":gradle:android-test-fixes",
@@ -925,6 +926,7 @@ project(":kotlin-gradle-plugin-test-utils-embeddable").projectDir =
     File("$rootDir/libraries/tools/kotlin-gradle-plugin-test-utils-embeddable")
 project(":kotlin-gradle-plugin-integration-tests").projectDir = File("$rootDir/libraries/tools/kotlin-gradle-plugin-integration-tests")
 project(":kotlin-gradle-plugins-bom").projectDir = File("$rootDir/libraries/tools/kotlin-gradle-plugins-bom")
+project(":kotlin-gradle-plugin-test-coverage").projectDir = File("$rootDir/libraries/tools/kotlin-gradle-plugin-test-coverage")
 project(":kotlin-privacy-manifests-plugin").projectDir = File("$rootDir/libraries/tools/kotlin-privacy-manifests-plugin")
 project(":gradle:android-test-fixes").projectDir = File("$rootDir/libraries/tools/gradle/android-test-fixes")
 project(":gradle:documentation").projectDir = File("$rootDir/libraries/tools/gradle/documentation")


### PR DESCRIPTION
If code coverage is enabled, run KGP integration tests with only latest supported Gradle version.

The side effect here that if a test has a constrain to run only with limited Gradle version then it will be ignored.