### PR TITLE
[Gradle] Display Android deprecation warnings on all AGP versions

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/KotlinAndroidIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/KotlinAndroidIT.kt
@@ -423,13 +423,13 @@ class KotlinAndroidIT : KGPBaseTest() {
         }
     }
 
-    @DisplayName("No 'org.jetbrains.kotlin.android' plugin deprecation with AGP <9.0")
+    @DisplayName("'org.jetbrains.kotlin.android' plugin deprecation warning on AGP <9.0")
     @GradleAndroidTest
     @AndroidTestVersions(
         minVersion = TestVersions.AGP.AGP_811,
         maxVersion = TestVersions.AGP.AGP_811,
     )
-    fun testKotlinAndroidNoDeprecationDiagnostic(
+    fun testKotlinAndroidAGP8DeprecationDiagnostic(
         gradleVersion: GradleVersion,
         agpVersion: String,
         jdkVersion: JdkVersions.ProvidedJdk,
@@ -452,8 +452,8 @@ class KotlinAndroidIT : KGPBaseTest() {
                 }
             }
             build("help") {
+                assertHasDiagnostic(KotlinToolingDiagnostics.DeprecatedKotlinAndroidPlugin)
                 assertNoDiagnostic(KotlinToolingDiagnostics.KotlinAndroidIsIncompatibleWithTheNewAgpDsl)
-                assertNoDiagnostic(KotlinToolingDiagnostics.DeprecatedKotlinAndroidPlugin)
                 assertNoDiagnostic(KotlinToolingDiagnostics.KMPIsIncompatibleWithTheNewAgpDsl)
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/diagnostics/AgpWithBuiltInKotlinAppliedCheck.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/diagnostics/AgpWithBuiltInKotlinAppliedCheck.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnosticOncePerProject
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnosticFactory
 import org.jetbrains.kotlin.gradle.utils.androidPluginIds
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -39,9 +40,9 @@ internal object AgpWithBuiltInKotlinAppliedCheck {
         // IncompatibleWithTheNewAgpDsl must not hide AgpWithBuiltInKotlinIsAlreadyApplied
         checkIfNewDslIsUsed(isKmpProject = false)
         reportKotlinAndroidDeprecation(
-            KotlinToolingDiagnostics.DeprecatedKotlinAndroidPlugin(path),
+            KotlinToolingDiagnostics.DeprecatedKotlinAndroidPlugin,
             agpVersionProvider,
-        )
+        ) { alreadyOnAgp9 -> invoke(path, alreadyOnAgp9) }
     }
 
     fun Project.runKmpAgpWithBuiltInKotlinIfAppliedCheck(
@@ -84,22 +85,24 @@ internal object AgpWithBuiltInKotlinAppliedCheck {
         }
     }
 
-    internal fun Project.reportKotlinAndroidDeprecation(
-        diagnostic: ToolingDiagnostic,
+    internal fun <T : ToolingDiagnosticFactory> Project.reportKotlinAndroidDeprecation(
+        diagnosticFactory: T,
         agpVersionProvider: AndroidGradlePluginVersionProvider = AndroidGradlePluginVersionProvider.Default,
+        createDiagnostic: T.(alreadyOnAgp9: Boolean) -> ToolingDiagnostic,
     ) {
         val wasChecked = AtomicBoolean(false)
         androidPluginIds.forEach { agpPluginId ->
             plugins.withId(agpPluginId) {
                 if (!wasChecked.getAndSet(true)) {
                     val androidVersion = agpVersionProvider.get()
-                    if (androidVersion != null && androidVersion >= minimalBuiltInKotlinSupportedAgpVersion) {
-                        // Report deprecation with AGP 9.+ when Android deprecated Variants API is enabled
+                    if (androidVersion != null) {
+                        val alreadyOnAgp9 = androidVersion >= minimalBuiltInKotlinSupportedAgpVersion
+                        // Report deprecation when Android deprecated Variants API is enabled
                         // and built-in Kotlin support is disabled. Other cases related to AGP 9.+ change are covered
                         // by other diagnostics like 'KotlinToolingDiagnostics.IncompatibleWithTheNewAgpDsl' or
                         // 'KotlinToolingDiagnostics.AgpWithBuiltInKotlinIsAlreadyApplied'.
                         // This diagnostic should be fired at the end of related diagnostics checks and only if the checks are passed.
-                        project.reportDiagnosticOncePerProject(diagnostic)
+                        project.reportDiagnosticOncePerProject(diagnosticFactory.createDiagnostic(alreadyOnAgp9))
                     }
                 }
             }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2155,7 +2155,7 @@ internal object KotlinToolingDiagnostics {
     }
 
     internal object NonKmpAgpIsDeprecated : ToolingDiagnosticFactory(WARNING, DiagnosticGroup.Kgp.Misconfiguration) {
-        operator fun invoke(androidPluginId: String) = build {
+        operator fun invoke(androidPluginId: String, alreadyOnAgp9: Boolean) = build {
             val titleStep = title(
                 "The 'org.jetbrains.kotlin.multiplatform' plugin deprecated compatibility with Android Gradle plugin: '$androidPluginId'"
             )
@@ -2167,7 +2167,16 @@ internal object KotlinToolingDiagnostics {
                         |The 'org.jetbrains.kotlin.multiplatform' plugin is not compatible with 'com.android.library' starting with Android Gradle Plugin 9.0.0.
                         """.trimMargin()
                     )
-                    .solution("Please use the 'com.android.kotlin.multiplatform.library' plugin instead of 'com.android.library'.")
+                    .run {
+                        if (alreadyOnAgp9) {
+                            solution("Please use the 'com.android.kotlin.multiplatform.library' plugin instead of 'com.android.library'.")
+                        } else {
+                            solution(
+                                "Please update your project to AGP 9.0 or newer (see https://kotl.in/agp9-blog) and " +
+                                        "use the 'com.android.kotlin.multiplatform.library' plugin instead of 'com.android.library'."
+                            )
+                        }
+                    }
             } else {
                 titleStep
                     .description(
@@ -2179,7 +2188,16 @@ internal object KotlinToolingDiagnostics {
                         |Read more: https://kotl.in/kmp-project-structure-migration
                         """.trimMargin()
                     )
-                    .solution("Please change the structure of your project and move the usage of '$androidPluginId' into a separate subproject.")
+                    .run {
+                        if (alreadyOnAgp9) {
+                            solution("Please change the structure of your project and move the usage of '$androidPluginId' into a separate subproject.")
+                        } else {
+                            solution(
+                                "Please update your project to AGP 9.0 or newer (see https://kotl.in/agp9-blog), change the " +
+                                        "structure of your project and move the usage of '$androidPluginId' into a separate subproject."
+                            )
+                        }
+                    }
             }
             solutionStep.documentationLink(URI("https://kotl.in/gradle/agp-new-kmp"))
         }
@@ -2188,10 +2206,17 @@ internal object KotlinToolingDiagnostics {
     internal object DeprecatedKotlinAndroidPlugin : ToolingDiagnosticFactory(WARNING, DiagnosticGroup.Kgp.Deprecation) {
         operator fun invoke(
             projectPath: String,
+            alreadyOnAgp9: Boolean,
         ) = build {
             title("Deprecated 'org.jetbrains.kotlin.android' plugin usage")
                 .description("The 'org.jetbrains.kotlin.android' plugin in project '$projectPath' is no longer required for Kotlin support since AGP 9.0.")
-                .solution("Remove both `android.builtInKotlin=true` and `android.newDsl=false` from `gradle.properties`, then migrate to built-in Kotlin.")
+                .run {
+                    if (alreadyOnAgp9) {
+                        solution("Remove both `android.builtInKotlin=true` and `android.newDsl=false` from `gradle.properties`, then migrate to built-in Kotlin.")
+                    } else {
+                        solution("Update your project to AGP 9.0 or newer (see https://kotl.in/agp9-blog) and migrate to built-in Kotlin.")
+                    }
+                }
                 .documentationLink(URI("https://kotl.in/gradle/agp-built-in-kotlin"))
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/android/KotlinAndroidTargetPreset.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/android/KotlinAndroidTargetPreset.kt
@@ -40,8 +40,8 @@ internal abstract class KotlinAndroidTargetPreset @Inject constructor(
         } else {
             project.checkIfNewDslIsUsed(isKmpProject = true)
             project.reportKotlinAndroidDeprecation(
-                KotlinToolingDiagnostics.NonKmpAgpIsDeprecated(androidPluginId)
-            )
+                KotlinToolingDiagnostics.NonKmpAgpIsDeprecated,
+            ) { alreadyOnAgp9 -> invoke(androidPluginId, alreadyOnAgp9) }
         }
 
         return project.objects.KotlinAndroidTarget(project, name, true).apply {


### PR DESCRIPTION
Prior to this change, KGP would only display deprecation warnings for org.jetbrains.kotlin.android plugin and KMP plugin's android target when those are used together with AGP 9.x. With this change, these warnings will now be shown regardless of the AGP version, and the warning description will suggest upgrading to AGP 9.0 or newer.

^KT-88622 Verification Pending