### PR TITLE
[Gradle] Fix assertion in KotlinWebpackUpToDateIT

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/web/KotlinWebpackUpToDateIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/web/KotlinWebpackUpToDateIT.kt
@@ -124,7 +124,7 @@ sealed class KotlinWebpackUpToDateIT(
                             .trim()
                     }
 
-                val expectedFileBasedDepPath = projectPath.absolute().resolve("sp2/foo-npm-dep").pathString
+                val expectedFileBasedDepPath = projectPath.toRealPath().resolve("sp2/foo-npm-dep").pathString
                 assertEquals(
                     "$buildTaskPath doNotCacheIf=true. Task depends on file-based NPM dependencies: [$expectedFileBasedDepPath]. See KT-86309.",
                     fileBasedNpmDepsLogLines,


### PR DESCRIPTION
The test compared the logged file-based NPM dependency path against `projectPath.absolute()`. On macOS the test project lives under `/var/folders/`, which is a symlink to `/private/var/folders/...`.

`absolute()` only prepends the working directory without resolving symlinks, while the Gradle build logs the canonical path, so the assertion failed on macOS.

Instead use `toRealPath()` to resolves the symlink and yields the same canonical path the build reports, on every platform.