### PR TITLE
[Wasm] Emit return_call_ref for indirect (callRef) tail calls

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/BodyGenerator.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/BodyGenerator.kt
@@ -58,12 +58,20 @@ class BodyGenerator(
      * [WasmTailCallLowering] marks structurally tail-positioned calls with
      * [WASM_TAIL_CALL] origin. On top of that, the caller's Wasm result type
      * must match the callee's, because `return_call` requires them to be equal.
+     *
+     * [calleeReturnType] defaults to the callee's declared return type. Indirect (callRef)
+     * dispatch passes the concrete result type the wasm function type is built from,
+     * because the callRef intrinsic itself declares the erased type parameter `T`.
      */
-    private fun isEligibleForTailCall(call: IrFunctionAccessExpression, callee: IrFunction): Boolean {
+    private fun isEligibleForTailCall(
+        call: IrFunctionAccessExpression,
+        callee: IrFunction,
+        calleeReturnType: IrType = callee.returnType,
+    ): Boolean {
         if (call.origin !== WASM_TAIL_CALL) return false
         val caller = functionContext.irFunction ?: return false
         val callerResultType = wasmModuleTypeTransformer.transformResultType(caller.returnType)
-        val calleeResultType = wasmModuleTypeTransformer.transformResultType(callee.returnType)
+        val calleeResultType = wasmModuleTypeTransformer.transformResultType(calleeReturnType)
         return callerResultType == calleeResultType
     }
 
@@ -839,8 +847,13 @@ class BodyGenerator(
             callRefArguments.forEach { generateExpression(it!!) }
             val functionTypeReference = typeCodegenContext.referenceWasmFunctionType(wasmFunctionType)
             generateExpression(call.arguments[0]!!)
-            body.buildInstr(WasmOp.CALL_REF, location, functionTypeReference)
-            if (resultType.isUnit())
+            val isTailCallRef = isEligibleForTailCall(call, call.symbol.owner, calleeReturnType = resultType)
+            body.buildInstr(
+                if (isTailCallRef) WasmOp.RETURN_CALL_REF else WasmOp.CALL_REF,
+                location,
+                functionTypeReference,
+            )
+            if (!isTailCallRef && resultType.isUnit())
                 body.buildGetUnit()
             return
         }

--- a/compiler/testData/codegen/box/wasm-ir-checks/wasmTailCallCallRef.kt
+++ b/compiler/testData/codegen/box/wasm-ir-checks/wasmTailCallCallRef.kt
@@ -1,0 +1,36 @@
+// TARGET_BACKEND: WASM
+// ENABLE_TAIL_CALLS
+
+// Stress test for tail-call emission on the `callRef` (indirect / closure) dispatch path.
+// Each level of recursion goes through a callable-reference `invoke` bridge whose body is
+// `return callRef(this.func, ...)`. Unless that callRef is emitted as `return_call_ref`, every
+// level keeps the invoke frame and the recursion overflows the host stack at depth 1_000_000.
+//
+// The result type is `Any` on purpose: the generic `Function*.invoke` is erased to return
+// `kotlin.Any`, so the surrounding calls only stay in tail position (and the chain only runs in
+// constant stack) when the enclosing functions also flow `Any`. This isolates the callRef
+// emission from the separate question of Unit/primitive return-type erasure.
+
+// Recursion through a freshly-allocated closure on every level.
+fun closureCountdown(n: Int): Any {
+    if (n == 0) return 0
+    val step: () -> Any = { closureCountdown(n - 1) }
+    return step()
+}
+
+// Recursion through a bound function reference.
+fun refTarget(n: Int): Any = if (n == 0) 0 else refCountdown(n - 1)
+
+fun refCountdown(n: Int): Any {
+    val step: (Int) -> Any = ::refTarget
+    return step(n)
+}
+
+fun box(): String {
+    val depth = 1_000_000
+
+    if (closureCountdown(depth) != 0) return "fail closure"
+    if (refCountdown(depth) != 0) return "fail ref"
+
+    return "OK"
+}


### PR DESCRIPTION
## Summary

Tail-call emission in #6396 covered direct calls (return_call) and virtual dispatch (return_call_ref through the vtable), but the callRef intrinsic path, used for invoking a function reference or closure through its funcref, always emitted a plain call_ref, even in tail position. Every callable-reference invoke bridge generated by WasmCallableReferenceLowering ends in `return callRef(this.func, ...)`, so this left a non-tail frame on every indirect higher-order call.

Emit return_call_ref when the callRef is in tail position and the wasm-level result type of the function reference matches the enclosing function's. The eligibility check is shared with the direct and virtual paths: isEligibleForTailCall gains a calleeResultType parameter defaulting to the callee's declared return type, and the callRef site passes the concrete result type the wasm function type is built from, because the callRef intrinsic itself declares the erased type parameter T. When the types differ, the non-tail call_ref path and its trailing get_unit for Unit results are kept unchanged.

The box test recurses through a closure and through a bound function reference at depth 1_000_000, which overflows the host stack without this change.

##  Changes

- `BodyGenerator` gains an optional `calleeReturnType` parameter in `isEligibleForTailCall`, letting indirect dispatch supply the concrete result type. Eligible `callRef` sites emit `RETURN_CALL_REF` and skip the trailing `getUnit`.
- `wasmTailCallCallRef.kt` stress-tests closure allocation and bound function reference dispatch at depth 1M.