### PR TITLE
[JVM] Adapt indy lambdas to erased SAM signatures

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -199,7 +199,13 @@ open class UpgradeCallableReferences(
         override fun visitTypeOperator(expression: IrTypeOperatorCall, data: IrDeclarationParent): IrExpression {
             if (upgradeSamConversions && expression.operator == IrTypeOperator.SAM_CONVERSION) {
                 expression.transformChildren(this, data)
-                val argument = expression.argument
+                val argument = expression.argument.let {
+                    if (it is IrTypeOperatorCall && it.operator == IrTypeOperator.IMPLICIT_CAST) {
+                        it.argument
+                    } else {
+                        it
+                    }
+                }
                 if (argument !is IrRichFunctionReference) return expression
                 return argument.apply {
                     startOffset = expression.startOffset

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -44,6 +44,8 @@ open class UpgradeCallableReferences(
         irFunction.transform(UpgradeTransformer(), irFunction)
     }
 
+    protected open fun getSamConversionArgument(argument: IrExpression): IrExpression = argument
+
     private data class AdaptedBlock(
         val function: IrSimpleFunction,
         val reference: IrFunctionReference,
@@ -199,13 +201,7 @@ open class UpgradeCallableReferences(
         override fun visitTypeOperator(expression: IrTypeOperatorCall, data: IrDeclarationParent): IrExpression {
             if (upgradeSamConversions && expression.operator == IrTypeOperator.SAM_CONVERSION) {
                 expression.transformChildren(this, data)
-                val argument = expression.argument.let {
-                    if (it is IrTypeOperatorCall && it.operator == IrTypeOperator.IMPLICIT_CAST) {
-                        it.argument
-                    } else {
-                        it
-                    }
-                }
+                val argument = getSamConversionArgument(expression.argument)
                 if (argument !is IrRichFunctionReference) return expression
                 return argument.apply {
                     startOffset = expression.startOffset

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
@@ -14,4 +14,11 @@ internal class JvmUpgradeCallableReferences(context: JvmBackendContext) : Upgrad
     upgradeSamConversions = true,
     castDispatchReceiver = false,
     generateFakeAccessorsForReflectionProperty = true,
-)
+) {
+    override fun getSamConversionArgument(argument: IrExpression): IrExpression =
+        if (argument is IrTypeOperatorCall && argument.operator == IrTypeOperator.IMPLICIT_CAST) {
+            argument.argument
+        } else {
+            argument
+        }
+}

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.jvm.ir.getInlineClassUnderlyingType
 import org.jetbrains.kotlin.backend.jvm.ir.getJvmAnnotationRetention
 import org.jetbrains.kotlin.backend.jvm.ir.isCompiledToJvmDefault
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClass
+import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
 import org.jetbrains.kotlin.builtins.functions.BuiltInFunctionArity
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.Modality
@@ -19,16 +20,22 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrRichFunctionReference
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.overrides.buildFakeOverrideMember
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_SERIALIZABLE_LAMBDA_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.Variance
 import java.lang.annotation.RetentionPolicy
 
@@ -307,6 +314,8 @@ internal class LambdaMetafactoryArgumentsBuilder(
             val constraint = constraints.parameters[methodParameter]
             if (!checkTypeCompliesWithConstraint(implParameter.type, constraint))
                 return false
+            if (!isReferenceParameterAdaptable(implParameter.type, methodParameter.type))
+                return false
         }
         if (!checkTypeCompliesWithConstraint(implFun.returnType, constraints.returnType))
             return false
@@ -352,6 +361,7 @@ internal class LambdaMetafactoryArgumentsBuilder(
             if (parameterConstraint.requiresImplLambdaBoxing()) {
                 makeLambdaParameterNullable(implFun, implParameter)
             }
+            adaptReferenceLambdaParameter(implFun, implParameter, methodParameter.type)
         }
         if (constraints.returnType.requiresImplLambdaBoxing() ||
             implFun.returnType.isUnit() && !fakeInstanceMethod.returnType.isUnit()
@@ -374,6 +384,41 @@ internal class LambdaMetafactoryArgumentsBuilder(
                 super.visitGetValue(expression)
             }
         }, null)
+    }
+
+    private fun isReferenceParameterAdaptable(implType: IrType, methodType: IrType): Boolean {
+        if (implType == methodType) return true
+        if (implType.isPrimitiveType() || methodType.isPrimitiveType()) return false
+        if (implType.isInlineClassType() || methodType.isInlineClassType()) return false
+        return isSubtypeOf(implType, methodType) || isSubtypeOf(methodType, implType)
+    }
+
+    private fun isSubtypeOf(subType: IrType, superType: IrType): Boolean =
+        AbstractTypeChecker.isSubtypeOf(createIrTypeCheckerState(context.typeSystem), subType, superType)
+
+    private fun adaptReferenceLambdaParameter(function: IrFunction, parameter: IrValueParameter, methodType: IrType) {
+        val implementationType = parameter.type
+        if (implementationType == methodType || !isReferenceParameterAdaptable(implementationType, methodType)) return
+        if (!isSubtypeOf(implementationType, methodType)) return
+
+        // LambdaMetafactory passes the erased SAM parameter type to the implementation method.
+        // Keep the lambda's original Kotlin type at each use site and insert the required JVM cast.
+        parameter.type = methodType
+        function.body?.transformChildrenVoid(object : IrElementTransformerVoid() {
+            override fun visitGetValue(expression: IrGetValue): IrExpression {
+                if (expression.symbol != parameter.symbol) return super.visitGetValue(expression)
+                val transformed = super.visitGetValue(expression) as IrGetValue
+                transformed.type = methodType
+                return IrTypeOperatorCallImpl(
+                    expression.startOffset,
+                    expression.endOffset,
+                    implementationType,
+                    IrTypeOperator.IMPLICIT_CAST,
+                    implementationType,
+                    transformed,
+                )
+            }
+        })
     }
 
     private fun validateMethodParameters(

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_groundSamType.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_groundSamType.kt
@@ -1,0 +1,43 @@
+// TARGET_BACKEND: JVM
+// FULL_JDK
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// JVM_IR_TEMPLATES
+// 4 java/lang/invoke/LambdaMetafactory
+
+import java.util.Comparator
+import java.util.HashMap
+import java.util.function.Consumer
+
+fun <T> consume(block: Consumer<in T>) {}
+
+fun use() {
+    consume<String> { }
+}
+
+fun useComparingInt(): Boolean {
+    val comparator = Comparator.comparingInt<String> { it.length }
+    return comparator.compare("a", "bb") < 0
+}
+
+fun useMapCompute(): Boolean {
+    val map = HashMap<String, Int>()
+    map["value"] = 2
+    return map.compute("value") { key, value -> key.length + (value ?: 0) } == 7
+}
+
+fun useMapComputeIfAbsent(): Boolean {
+    val map = HashMap<String, Int>()
+    return map.computeIfAbsent("value") { it.length } == 5
+}
+
+fun box(): String {
+    use()
+    if (!useComparingInt()) return "Fail comparingInt"
+    if (!useMapCompute()) return "Fail compute"
+    if (!useMapComputeIfAbsent()) return "Fail computeIfAbsent"
+    return "OK"
+}


### PR DESCRIPTION
Fixes [KT-57995](https://youtrack.jetbrains.com/issue/KT-57995).

Contravariant Java SAM parameters can wrap a rich lambda reference in an
implicit cast. This prevents `FunctionReferenceLowering` from handling it
directly and produces an extra adapter method.

Upgrade these SAM conversions through the cast. At the JVM metafactory
boundary, widen adaptable lambda parameters to the erased SAM parameter types
and insert casts at their use sites, keeping the `LambdaMetafactory` signature
valid without proxy methods.