### PR TITLE
[Parcelize] Improve diagnostics for invalid `@Parcelize` targets

### DIFF
--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeClassChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeClassChecker.kt
@@ -44,28 +44,38 @@ class FirParcelizeClassChecker(private val parcelizeAnnotations: List<ClassId>) 
         val source = klass.source ?: return
         val classKind = klass.classKind
 
-        if (klass is FirRegularClass) {
-            if (classKind == ClassKind.ANNOTATION_CLASS || classKind == ClassKind.INTERFACE && !klass.isSealed) {
-                reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_SHOULD_BE_CLASS, context)
-                return
-            }
+        when (klass) {
+            is FirRegularClass -> {
+                if (classKind == ClassKind.ANNOTATION_CLASS) {
+                    reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_ANNOTATION_CLASS, context)
+                    return
+                }
 
-            klass.companionObjectSymbol?.let { companionSymbol ->
-                if (companionSymbol.classId.shortClassName == CREATOR_NAME) {
-                    reporter.reportOn(companionSymbol.source, KtErrorsParcelize.CREATOR_DEFINITION_IS_NOT_ALLOWED, context)
+                if (classKind == ClassKind.INTERFACE && !klass.isSealed) {
+                    reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_NON_SEALED_INTERFACE, context)
+                    return
+                }
+
+                klass.companionObjectSymbol?.let { companionSymbol ->
+                    if (companionSymbol.classId.shortClassName == CREATOR_NAME) {
+                        reporter.reportOn(companionSymbol.source, KtErrorsParcelize.CREATOR_DEFINITION_IS_NOT_ALLOWED, context)
+                    }
+                }
+
+                if (klass.isInner) {
+                    reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_INNER_CLASS, context)
+                }
+
+                if (klass.isLocal) {
+                    reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_LOCAL_CLASS, context)
                 }
             }
-
-            if (klass.isInner) {
-                reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_INNER_CLASS, context)
+            is FirAnonymousObject -> {
+                if (classKind != ClassKind.ENUM_ENTRY) {
+                    reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_ANONYMOUS_OBJECT, context)
+                    return
+                }
             }
-
-            if (klass.isLocal) {
-                reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_CANT_BE_LOCAL_CLASS, context)
-            }
-        } else if (classKind != ClassKind.ENUM_ENTRY) {
-            reporter.reportOn(source, KtErrorsParcelize.PARCELABLE_SHOULD_BE_CLASS, context)
-            return
         }
 
         if (classKind == ClassKind.CLASS && klass.isAbstract) {

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/KtDefaultErrorMessagesParcelize.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/KtDefaultErrorMessagesParcelize.kt
@@ -30,12 +30,14 @@ import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.INAPPLIC
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.INAPPLICABLE_IGNORED_ON_PARCEL_CONSTRUCTOR_PROPERTY
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.NO_PARCELABLE_SUPERTYPE
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.OVERRIDING_WRITE_TO_PARCEL_IS_NOT_ALLOWED
+import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CANT_BE_ANNOTATION_CLASS
+import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CANT_BE_ANONYMOUS_OBJECT
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CANT_BE_INNER_CLASS
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CANT_BE_LOCAL_CLASS
+import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CANT_BE_NON_SEALED_INTERFACE
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_CONSTRUCTOR_PARAMETER_SHOULD_BE_VAL_OR_VAR
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_DELEGATE_IS_NOT_ALLOWED
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY
-import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_SHOULD_BE_CLASS
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_SHOULD_BE_INSTANTIABLE
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_SHOULD_HAVE_PRIMARY_CONSTRUCTOR
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.PARCELABLE_SHOULD_NOT_BE_ENUM_CLASS
@@ -50,8 +52,18 @@ import org.jetbrains.kotlin.parcelize.fir.diagnostics.KtErrorsParcelize.VALUE_PA
 object KtDefaultErrorMessagesParcelize : BaseDiagnosticRendererFactory() {
     override val MAP by KtDiagnosticFactoryToRendererMap("Parcelize") { map ->
         map.put(
-            PARCELABLE_SHOULD_BE_CLASS,
-            "'Parcelable' must be a class."
+            PARCELABLE_CANT_BE_NON_SEALED_INTERFACE,
+            "'Parcelable' cannot be a non-sealed interface."
+        )
+
+        map.put(
+            PARCELABLE_CANT_BE_ANNOTATION_CLASS,
+            "'Parcelable' cannot be an 'annotation class'."
+        )
+
+        map.put(
+            PARCELABLE_CANT_BE_ANONYMOUS_OBJECT,
+            "'Parcelable' cannot be an anonymous object."
         )
 
         map.put(

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/KtErrorsParcelize.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/KtErrorsParcelize.kt
@@ -28,7 +28,9 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 
 object KtErrorsParcelize : KtDiagnosticsContainer() {
-    val PARCELABLE_SHOULD_BE_CLASS by error0<PsiElement>(NAME_IDENTIFIER)
+    val PARCELABLE_CANT_BE_NON_SEALED_INTERFACE by error0<PsiElement>(NAME_IDENTIFIER)
+    val PARCELABLE_CANT_BE_ANNOTATION_CLASS by error0<PsiElement>(NAME_IDENTIFIER)
+    val PARCELABLE_CANT_BE_ANONYMOUS_OBJECT by error0<PsiElement>(NAME_IDENTIFIER)
     val PARCELABLE_DELEGATE_IS_NOT_ALLOWED by error0<PsiElement>(DELEGATED_SUPERTYPE_BY_KEYWORD)
     val PARCELABLE_SHOULD_NOT_BE_ENUM_CLASS by error0<PsiElement>()
     val PARCELABLE_SHOULD_BE_INSTANTIABLE by error0<PsiElement>(ABSTRACT_MODIFIER)

--- a/plugins/parcelize/parcelize-compiler/testData/diagnostics/modality.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/diagnostics/modality.kt
@@ -29,7 +29,7 @@ class Outer {
 
 fun foo() {
     @Parcelize
-    <!ABSTRACT_MEMBER_NOT_IMPLEMENTED, PARCELABLE_SHOULD_BE_CLASS!>object<!> : Parcelable {}
+    <!ABSTRACT_MEMBER_NOT_IMPLEMENTED, PARCELABLE_CANT_BE_ANONYMOUS_OBJECT!>object<!> : Parcelable {}
 
     object : Open("") {}
 

--- a/plugins/parcelize/parcelize-compiler/testData/diagnostics/wrongAnnotationTarget.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/diagnostics/wrongAnnotationTarget.kt
@@ -4,7 +4,7 @@ import kotlinx.parcelize.Parcelize
 import android.os.Parcelable
 
 @Parcelize
-interface <!PARCELABLE_SHOULD_BE_CLASS!>Intf<!> : Parcelable
+interface <!PARCELABLE_CANT_BE_NON_SEALED_INTERFACE!>Intf<!> : Parcelable
 
 @Parcelize
 object <!NO_PARCELABLE_SUPERTYPE!>Obj<!>
@@ -22,4 +22,4 @@ enum class <!NO_PARCELABLE_SUPERTYPE!>Enum<!> {
 }
 
 @Parcelize
-annotation class <!ANNOTATION_CLASS_MEMBER, ANNOTATION_CLASS_MEMBER, PARCELABLE_SHOULD_BE_CLASS!>Anno<!>
+annotation class <!ANNOTATION_CLASS_MEMBER, ANNOTATION_CLASS_MEMBER, PARCELABLE_CANT_BE_ANNOTATION_CLASS!>Anno<!>


### PR DESCRIPTION
https://issuetracker.google.com/177850556

Previously, annotating non-sealed interfaces, annotation classes, or anonymous objects with `@Parcelize` produced a generic error message: "'Parcelable' must be a class." This was imprecise because objects and sealed interfaces are valid targets, and the error did not clearly describe why the construct was rejected.

Replace `PARCELABLE_SHOULD_BE_CLASS` with three dedicated diagnostics:
- `PARCELABLE_CANT_BE_NON_SEALED_INTERFACE`
- `PARCELABLE_CANT_BE_ANNOTATION_CLASS`
- `PARCELABLE_CANT_BE_ANONYMOUS_OBJECT`