### PR TITLE
🍒 [2.4.20] [K/JS] Keep associated obj annotation only if getInstance survives DCE

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UselessDeclarationsRemover.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UselessDeclarationsRemover.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
 import org.jetbrains.kotlin.ir.backend.js.defaultConstructorForReflection
 import org.jetbrains.kotlin.ir.backend.js.ir.JsIrBuilder
+import org.jetbrains.kotlin.ir.backend.js.objectGetInstanceFunction
 import org.jetbrains.kotlin.ir.backend.js.utils.associatedObject
 import org.jetbrains.kotlin.ir.backend.js.utils.findDefaultConstructorForReflection
 import org.jetbrains.kotlin.ir.backend.js.utils.prependFunctionCall
@@ -43,18 +44,33 @@ class UselessDeclarationsRemover(
         process(declaration)
     }
 
+    /**
+     * Whether an `@AssociatedObjectKey`-annotated annotation may stay on the declaration.
+     *
+     * It has to be dropped as soon as [org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.JsClassGenerator]
+     * would be unable to emit the `associatedObjects` entry for it: that entry references the
+     * associated object's `getInstance` function, and the namer cannot produce a name for a declaration
+     * DCE has already removed (KT-88571).
+     *
+     * The object itself being useful is *not* sufficient. A companion object's instance is created in the
+     * containing class's `static_init`, not in its own `getInstance`, so the object may well survive DCE
+     * while `getInstance` does not — e.g. an enum whose entries force `static_init` to be retained, but
+     * whose companion is never accessed from Kotlin code.
+     *
+     * This mirrors [JsUsefulDeclarationProcessor.handleAssociatedObjects], which enqueues `getInstance`
+     * only for classes reachable as JS classes. Whenever it declines to, the annotation must go too,
+     * otherwise the two decisions contradict each other.
+     */
     private fun IrAnnotation.shouldKeepAnnotation(): Boolean {
-        associatedObject()?.let { obj ->
-            if (obj !in usefulDeclarations) return false
-        }
-        return true
+        val obj = associatedObject() ?: return true
+        if (obj !in usefulDeclarations) return false
+        val getInstance = obj.objectGetInstanceFunction
+        return getInstance == null || getInstance in usefulDeclarations
     }
 
     override fun visitClass(declaration: IrClass) {
         process(declaration)
-        // Remove annotations for `findAssociatedObject` feature, which reference objects eliminated by the DCE.
-        // Otherwise `JsClassGenerator.generateAssociatedKeyProperties` will try to reference the object factory (which is removed).
-        // That will result in an error from the Namer. It cannot generate a name for an absent declaration.
+        // Drop `findAssociatedObject` annotations whose association can no longer be emitted. See `shouldKeepAnnotation`.
         if (removeUnusedAssociatedObjects && declaration.annotations.any { !it.shouldKeepAnnotation() }) {
             declaration.annotations = declaration.annotations.memoryOptimizedFilter { it.shouldKeepAnnotation() }
         }

--- a/compiler/testData/codegen/box/associatedObjects/kt88571.kt
+++ b/compiler/testData/codegen/box/associatedObjects/kt88571.kt
@@ -1,0 +1,27 @@
+// ISSUE: KT-88571
+// DONT_TARGET_EXACT_BACKEND: JVM_IR
+// ^ @AssociatedObjectKey is not available in Kotlin/JVM
+
+// WITH_STDLIB
+// ONLY_IR_DCE
+
+import kotlin.reflect.*
+
+@OptIn(ExperimentalAssociatedObjects::class)
+@AssociatedObjectKey
+@Retention(AnnotationRetention.BINARY)
+annotation class ObjectKey(val kClass: KClass<*>)
+
+// JS/Wasm: The enum entries keep `static_init` alive, and `static_init` is what constructs the companion object.
+//   So the associated object survives DCE while its `getInstance` function does not.
+@ObjectKey(MODE.Companion::class)
+enum class MODE {
+    ALL;
+
+    companion object
+}
+
+fun box(): String {
+    // JS/Wasm: Touches an entry only, never the MODE companion, so `MODE$Companion$getInstance` stays unreachable.
+    return if (MODE.ALL.toString() == "ALL") "OK" else "FAIL"
+}

--- a/plugins/kotlinx-serialization/testData/boxIr/kt88571.kt
+++ b/plugins/kotlinx-serialization/testData/boxIr/kt88571.kt
@@ -1,0 +1,17 @@
+// ISSUE: KT-88571
+// WITH_STDLIB
+// ONLY_IR_DCE
+
+import kotlinx.serialization.*
+
+// JS/Wasm: The enum entries keep `static_init` alive, and `static_init` is what constructs the companion object.
+//   So the associated object survives DCE while its `getInstance` function does not.
+@Serializable
+enum class MODE {
+    ALL
+}
+
+fun box(): String {
+    // JS/Wasm: Touches an entry only, never the MODE companion, so `MODE$Companion$getInstance` stays unreachable.
+    return if (MODE.ALL.toString() == "ALL") "OK" else "FAIL"
+}

--- a/plugins/kotlinx-serialization/testData/boxIr/kt88571SerializerFunction.kt
+++ b/plugins/kotlinx-serialization/testData/boxIr/kt88571SerializerFunction.kt
@@ -1,0 +1,22 @@
+// ISSUE: KT-88571
+// WITH_STDLIB
+// ONLY_IR_DCE
+
+import kotlinx.serialization.*
+
+// JS/Wasm: The enum entries keep `static_init` alive, and `static_init` is what constructs the companion object.
+//   So the associated object survives DCE while its `getInstance` function does not, unless something else
+//   keeps `getInstance` reachable directly.
+@Serializable
+enum class MODE {
+    ALL
+}
+
+// Calling the reified `serializer<T>()` function resolves the serializer via the associated object
+// lookup mechanism, which requires `MODE.Companion.getInstance` to stay reachable so the DCE-kept
+// `SerializerFactory` association can still be emitted/used.
+fun box(): String {
+    val descriptorName = serializer<MODE>().descriptor.serialName
+    if (descriptorName != "MODE") return descriptorName
+    return if (MODE.ALL.toString() == "ALL") "OK" else "FAIL"
+}

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeTestGenerated.java
@@ -257,6 +257,18 @@ public class SerializationNativeTestGenerated extends AbstractNativeCodegenBoxTe
   }
 
   @Test
+  @TestMetadata("kt88571.kt")
+  public void testKt88571() {
+    run("kt88571.kt");
+  }
+
+  @Test
+  @TestMetadata("kt88571SerializerFunction.kt")
+  public void testKt88571SerializerFunction() {
+    run("kt88571SerializerFunction.kt");
+  }
+
+  @Test
   @TestMetadata("localSerializable.kt")
   public void testLocalSerializable() {
     run("localSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeWithInlinedFunInKlibTestGenerated.java
@@ -258,6 +258,18 @@ public class SerializationNativeWithInlinedFunInKlibTestGenerated extends Abstra
   }
 
   @Test
+  @TestMetadata("kt88571.kt")
+  public void testKt88571() {
+    run("kt88571.kt");
+  }
+
+  @Test
+  @TestMetadata("kt88571SerializerFunction.kt")
+  public void testKt88571SerializerFunction() {
+    run("kt88571SerializerFunction.kt");
+  }
+
+  @Test
   @TestMetadata("localSerializable.kt")
   public void testLocalSerializable() {
     run("localSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLReversedSerializationBlackBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLReversedSerializationBlackBoxTestGenerated.java
@@ -253,6 +253,18 @@ public class LLReversedSerializationBlackBoxTestGenerated extends AbstractLLReve
     }
 
     @Test
+    @TestMetadata("kt88571.kt")
+    public void testKt88571() {
+      run("kt88571.kt");
+    }
+
+    @Test
+    @TestMetadata("kt88571SerializerFunction.kt")
+    public void testKt88571SerializerFunction() {
+      run("kt88571SerializerFunction.kt");
+    }
+
+    @Test
     @TestMetadata("localSerializable.kt")
     public void testLocalSerializable() {
       run("localSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLSerializationBlackBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLSerializationBlackBoxTestGenerated.java
@@ -253,6 +253,18 @@ public class LLSerializationBlackBoxTestGenerated extends AbstractLLSerializatio
     }
 
     @Test
+    @TestMetadata("kt88571.kt")
+    public void testKt88571() {
+      run("kt88571.kt");
+    }
+
+    @Test
+    @TestMetadata("kt88571SerializerFunction.kt")
+    public void testKt88571SerializerFunction() {
+      run("kt88571SerializerFunction.kt");
+    }
+
+    @Test
     @TestMetadata("localSerializable.kt")
     public void testLocalSerializable() {
       run("localSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationFirLightTreeBlackBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationFirLightTreeBlackBoxTestGenerated.java
@@ -253,6 +253,18 @@ public class SerializationFirLightTreeBlackBoxTestGenerated extends AbstractSeri
     }
 
     @Test
+    @TestMetadata("kt88571.kt")
+    public void testKt88571() {
+      run("kt88571.kt");
+    }
+
+    @Test
+    @TestMetadata("kt88571SerializerFunction.kt")
+    public void testKt88571SerializerFunction() {
+      run("kt88571SerializerFunction.kt");
+    }
+
+    @Test
     @TestMetadata("localSerializable.kt")
     public void testLocalSerializable() {
       run("localSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxTestGenerated.java
@@ -250,6 +250,18 @@ public class SerializationJsBoxTestGenerated extends AbstractSerializationJsBoxT
   }
 
   @Test
+  @TestMetadata("kt88571.kt")
+  public void testKt88571() {
+    run("kt88571.kt");
+  }
+
+  @Test
+  @TestMetadata("kt88571SerializerFunction.kt")
+  public void testKt88571SerializerFunction() {
+    run("kt88571SerializerFunction.kt");
+  }
+
+  @Test
   @TestMetadata("localSerializable.kt")
   public void testLocalSerializable() {
     run("localSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxWithInlinedFunInKlibTestGenerated.java
@@ -250,6 +250,18 @@ public class SerializationJsBoxWithInlinedFunInKlibTestGenerated extends Abstrac
   }
 
   @Test
+  @TestMetadata("kt88571.kt")
+  public void testKt88571() {
+    run("kt88571.kt");
+  }
+
+  @Test
+  @TestMetadata("kt88571SerializerFunction.kt")
+  public void testKt88571SerializerFunction() {
+    run("kt88571SerializerFunction.kt");
+  }
+
+  @Test
   @TestMetadata("localSerializable.kt")
   public void testLocalSerializable() {
     run("localSerializable.kt");


### PR DESCRIPTION
Cherry-picked version of #7528.

YT issue: KT-88571.
The reason for the cherry pick: It's a **critical** regression.
RCA is defined in the KT-88571 comments.