### PR TITLE
[KT-88597] Fix failing Gradle Integration Tests Gradle Kotlin JS with Browser tests Linux

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
@@ -161,7 +161,7 @@ class JsBrowserTestsIT : KGPBaseTest() {
 
     @GradleTest
     fun `smoke js browser test`(
-        gradleVersion: GradleVersion
+        gradleVersion: GradleVersion,
     ) {
         project(
             "empty",
@@ -204,7 +204,8 @@ class JsBrowserTestsIT : KGPBaseTest() {
                                 assertTrue(42 == 0)
                             }
                         }
-                        """.trimIndent())
+                        """.trimIndent()
+                    )
                 }
             }
 
@@ -227,9 +228,13 @@ class JsBrowserTestsIT : KGPBaseTest() {
     @GradleTest
     @OsCondition(
         supportedOn = [OS.LINUX, OS.MAC, OS.WINDOWS],
-        enabledOnCI = [OS.LINUX, OS.MAC])
+        enabledOnCI = [OS.LINUX, OS.MAC]
+    )
     fun `prints clear error message when a test times out`(gradleVersion: GradleVersion) {
-        project("empty", gradleVersion = gradleVersion) {
+        project(
+            "empty", gradleVersion = gradleVersion,
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
+        ) {
             plugins {
                 kotlin("multiplatform")
             }


### PR DESCRIPTION
- Disable isolated projects for failing js test
- Please see [green CI run](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_GradleIntegrationTestsGradleKotlinJSwithBrowsertests_LINUX/1034472360)

^KT-88597