### PR TITLE
[Gradle] Clean up TestFixturesIT: remove redundant test and standardize KMP naming

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TestFixturesIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TestFixturesIT.kt
@@ -33,32 +33,12 @@ class TestFixturesIT : KGPBaseTest() {
         }
     }
 
-    @DisplayName("Test fixtures can access internals of the main JVM source set in KMP projects using 'withJava()'")
+    @DisplayName("Test fixtures can access internals of the main JVM source set in KMP projects")
     @MppGradlePluginTests
     @GradleTest
-    @TestMetadata(MPP_TEST_FIXTURES_PROJECT_NAME)
-    fun testInternalAccessInMppProjectWithJava(gradleVersion: GradleVersion) {
-        project(MPP_TEST_FIXTURES_PROJECT_NAME, gradleVersion) {
-            applyJavaPluginIfRequired(gradleVersion)
-            if (!isWithJavaSupported) buildGradle.replaceText("withJava()", "")
-            kotlinSourcesDir("jvmTestFixtures").resolve("Netherlands.kt").appendText(
-                //language=kt
-                """
-
-                    fun isCityFromNetherlands(city: City) = city.isNetherlands()
-                """.trimIndent()
-            )
-
-            build("compileTestFixturesKotlinJvm")
-        }
-    }
-
-    @DisplayName("Test fixtures can access internals of the main JVM source set in Kotlin MPP projects")
-    @MppGradlePluginTests
-    @GradleTest
-    @TestMetadata(MPP_TEST_FIXTURES_PROJECT_NAME)
-    fun testInternalAccessInMppProject(gradleVersion: GradleVersion) {
-        project(MPP_TEST_FIXTURES_PROJECT_NAME, gradleVersion) {
+    @TestMetadata(KMP_TEST_FIXTURES_PROJECT_NAME)
+    fun testInternalAccessInKmpProject(gradleVersion: GradleVersion) {
+        project(KMP_TEST_FIXTURES_PROJECT_NAME, gradleVersion) {
             applyJavaPluginIfRequired(gradleVersion)
             if (!isWithJavaSupported) buildGradle.replaceText("withJava()", "")
             kotlinSourcesDir("jvmTestFixtures").resolve("Netherlands.kt").appendText(
@@ -98,12 +78,12 @@ class TestFixturesIT : KGPBaseTest() {
         }
     }
 
-    @DisplayName("JVM test code can access internals of the test fixtures source set in Kotlin MPP projects")
+    @DisplayName("JVM test code can access internals of the test fixtures source set in KMP projects")
     @MppGradlePluginTests
     @GradleTest
-    @TestMetadata(MPP_TEST_FIXTURES_PROJECT_NAME)
-    fun testInternalAccessFromTestsInMppProject(gradleVersion: GradleVersion) {
-        project(MPP_TEST_FIXTURES_PROJECT_NAME, gradleVersion) {
+    @TestMetadata(KMP_TEST_FIXTURES_PROJECT_NAME)
+    fun testInternalAccessFromTestsInKmpProject(gradleVersion: GradleVersion) {
+        project(KMP_TEST_FIXTURES_PROJECT_NAME, gradleVersion) {
             applyJavaPluginIfRequired(gradleVersion)
             if (!isWithJavaSupported) buildGradle.replaceText("withJava()", "")
             kotlinSourcesDir("jvmTestFixtures").resolve("Netherlands.kt").appendText(
@@ -128,9 +108,9 @@ class TestFixturesIT : KGPBaseTest() {
     @DisplayName("Test associated 'functionalTest' compilation can compile and run with test and testFixtures in JVM project")
     @MppGradlePluginTests
     @GradleTest
-    @TestMetadata(MPP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME)
+    @TestMetadata(KMP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME)
     fun testTestFixturesAndFunctionalTestsInJvmProject(gradleVersion: GradleVersion) {
-        project(MPP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME, gradleVersion) {
+        project(KMP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME, gradleVersion) {
             applyJavaPluginIfRequired(gradleVersion)
             if (!isWithJavaSupported) buildGradleKts.replaceText("withJava()", "")
 
@@ -146,12 +126,12 @@ class TestFixturesIT : KGPBaseTest() {
         }
     }
 
-    @DisplayName("Test associated 'functionalTest' compilation can compile and run with test and testFixtures in Multiplatform project")
+    @DisplayName("Test associated 'functionalTest' compilation can compile and run with test and testFixtures in KMP project")
     @MppGradlePluginTests
     @GradleTest
-    @TestMetadata(MPP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME)
-    fun testTestFixturesAndFunctionalTestsInMppProject(gradleVersion: GradleVersion) {
-        project(MPP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME, gradleVersion) {
+    @TestMetadata(KMP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME)
+    fun testTestFixturesAndFunctionalTestsInKmpProject(gradleVersion: GradleVersion) {
+        project(KMP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME, gradleVersion) {
             applyJavaPluginIfRequired(gradleVersion)
             if (!isWithJavaSupported) buildGradleKts.replaceText("withJava()", "")
 
@@ -201,8 +181,9 @@ class TestFixturesIT : KGPBaseTest() {
     @GradleTestVersions(
         minVersion = TestVersions.Gradle.G_8_4 // 'testFixturesApi' configuration is only available in KMP projects since this version
     )
+    @TestMetadata(KMP_JVM_TEST_FIXTURES_PROJECT_NAME)
     fun testProjectDependencyOnKmpTestFixtures(gradleVersion: GradleVersion) {
-        project("kmp-jvm-test-fixtures", gradleVersion) {
+        project(KMP_JVM_TEST_FIXTURES_PROJECT_NAME, gradleVersion) {
             build(":lib:testClasses")
         }
     }
@@ -228,7 +209,8 @@ class TestFixturesIT : KGPBaseTest() {
 
     companion object {
         private const val JVM_TEST_FIXTURES_PROJECT_NAME = "jvm-test-fixtures"
-        private const val MPP_TEST_FIXTURES_PROJECT_NAME = "mpp-test-fixtures"
-        private const val MPP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME = "mpp-test-fixtures-functionalTest"
+        private const val KMP_TEST_FIXTURES_PROJECT_NAME = "mpp-test-fixtures"
+        private const val KMP_TEST_FIXTURES_WITH_FUNCTIONAL_TEST_PROJECT_NAME = "mpp-test-fixtures-functionalTest"
+        private const val KMP_JVM_TEST_FIXTURES_PROJECT_NAME = "kmp-jvm-test-fixtures"
     }
 }


### PR DESCRIPTION
 ### Summary
- Removed obsolete duplicate test `testInternalAccessInMppProjectWithJava`
- Standardized naming and annotations across `TestFixturesIT` to consistently use `KMP`