### PR TITLE
[KT-88106] [2.4.20] dump xcodebuild args task fails on changing the package version from exact to from

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -486,6 +486,36 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
 
     @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
     @GradleTest
+    fun `KT-88106 - Firebase dump task fails when version key changes from exact to from`(version: GradleVersion) {
+        val useFromVersionKey = "useFromVersionKey"
+
+        project("empty", version) {
+            withLockFileFixture {
+                initSwiftPmProject(
+                    cacheDirFile,
+                    nativeTargets = {
+                        listOf(
+                            macosArm64()
+                        )
+                    }) {
+                    swiftPMDependencies {
+                        swiftPackage(
+                            url = url("https://github.com/firebase/firebase-ios-sdk.git"),
+                            version = if (project.hasProperty(useFromVersionKey)) from("12.9.0") else exact("12.9.0"),
+                            products = listOf(product("FirebaseFirestore")),
+                        )
+                    }
+                }
+
+                build("dumpXcodebuildArgsMacosx")
+
+                buildAndFail("dumpXcodebuildArgsMacosx", "-P$useFromVersionKey=true")
+            }
+        }
+    }
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
     fun `KT-88104 - dump task does not fail after root build directory is removed`(version: GradleVersion) {
         val libraryProjectName = "lib1"
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -486,7 +486,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
 
     @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
     @GradleTest
-    fun `KT-88106 - Firebase dump task fails when version key changes from exact to from`(version: GradleVersion) {
+    fun `KT-88106 - Firebase dump task does not fail when version key changes from exact to from`(version: GradleVersion) {
         val useFromVersionKey = "useFromVersionKey"
 
         project("empty", version) {
@@ -509,7 +509,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
 
                 build("dumpXcodebuildArgsMacosx")
 
-                buildAndFail("dumpXcodebuildArgsMacosx", "-P$useFromVersionKey=true")
+                build("dumpXcodebuildArgsMacosx", "-P$useFromVersionKey=true")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -487,7 +487,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
     @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
     @GradleTest
     fun `KT-88106 - Firebase dump task does not fail when version key changes from exact to from`(version: GradleVersion) {
-        val useFromVersionKey = "useFromVersionKey"
+        val useNewerFirebaseVersion = "useNewerFirebaseVersion"
 
         project("empty", version) {
             withLockFileFixture {
@@ -501,7 +501,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
                     swiftPMDependencies {
                         swiftPackage(
                             url = url("https://github.com/firebase/firebase-ios-sdk.git"),
-                            version = if (project.hasProperty(useFromVersionKey)) from("12.9.0") else exact("12.9.0"),
+                            version = exact(if (project.hasProperty(useNewerFirebaseVersion)) "12.17.0" else "12.9.0"),
                             products = listOf(product("FirebaseFirestore")),
                         )
                     }
@@ -509,7 +509,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
 
                 build("dumpXcodebuildArgsMacosx")
 
-                build("dumpXcodebuildArgsMacosx", "-P$useFromVersionKey=true")
+                build("dumpXcodebuildArgsMacosx", "-P$useNewerFirebaseVersion=true")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
@@ -185,6 +185,7 @@ internal abstract class XcodebuildArgsDumpWorkAction @Inject constructor(
                 "CODE_SIGN_IDENTITY=",
                 "COMPILER_INDEX_STORE_ENABLE=NO",
                 "SWIFT_INDEX_STORE_ENABLE=NO",
+                "SWIFT_ENABLE_EXPLICIT_MODULES=NO",
             )
 
             args.addAll(parameters.additionalXcodeArgs.get())

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
@@ -185,6 +185,8 @@ internal abstract class XcodebuildArgsDumpWorkAction @Inject constructor(
                 "CODE_SIGN_IDENTITY=",
                 "COMPILER_INDEX_STORE_ENABLE=NO",
                 "SWIFT_INDEX_STORE_ENABLE=NO",
+                // Remove the flag below once SPM issue #10429 is fixed:
+                // https://github.com/swiftlang/swift-package-manager/issues/10429
                 "SWIFT_ENABLE_EXPLICIT_MODULES=NO",
             )
 


### PR DESCRIPTION
- Reproduce the bug with failing xcodebuild dump IT test.
- Add xcodebuild flag and change package generation fingerprint fixing the bug

^KT-88106 