### PR TITLE
[K/N] Pass GCC/lld libraries via a response file to avoid "Argument list too long"

### DIFF
--- a/native/utils/src/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -83,6 +83,21 @@ private fun responseFileArg(tempFiles: TempFiles, responseFilePrefix: String, pa
     return "@${responseFile.absolutePathString()}"
 }
 
+/**
+ * Converts a list of strings into a format suitable for use as a GCC spread argument.
+ */
+private fun List<String>.asGccSpreadArgument(filePrefixName: String, tempFiles: TempFiles): List<String> {
+    if (isEmpty()) return emptyList()
+
+    val argumentsListPath = tempFiles.create(filePrefixName).also {
+        it.writeLines(this@asGccSpreadArgument)
+    }
+
+    // We use the `@` operator to spread the file content into the arg list to avoid
+    // ld.lld error=7 (Argument list too long).
+    return listOf("@${argumentsListPath.absolutePathString()}")
+}
+
 class LinkerArguments(
     val tempFiles: TempFiles,
     val objectFiles: List<ObjectFile>,
@@ -430,6 +445,8 @@ class GccBasedLinker(targetProperties: GccConfigurables)
         }
         val dynamic = kind == LinkerOutputKind.DYNAMIC_LIBRARY
         val crtPrefix = "$absoluteTargetSysRoot/$crtFilesLocation"
+        val staticLibrariesArgs = staticLibraries.asGccSpreadArgument("static", tempFiles)
+        val dynamicLibrariesArgs = dynamicLibraries.asGccSpreadArgument("dynamic", tempFiles)
         // TODO: Can we extract more to the konan.configurables?
         return listOf(Command(absoluteLinker).apply {
             +"--sysroot=${absoluteTargetSysRoot}"
@@ -466,8 +483,8 @@ class GccBasedLinker(targetProperties: GccConfigurables)
                     +provideCompilerRtLibrary("tsan_cxx")!!
                 }
             }
-            +staticLibraries
-            +dynamicLibraries
+            +staticLibrariesArgs
+            +dynamicLibrariesArgs
             +linkerArgs
             // See explanation about `-u__llvm_profile_runtime` here:
             // https://github.com/llvm/llvm-project/blob/21e270a479a24738d641e641115bce6af6ed360a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp#L930

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -84,18 +84,13 @@ private fun responseFileArg(tempFiles: TempFiles, responseFilePrefix: String, pa
 }
 
 /**
- * Converts a list of strings into a format suitable for use as a GCC spread argument.
+ * Passes [this] to GCC/lld via a quoted `@response` file.
+ * Quoting is required so paths with spaces are not split when lld expands the file.
+ * Using `@file` also avoids ld.lld error=7 (Argument list too long).
  */
 private fun List<String>.asGccSpreadArgument(filePrefixName: String, tempFiles: TempFiles): List<String> {
     if (isEmpty()) return emptyList()
-
-    val argumentsListPath = tempFiles.create(filePrefixName).also {
-        it.writeLines(this@asGccSpreadArgument)
-    }
-
-    // We use the `@` operator to spread the file content into the arg list to avoid
-    // ld.lld error=7 (Argument list too long).
-    return listOf("@${argumentsListPath.absolutePathString()}")
+    return listOf(responseFileArg(tempFiles, filePrefixName, this))
 }
 
 class LinkerArguments(


### PR DESCRIPTION
This shows up especially on large projects or when compiler caches pull in hundreds of static libraries: the link command never starts, even though the inputs themselves are valid.

## Youtrack issue
https://youtrack.jetbrains.com/issue/KT-88715

## Cause

`GccBasedLinker` put every static and dynamic library path on the linker command line. The OS has a hard limit on `exec` argument length (`E2BIG` / error 7). Apple (`-filelist`) and MinGW (`@.rsp`) already avoided this; the GCC/lld path did not.

## Fix

Write library paths into a temporary response file (`tempFiles`) and pass `@<file>` to the linker instead of the full list. Empty lists are still passed through unchanged. `ld.lld` reads the paths from the file, so the command line stays short.

This matches the existing Native approach used on other targets.