### PR TITLE
[stdlib] Compare allEqualBy selector values with ==

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -14946,10 +14946,8 @@ public inline fun <T, K> Array<out T>.allEqualBy(selector: (T) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -14979,10 +14977,8 @@ public inline fun <K> ByteArray.allEqualBy(selector: (Byte) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15012,10 +15008,8 @@ public inline fun <K> ShortArray.allEqualBy(selector: (Short) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15045,10 +15039,8 @@ public inline fun <K> IntArray.allEqualBy(selector: (Int) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15078,10 +15070,8 @@ public inline fun <K> LongArray.allEqualBy(selector: (Long) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15111,10 +15101,8 @@ public inline fun <K> FloatArray.allEqualBy(selector: (Float) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15144,10 +15132,8 @@ public inline fun <K> DoubleArray.allEqualBy(selector: (Double) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15177,10 +15163,8 @@ public inline fun <K> BooleanArray.allEqualBy(selector: (Boolean) -> K): Boolean
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -15210,10 +15194,8 @@ public inline fun <K> CharArray.allEqualBy(selector: (Char) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -2061,10 +2061,8 @@ public inline fun <T, K> Iterable<T>.allEqualBy(selector: (T) -> K): Boolean {
         if (isFirst) {
             firstKey = key
             isFirst = false
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
         if (!iterator.hasNext()) break
         element = iterator.next()

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1545,10 +1545,8 @@ public inline fun <T, K> Sequence<T>.allEqualBy(selector: (T) -> K): Boolean {
         if (isFirst) {
             firstKey = key
             isFirst = false
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
         if (!iterator.hasNext()) break
         element = iterator.next()

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -6357,10 +6357,8 @@ public inline fun <K> UIntArray.allEqualBy(selector: (UInt) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -6391,10 +6389,8 @@ public inline fun <K> ULongArray.allEqualBy(selector: (ULong) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -6425,10 +6421,8 @@ public inline fun <K> UByteArray.allEqualBy(selector: (UByte) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true
@@ -6459,10 +6453,8 @@ public inline fun <K> UShortArray.allEqualBy(selector: (UShort) -> K): Boolean {
         val key = selector(this[i])
         if (i == 0) {
             firstKey = key
-        } else {
-            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-            val equal = firstKey?.equals(key) ?: (key == null)
-            if (!equal) return false
+        } else if (firstKey != key) {
+            return false
         }
     }
     return true

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
@@ -322,10 +322,8 @@ object Aggregates : TemplateGroupBase() {
                 if (isFirst) {
                     firstKey = key
                     isFirst = false
-                } else {
-                    // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-                    val equal = firstKey?.equals(key) ?: (key == null)
-                    if (!equal) return false
+                } else if (firstKey != key) {
+                    return false
                 }
                 if (!iterator.hasNext()) break
                 element = iterator.next()
@@ -341,10 +339,8 @@ object Aggregates : TemplateGroupBase() {
                 val key = selector(this[i])
                 if (i == 0) {
                     firstKey = key
-                } else {
-                    // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-                    val equal = firstKey?.equals(key) ?: (key == null)
-                    if (!equal) return false
+                } else if (firstKey != key) {
+                    return false
                 }
             }
             return true


### PR DESCRIPTION
The explicit `equals` call was a workaround for KT-86678, where `==` on boxed `Double`/`Float` was wrong for NaN on Native. It is fixed now.

^KT-86680 Fixed
