### PR TITLE
[Tests][Native] Add regression test for KT-83236 `The symbol table has been sealed`

### DIFF
--- a/native/native.tests/testData/codegen/cinterop/objc/kt83236.kt
+++ b/native/native.tests/testData/codegen/cinterop/objc/kt83236.kt
@@ -1,0 +1,58 @@
+// ISSUE: KT-83236
+// TARGET_BACKEND: NATIVE
+// NATIVE_STANDALONE
+// DISABLE_NATIVE: isAppleTarget=false
+// WITH_PLATFORM_LIBS
+
+// The Objective-C members below use Foundation's NSRoundingMode, which is a CEnum.
+// The following problem was triggered while deserializing inherited Objective-C members for a Kotlin subclass,
+// when enum is not mentioned by name from Kotlin:
+// exception: java.lang.IllegalArgumentException: The symbol table has been sealed. irClass = CLASS IR_EXTERNAL_DECLARATION_STUB ENUM_CLASS name:NSRoundingMode modality:FINAL visibility:public superTypes:[kotlin.Enum<lib.NSRoundingMode>; kotlinx.cinterop.CEnum]
+//     at org.jetbrains.kotlin.backend.konan.optimizations.DataFlowIR$SymbolTable.mapClassReferenceType(DataFlowIR.kt:529)
+
+// MODULE: cinterop
+// FILE: lib.def
+language = Objective-C
+headers = lib.h
+headerFilter = lib.h
+
+// FILE: lib.h
+#import <Foundation/Foundation.h>
+
+@protocol KT83236Protocol <NSObject>
+@property(nonatomic, assign) NSRoundingMode roundingMode;
+@end
+
+@interface KT83236Object : NSObject <KT83236Protocol>
+@end
+
+// FILE: lib.m
+#import "lib.h"
+
+@implementation KT83236Object
+
+- (NSRoundingMode)roundingMode {
+    return NSRoundPlain;
+}
+
+- (void)setRoundingMode:(NSRoundingMode)roundingMode {
+}
+
+@end
+
+// MODULE: lib(cinterop)
+// FILE: lib.kt
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+import lib.KT83236Object
+
+class KT83236KotlinSubclass : KT83236Object()
+
+// MODULE: main(lib, cinterop)
+// FILE: main.kt
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+fun box(): String {
+    KT83236KotlinSubclass()
+    return "OK"
+}


### PR DESCRIPTION
Regression test is added for [^KT-83236](https://youtrack.jetbrains.com/issue/KT-83236) PeopleInSpace_mpp compilation error: The symbol table has been sealed

Should a test with such testdata be executed for parent commit of its workaround [e534b991c018](https://github.com/jetbrains/kotlin/commit/e534b991c018), with `-Pkotlin.internal.native.test.optimizationMode=OPT`, it will crash with 
```
exception: java.lang.IllegalArgumentException: The symbol table has been sealed. irClass = CLASS IR_EXTERNAL_DECLARATION_STUB ENUM_CLASS name:NSRoundingMode modality:FINAL visibility:public superTypes:[kotlin.Enum<lib.NSRoundingMode>; kotlinx.cinterop.CEnum]
	at org.jetbrains.kotlin.backend.konan.optimizations.DataFlowIR$SymbolTable.mapClassReferenceType(DataFlowIR.kt:529)
```

Workaround in [e534b991c018](https://github.com/jetbrains/kotlin/commit/e534b991c018), and following proper fix [40f054a6e476](https://github.com/jetbrains/kotlin/commit/40f054a6e476) have fixed this crash.