### PR TITLE
[Gradle] Add Multiplatform test filtering integration tests

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestFilteringIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestFilteringIT.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.mpp
+
+import org.gradle.api.tasks.testing.Test
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.junit.jupiter.api.DisplayName
+
+@MppGradlePluginTests
+@DisplayName("Tests for Multiplatform test filtering")
+class MppTestFilteringIT : KGPBaseTest() {
+
+    private fun TestProject.setupSampleSources(includeJs: Boolean = false) {
+        buildScriptInjection {
+            kotlinMultiplatform.jvm()
+            if (includeJs) {
+                kotlinMultiplatform.js {
+                    nodejs()
+                }
+            }
+            kotlinMultiplatform.sourceSets.getByName("commonTest").dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+
+        kotlinSourcesDir("commonTest").apply {
+            source("org/example/project/SampleTest.kt") {
+                """
+                package org.example.project
+
+                import kotlin.test.Test
+                import kotlin.test.assertTrue
+
+                class SampleTest {
+                    @Test
+                    fun testOne() {
+                        assertTrue(true)
+                    }
+
+                    @Test
+                    fun testTwo() {
+                        assertTrue(true)
+                    }
+                }
+                """.trimIndent()
+            }
+
+            source("org/example/project/OtherTest.kt") {
+                """
+                package org.example.project
+
+                import kotlin.test.Test
+                import kotlin.test.assertTrue
+
+                class OtherTest {
+                    @Test
+                    fun testOther() {
+                        assertTrue(true)
+                    }
+                }
+                """.trimIndent()
+            }
+
+            source("org/example/other/ExternalTest.kt") {
+                """
+                package org.example.other
+
+                import kotlin.test.Test
+                import kotlin.test.assertTrue
+
+                class ExternalTest {
+                    @Test
+                    fun testExternal() {
+                        assertTrue(true)
+                    }
+                }
+                """.trimIndent()
+            }
+        }
+    }
+
+    @DisplayName("CLI --tests filtering: class, method, wildcard, and package patterns")
+    @GradleTest
+    fun testCliTestsFiltering(gradleVersion: GradleVersion) {
+        project("base-kotlin-multiplatform-library", gradleVersion) {
+            setupSampleSources()
+
+            // Filter by simple class name
+            build(":jvmTest", "--tests", "SampleTest") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+
+            // Filter by fully-qualified and simple method names
+            build(":jvmTest", "--tests", "org.example.project.SampleTest.testOne") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+            )
+
+            build(":jvmTest", "--tests", "SampleTest.testOne") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+            )
+
+            // Filter by wildcard class pattern
+            build(":jvmTest", "--tests", "*SampleTest") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+
+            // Filter by package wildcard pattern
+            build(":jvmTest", "--tests", "org.example.project.*") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+                "org.example.project.OtherTest#testOther",
+            )
+
+            // Filter with multiple --tests arguments (union)
+            build(":jvmTest", "--tests", "*SampleTest", "--tests", "*ExternalTest") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+                "org.example.other.ExternalTest#testExternal",
+            )
+        }
+    }
+
+    @DisplayName("Task DSL filter configuration: include, exclude, and CLI narrowing behavior")
+    @GradleTest
+    fun testDslTaskFilterConfiguration(gradleVersion: GradleVersion) {
+        project("base-kotlin-multiplatform-library", gradleVersion) {
+            setupSampleSources()
+
+            // 1. Task DSL includeTestsMatching pattern
+            buildScriptInjection {
+                project.tasks.withType(Test::class.java).configureEach {
+                    it.filter.includeTestsMatching("*SampleTest")
+                }
+            }
+            build(":jvmTest") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+
+            // 2. Task DSL include pattern + exclude pattern
+            buildScriptInjection {
+                project.tasks.withType(Test::class.java).configureEach {
+                    it.filter.setIncludePatterns("org.example.project.*")
+                    it.filter.excludeTestsMatching("*OtherTest")
+                }
+            }
+            build(":jvmTest") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+
+            // 3. CLI narrowing behavior: script include filter is further narrowed by CLI --tests
+            buildScriptInjection {
+                project.tasks.withType(Test::class.java).configureEach {
+                    it.filter.setIncludePatterns("*SampleTest")
+                    it.filter.setExcludePatterns()
+                }
+            }
+
+            // CLI pattern includes org.example.project.*, but script limits to *SampleTest -> only SampleTest runs
+            build(":jvmTest", "--tests", "org.example.project.*") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+
+            // CLI pattern matches *OtherTest, but script limits to *SampleTest -> intersection is empty, build fails
+            buildAndFail(":jvmTest", "--tests", "*OtherTest") {
+                assertTasksFailed(":jvmTest")
+            }
+        }
+    }
+
+    @DisplayName("jvmTest fails on non-matching --tests filter, jsNodeTest does not")
+    @GradleTest
+    fun testTargetBehavioralAsymmetryOnNoMatchingTests(gradleVersion: GradleVersion) {
+        project(
+            "base-kotlin-multiplatform-library",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
+        ) {
+            setupSampleSources(includeJs = true)
+
+            // 1. :jvmTest fails by default on NoSuchTest because Gradle's standard Test task has isFailOnNoMatchingTests = true by default.
+            buildAndFail(":jvmTest", "--tests", "NoSuchTest") {
+                assertTasksFailed(":jvmTest")
+            }
+            assertExecutedTestCases(":jvmTest")
+
+            // 2. :jsNodeTest succeeds on NoSuchTest because KotlinTest (base class for KotlinJsTest)
+            // explicitly sets isFailOnNoMatchingTests = false.
+            build(":jsNodeTest", "--tests", "NoSuchTest") {
+                assertTasksExecuted(":jsNodeTest")
+            }
+            assertExecutedTestCases(":jsNodeTest")
+        }
+    }
+
+    @DisplayName("Disable failOnNoMatchingTests on JVM test task allows non-matching filter to succeed")
+    @GradleTest
+    fun testDisableFailOnNoMatchingTests(gradleVersion: GradleVersion) {
+        project("base-kotlin-multiplatform-library", gradleVersion) {
+            setupSampleSources()
+
+            buildScriptInjection {
+                project.tasks.withType(Test::class.java).configureEach {
+                    it.filter.isFailOnNoMatchingTests = false
+                }
+            }
+
+            build(":jvmTest", "--tests", "NoSuchTest") {
+                assertTasksExecuted(":jvmTest")
+            }
+            assertExecutedTestCases(":jvmTest")
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestFilteringIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestFilteringIT.kt
@@ -150,13 +150,12 @@ class MppTestFilteringIT : KGPBaseTest() {
         }
     }
 
-    @DisplayName("Task DSL filter configuration: include, exclude, and CLI narrowing behavior")
+    @DisplayName("Task DSL filter configuration: includeTestsMatching")
     @GradleTest
-    fun testDslTaskFilterConfiguration(gradleVersion: GradleVersion) {
+    fun testDslIncludeTestsMatching(gradleVersion: GradleVersion) {
         project("base-kotlin-multiplatform-library", gradleVersion) {
             setupSampleSources()
 
-            // 1. Task DSL includeTestsMatching pattern
             buildScriptInjection {
                 project.tasks.withType(Test::class.java).configureEach {
                     it.filter.includeTestsMatching("*SampleTest")
@@ -170,11 +169,18 @@ class MppTestFilteringIT : KGPBaseTest() {
                 "org.example.project.SampleTest#testOne",
                 "org.example.project.SampleTest#testTwo",
             )
+        }
+    }
 
-            // 2. Task DSL include pattern + exclude pattern
+    @DisplayName("Task DSL filter configuration: include and exclude patterns")
+    @GradleTest
+    fun testDslIncludeAndExcludePatterns(gradleVersion: GradleVersion) {
+        project("base-kotlin-multiplatform-library", gradleVersion) {
+            setupSampleSources()
+
             buildScriptInjection {
                 project.tasks.withType(Test::class.java).configureEach {
-                    it.filter.setIncludePatterns("org.example.project.*")
+                    it.filter.includeTestsMatching("org.example.project.*")
                     it.filter.excludeTestsMatching("*OtherTest")
                 }
             }
@@ -186,12 +192,18 @@ class MppTestFilteringIT : KGPBaseTest() {
                 "org.example.project.SampleTest#testOne",
                 "org.example.project.SampleTest#testTwo",
             )
+        }
+    }
 
-            // 3. CLI narrowing behavior: script include filter is further narrowed by CLI --tests
+    @DisplayName("Task DSL filter configuration: CLI narrowing behavior")
+    @GradleTest
+    fun testDslCliNarrowing(gradleVersion: GradleVersion) {
+        project("base-kotlin-multiplatform-library", gradleVersion) {
+            setupSampleSources()
+
             buildScriptInjection {
                 project.tasks.withType(Test::class.java).configureEach {
-                    it.filter.setIncludePatterns("*SampleTest")
-                    it.filter.setExcludePatterns()
+                    it.filter.includeTestsMatching("*SampleTest")
                 }
             }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestFilteringIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestFilteringIT.kt
@@ -80,6 +80,27 @@ class MppTestFilteringIT : KGPBaseTest() {
                 }
                 """.trimIndent()
             }
+
+            source("org/example/failing/FailingTest.kt") {
+                """
+                package org.example.failing
+
+                import kotlin.test.Test
+                import kotlin.test.assertTrue
+
+                class FailingTest {
+                    @Test
+                    fun testPass() {
+                        assertTrue(true)
+                    }
+
+                    @Test
+                    fun testFail() {
+                        assertTrue(false, "Expected test failure")
+                    }
+                }
+                """.trimIndent()
+            }
         }
     }
 
@@ -265,6 +286,24 @@ class MppTestFilteringIT : KGPBaseTest() {
                 assertTasksExecuted(":jvmTest")
             }
             assertExecutedTestCases(":jvmTest")
+        }
+    }
+
+    @DisplayName("CLI --tests executes all filtered test cases even when tests fail")
+    @GradleTest
+    fun testCliFilteringWithFailingTests(gradleVersion: GradleVersion) {
+        project("base-kotlin-multiplatform-library", gradleVersion) {
+            setupSampleSources()
+            // Filter matches both testPass and testFail in FailingTest.
+            // Task must fail, but both test cases must be executed (no premature termination).
+            buildAndFail(":jvmTest", "--tests", "FailingTest") {
+                assertTasksFailed(":jvmTest")
+            }
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.failing.FailingTest#testPass",
+                "org.example.failing.FailingTest#testFail",
+            )
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
@@ -20,7 +20,6 @@ import kotlin.io.path.absolutePathString
 import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * @param stripBrowserVersionInfoFromTestCaseNames Some test executor implementations include browser version info in test case names,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
@@ -13,12 +13,14 @@ import org.jdom.Content
 import org.jdom.Element
 import org.jdom.Text
 import org.jetbrains.kotlin.test.util.trimTrailingWhitespaces
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * @param stripBrowserVersionInfoFromTestCaseNames Some test executor implementations include browser version info in test case names,
@@ -137,6 +139,56 @@ internal fun readValidateAndCleanupTestResults(
 internal fun prettyPrintXml(uglyXml: String): String =
     JDOMUtil.write(JDOMUtil.load(uglyXml.reader()))
 
+fun GradleProject.readTestCases(
+    taskName: String,
+    subprojectName: String? = null,
+): List<TestCaseResult> {
+    val testReportDir = testResultsAndReportsDirs(taskName, subprojectName).first
+
+    if (!Files.exists(testReportDir)) {
+        return emptyList()
+    }
+
+    val xmlFiles = testReportDir.allFilesWithExtension("xml")
+    return xmlFiles.flatMap { xmlFile ->
+        val root = JDOMUtil.load(xmlFile)
+        val testCases = when (root.name) {
+            "testcase" -> listOf(root)
+            "testsuites" -> root.getChildren("testcase") + root.getChildren("testsuite").flatMap { it.getChildren("testcase") }
+            else -> root.getChildren("testcase")
+        }
+        testCases.map { testCaseElement ->
+            val className = testCaseElement.getAttributeValue("classname")
+                ?: testCaseElement.getAttributeValue("className")
+                ?: ""
+            val name = testCaseElement.getAttributeValue("name") ?: ""
+            val failureElement = testCaseElement.getChild("failure") ?: testCaseElement.getChild("error")
+            val failure = failureElement?.let {
+                TestFailureInfo(
+                    message = it.getAttributeValue("message"),
+                    type = it.getAttributeValue("type"),
+                    stackTrace = it.textTrim.ifEmpty { null } ?: it.text.ifEmpty { null }
+                )
+            }
+            TestCaseResult(
+                className = className,
+                name = name,
+                failure = failure
+            )
+        }
+    }
+}
+
+fun GradleProject.assertExecutedTestCases(
+    taskName: String,
+    vararg expectedIds: String,
+    subprojectName: String? = null,
+) {
+    val actualIds = readTestCases(taskName, subprojectName).map { it.id }.toSortedSet()
+    val expected = expectedIds.toSortedSet()
+    assertEquals(expected, actualIds)
+}
+
 private fun GradleProject.testResultsAndReportsDirs(
     taskName: String,
     subprojectName: String? = null,
@@ -194,3 +246,17 @@ private fun String.hashTestPathSegment(): String {
 }
 
 private val TEST_PATH_HASHER: HashFunction = Hashing.farmHashFingerprint64()
+
+data class TestCaseResult(
+    val className: String,
+    val name: String,
+    val failure: TestFailureInfo? = null,
+) {
+    val id: String = "$className#${name.substringBefore('[')}"
+}
+
+data class TestFailureInfo(
+    val message: String? = null,
+    val type: String? = null,
+    val stackTrace: String? = null,
+)


### PR DESCRIPTION
### Problem
KMP test filtering (via `--tests` CLI arguments and task filter DSLs) lacked dedicated integration test coverage. Non-JVM targets (`jsNodeTest`, etc.) rely on custom KGP tasks (`KotlinTest`) that translate filter patterns into platform runner arguments and set `isFailOnNoMatchingTests =  false`, which needs protection against regressions across Gradle versions. 
### Solution                                                                                                                                                     
- Test Infrastructure (`testAssertions.kt`): added `readTestCases` and `assertExecutedTestCases` helpers to inspect executed test IDs from XML test results.                                                                                                                                                         
- Integration Tests (`MppTestFilteringIT.kt`): added coverage for:                                                                                           
  - CLI `--tests` filtering with class, method, wildcard (`*`), and package patterns.                                                                            
  - Task filter DSL configuration (`includeTestsMatching`, `excludeTestsMatching`, CLI narrowing).                                                               
  - Target behavioral asymmetry (`:jvmTest` fails on non-matching filter, `:jsNodeTest` succeeds).                                                               
  - Gradle compatibility across supported Gradle versions.
  
  ^KQA-3419