### PR TITLE
Reflection: fix flaky IllegalAccessException from Java field access

### DIFF
--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKProperty.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKProperty.kt
@@ -22,7 +22,6 @@ import java.lang.reflect.Member
 import java.lang.reflect.Modifier
 import java.lang.reflect.Type
 import kotlin.LazyThreadSafetyMode.PUBLICATION
-import kotlin.jvm.internal.CallableReference
 import kotlin.reflect.KFunction
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KProperty
@@ -290,7 +289,7 @@ private fun DescriptorKProperty.Accessor<*, *>.computeCallerForAccessor(isGetter
             }
         }
         is JavaField -> {
-            computeFieldCaller(jvmSignature.field)
+            computeFieldCaller(property.javaField ?: jvmSignature.field)
         }
         is JavaMethodProperty -> {
             val method =


### PR DESCRIPTION
`jvmSignature` is computed a few lines above from a soft-referenced descriptor. So, if the descriptor was garbage-collected after the call to `isAccessible = true` and before the call to `get`, `jvmSignature` would be `JavaField` with a new `Field` object, which is inaccessible, which led to `IllegalAccessException`. The solution is to use the strongly-referenced `javaField` instead.

Note that this issue was present only in K1-based implementation. New implementation in `KotlinKProperty` doesn't use soft references at all.

No tests added because this is about the K1-based implementation only, and because creating such a test would be a bit non-trivial.

 #KTI-3488 Fixed