### PR TITLE
[Stdlib] Improve AbstractCoroutineContextKey's deprecation message

### DIFF
--- a/libraries/stdlib/src/kotlin/coroutines/CoroutineContextImpl.kt
+++ b/libraries/stdlib/src/kotlin/coroutines/CoroutineContextImpl.kt
@@ -49,7 +49,7 @@ public abstract class AbstractCoroutineContextElement(public override val key: K
 @ExperimentalStdlibApi
 @Deprecated(
     "Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage " +
-            "depending on implementation details. Prefer retrieving the element by its base key and casting " +
+            "users to depend on implementation details. Prefer retrieving the element by its base key and casting " +
             "it explicitly when needed or introducing a dedicated extension property."
 )
 @DeprecatedSinceKotlin(warningSince = "2.4")
@@ -74,7 +74,7 @@ public abstract class AbstractCoroutineContextKey<B : Element, E : B>(
 @ExperimentalStdlibApi
 @Deprecated(
     "Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage " +
-            "depending on implementation details. Prefer retrieving the element by its base key and casting " +
+            "users to depend on implementation details. Prefer retrieving the element by its base key and casting " +
             "it explicitly when needed or introducing a dedicated extension property."
 )
 @DeprecatedSinceKotlin(warningSince = "2.4")
@@ -99,7 +99,7 @@ public fun <E : Element> Element.getPolymorphicElement(key: Key<E>): E? {
 @ExperimentalStdlibApi
 @Deprecated(
     "Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage " +
-            "depending on implementation details. Prefer retrieving the element by its base key and casting " +
+            "users to depend on implementation details. Prefer retrieving the element by its base key and casting " +
             "it explicitly when needed or introducing a dedicated extension property."
 )
 @DeprecatedSinceKotlin(warningSince = "2.4")

--- a/native/objcexport-header-generator/testData/dependencies/coroutineDispatcherKey/!coroutineDispatcherKey.h
+++ b/native/objcexport-header-generator/testData/dependencies/coroutineDispatcherKey/!coroutineDispatcherKey.h
@@ -39,7 +39,7 @@ __attribute__((objc_subclassing_restricted))
  *   kotlin.DeprecatedSinceKotlin(warningSince="2.4")
 */
 @interface KotlinAbstractCoroutineContextKey<B, E> : Base <KotlinCoroutineContextKey>
-- (instancetype)initWithBaseKey:(id<KotlinCoroutineContextKey>)baseKey safeCast:(E _Nullable (^)(id<KotlinCoroutineContextElement>))safeCast __attribute__((swift_name("init(baseKey:safeCast:)"))) __attribute__((objc_designated_initializer)) __attribute__((deprecated("Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage depending on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.")));
+- (instancetype)initWithBaseKey:(id<KotlinCoroutineContextKey>)baseKey safeCast:(E _Nullable (^)(id<KotlinCoroutineContextElement>))safeCast __attribute__((swift_name("init(baseKey:safeCast:)"))) __attribute__((objc_designated_initializer)) __attribute__((deprecated("Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage users to depend on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.")));
 @end
 
 

--- a/native/objcexport-header-generator/testData/dependencies/kotlinxCoroutines/!kotlinxCoroutines.h
+++ b/native/objcexport-header-generator/testData/dependencies/kotlinxCoroutines/!kotlinxCoroutines.h
@@ -419,7 +419,7 @@ __attribute__((objc_subclassing_restricted))
  *   kotlin.DeprecatedSinceKotlin(warningSince="2.4")
 */
 @interface KotlinAbstractCoroutineContextKey<B, E> : Base <KotlinCoroutineContextKey>
-- (instancetype)initWithBaseKey:(id<KotlinCoroutineContextKey>)baseKey safeCast:(E _Nullable (^)(id<KotlinCoroutineContextElement>))safeCast __attribute__((swift_name("init(baseKey:safeCast:)"))) __attribute__((objc_designated_initializer)) __attribute__((deprecated("Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage depending on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.")));
+- (instancetype)initWithBaseKey:(id<KotlinCoroutineContextKey>)baseKey safeCast:(E _Nullable (^)(id<KotlinCoroutineContextElement>))safeCast __attribute__((swift_name("init(baseKey:safeCast:)"))) __attribute__((objc_designated_initializer)) __attribute__((deprecated("Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage users to depend on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.")));
 @end
 
 


### PR DESCRIPTION
The wording was a bit confusing and looked like there was a missing word in between "encouraging" and "depending on implementation details".