### PR TITLE
Split Standalone components into dedicated Analysis API JARs

### DIFF
--- a/prepare/analysis-api/kotlin-analysis-api-implementation/build.gradle.kts
+++ b/prepare/analysis-api/kotlin-analysis-api-implementation/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 val analysisApiSurfaceDependencies: List<String> = CompilerModules.analysisApiSurfaceDependencies
 val compilerModules: Array<String> = CompilerModules.compilerModules
 val analysisApiSurfaceModules: Array<String> = CompilerModules.analysisApiSurfaceModules
+val analysisApiStandaloneModules: Array<String> = CompilerModules.analysisApiStandaloneModules
 val analysisApiModules: Array<String> = CompilerModules.analysisApiModules
 
 val additionalCompilerProjects = listOf(
@@ -57,6 +58,9 @@ analysisApiArtifact {
             // Avoid copying content of 'kotlin-analysis-api-surface'
             removeAll(analysisApiSurfaceDependencies)
             removeAll(analysisApiSurfaceModules)
+
+            // Standalone modules are shipped by the dedicated standalone artifacts
+            removeAll(analysisApiStandaloneModules)
 
             // Avoid copying content of 'kotlin-analysis-api-fir-diagnostics'
             remove(":analysis:analysis-api-fir-diagnostics")

--- a/prepare/analysis-api/kotlin-analysis-api-standalone-implementation/build.gradle.kts
+++ b/prepare/analysis-api/kotlin-analysis-api-standalone-implementation/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("common-configuration")
+    id("test-federation-convention")
+    id("com.autonomousapps.dependency-analysis")
+    `java-library`
+    id("analysis-api-artifact")
+}
+
+val analysisApiStandaloneSurfaceModules: Array<String> = CompilerModules.analysisApiStandaloneSurfaceModules
+val analysisApiStandaloneModules: Array<String> = CompilerModules.analysisApiStandaloneModules
+
+dependencies {
+    api(project(":prepare:analysis-api:kotlin-analysis-api-standalone-surface"))
+    implementation(project(":prepare:analysis-api:kotlin-analysis-api-implementation"))
+}
+
+analysisApiArtifact {
+    content {
+        val implementationProjects = buildSet {
+            addAll(analysisApiStandaloneModules)
+
+            // Avoid copying content of 'kotlin-analysis-api-standalone-surface'
+            removeAll(analysisApiStandaloneSurfaceModules)
+        }
+
+        projects(implementationProjects)
+    }
+}

--- a/prepare/analysis-api/kotlin-analysis-api-standalone-implementation/expected-pom.xml
+++ b/prepare/analysis-api/kotlin-analysis-api-standalone-implementation/expected-pom.xml
@@ -3,10 +3,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jetbrains.kotlin</groupId>
-  <artifactId>kotlin-analysis-api</artifactId>
+  <artifactId>kotlin-analysis-api-standalone-implementation</artifactId>
   <version>@ARTIFACT_VERSION@</version>
-  <name>Kotlin Analysis Api</name>
-  <description>Kotlin Analysis Api</description>
+  <name>Kotlin Analysis Api Standalone Implementation</name>
+  <description>Kotlin Analysis Api Standalone Implementation</description>
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
@@ -29,12 +29,6 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-analysis-api-surface</artifactId>
-      <version>@ARTIFACT_VERSION@</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-analysis-api-standalone-surface</artifactId>
       <version>@ARTIFACT_VERSION@</version>
       <scope>compile</scope>
@@ -42,12 +36,6 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-analysis-api-implementation</artifactId>
-      <version>@ARTIFACT_VERSION@</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-analysis-api-standalone-implementation</artifactId>
       <version>@ARTIFACT_VERSION@</version>
       <scope>runtime</scope>
     </dependency>

--- a/prepare/analysis-api/kotlin-analysis-api-standalone-surface/build.gradle.kts
+++ b/prepare/analysis-api/kotlin-analysis-api-standalone-surface/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("common-configuration")
+    id("test-federation-convention")
+    id("com.autonomousapps.dependency-analysis")
+    `java-library`
+    id("analysis-api-artifact")
+}
+
+val analysisApiStandaloneSurfaceModules: Array<String> = CompilerModules.analysisApiStandaloneSurfaceModules
+
+dependencies {
+    api(project(":prepare:analysis-api:kotlin-analysis-api-surface"))
+}
+
+analysisApiArtifact {
+    content {
+        projects(analysisApiStandaloneSurfaceModules)
+    }
+}

--- a/prepare/analysis-api/kotlin-analysis-api-standalone-surface/expected-pom.xml
+++ b/prepare/analysis-api/kotlin-analysis-api-standalone-surface/expected-pom.xml
@@ -3,10 +3,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jetbrains.kotlin</groupId>
-  <artifactId>kotlin-analysis-api</artifactId>
+  <artifactId>kotlin-analysis-api-standalone-surface</artifactId>
   <version>@ARTIFACT_VERSION@</version>
-  <name>Kotlin Analysis Api</name>
-  <description>Kotlin Analysis Api</description>
+  <name>Kotlin Analysis Api Standalone Surface</name>
+  <description>Kotlin Analysis Api Standalone Surface</description>
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
@@ -32,24 +32,6 @@
       <artifactId>kotlin-analysis-api-surface</artifactId>
       <version>@ARTIFACT_VERSION@</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-analysis-api-standalone-surface</artifactId>
-      <version>@ARTIFACT_VERSION@</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-analysis-api-implementation</artifactId>
-      <version>@ARTIFACT_VERSION@</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-analysis-api-standalone-implementation</artifactId>
-      <version>@ARTIFACT_VERSION@</version>
-      <scope>runtime</scope>
     </dependency>
   </dependencies>
 </project>

--- a/prepare/analysis-api/kotlin-analysis-api/build.gradle.kts
+++ b/prepare/analysis-api/kotlin-analysis-api/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 dependencies {
     api(project(":prepare:analysis-api:kotlin-analysis-api-surface"))
     implementation(project(":prepare:analysis-api:kotlin-analysis-api-implementation"))
+
+    // The meta-artifact is designed for Standalone users, so it also bundles the Standalone artifacts
+    api(project(":prepare:analysis-api:kotlin-analysis-api-standalone-surface"))
+    implementation(project(":prepare:analysis-api:kotlin-analysis-api-standalone-implementation"))
 }
 
 analysisApiArtifact {

--- a/repo/kotlin-build-helpers/src/CompilerModules.kt
+++ b/repo/kotlin-build-helpers/src/CompilerModules.kt
@@ -205,7 +205,16 @@ object CompilerModules {
 
     val analysisApiSurfaceModules = arrayOf(
         ":analysis:analysis-api",
+    )
+
+    val analysisApiStandaloneSurfaceModules = arrayOf(
         ":analysis:analysis-api-standalone",
+    )
+
+    val analysisApiStandaloneModules = arrayOf(
+        *analysisApiStandaloneSurfaceModules,
+        ":analysis:analysis-api-standalone:analysis-api-fir-standalone-base",
+        ":analysis:analysis-api-standalone:analysis-api-standalone-base",
     )
 
     /**
@@ -214,12 +223,11 @@ object CompilerModules {
      */
     val analysisApiModules = arrayOf(
         *analysisApiSurfaceModules,
+        *analysisApiStandaloneModules,
         ":analysis:analysis-api-fir",
         ":analysis:analysis-api-fir-diagnostics",
         ":analysis:analysis-api-impl-base",
         ":analysis:analysis-api-platform-interface",
-        ":analysis:analysis-api-standalone:analysis-api-fir-standalone-base",
-        ":analysis:analysis-api-standalone:analysis-api-standalone-base",
         ":analysis:analysis-internal-utils",
         ":analysis:decompiled:decompiler-js",
         ":analysis:decompiled:decompiler-native",
@@ -249,6 +257,8 @@ object CompilerModules {
         ":prepare:analysis-api:kotlin-analysis-api-platform-interface",
         ":prepare:analysis-api:kotlin-analysis-api-implementation",
         ":prepare:analysis-api:kotlin-analysis-api-fir-diagnostics",
+        ":prepare:analysis-api:kotlin-analysis-api-standalone-surface",
+        ":prepare:analysis-api:kotlin-analysis-api-standalone-implementation",
         ":prepare:analysis-api:kotlin-analysis-api-intellij-api-surface-components",
         ":prepare:analysis-api:kotlin-analysis-api-intellij-implementation-components",
         ":prepare:analysis-api:kotlin-analysis-api-allopen-compiler-plugin-support",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -633,6 +633,8 @@ include(
     ":prepare:analysis-api:kotlin-analysis-api-platform-interface",
     ":prepare:analysis-api:kotlin-analysis-api-implementation",
     ":prepare:analysis-api:kotlin-analysis-api-fir-diagnostics",
+    ":prepare:analysis-api:kotlin-analysis-api-standalone-surface",
+    ":prepare:analysis-api:kotlin-analysis-api-standalone-implementation",
     ":prepare:analysis-api:kotlin-analysis-api-intellij-api-surface-components",
     ":prepare:analysis-api:kotlin-analysis-api-intellij-implementation-components",
     ":prepare:analysis-api:kotlin-analysis-api-allopen-compiler-plugin-support",


### PR DESCRIPTION
Previously the 'kotlin-analysis-api-surface' and
'kotlin-analysis-api-implementation' artifacts bundled Standalone modules, which aren't needed for the IDE.

Now, Standalone modules are moved into two new artifacts, 'kotlin-analysis-api-standalone-surface' and
'kotlin-analysis-api-standalone-implementation', layered on top of the regular surface/implementation JARs. The umbrella 'kotlin-analysis-api' meta-artifact, intended for Standalone users, now additionally depends on both new JARs, so its merged classpath stays complete.