### PR TITLE
[wasm]: Don't erase js external interop types when caching adapters.

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/JsInteropFunctionsLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/JsInteropFunctionsLowering.kt
@@ -741,7 +741,7 @@ class JsInteropFunctionsLowering(val context: WasmBackendContext) : DeclarationT
 
     private fun jsInteropNotNullTypeSignature(type: IrType): String {
         if (isExternalType(type)) {
-            return "Js"
+            return type.classFqName?.asString() ?: "Js"
         }
         require(type is IrSimpleType)
         if (type.isFunction()) {

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/JsInteropFunctionsLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/JsInteropFunctionsLowering.kt
@@ -741,7 +741,13 @@ class JsInteropFunctionsLowering(val context: WasmBackendContext) : DeclarationT
 
     private fun jsInteropNotNullTypeSignature(type: IrType): String {
         if (isExternalType(type)) {
-            return type.classFqName?.asString() ?: "Js"
+            val klass = type.classOrNull?.owner
+            // External interfaces have no runtime type checks.
+            if (klass != null && klass.isInterface) {
+                return "Js"
+            }
+            // External classes retain distinct names to prevent type check collisions.
+            return klass?.fqNameWhenAvailable?.asString() ?: "Js"
         }
         require(type is IrSimpleType)
         if (type.isFunction()) {

--- a/compiler/testData/codegen/boxWasmJsInterop/kt88434.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/kt88434.kt
@@ -1,5 +1,6 @@
 // WITH_STDLIB
 // RUN_THIRD_PARTY_OPTIMIZER
+// TARGET_BACKEND: WASM
 
 // KT-88434
 //
@@ -7,8 +8,8 @@
 // argument/return type collapse to the same JS-erased signature string
 // `(Js)->Js` in JsInteropFunctionsLowering. The JS->Kotlin closure converter is
 // cached per that signature string, so the converter created for the first
-// type is reused for the second, carrying the first type's runtime checks
-// (e.g. an instanceof/ref.test for `Array`). When the reused converter is
+// type was reused for the second, carrying the first type's runtime checks
+// (e.g. an instanceof/ref.test for `Array`). When the reused converter was
 // invoked on a value of the second type the check fails and a
 // ClassCastException is thrown.
 

--- a/compiler/testData/codegen/boxWasmJsInterop/kt88434.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/kt88434.kt
@@ -1,0 +1,38 @@
+// WITH_STDLIB
+// RUN_THIRD_PARTY_OPTIMIZER
+
+// KT-88434
+//
+// Two distinct external function types whose only difference is their (external)
+// argument/return type collapse to the same JS-erased signature string
+// `(Js)->Js` in JsInteropFunctionsLowering. The JS->Kotlin closure converter is
+// cached per that signature string, so the converter created for the first
+// type is reused for the second, carrying the first type's runtime checks
+// (e.g. an instanceof/ref.test for `Array`). When the reused converter is
+// invoked on a value of the second type the check fails and a
+// ClassCastException is thrown.
+
+@JsName("Array")
+external class A : JsAny {
+    val length: Int
+}
+
+external interface B : JsAny {
+    val x: Int
+}
+
+fun array(): A = js("[]")
+fun obj(): B = js("({ x: 1 })")
+
+fun arrayClosure(): (A) -> A = js("x => x")
+fun objectClosure(): (B) -> B = js("x => x")
+
+fun box(): String {
+    val a: A = arrayClosure()(array())
+    if (a.length != 0) return "Fail: array closure returned wrong length"
+
+    val b: B = objectClosure()(obj())
+    if (b.x != 1) return "Fail: object closure returned wrong x"
+
+    return "OK"
+}


### PR DESCRIPTION
As the test case shows, it's possible for different external JS types such as Array and Object to have different converter behavior w.r.t casting. However, the js interop code was too eager in erasing and hence caching the same converter for these types which need different handling.

^KT-88434 Fixed