### PR TITLE
[Wasm] enable FirSuperCallWithDefaultsChecker ^KT-88725

### DIFF
--- a/analysis/low-level-api-fir/low-level-api-fir-compiler-tests/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/compiler/based/TestGenerator.kt
+++ b/analysis/low-level-api-fir/low-level-api-fir-compiler-tests/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/compiler/based/TestGenerator.kt
@@ -150,10 +150,12 @@ fun main(args: Array<String>) {
         testGroup(generatedTestRoot, "compiler/testData/diagnostics") {
             fun TestGroup.TestClass.modelInitWasmJs() {
                 model("wasmTests", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
+                model("tests/defaultArguments", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
             }
 
             fun TestGroup.TestClass.modelInitWasmWasi() {
                 model("wasmWasiTests", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
+                model("tests/defaultArguments", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
             }
 
             testClass<AbstractLLWasmJsDiagnosticsTest>(suiteTestClassName = "LLWasmJsDiagnosticsFe10TestGenerated") {

--- a/compiler/fir/checkers/checkers.wasm/src/org/jetbrains/kotlin/fir/analysis/wasm/checkers/WasmExpressionCheckers.kt
+++ b/compiler/fir/checkers/checkers.wasm/src/org/jetbrains/kotlin/fir/analysis/wasm/checkers/WasmExpressionCheckers.kt
@@ -24,6 +24,7 @@ object WasmBaseExpressionCheckers : ExpressionCheckers() {
 
     override val functionCallCheckers: Set<FirFunctionCallChecker>
         get() = setOf(
+            FirSuperCallWithDefaultsChecker,
             FirWasmReifiedExternalChecker
         )
 }

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateWasmTests.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateWasmTests.kt
@@ -94,6 +94,7 @@ fun main(args: Array<String>) {
         testGroup(testsRoot, "compiler/testData/diagnostics") {
             testClass<AbstractWasmJsDiagnosticTest> {
                 model("wasmTests", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
+                model("tests/defaultArguments", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
                 model("wasmDiagnosticsKlibTests", excludedPattern = TestGeneratorUtil.KT_OR_KTS_WITH_FIR_PREFIX)
                 model("testsWithAnyBackend", excludedPattern = TestGeneratorUtil.KT_OR_KTS_WITH_FIR_PREFIX)
             }


### PR DESCRIPTION
In K/Wasm following code also works incorrectly, so we prohibit `super` calls with default arguments, as it's done in K/Native, K/JVM.
```
interface I { // can also be an abstract class
    fun foo(p1: Int, p2: Int = 0)
}

open class A : I {
    override fun foo(p1: Int, p2: Int) {
        println("A::foo $p1 $p2")
    }
}

class B : A() {
    override fun foo(p1: Int, p2: Int) {
        println("B::foo $p1 $p2")
    }

    fun bar() {
        super.foo(1, 2)
        super.foo(1) // should print "A::foo 1 0", but prints "B::foo 1 0" instead
        foo(1, 2)
        foo(1)
    }
}

fun main() {
    B().bar()
}
```

Fixes ^KT-88725