### PR TITLE
[Swift Export] Exclude enums from sealed types

### DIFF
--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirSealedType.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirSealedType.kt
@@ -96,7 +96,8 @@ internal class SirSealedTypeEnum(
     }
 
     private val sealedInheritors: List<KaNamedClassSymbol> by lazyWithSessions {
-        ktSymbol.sealedClassInheritors
+        // Don't include enums, they don't conform to protocols (KT-88682 / KT-88716)
+        ktSymbol.sealedClassInheritors.filter { it.classKind != KaClassKind.ENUM_CLASS }
     }
 
     val isEmpty: Boolean get() = sealedInheritors.isEmpty()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.h
@@ -23,6 +23,22 @@ void * org_kotlin_foo_DeprecatedWarningSubClass_init_allocate();
 
 _Bool org_kotlin_foo_DeprecatedWarningSubClass_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
 
+void * org_kotlin_foo_EnumClassA_ONE();
+
+void * org_kotlin_foo_EnumClassA_THREE();
+
+void * org_kotlin_foo_EnumClassA_TWO();
+
+int32_t org_kotlin_foo_EnumClassA_ordinal(void * self);
+
+void * org_kotlin_foo_EnumClassB_FIVE();
+
+void * org_kotlin_foo_EnumClassB_FOUR();
+
+void * org_kotlin_foo_EnumClassB_SIX();
+
+int32_t org_kotlin_foo_EnumClassB_ordinal(void * self);
+
 void * org_kotlin_foo_MyClassA_init_allocate();
 
 _Bool org_kotlin_foo_MyClassA_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.kt
@@ -98,6 +98,56 @@ public fun org_kotlin_foo_DeprecatedWarningSubClass_init_initialize__TypesOfArgu
     return run { _result; true }
 }
 
+@ExportedBridge("org_kotlin_foo_EnumClassA_ONE")
+public fun org_kotlin_foo_EnumClassA_ONE(): kotlin.native.internal.NativePtr {
+    val _result = run { org.kotlin.foo.EnumClassA.ONE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassA_THREE")
+public fun org_kotlin_foo_EnumClassA_THREE(): kotlin.native.internal.NativePtr {
+    val _result = run { org.kotlin.foo.EnumClassA.THREE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassA_TWO")
+public fun org_kotlin_foo_EnumClassA_TWO(): kotlin.native.internal.NativePtr {
+    val _result = run { org.kotlin.foo.EnumClassA.TWO }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassA_ordinal")
+public fun org_kotlin_foo_EnumClassA_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as org.kotlin.foo.EnumClassA
+    val _result = run { __self.ordinal }
+    return _result
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassB_FIVE")
+public fun org_kotlin_foo_EnumClassB_FIVE(): kotlin.native.internal.NativePtr {
+    val _result = run { org.kotlin.foo.EnumClassB.FIVE }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassB_FOUR")
+public fun org_kotlin_foo_EnumClassB_FOUR(): kotlin.native.internal.NativePtr {
+    val _result = run { org.kotlin.foo.EnumClassB.FOUR }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassB_SIX")
+public fun org_kotlin_foo_EnumClassB_SIX(): kotlin.native.internal.NativePtr {
+    val _result = run { org.kotlin.foo.EnumClassB.SIX }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("org_kotlin_foo_EnumClassB_ordinal")
+public fun org_kotlin_foo_EnumClassB_ordinal(self: kotlin.native.internal.NativePtr): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as org.kotlin.foo.EnumClassB
+    val _result = run { __self.ordinal }
+    return _result
+}
+
 @ExportedBridge("org_kotlin_foo_MyClassA_init_allocate")
 public fun org_kotlin_foo_MyClassA_init_allocate(): kotlin.native.internal.NativePtr {
     val _result = run { kotlin.native.internal.createUninitializedInstance<org.kotlin.foo.MyClassA>() }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.swift
@@ -17,6 +17,8 @@ public typealias DeprecatedErrorSubClass_SealedType = ExportedKotlinPackages.org
 public typealias DeprecatedWarningSubClass = ExportedKotlinPackages.org.kotlin.foo.DeprecatedWarningSubClass
 @available(*, deprecated, message: "deprecated")
 public typealias DeprecatedWarningSubClass_SealedType = ExportedKotlinPackages.org.kotlin.foo.DeprecatedWarningSubClass_SealedType
+public typealias EnumClassA = ExportedKotlinPackages.org.kotlin.foo.EnumClassA
+public typealias EnumClassB = ExportedKotlinPackages.org.kotlin.foo.EnumClassB
 public typealias InterfaceC = ExportedKotlinPackages.org.kotlin.foo.InterfaceC
 public typealias InterfaceC_SealedType = ExportedKotlinPackages.org.kotlin.foo.InterfaceC_SealedType
 public typealias MyClassA = ExportedKotlinPackages.org.kotlin.foo.MyClassA
@@ -168,6 +170,126 @@ extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.org.kotlin.foo._InterfaceC {
 }
 extension ExportedKotlinPackages.org.kotlin.foo {
+    public enum EnumClassA: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {
+        case ONE
+        case TWO
+        case THREE
+        public var description: Swift.String {
+            get {
+                switch self {
+                case .ONE: "ONE"
+                case .TWO: "TWO"
+                case .THREE: "THREE"
+                default: fatalError()
+                }
+            }
+        }
+        public var rawValue: Swift.Int32 {
+            get {
+                switch self {
+                case .ONE: 0
+                case .TWO: 1
+                case .THREE: 2
+                default: fatalError()
+                }
+            }
+        }
+        public init?(
+            _ description: Swift.String
+        ) {
+            switch description {
+            case "ONE": self = .ONE
+            case "TWO": self = .TWO
+            case "THREE": self = .THREE
+            default: return nil
+            }
+        }
+        public init?(
+            rawValue: Swift.Int32
+        ) {
+            guard 0..<3 ~= rawValue else { return nil }
+            self = EnumClassA.allCases[Int(rawValue)]
+        }
+        public init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer!,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            switch org_kotlin_foo_EnumClassA_ordinal(__externalRCRefUnsafe) {
+            case 0: self = .ONE
+            case 1: self = .TWO
+            case 2: self = .THREE
+            default: fatalError()
+            }
+        }
+        public func __externalRCRef() -> Swift.UnsafeMutableRawPointer! {
+            return switch self {
+            case .ONE: org_kotlin_foo_EnumClassA_ONE()
+            case .TWO: org_kotlin_foo_EnumClassA_TWO()
+            case .THREE: org_kotlin_foo_EnumClassA_THREE()
+            default: fatalError()
+            }
+        }
+    }
+    public enum EnumClassB: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {
+        case FOUR
+        case FIVE
+        case SIX
+        public var description: Swift.String {
+            get {
+                switch self {
+                case .FOUR: "FOUR"
+                case .FIVE: "FIVE"
+                case .SIX: "SIX"
+                default: fatalError()
+                }
+            }
+        }
+        public var rawValue: Swift.Int32 {
+            get {
+                switch self {
+                case .FOUR: 0
+                case .FIVE: 1
+                case .SIX: 2
+                default: fatalError()
+                }
+            }
+        }
+        public init?(
+            _ description: Swift.String
+        ) {
+            switch description {
+            case "FOUR": self = .FOUR
+            case "FIVE": self = .FIVE
+            case "SIX": self = .SIX
+            default: return nil
+            }
+        }
+        public init?(
+            rawValue: Swift.Int32
+        ) {
+            guard 0..<3 ~= rawValue else { return nil }
+            self = EnumClassB.allCases[Int(rawValue)]
+        }
+        public init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer!,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            switch org_kotlin_foo_EnumClassB_ordinal(__externalRCRefUnsafe) {
+            case 0: self = .FOUR
+            case 1: self = .FIVE
+            case 2: self = .SIX
+            default: fatalError()
+            }
+        }
+        public func __externalRCRef() -> Swift.UnsafeMutableRawPointer! {
+            return switch self {
+            case .FOUR: org_kotlin_foo_EnumClassB_FOUR()
+            case .FIVE: org_kotlin_foo_EnumClassB_FIVE()
+            case .SIX: org_kotlin_foo_EnumClassB_SIX()
+            default: fatalError()
+            }
+        }
+    }
     public enum MySealedClass_SealedType: KotlinRuntimeSupport.SealedType {
         case myClassAInner(ExportedKotlinPackages.org.kotlin.foo.MyClassA.Inner_SealedType)
         case myClassBInner(ExportedKotlinPackages.org.kotlin.foo.MyClassB.Inner_SealedType)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/sealedTypes.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/sealedTypes.kt
@@ -25,6 +25,14 @@ internal class ClassF : SealedInterfaceA
 
 internal class ClassG : SealedClassA()
 
+enum class EnumClassA : SealedInterfaceA {
+    ONE, TWO, THREE
+}
+
+enum class EnumClassB : InterfaceC {
+    FOUR, FIVE, SIX
+}
+
 // FILE: deprecation.kt
 package org.kotlin.foo
 


### PR DESCRIPTION
ATM enums don't conform to protocols so we can simply exclude them.

^KT-88682 Fixed