### PR TITLE
[JS & Wasm] Genericize the IC infrastructure 

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebBackendPipelinePhase.kt
@@ -15,18 +15,23 @@ import org.jetbrains.kotlin.cli.reportInfo
 import org.jetbrains.kotlin.cli.reportLog
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.perfManager
+import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.ir.backend.js.ic.*
 import org.jetbrains.kotlin.js.config.*
 import org.jetbrains.kotlin.util.PhaseType
 import java.io.File
 
-abstract class WebBackendPipelinePhase<Output : WebBackendPipelineArtifact, IntermediateOutput>(
-    name: String
+abstract class WebBackendPipelinePhase<Output, IntermediateOutput, TModuleArtifact, TFileArtifact, TFragments, TBackendContext>(
+    name: String,
 ) : PipelinePhase<ConfigurationPipelineArtifact, Output>(
     name = name,
     preActions = emptySet(),
     postActions = setOf(CheckCompilationErrors.CheckDiagnosticCollector)
-) {
+) where TFragments : IrICProgramFragments,
+        Output : WebBackendPipelineArtifact,
+        TFileArtifact : SrcFileArtifact,
+        TModuleArtifact : ModuleArtifact,
+        TBackendContext : JsCommonBackendContext {
     override fun executePhase(input: ConfigurationPipelineArtifact): Output? {
         val configuration = input.configuration
 
@@ -101,7 +106,7 @@ abstract class WebBackendPipelinePhase<Output : WebBackendPipelineArtifact, Inte
         outputDir: File,
         targetConfiguration: CompilerConfiguration,
         artifactConfiguration: WebArtifactConfiguration,
-    ): List<ModuleArtifact> {
+    ): List<TModuleArtifact> {
 
         targetConfiguration.reportLog("")
         targetConfiguration.reportLog("Building cache:")
@@ -150,12 +155,12 @@ abstract class WebBackendPipelinePhase<Output : WebBackendPipelineArtifact, Inte
         cacheDirectory: String,
         configuration: CompilerConfiguration,
         artifactConfiguration: WebArtifactConfiguration,
-    ): CacheUpdater
+    ): CacheUpdater<TModuleArtifact, TFileArtifact, TFragments, TBackendContext>
 
     protected abstract val klibLoadingPhase: WebIrLoadingPipelinePhase
 
     abstract fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
+        icCaches: List<TModuleArtifact>,
         configuration: CompilerConfiguration,
     ): IntermediateOutput?
 

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebCliPipeline.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebCliPipeline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -11,7 +11,9 @@ import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.KotlinWasmCompilerArguments
 import org.jetbrains.kotlin.cli.pipeline.*
 import org.jetbrains.kotlin.cli.pipeline.web.js.JsBackendPipelinePhase
-import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmBackendPipelinePhase
+import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmMultiModuleBackendPipelinePhase
+import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmRegularBackendPipelinePhase
+import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmSingleModuleBackendPipelinePhase
 import org.jetbrains.kotlin.config.phaser.CompilerPhase
 import org.jetbrains.kotlin.util.PerformanceManager
 
@@ -19,11 +21,11 @@ abstract class WebCliPipeline<T : CommonJsAndWasmCompilerArguments>(
     override val defaultPerformanceManager: PerformanceManager,
 ) : AbstractCliPipeline<T>() {
 
-    abstract fun createCodeGenerationPhase(): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<T>, *>
+    abstract fun createCodeGenerationPhase(arguments: T): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<T>, *>
 
     override fun createCompoundPhase(arguments: T): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<T>, *> {
         return when {
-            arguments.includes != null -> createCodeGenerationPhase()
+            arguments.includes != null -> createCodeGenerationPhase(arguments)
             else -> createKlibSerializationPhase()
         }
     }
@@ -41,7 +43,7 @@ abstract class WebCliPipeline<T : CommonJsAndWasmCompilerArguments>(
 }
 
 class JsCliPipeline(defaultPerformanceManager: PerformanceManager) : WebCliPipeline<K2JSCompilerArguments>(defaultPerformanceManager) {
-    override fun createCodeGenerationPhase(): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<K2JSCompilerArguments>, *> {
+    override fun createCodeGenerationPhase(arguments: K2JSCompilerArguments): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<K2JSCompilerArguments>, *> {
         return JsConfigurationPhase then
                 JsBackendPipelinePhase
     }
@@ -51,9 +53,14 @@ class JsCliPipeline(defaultPerformanceManager: PerformanceManager) : WebCliPipel
 
 class WasmCliPipeline(defaultPerformanceManager: PerformanceManager) :
     WebCliPipeline<KotlinWasmCompilerArguments>(defaultPerformanceManager) {
-    override fun createCodeGenerationPhase(): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<KotlinWasmCompilerArguments>, out WebBackendPipelineArtifact> {
+    override fun createCodeGenerationPhase(arguments: KotlinWasmCompilerArguments): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<KotlinWasmCompilerArguments>, out WebBackendPipelineArtifact> {
+        val backendPhase = when {
+            arguments.wasmIncludedModuleOnly -> WasmSingleModuleBackendPipelinePhase
+            arguments.wasmGenerateClosedWorldMultimodule -> WasmMultiModuleBackendPipelinePhase
+            else -> WasmRegularBackendPipelinePhase
+        }
         return WasmConfigurationPhase then
-                WasmBackendPipelinePhase
+                backendPhase
     }
 
     override val webConfigurationPhase = WasmConfigurationPhase

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/js/JsBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/js/JsBackendPipelinePhase.kt
@@ -14,27 +14,34 @@ import org.jetbrains.kotlin.cli.reportLog
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.perfManager
 import org.jetbrains.kotlin.ir.backend.js.JsICContext
+import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
 import org.jetbrains.kotlin.ir.backend.js.SourceMapsInfo
 import org.jetbrains.kotlin.ir.backend.js.ic.CacheUpdater
 import org.jetbrains.kotlin.ir.backend.js.ic.JsExecutableProducer
 import org.jetbrains.kotlin.ir.backend.js.ic.JsModuleArtifact
-import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
+import org.jetbrains.kotlin.ir.backend.js.ic.JsSrcFileArtifact
 import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.CompilationOutputs
 import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.CompilerResult
+import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.JsIrProgramFragments
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.config.artifactConfigurations
 import org.jetbrains.kotlin.util.PhaseType
 import org.jetbrains.kotlin.util.tryMeasurePhaseTime
 import java.io.File
 
-object JsBackendPipelinePhase : WebBackendPipelinePhase<JsBackendPipelineArtifact, JsBackendPipelineArtifact>(
-    name = "JsBackendPipelinePhase",
-) {
+object JsBackendPipelinePhase : WebBackendPipelinePhase<
+        JsBackendPipelineArtifact,
+        JsBackendPipelineArtifact,
+        JsModuleArtifact,
+        JsSrcFileArtifact,
+        JsIrProgramFragments,
+        JsIrBackendContext,
+        >(name = "JsBackendPipelinePhase") {
     override val klibLoadingPhase: WebIrLoadingPipelinePhase
         get() = JsIrLoadingPipelinePhase
 
     override fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
+        icCaches: List<JsModuleArtifact>,
         configuration: CompilerConfiguration,
     ): JsBackendPipelineArtifact = configuration.perfManager.tryMeasurePhaseTime(PhaseType.Backend) {
         val outputs = configuration
@@ -44,17 +51,16 @@ object JsBackendPipelinePhase : WebBackendPipelinePhase<JsBackendPipelineArtifac
     }
 
     private fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
+        icCaches: List<JsModuleArtifact>,
         configuration: CompilerConfiguration,
         artifactConfiguration: WebArtifactConfiguration,
     ): CompilationOutputs {
         val beforeIc2Js = System.currentTimeMillis()
 
-        val jsArtifacts = icCaches.filterIsInstance<JsModuleArtifact>()
         val jsExecutableProducer = JsExecutableProducer(
             artifactConfiguration,
             sourceMapsInfo = SourceMapsInfo.from(configuration),
-            caches = jsArtifacts,
+            caches = icCaches,
         )
         (val outputs = compilationOut, val rebuiltModules = buildModules) = jsExecutableProducer.buildExecutable(outJsProgram = false)
         outputs.writeAll()
@@ -74,7 +80,7 @@ object JsBackendPipelinePhase : WebBackendPipelinePhase<JsBackendPipelineArtifac
         cacheDirectory: String,
         configuration: CompilerConfiguration,
         artifactConfiguration: WebArtifactConfiguration
-    ): CacheUpdater = CacheUpdater(
+    ) = CacheUpdater(
         cacheDir = cacheDirectory,
         compilerConfiguration = configuration,
         artifactConfiguration = artifactConfiguration,

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmBackendPipelinePhase.kt
@@ -17,6 +17,9 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.perfManager
 import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
 import org.jetbrains.kotlin.ir.backend.js.ic.CacheUpdater
+import org.jetbrains.kotlin.ir.backend.js.ic.IrICProgramFragments
+import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
+import org.jetbrains.kotlin.ir.backend.js.ic.SrcFileArtifact
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.config.outputDir
 import org.jetbrains.kotlin.js.config.sourceMap
@@ -26,9 +29,18 @@ import org.jetbrains.kotlin.wasm.config.wasmDebug
 import org.jetbrains.kotlin.wasm.config.wasmGenerateDwarf
 import org.jetbrains.kotlin.wasm.config.wasmGenerateWat
 
-abstract class WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPipelineArtifact, List<WasmIrModuleConfiguration>>(
-    name = "WasmBackendPipelinePhase",
-) {
+abstract class WasmBackendPipelinePhase<TModuleArtifact, TFileArtifact, TFragments, TIcContext> : WebBackendPipelinePhase<
+        WasmBackendPipelineArtifact,
+        List<WasmIrModuleConfiguration>,
+        TModuleArtifact,
+        TFileArtifact,
+        TFragments,
+        WasmBackendContext
+        >(name = "WasmBackendPipelinePhase")
+        where TModuleArtifact : ModuleArtifact,
+              TFileArtifact : SrcFileArtifact,
+              TFragments : IrICProgramFragments,
+              TIcContext : WasmICContextBase<TModuleArtifact, TFileArtifact, TFragments> {
     override val klibLoadingPhase: WebIrLoadingPipelinePhase
         get() = WasmIrLoadingPipelinePhase
 
@@ -56,13 +68,13 @@ abstract class WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPip
         skipLocalNames: Boolean,
         skipCommentInstructions: Boolean,
         skipLocations: Boolean,
-    ): WasmICContextBase
+    ): TIcContext
 
     override fun createCacheUpdater(
         cacheDirectory: String,
         configuration: CompilerConfiguration,
         artifactConfiguration: WebArtifactConfiguration
-    ): CacheUpdater {
+    ): CacheUpdater<TModuleArtifact, TFileArtifact, TFragments, WasmBackendContext> {
         val icContext = createIcContext(
             false,
             !configuration.wasmDebug,

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmBackendPipelinePhase.kt
@@ -7,9 +7,7 @@ package org.jetbrains.kotlin.cli.pipeline.web.wasm
 
 import org.jetbrains.kotlin.backend.wasm.*
 import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextMultimodule
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextSingleModule
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextWholeWorld
+import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextBase
 import org.jetbrains.kotlin.cli.pipeline.web.WasmBackendPipelineArtifact
 import org.jetbrains.kotlin.cli.pipeline.web.WebBackendPipelinePhase
 import org.jetbrains.kotlin.cli.pipeline.web.WebIrLoadingPipelinePhase
@@ -17,19 +15,18 @@ import org.jetbrains.kotlin.cli.pipeline.web.WebLoadedIrPipelineArtifact
 import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmCompilationMode.Companion.wasmCompilationMode
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.perfManager
+import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
 import org.jetbrains.kotlin.ir.backend.js.ic.CacheUpdater
-import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.config.outputDir
 import org.jetbrains.kotlin.js.config.sourceMap
-import org.jetbrains.kotlin.library.isWasmStdlib
 import org.jetbrains.kotlin.util.PhaseType
 import org.jetbrains.kotlin.util.tryMeasurePhaseTime
 import org.jetbrains.kotlin.wasm.config.wasmDebug
 import org.jetbrains.kotlin.wasm.config.wasmGenerateDwarf
 import org.jetbrains.kotlin.wasm.config.wasmGenerateWat
 
-object WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPipelineArtifact, List<WasmIrModuleConfiguration>>(
+abstract class WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPipelineArtifact, List<WasmIrModuleConfiguration>>(
     name = "WasmBackendPipelinePhase",
 ) {
     override val klibLoadingPhase: WebIrLoadingPipelinePhase
@@ -54,30 +51,19 @@ object WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPipelineArt
         WasmBackendPipelineArtifact(results, outputDir, configuration)
     }
 
-    override fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
-        configuration: CompilerConfiguration,
-    ): List<WasmIrModuleConfiguration> {
-        val fragmentCompiler = when (configuration.wasmCompilationMode()) {
-            WasmCompilationMode.MULTI_MODULE -> ::compileIncrementallyMultimodule
-            WasmCompilationMode.SINGLE_MODULE -> ::compileIncrementallySingleModule
-            WasmCompilationMode.REGULAR -> ::compileIncrementallyWholeWorld
-        }
-        return fragmentCompiler(icCaches, configuration)
-    }
+    protected abstract fun createIcContext(
+        allowIncompleteImplementations: Boolean,
+        skipLocalNames: Boolean,
+        skipCommentInstructions: Boolean,
+        skipLocations: Boolean,
+    ): WasmICContextBase
 
     override fun createCacheUpdater(
         cacheDirectory: String,
         configuration: CompilerConfiguration,
         artifactConfiguration: WebArtifactConfiguration
     ): CacheUpdater {
-        val compilationMode = configuration.wasmCompilationMode()
-        val contextConstructor = when (compilationMode) {
-            WasmCompilationMode.REGULAR -> ::WasmICContextWholeWorld
-            WasmCompilationMode.MULTI_MODULE -> ::WasmICContextMultimodule
-            WasmCompilationMode.SINGLE_MODULE -> ::WasmICContextSingleModule
-        }
-        val icContext = contextConstructor(
+        val icContext = createIcContext(
             false,
             !configuration.wasmDebug,
             !configuration.wasmGenerateWat,
@@ -89,21 +75,20 @@ object WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPipelineArt
             artifactConfiguration = artifactConfiguration,
             icContext = icContext,
             checkForClassStructuralChanges = true,
-            loadBodiesOnlyForMainModule = compilationMode == WasmCompilationMode.SINGLE_MODULE,
+            loadBodiesOnlyForMainModule = configuration.wasmCompilationMode() == WasmCompilationMode.SINGLE_MODULE,
         )
     }
+
+    protected abstract fun createNonIncrementalCompiler(
+        configuration: CompilerConfiguration,
+        irFactory: IrFactoryImplForWasmIC,
+        module: ModulesStructure,
+    ): WasmCompilerBase
 
     override fun compileNonIncrementally(loadedIrArtifact: WebLoadedIrPipelineArtifact): List<WasmIrModuleConfiguration> {
         (val loadedIr = moduleInfo, val module = moduleStructure, val configuration) = loadedIrArtifact
         val irFactory = loadedIr.bultins.irFactory as IrFactoryImplForWasmIC
-        val compiler = when (configuration.wasmCompilationMode()) {
-            WasmCompilationMode.MULTI_MODULE ->
-                WholeWorldMultiModuleCompiler(configuration, irFactory)
-            WasmCompilationMode.SINGLE_MODULE ->
-                SingleModuleCompiler(configuration, irFactory, isWasmStdlib = module.klibs.included?.isWasmStdlib == true)
-            WasmCompilationMode.REGULAR ->
-                WholeWorldCompiler(configuration, irFactory)
-        }
+        val compiler = createNonIncrementalCompiler(configuration, irFactory, module)
 
         val [allModules, context] = configuration.perfManager.tryMeasurePhaseTime(PhaseType.IrLinking) {
             linkIr(loadedIr, configuration)

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmMultiModuleBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmMultiModuleBackendPipelinePhase.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.cli.pipeline.web.wasm
+
+import org.jetbrains.kotlin.backend.wasm.WasmIrModuleConfiguration
+import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
+import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextMultimodule
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
+import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
+
+object WasmMultiModuleBackendPipelinePhase : WasmBackendPipelinePhase() {
+    override fun compileIncrementally(
+        icCaches: List<ModuleArtifact>,
+        configuration: CompilerConfiguration
+    ): List<WasmIrModuleConfiguration> = compileIncrementallyMultimodule(icCaches, configuration)
+
+    override fun createIcContext(
+        allowIncompleteImplementations: Boolean,
+        skipLocalNames: Boolean,
+        skipCommentInstructions: Boolean,
+        skipLocations: Boolean
+    ): WasmICContextMultimodule = WasmICContextMultimodule(
+        allowIncompleteImplementations,
+        skipLocalNames,
+        skipCommentInstructions,
+        skipLocations,
+    )
+
+    override fun createNonIncrementalCompiler(
+        configuration: CompilerConfiguration,
+        irFactory: IrFactoryImplForWasmIC,
+        module: ModulesStructure,
+    ): WholeWorldMultiModuleCompiler = WholeWorldMultiModuleCompiler(configuration, irFactory)
+}

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmMultiModuleBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmMultiModuleBackendPipelinePhase.kt
@@ -8,13 +8,20 @@ package org.jetbrains.kotlin.cli.pipeline.web.wasm
 import org.jetbrains.kotlin.backend.wasm.WasmIrModuleConfiguration
 import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
 import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextMultimodule
+import org.jetbrains.kotlin.backend.wasm.ic.WasmIrProgramFragmentsMultimodule
+import org.jetbrains.kotlin.backend.wasm.ic.WasmModuleArtifactMultimodule
+import org.jetbrains.kotlin.backend.wasm.ic.WasmSrcFileArtifactMultimodule
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
-import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
 
-object WasmMultiModuleBackendPipelinePhase : WasmBackendPipelinePhase() {
+object WasmMultiModuleBackendPipelinePhase : WasmBackendPipelinePhase<
+        WasmModuleArtifactMultimodule,
+        WasmSrcFileArtifactMultimodule,
+        WasmIrProgramFragmentsMultimodule,
+        WasmICContextMultimodule
+        >() {
     override fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
+        icCaches: List<WasmModuleArtifactMultimodule>,
         configuration: CompilerConfiguration
     ): List<WasmIrModuleConfiguration> = compileIncrementallyMultimodule(icCaches, configuration)
 

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmRegularBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmRegularBackendPipelinePhase.kt
@@ -6,15 +6,18 @@
 package org.jetbrains.kotlin.cli.pipeline.web.wasm
 
 import org.jetbrains.kotlin.backend.wasm.WasmIrModuleConfiguration
-import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextWholeWorld
+import org.jetbrains.kotlin.backend.wasm.ic.*
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
-import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
 
-object WasmRegularBackendPipelinePhase : WasmBackendPipelinePhase() {
+object WasmRegularBackendPipelinePhase : WasmBackendPipelinePhase<
+        WasmModuleArtifact,
+        WasmSrcFileArtifact,
+        WasmIrProgramFragments,
+        WasmICContextWholeWorld,
+        >() {
     override fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
+        icCaches: List<WasmModuleArtifact>,
         configuration: CompilerConfiguration
     ): List<WasmIrModuleConfiguration> = compileIncrementallyWholeWorld(icCaches, configuration)
 

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmRegularBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmRegularBackendPipelinePhase.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.cli.pipeline.web.wasm
+
+import org.jetbrains.kotlin.backend.wasm.WasmIrModuleConfiguration
+import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
+import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextWholeWorld
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
+import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
+
+object WasmRegularBackendPipelinePhase : WasmBackendPipelinePhase() {
+    override fun compileIncrementally(
+        icCaches: List<ModuleArtifact>,
+        configuration: CompilerConfiguration
+    ): List<WasmIrModuleConfiguration> = compileIncrementallyWholeWorld(icCaches, configuration)
+
+    override fun createIcContext(
+        allowIncompleteImplementations: Boolean,
+        skipLocalNames: Boolean,
+        skipCommentInstructions: Boolean,
+        skipLocations: Boolean
+    ): WasmICContextWholeWorld = WasmICContextWholeWorld(
+        allowIncompleteImplementations,
+        skipLocalNames,
+        skipCommentInstructions,
+        skipLocations,
+    )
+
+    override fun createNonIncrementalCompiler(
+        configuration: CompilerConfiguration,
+        irFactory: IrFactoryImplForWasmIC,
+        module: ModulesStructure,
+    ): WholeWorldCompiler = WholeWorldCompiler(configuration, irFactory)
+}

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmSingleModuleBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmSingleModuleBackendPipelinePhase.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.cli.pipeline.web.wasm
+
+import org.jetbrains.kotlin.backend.wasm.WasmIrModuleConfiguration
+import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
+import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextSingleModule
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
+import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
+import org.jetbrains.kotlin.library.isWasmStdlib
+
+object WasmSingleModuleBackendPipelinePhase : WasmBackendPipelinePhase() {
+    override fun compileIncrementally(
+        icCaches: List<ModuleArtifact>,
+        configuration: CompilerConfiguration
+    ): List<WasmIrModuleConfiguration> = compileIncrementallySingleModule(icCaches, configuration)
+
+    override fun createIcContext(
+        allowIncompleteImplementations: Boolean,
+        skipLocalNames: Boolean,
+        skipCommentInstructions: Boolean,
+        skipLocations: Boolean
+    ): WasmICContextSingleModule = WasmICContextSingleModule(
+        allowIncompleteImplementations,
+        skipLocalNames,
+        skipCommentInstructions,
+        skipLocations,
+    )
+
+    override fun createNonIncrementalCompiler(
+        configuration: CompilerConfiguration,
+        irFactory: IrFactoryImplForWasmIC,
+        module: ModulesStructure
+    ): SingleModuleCompiler = SingleModuleCompiler(
+        configuration,
+        irFactory,
+        isWasmStdlib = module.klibs.included?.isWasmStdlib == true,
+    )
+}

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmSingleModuleBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmSingleModuleBackendPipelinePhase.kt
@@ -8,14 +8,22 @@ package org.jetbrains.kotlin.cli.pipeline.web.wasm
 import org.jetbrains.kotlin.backend.wasm.WasmIrModuleConfiguration
 import org.jetbrains.kotlin.backend.wasm.ic.IrFactoryImplForWasmIC
 import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextSingleModule
+import org.jetbrains.kotlin.backend.wasm.ic.WasmIrProgramFragmentsSingleModule
+import org.jetbrains.kotlin.backend.wasm.ic.WasmModuleArtifactSingleModule
+import org.jetbrains.kotlin.backend.wasm.ic.WasmSrcFileArtifactSingleModule
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.ir.backend.js.ModulesStructure
-import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
 import org.jetbrains.kotlin.library.isWasmStdlib
 
-object WasmSingleModuleBackendPipelinePhase : WasmBackendPipelinePhase() {
+object WasmSingleModuleBackendPipelinePhase : WasmBackendPipelinePhase<
+        WasmModuleArtifactSingleModule,
+        WasmSrcFileArtifactSingleModule,
+        WasmIrProgramFragmentsSingleModule,
+        WasmICContextSingleModule,
+        >() {
+
     override fun compileIncrementally(
-        icCaches: List<ModuleArtifact>,
+        icCaches: List<WasmModuleArtifactSingleModule>,
         configuration: CompilerConfiguration
     ): List<WasmIrModuleConfiguration> = compileIncrementallySingleModule(icCaches, configuration)
 

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/compilerWithIC.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/compilerWithIC.kt
@@ -9,8 +9,10 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.phaser.PhaserState
 import org.jetbrains.kotlin.ir.IrBuiltIns
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
-import org.jetbrains.kotlin.ir.backend.js.ic.*
+import org.jetbrains.kotlin.ir.backend.js.ic.IrCompilerICInterface
+import org.jetbrains.kotlin.ir.backend.js.ic.JsModuleArtifact
+import org.jetbrains.kotlin.ir.backend.js.ic.JsSrcFileArtifact
+import org.jetbrains.kotlin.ir.backend.js.ic.PlatformDependentICContext
 import org.jetbrains.kotlin.ir.backend.js.lower.collectNativeImplementations
 import org.jetbrains.kotlin.ir.backend.js.lower.generateJsTests
 import org.jetbrains.kotlin.ir.backend.js.lower.moveBodilessDeclarationsToSeparatePlace
@@ -25,7 +27,8 @@ import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.js.config.JsGenerationGranularity
 import java.io.File
 
-class JsICContext(private val granularity: JsGenerationGranularity) : PlatformDependentICContext {
+class JsICContext(private val granularity: JsGenerationGranularity) :
+    PlatformDependentICContext<JsModuleArtifact, JsSrcFileArtifact, JsIrProgramFragments, JsIrBackendContext> {
     override fun getICCacheStableKeys(): Set<CompilerConfigurationKey<*>> =
         setOf(
             JSConfigurationKeys.LIBRARIES,
@@ -36,13 +39,12 @@ class JsICContext(private val granularity: JsGenerationGranularity) : PlatformDe
     override fun createIrFactory(): IrFactory =
         IrFactoryImplForJsIC(WholeWorldStageController())
 
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
     override fun createBackendContext(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         symbolTable: SymbolTable,
         configuration: CompilerConfiguration,
-    ): JsCommonBackendContext {
+    ): JsIrBackendContext {
         return JsIrBackendContext(
             mainModule,
             irBuiltIns,
@@ -56,31 +58,30 @@ class JsICContext(private val granularity: JsGenerationGranularity) : PlatformDe
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface =
-        JsIrCompilerWithIC(mainModule, context as JsIrBackendContext, granularity)
+        context: JsIrBackendContext,
+    ): IrCompilerICInterface<JsIrProgramFragments> =
+        JsIrCompilerWithIC(mainModule, context, granularity)
 
-    override fun createSrcFileArtifact(srcFilePath: String, fragments: IrICProgramFragments?, astArtifact: File?): SrcFileArtifact =
-        JsSrcFileArtifact(srcFilePath, fragments as? JsIrProgramFragments, astArtifact)
+    override fun createSrcFileArtifact(srcFilePath: String, fragments: JsIrProgramFragments?, astArtifact: File?): JsSrcFileArtifact =
+        JsSrcFileArtifact(srcFilePath, fragments, astArtifact)
 
     override fun createModuleArtifact(
         moduleName: String,
-        fileArtifacts: List<SrcFileArtifact>,
+        fileArtifacts: List<JsSrcFileArtifact>,
         artifactsDir: File?,
         forceRebuild: Boolean,
         externalModuleName: String?,
-    ): ModuleArtifact =
-        JsModuleArtifact(moduleName, fileArtifacts.map { it as JsSrcFileArtifact }, artifactsDir, forceRebuild, externalModuleName)
+    ): JsModuleArtifact =
+        JsModuleArtifact(moduleName, fileArtifacts, artifactsDir, forceRebuild, externalModuleName)
 }
 
-@OptIn(ObsoleteDescriptorBasedAPI::class)
 class JsIrCompilerWithIC(
     private val mainModule: IrModuleFragment,
     private val context: JsIrBackendContext,
     private val granularity: JsGenerationGranularity,
-) : IrCompilerICInterface {
+) : IrCompilerICInterface<JsIrProgramFragments> {
 
-    override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> IrICProgramFragments> {
+    override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> JsIrProgramFragments> {
         val shouldGeneratePolyfills = context.configuration.getBoolean(JSConfigurationKeys.GENERATE_POLYFILLS)
 
         allModules.forEach {

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/CacheUpdater.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/CacheUpdater.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.ir.backend.js.JsICContext
 import org.jetbrains.kotlin.ir.backend.js.loadWebKlibs
+import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.JsIrProgramFragments
 import org.jetbrains.kotlin.ir.declarations.IrFactory
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
@@ -37,9 +38,9 @@ import java.nio.file.Files
 import java.util.*
 import kotlin.streams.toList
 
-abstract class IrICModule {
+abstract class IrICModule<TFragment : IrICProgramFragment> {
     abstract val moduleName: String
-    abstract val fragments: List<IrICProgramFragment>
+    abstract val fragments: List<TFragment>
 }
 
 abstract class IrICProgramFragment
@@ -48,12 +49,12 @@ abstract class IrICProgramFragments {
     abstract fun serialize(stream: OutputStream)
 }
 
-fun interface IrCompilerICInterface {
+fun interface IrCompilerICInterface<out TFragments : IrICProgramFragments> {
     /**
      * It is expected that the method implementation runs a lowering pipeline
      * and produces a list of generators capable of generating JS AST fragments.
      */
-    fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> IrICProgramFragments>
+    fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> TFragments>
 }
 
 enum class DirtyFileState(val str: String) {
@@ -67,7 +68,11 @@ enum class DirtyFileState(val str: String) {
     REMOVED_FILE("removed file")
 }
 
-interface PlatformDependentICContext {
+interface PlatformDependentICContext<out TModuleArtifact, TFileArtifact, TFragments, TBackendContext>
+        where TModuleArtifact : ModuleArtifact,
+              TFileArtifact : SrcFileArtifact,
+              TFragments : IrICProgramFragments,
+              TBackendContext : JsCommonBackendContext {
     fun getICCacheStableKeys(): Set<CompilerConfigurationKey<*>>
 
     fun createIrFactory(): IrFactory
@@ -77,7 +82,7 @@ interface PlatformDependentICContext {
         irBuiltIns: IrBuiltIns,
         symbolTable: SymbolTable,
         configuration: CompilerConfiguration,
-    ): JsCommonBackendContext
+    ): TBackendContext
 
     /**
      * It is expected that the method implementation creates a backend context and initializes all builtins and intrinsics.
@@ -86,18 +91,18 @@ interface PlatformDependentICContext {
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface
+        context: TBackendContext,
+    ): IrCompilerICInterface<TFragments>
 
-    fun createSrcFileArtifact(srcFilePath: String, fragments: IrICProgramFragments?, astArtifact: File? = null): SrcFileArtifact
+    fun createSrcFileArtifact(srcFilePath: String, fragments: TFragments?, astArtifact: File? = null): TFileArtifact
 
     fun createModuleArtifact(
         moduleName: String,
-        fileArtifacts: List<SrcFileArtifact>,
+        fileArtifacts: List<TFileArtifact>,
         artifactsDir: File? = null,
         forceRebuild: Boolean = false,
         externalModuleName: String? = null
-    ): ModuleArtifact
+    ): TModuleArtifact
 }
 
 /**
@@ -114,14 +119,17 @@ interface PlatformDependentICContext {
  *  For a better understanding of what happens here, pay attention to [stopwatch] usages.
  *  In every place, it has a short description about the code it measures.
  */
-class CacheUpdater(
+class CacheUpdater<TModuleArtifact, TFileArtifact, TFragments, TBackendContext>(
     cacheDir: String,
     private val compilerConfiguration: CompilerConfiguration,
     artifactConfiguration: WebArtifactConfiguration,
-    private val icContext: PlatformDependentICContext,
+    private val icContext: PlatformDependentICContext<TModuleArtifact, TFileArtifact, TFragments, TBackendContext>,
     checkForClassStructuralChanges: Boolean = false,
     private val loadBodiesOnlyForMainModule: Boolean = false,
-) {
+) where TModuleArtifact : ModuleArtifact,
+        TFileArtifact : SrcFileArtifact,
+        TFragments : IrICProgramFragments,
+        TBackendContext : JsCommonBackendContext {
     private val stopwatch = StopwatchIC()
 
     private val dirtyFileStats = KotlinSourceFileMutableMap<EnumSet<DirtyFileState>>()
@@ -672,8 +680,8 @@ class CacheUpdater(
     private fun commitCacheAndBuildModuleArtifacts(
         incrementalCacheArtifacts: Map<KotlinLibraryFile, IncrementalCacheArtifact>,
         moduleNames: Map<KotlinLibraryFile, String>,
-        rebuiltFileFragments: KotlinSourceFileMap<IrICProgramFragments>
-    ): List<ModuleArtifact> = stopwatch.measure("Incremental cache - committing artifacts") {
+        rebuiltFileFragments: KotlinSourceFileMap<TFragments>
+    ): List<TModuleArtifact> = stopwatch.measure("Incremental cache - committing artifacts") {
         incrementalCacheArtifacts.map { [libFile, incrementalCacheArtifact] ->
             val rebuildFileFragments = rebuiltFileFragments[libFile] ?: emptyMap()
             incrementalCacheArtifact.commitCache(
@@ -688,10 +696,10 @@ class CacheUpdater(
     }
 
     private fun compileDirtyFiles(
-        compilerForIC: IrCompilerICInterface,
+        compilerForIC: IrCompilerICInterface<TFragments>,
         loadedIr: LoadedJsIr,
         dirtyFiles: Map<KotlinLibraryFile, Set<KotlinSourceFile>>
-    ): MutableList<Triple<KotlinLibraryFile, KotlinSourceFile, () -> IrICProgramFragments>> =
+    ): MutableList<Triple<KotlinLibraryFile, KotlinSourceFile, () -> TFragments>> =
         stopwatch.measure("Processing IR - lowering") {
             val dirtyFilesForCompiling = mutableListOf<IrFile>()
             val dirtyFilesForRestoring = mutableListOf<Pair<KotlinLibraryFile, KotlinSourceFile>>()
@@ -716,14 +724,14 @@ class CacheUpdater(
             }
         }
 
-    private data class IrForDirtyFilesAndCompiler(
+    private data class IrForDirtyFilesAndCompiler<TFragments : IrICProgramFragments>(
         val incrementalCacheArtifacts: Map<KotlinLibraryFile, IncrementalCacheArtifact>,
         val loadedIr: LoadedJsIr,
         val dirtyFiles: Map<KotlinLibraryFile, Set<KotlinSourceFile>>,
-        val irCompiler: IrCompilerICInterface
+        val irCompiler: IrCompilerICInterface<TFragments>
     )
 
-    private fun loadIrForDirtyFilesAndInitCompiler(): IrForDirtyFilesAndCompiler {
+    private fun loadIrForDirtyFilesAndInitCompiler(): IrForDirtyFilesAndCompiler<TFragments> {
         val updater = CacheUpdaterInternal()
 
         stopwatch.startNext("Modified files - checking hashes and collecting")
@@ -803,13 +811,13 @@ class CacheUpdater(
         return IrForDirtyFilesAndCompiler(incrementalCachesArtifacts, loadedIr, dirtyFiles, compilerForIC)
     }
 
-    private data class FragmentGenerators(
+    private data class FragmentGenerators<TFragments : IrICProgramFragments>(
         val incrementalCacheArtifacts: Map<KotlinLibraryFile, IncrementalCacheArtifact>,
         val moduleNames: Map<KotlinLibraryFile, String>,
-        val generators: MutableList<Triple<KotlinLibraryFile, KotlinSourceFile, () -> IrICProgramFragments>>
+        val generators: MutableList<Triple<KotlinLibraryFile, KotlinSourceFile, () -> TFragments>>
     )
 
-    private fun loadIrAndMakeIrFragmentGenerators(): FragmentGenerators {
+    private fun loadIrAndMakeIrFragmentGenerators(): FragmentGenerators<TFragments> {
         (val incrementalCachesArtifacts = incrementalCacheArtifacts, val loadedIr, val dirtyFiles, val irCompiler) = loadIrForDirtyFilesAndInitCompiler()
 
         val moduleNames = loadedIr.orderedFragments.entries.associate { it.key to it.value.name.asString() }
@@ -820,9 +828,9 @@ class CacheUpdater(
     }
 
     private fun generateIrFragments(
-        generators: MutableList<Triple<KotlinLibraryFile, KotlinSourceFile, () -> IrICProgramFragments>>
-    ): KotlinSourceFileMap<IrICProgramFragments> = stopwatch.measure("Processing IR - generating program fragments") {
-        val rebuiltFragments = KotlinSourceFileMutableMap<IrICProgramFragments>()
+        generators: MutableList<Triple<KotlinLibraryFile, KotlinSourceFile, () -> TFragments>>
+    ): KotlinSourceFileMap<TFragments> = stopwatch.measure("Processing IR - generating program fragments") {
+        val rebuiltFragments = KotlinSourceFileMutableMap<TFragments>()
         while (generators.isNotEmpty()) {
             val [libFile, srcFile, fragmentGenerator] = generators.removeFirst()
             rebuiltFragments[libFile, srcFile] = fragmentGenerator()
@@ -842,7 +850,7 @@ class CacheUpdater(
      *   It contains either paths to files with serialized JS AST or the deserialized [IrICProgramFragments] objects themselves
      *   for every file in the generating JS module. The list should be used for building the final JS module in [JsExecutableProducer]
      */
-    fun actualizeCaches(): List<ModuleArtifact> {
+    fun actualizeCaches(): List<TModuleArtifact> {
         stopwatch.clear()
         dirtyFileStats.clear()
 
@@ -860,7 +868,7 @@ fun rebuildCacheForDirtyFiles(
     configuration: CompilerConfiguration,
     orderedLibraries: List<KotlinLibrary>,
     dirtyFiles: Collection<String>?,
-): Pair<IrModuleFragment, List<Pair<IrFile, IrICProgramFragments>>> {
+): Pair<IrModuleFragment, List<Pair<IrFile, JsIrProgramFragments>>> {
     val irInterner = IrInterningService()
     val emptyMetadata = object : KotlinSourceFileExports() {
         override val inverseDependencies = KotlinSourceFileMap<Set<IdSignature>>(emptyMap())

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/IncrementalCacheArtifact.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/IncrementalCacheArtifact.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlin.ir.backend.js.ic
 
+import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.utils.newHashSetWithExpectedSize
 import java.io.BufferedOutputStream
 import java.io.File
@@ -64,11 +65,14 @@ internal class IncrementalCacheArtifact(
         }
     }
 
-    fun buildModuleArtifact(
+    fun <TModuleArtifact, TFileArtifact, TFragments> buildModuleArtifact(
         moduleName: String,
-        rebuiltFileFragments: Map<KotlinSourceFile, IrICProgramFragments>,
-        icContext: PlatformDependentICContext,
-    ): ModuleArtifact {
+        rebuiltFileFragments: Map<KotlinSourceFile, TFragments>,
+        icContext: PlatformDependentICContext<TModuleArtifact, TFileArtifact, TFragments, *>,
+    ): TModuleArtifact
+            where TModuleArtifact : ModuleArtifact,
+                  TFileArtifact : SrcFileArtifact,
+                  TFragments : IrICProgramFragments {
         val fileArtifacts = srcCacheActions.map { srcFileAction ->
             val rebuiltFileFragment = rebuiltFileFragments[srcFileAction.srcFile]
             icContext.createSrcFileArtifact(srcFileAction.srcFile.path, rebuiltFileFragment, srcFileAction.binaryAstFile)

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/JsIrLinkerLoader.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/JsIrLinkerLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.ir.InternalSymbolFinderAPI
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.backend.js.FunctionTypeInterfacePackages
 import org.jetbrains.kotlin.ir.backend.js.lower.serialization.ir.JsIrLinker
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -128,7 +127,7 @@ internal class JsIrLinkerLoader(
     private val compilerConfiguration: CompilerConfiguration,
     private val orderedLibraries: List<KotlinLibrary>,
     private val mainModuleFriends: Collection<KotlinLibrary>,
-    private val icContext: PlatformDependentICContext,
+    private val icContext: PlatformDependentICContext<*, *, *, *>,
     private val stubbedSignatures: Set<IdSignature>,
     private val loadBodiesOnlyForMainModule: Boolean,
     private val mainLibrary: KotlinLibrary,
@@ -243,7 +242,6 @@ internal class JsIrLinkerLoader(
             }
         }
 
-        @OptIn(ObsoleteDescriptorBasedAPI::class)
         val loadedIr = LoadedJsIr(irModules, irBuiltIns, linker)
 
         // This should be done because referenced declaration from the compiler should be loaded as well

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIrProgramFragment.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIrProgramFragment.kt
@@ -52,7 +52,7 @@ class JsIrModule(
     override val fragments: List<JsIrProgramFragment>,
     val reexportedInModuleWithName: String? = null,
     val importedWithEffectInModuleWithName: String? = null,
-) : IrICModule() {
+) : IrICModule<JsIrProgramFragment>() {
     fun makeModuleHeader(): JsIrModuleHeader {
         val nameBindings = mutableMapOf<String, String>()
         val definitions = mutableSetOf<String>()

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/compilerWithIC.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/compilerWithIC.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.backend.wasm.ic.WasmIrProgramFragmentsMultimodule
 import org.jetbrains.kotlin.backend.wasm.ic.WasmIrProgramFragmentsSingleModule
 import org.jetbrains.kotlin.backend.wasm.ic.overrideBuiltInsSignatures
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.*
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.backend.js.WholeWorldStageController
 import org.jetbrains.kotlin.ir.backend.js.ic.IrCompilerICInterface
 import org.jetbrains.kotlin.ir.backend.js.ic.IrICProgramFragments
@@ -19,17 +18,16 @@ import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.wasm.config.wasmDisableCrossFileOptimisations
 
-@OptIn(ObsoleteDescriptorBasedAPI::class)
-abstract class WasmCompilerWithIC(
+abstract class WasmCompilerWithIC<TProgramFragments : IrICProgramFragments>(
     val mainModule: IrModuleFragment,
     val context: WasmBackendContext,
-) : IrCompilerICInterface {
+) : IrCompilerICInterface<TProgramFragments> {
     protected val idSignatureRetriever = context.irFactory as IdSignatureRetriever
     protected val wasmModuleMetadataCache: WasmModuleMetadataCache = WasmModuleMetadataCache(context)
 
-    abstract fun compileFile(irFile: IrFile): IrICProgramFragments
+    abstract fun compileFile(irFile: IrFile): TProgramFragments
 
-    override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> IrICProgramFragments> {
+    override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> TProgramFragments> {
         //TODO: Lower only needed files but not all loaded by IrLoader KT-71041
 
         context.configuration.wasmDisableCrossFileOptimisations = true
@@ -45,14 +43,13 @@ abstract class WasmCompilerWithIC(
     }
 }
 
-@OptIn(ObsoleteDescriptorBasedAPI::class)
 open class WasmCompilerWithICMultimodule(
     mainModule: IrModuleFragment,
     private val allowIncompleteImplementations: Boolean,
     private val skipCommentInstructions: Boolean,
     private val skipLocations: Boolean,
     context: WasmBackendContext,
-) : WasmCompilerWithIC(
+) : WasmCompilerWithIC<WasmIrProgramFragmentsMultimodule>(
     mainModule = mainModule,
     context = context,
 ) {
@@ -124,14 +121,13 @@ open class WasmCompilerWithICMultimodule(
     }
 }
 
-@OptIn(ObsoleteDescriptorBasedAPI::class)
 open class WasmCompilerWithICSingleModule(
     mainModule: IrModuleFragment,
     private val allowIncompleteImplementations: Boolean,
     private val skipCommentInstructions: Boolean,
     private val skipLocations: Boolean,
     context: WasmBackendContext,
-) : WasmCompilerWithIC(
+) : WasmCompilerWithIC<WasmIrProgramFragmentsSingleModule>(
     mainModule = mainModule,
     context = context,
 ) {
@@ -237,14 +233,13 @@ open class WasmCompilerWithICSingleModule(
 }
 
 
-@OptIn(ObsoleteDescriptorBasedAPI::class)
 open class WasmCompilerWithICWholeWorld(
     mainModule: IrModuleFragment,
     private val allowIncompleteImplementations: Boolean,
     private val skipCommentInstructions: Boolean,
     private val skipLocations: Boolean,
     context: WasmBackendContext,
-) : WasmCompilerWithIC(
+) : WasmCompilerWithIC<WasmIrProgramFragments>(
     mainModule = mainModule,
     context = context,
 ) {

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ic/IrFactoryImplForWasmIC.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ic/IrFactoryImplForWasmIC.kt
@@ -1,17 +1,10 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlin.backend.wasm.ic
 
-import org.jetbrains.kotlin.wasm.config.WasmConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.ir.backend.js.WholeWorldStageController
-import org.jetbrains.kotlin.ir.backend.js.ic.*
-import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.util.IdSignature
-import org.jetbrains.kotlin.ir.util.fileOrNull
 import org.jetbrains.kotlin.backend.common.compilationException
 import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
 import org.jetbrains.kotlin.backend.wasm.WasmCompilerWithICMultimodule
@@ -26,17 +19,30 @@ import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.Functions.tryGetAsso
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.Functions.unitGetInstanceBuiltIn
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.HeapTypes.anyBuiltInType
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.HeapTypes.throwableBuiltInType
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.ir.IrBuiltIns
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
-import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
+import org.jetbrains.kotlin.ir.backend.js.WholeWorldStageController
+import org.jetbrains.kotlin.ir.backend.js.ic.IrICProgramFragments
+import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
+import org.jetbrains.kotlin.ir.backend.js.ic.PlatformDependentICContext
+import org.jetbrains.kotlin.ir.backend.js.ic.SrcFileArtifact
 import org.jetbrains.kotlin.ir.backend.js.utils.findUnitGetInstanceFunction
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.irAttribute
+import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.SymbolTable
+import org.jetbrains.kotlin.ir.util.fileOrNull
 import org.jetbrains.kotlin.js.config.JSConfigurationKeys
+import org.jetbrains.kotlin.wasm.config.WasmConfigurationKeys
 import java.io.File
 
-abstract class WasmICContextBase : PlatformDependentICContext {
+abstract class WasmICContextBase<TModuleArtifact, TFileArtifact, TFragments> :
+    PlatformDependentICContext<TModuleArtifact, TFileArtifact, TFragments, WasmBackendContext>
+        where TModuleArtifact : ModuleArtifact,
+              TFileArtifact : SrcFileArtifact,
+              TFragments : IrICProgramFragments {
+
     override fun getICCacheStableKeys(): Set<CompilerConfigurationKey<*>> =
         setOf(
             JSConfigurationKeys.LIBRARIES,
@@ -45,13 +51,12 @@ abstract class WasmICContextBase : PlatformDependentICContext {
             WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES
         )
 
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
     override fun createBackendContext(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         symbolTable: SymbolTable,
         configuration: CompilerConfiguration,
-    ): JsCommonBackendContext {
+    ): WasmBackendContext {
         // Hack (KT-71039, restored after KT-78040) - pre-load functional interfaces in case if IrLoader cut its count
         // `WasmAddFunctionSupertypeToSuspendFunctionLowering` of Kotlin/Wasm backend
         // adds `Function<...>` supertypes to `SuspendFunction<...>` interfaces.
@@ -80,7 +85,7 @@ open class WasmICContextMultimodule(
     protected val skipLocalNames: Boolean,
     private val skipCommentInstructions: Boolean,
     private val skipLocations: Boolean,
-) : WasmICContextBase() {
+) : WasmICContextBase<WasmModuleArtifactMultimodule, WasmSrcFileArtifactMultimodule, WasmIrProgramFragmentsMultimodule>() {
     override fun createIrFactory(): IrFactory =
         IrFactoryImplForWasmIC(WholeWorldStageController())
 
@@ -88,28 +93,32 @@ open class WasmICContextMultimodule(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface =
+        context: WasmBackendContext,
+    ): WasmCompilerWithICMultimodule =
         WasmCompilerWithICMultimodule(
             mainModule = mainModule,
             allowIncompleteImplementations = allowIncompleteImplementations,
             skipCommentInstructions = skipCommentInstructions,
             skipLocations = skipLocations,
-            context = context as WasmBackendContext,
+            context = context,
         )
 
-    override fun createSrcFileArtifact(srcFilePath: String, fragments: IrICProgramFragments?, astArtifact: File?): SrcFileArtifact =
-        WasmSrcFileArtifactMultimodule(fragments as? WasmIrProgramFragmentsMultimodule, astArtifact, skipLocalNames)
+    override fun createSrcFileArtifact(
+        srcFilePath: String,
+        fragments: WasmIrProgramFragmentsMultimodule?,
+        astArtifact: File?,
+    ): WasmSrcFileArtifactMultimodule =
+        WasmSrcFileArtifactMultimodule(fragments, astArtifact, skipLocalNames)
 
     override fun createModuleArtifact(
         moduleName: String,
-        fileArtifacts: List<SrcFileArtifact>,
+        fileArtifacts: List<WasmSrcFileArtifactMultimodule>,
         artifactsDir: File?,
         forceRebuild: Boolean,
         externalModuleName: String?,
-    ): ModuleArtifact =
+    ): WasmModuleArtifactMultimodule =
         WasmModuleArtifactMultimodule(
-            fileArtifacts = fileArtifacts.map { it as WasmSrcFileArtifactMultimodule },
+            fileArtifacts = fileArtifacts,
             moduleName = moduleName,
             externalModuleName = externalModuleName,
             forceRebuildWasm = forceRebuild
@@ -122,7 +131,7 @@ open class WasmICContextSingleModule(
     protected val skipLocalNames: Boolean,
     private val skipCommentInstructions: Boolean,
     private val skipLocations: Boolean,
-) : WasmICContextBase() {
+) : WasmICContextBase<WasmModuleArtifactSingleModule, WasmSrcFileArtifactSingleModule, WasmIrProgramFragmentsSingleModule>() {
     override fun createIrFactory(): IrFactory =
         IrFactoryImplForWasmIC(WholeWorldStageController())
 
@@ -130,27 +139,31 @@ open class WasmICContextSingleModule(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface =
+        context: WasmBackendContext,
+    ): WasmCompilerWithICSingleModule =
         WasmCompilerWithICSingleModule(
             mainModule = mainModule,
             allowIncompleteImplementations = allowIncompleteImplementations,
             skipCommentInstructions = skipCommentInstructions,
             skipLocations = skipLocations,
-            context = context as WasmBackendContext,
+            context = context,
         )
 
-    override fun createSrcFileArtifact(srcFilePath: String, fragments: IrICProgramFragments?, astArtifact: File?): SrcFileArtifact =
-        WasmSrcFileArtifactSingleModule(fragments as? WasmIrProgramFragmentsSingleModule, astArtifact, skipLocalNames)
+    override fun createSrcFileArtifact(
+        srcFilePath: String,
+        fragments: WasmIrProgramFragmentsSingleModule?,
+        astArtifact: File?,
+    ): WasmSrcFileArtifactSingleModule =
+        WasmSrcFileArtifactSingleModule(fragments, astArtifact, skipLocalNames)
 
     override fun createModuleArtifact(
         moduleName: String,
-        fileArtifacts: List<SrcFileArtifact>,
+        fileArtifacts: List<WasmSrcFileArtifactSingleModule>,
         artifactsDir: File?,
         forceRebuild: Boolean,
         externalModuleName: String?,
-    ): ModuleArtifact =
-        WasmModuleArtifactSingleModule(fileArtifacts.map { it as WasmSrcFileArtifactSingleModule }, moduleName, externalModuleName)
+    ): WasmModuleArtifactSingleModule =
+        WasmModuleArtifactSingleModule(fileArtifacts, moduleName, externalModuleName)
 }
 
 open class WasmICContextWholeWorld(
@@ -158,7 +171,7 @@ open class WasmICContextWholeWorld(
     protected val skipLocalNames: Boolean,
     private val skipCommentInstructions: Boolean,
     private val skipLocations: Boolean,
-) : WasmICContextBase() {
+) : WasmICContextBase<WasmModuleArtifact, WasmSrcFileArtifact, WasmIrProgramFragments>() {
     override fun createIrFactory(): IrFactory =
         IrFactoryImplForWasmIC(WholeWorldStageController())
 
@@ -166,27 +179,26 @@ open class WasmICContextWholeWorld(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface =
+        context: WasmBackendContext,
+    ): WasmCompilerWithICWholeWorld =
         WasmCompilerWithICWholeWorld(
             mainModule = mainModule,
             allowIncompleteImplementations = allowIncompleteImplementations,
             skipCommentInstructions = skipCommentInstructions,
             skipLocations = skipLocations,
-            context = context as WasmBackendContext,
+            context = context,
         )
 
-    override fun createSrcFileArtifact(srcFilePath: String, fragments: IrICProgramFragments?, astArtifact: File?): SrcFileArtifact =
-        WasmSrcFileArtifact(fragments as? WasmIrProgramFragments, astArtifact, skipLocalNames)
+    override fun createSrcFileArtifact(srcFilePath: String, fragments: WasmIrProgramFragments?, astArtifact: File?): WasmSrcFileArtifact =
+        WasmSrcFileArtifact(fragments, astArtifact, skipLocalNames)
 
     override fun createModuleArtifact(
         moduleName: String,
-        fileArtifacts: List<SrcFileArtifact>,
+        fileArtifacts: List<WasmSrcFileArtifact>,
         artifactsDir: File?,
         forceRebuild: Boolean,
         externalModuleName: String?,
-    ): ModuleArtifact =
-        WasmModuleArtifact(fileArtifacts.map { it as WasmSrcFileArtifact })
+    ): WasmModuleArtifact = WasmModuleArtifact(fileArtifacts)
 }
 
 class IrFactoryImplForWasmIC(stageController: StageController) : IrFactory(stageController), IdSignatureRetriever {

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ic/WasmModuleFragments.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ic/WasmModuleFragments.kt
@@ -66,4 +66,4 @@ open class WasmIrProgramFragments(
 class WasmIrModule(
     override val moduleName: String,
     override val fragments: List<WasmCompiledCodeFileFragment>,
-) : IrICModule()
+) : IrICModule<WasmCompiledCodeFileFragment>()

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/incremental/JsAbstractInvalidationTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/incremental/JsAbstractInvalidationTest.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.ir.backend.js.JsICContext
 import org.jetbrains.kotlin.ir.backend.js.SourceMapsInfo
 import org.jetbrains.kotlin.ir.backend.js.ic.CacheUpdater
 import org.jetbrains.kotlin.ir.backend.js.ic.JsExecutableProducer
-import org.jetbrains.kotlin.ir.backend.js.ic.JsModuleArtifact
 import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.CompilationOutputs
 import org.jetbrains.kotlin.js.config.*
 import org.jetbrains.kotlin.js.engine.ScriptExecutionException
@@ -177,7 +176,7 @@ abstract class JsAbstractInvalidationTest(
 
                 val removedModulesInfo = (projectInfo.modules - projStep.order.toSet()).map { setupTestStep(projStep, it) }
 
-                val icCaches = cacheUpdater.actualizeCaches().map { it as JsModuleArtifact }
+                val icCaches = cacheUpdater.actualizeCaches()
                 verifyCacheUpdateStats(projStep.id, cacheUpdater.getDirtyFileLastStats(), testInfo + removedModulesInfo)
 
                 val mainModuleName = icCaches.last().moduleExternalName

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/utils/JsIrIncrementalDataProvider.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/utils/JsIrIncrementalDataProvider.kt
@@ -137,11 +137,11 @@ class JsIrIncrementalDataProvider(private val testServices: TestServices) : Test
 
         val moduleCache = icCache[canonicalPath] ?: TestArtifactCache(mainModuleIr.name.asString())
 
-        for (rebuiltFile in rebuiltFiles) {
-            if (rebuiltFile.first.module == mainModuleIr) {
+        for ([irFile, programFragments] in rebuiltFiles) {
+            if (irFile.module == mainModuleIr) {
                 val output = ByteArrayOutputStream()
-                rebuiltFile.second.serialize(output)
-                moduleCache.binaryAsts[rebuiltFile.first.fileEntry.name] = output.toByteArray()
+                programFragments.serialize(output)
+                moduleCache.binaryAsts[irFile.fileEntry.name] = output.toByteArray()
             }
         }
 

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/incremental/WasmAbstractInvalidationTest.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/incremental/WasmAbstractInvalidationTest.kt
@@ -8,9 +8,7 @@ package org.jetbrains.kotlin.incremental
 
 import org.jetbrains.kotlin.CoreEnvironmentDeprecation
 import org.jetbrains.kotlin.backend.wasm.*
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextMultimodule
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextSingleModule
-import org.jetbrains.kotlin.backend.wasm.ic.WasmICContextWholeWorld
+import org.jetbrains.kotlin.backend.wasm.ic.*
 import org.jetbrains.kotlin.backend.wasm.lower.markFunctionToExport
 import org.jetbrains.kotlin.cli.create
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -26,10 +24,7 @@ import org.jetbrains.kotlin.codegen.ProjectInfo
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.targetPlatform
 import org.jetbrains.kotlin.ir.IrBuiltIns
-import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.ir.backend.js.ic.CacheUpdater
-import org.jetbrains.kotlin.ir.backend.js.ic.IrCompilerICInterface
-import org.jetbrains.kotlin.ir.backend.js.ic.IrICProgramFragments
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.types.isBoolean
@@ -79,15 +74,18 @@ private class WasmICContextMultimoduleForTesting : WasmICContextMultimodule(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext
-    ): IrCompilerICInterface = object : WasmCompilerWithICMultimodule(
+        context: WasmBackendContext,
+    ): WasmCompilerWithICMultimodule = object : WasmCompilerWithICMultimodule(
         mainModule = mainModule,
         allowIncompleteImplementations = false,
         skipCommentInstructions = false,
         skipLocations = false,
-        context = context as WasmBackendContext,
+        context = context,
     ) {
-        override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> IrICProgramFragments> {
+        override fun compile(
+            allModules: Collection<IrModuleFragment>,
+            dirtyFiles: Collection<IrFile>,
+        ): List<() -> WasmIrProgramFragmentsMultimodule> {
             markExportedDeclarations(dirtyFiles, super.context)
             return super.compile(allModules, dirtyFiles)
         }
@@ -104,15 +102,18 @@ private class WasmICContextSingleModuleForTesting : WasmICContextSingleModule(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface = object : WasmCompilerWithICSingleModule(
+        context: WasmBackendContext,
+    ): WasmCompilerWithICSingleModule = object : WasmCompilerWithICSingleModule(
         mainModule = mainModule,
         allowIncompleteImplementations = false,
         skipCommentInstructions = false,
         skipLocations = false,
-        context = context as WasmBackendContext,
+        context = context,
     ) {
-        override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> IrICProgramFragments> {
+        override fun compile(
+            allModules: Collection<IrModuleFragment>,
+            dirtyFiles: Collection<IrFile>,
+        ): List<() -> WasmIrProgramFragmentsSingleModule> {
             markExportedDeclarations(dirtyFiles, super.context)
             return super.compile(allModules, dirtyFiles)
         }
@@ -129,15 +130,15 @@ private class WasmICContextWholeWorldForTesting : WasmICContextWholeWorld(
         mainModule: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
         configuration: CompilerConfiguration,
-        context: JsCommonBackendContext,
-    ): IrCompilerICInterface = object : WasmCompilerWithICWholeWorld(
+        context: WasmBackendContext,
+    ): WasmCompilerWithICWholeWorld = object : WasmCompilerWithICWholeWorld(
         mainModule = mainModule,
         allowIncompleteImplementations = false,
         skipCommentInstructions = false,
         skipLocations = false,
-        context = context as WasmBackendContext,
+        context = context,
     ) {
-        override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> IrICProgramFragments> {
+        override fun compile(allModules: Collection<IrModuleFragment>, dirtyFiles: Collection<IrFile>): List<() -> WasmIrProgramFragments> {
             markExportedDeclarations(dirtyFiles, super.context)
             return super.compile(allModules, dirtyFiles)
         }

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/ModulesPrecompile.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/ModulesPrecompile.kt
@@ -13,17 +13,17 @@ import org.jetbrains.kotlin.cli.common.arguments.toLanguageVersionSettings
 import org.jetbrains.kotlin.cli.common.testEnvironment
 import org.jetbrains.kotlin.cli.create
 import org.jetbrains.kotlin.cli.pipeline.ConfigurationPipelineArtifact
-import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmBackendPipelinePhase
 import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmIrLoadingPipelinePhase
+import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmSingleModuleBackendPipelinePhase
 import org.jetbrains.kotlin.config.AnalysisFlags.allowFullyQualifiedNameInKClass
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.js.config.*
 import org.jetbrains.kotlin.platform.wasm.WasmTarget
 import org.jetbrains.kotlin.test.DebugMode
+import org.jetbrains.kotlin.test.testInfraError
 import org.jetbrains.kotlin.wasm.config.*
 import org.jetbrains.kotlin.wasm.test.handlers.writeTo
-import org.jetbrains.kotlin.test.testInfraError
 import java.io.File
 
 private val outputDir: File
@@ -107,7 +107,7 @@ internal fun precompileWasmModules(setup: PrecompileSetup) {
         }
 
         val loadedIr = WasmIrLoadingPipelinePhase.executePhase(input)
-        val parametersForCompile = WasmBackendPipelinePhase.compileNonIncrementally(loadedIr).first()
+        val parametersForCompile = WasmSingleModuleBackendPipelinePhase.compileNonIncrementally(loadedIr).first()
 
         val linkedModule = linkWasmIr(parametersForCompile)
         val compileResult = compileWasmIrToBinary(parametersForCompile, linkedModule)


### PR DESCRIPTION
This makes it more type-safe and allows use to get rid of a bunch of `as`-casts.