### PR TITLE
CLI: use `Inflater.inflate(ByteBuffer)` on JDK 11+

### DIFF
--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
@@ -171,9 +171,15 @@ private fun LargeDynamicMappedBuffer.parseCentralDirectoryRecordsNumberAndOffset
 private val setInflaterInputFromBuffer: ((Inflater, ByteBuffer) -> Unit)? =
     try {
         val method = Inflater::class.java.getMethod("setInput", ByteBuffer::class.java)
-        val setter: (Inflater, ByteBuffer) -> Unit = { inflater, buffer -> method.invoke(inflater, buffer) }
+        val setter: (Inflater, ByteBuffer) -> Unit = { inflater, buffer ->
+            try {
+                method.invoke(inflater, buffer)
+            } catch (e: InvocationTargetException) {
+                throw e.cause ?: e
+            }
+        }
         setter
-    } catch (e: Throwable) {
+    } catch (_: Throwable) {
         null
     }
 

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.cli.jvm.compiler.jarfs
 
+import java.lang.reflect.InvocationTargetException
 import java.nio.ByteBuffer
 import java.util.zip.Inflater
 
@@ -55,7 +56,7 @@ internal fun LargeDynamicMappedBuffer.contentsToByteArray(
 
                 val result = ByteArray(zipEntryDescription.uncompressedSize.toInt())
 
-                inflater.inflate(result)
+                inflateToByteArray(inflater, result)
                 inflater.end()
 
                 result
@@ -162,7 +163,7 @@ private fun LargeDynamicMappedBuffer.parseCentralDirectoryRecordsNumberAndOffset
 /**
  * `Inflater.setInput(ByteBuffer)` exists since JDK 11. When it is available, we can feed the inflater a slice of the
  * memory-mapped buffer directly, avoiding both the allocation and the `ByteBuffer.get(...)` copy of the compressed data
- * (the latter pins a heap array via `Unsafe.copyMemory`/GCLocker since JDK 17, see KT-69758).
+ * (see KT-69758).
  *
  * On older JDKs (8-10) the method is absent, this stays `null`, and we fall back to the copying path.
  * TODO: Get rid of this property once this module is switched to JDK 11+ (KT-86803)
@@ -175,6 +176,61 @@ private val setInflaterInputFromBuffer: ((Inflater, ByteBuffer) -> Unit)? =
     } catch (e: Throwable) {
         null
     }
+
+/**
+ * `Inflater.inflate(ByteBuffer)` exists since JDK 11. When it is available, we inflate into a direct buffer and copy the result out,
+ * instead of inflating into the heap array directly: the latter pins the array via `GetPrimitiveArrayCritical`, which blocks GC until
+ * the call is over, and under load leads to spurious `OutOfMemoryError`s on JDKs before 22 (KTI-3258).
+ *
+ * On older JDKs (8-10), we fall back to inflating into the array.
+ * TODO: Get rid of this property once this module is switched to JDK 11+ (KT-86803)
+ */
+private val inflateToBuffer: ((Inflater, ByteBuffer) -> Int)? =
+    try {
+        val method = Inflater::class.java.getMethod("inflate", ByteBuffer::class.java)
+        val inflate: (Inflater, ByteBuffer) -> Int = { inflater, buffer ->
+            try {
+                method.invoke(inflater, buffer) as Int
+            } catch (e: InvocationTargetException) {
+                throw e.cause ?: e
+            }
+        }
+        inflate
+    } catch (_: Throwable) {
+        null
+    }
+
+private const val INITIAL_DIRECT_BUFFER_SIZE = 1 shl 16
+
+/** Entries above this size are inflated into the heap array, so that a single large entry doesn't keep a large buffer per thread. */
+private const val MAX_DIRECT_BUFFER_SIZE = 1 shl 22
+
+private val directBuffer: ThreadLocal<ByteBuffer> = ThreadLocal()
+
+private fun inflateToByteArray(inflater: Inflater, result: ByteArray) {
+    val inflate = inflateToBuffer
+    val buffer = if (inflate != null) directBufferOfAtLeast(result.size) else null
+    if (inflate == null || buffer == null) {
+        inflater.inflate(result)
+        return
+    }
+
+    buffer.clear()
+    buffer.limit(result.size)
+    // A single `inflate` call is not guaranteed to fill the whole buffer.
+    while (buffer.hasRemaining()) {
+        if (inflate(inflater, buffer) == 0) break
+    }
+    buffer.flip()
+    buffer.get(result, 0, buffer.remaining())
+}
+
+private fun directBufferOfAtLeast(size: Int): ByteBuffer? {
+    if (size > MAX_DIRECT_BUFFER_SIZE) return null
+    directBuffer.get()?.takeIf { it.capacity() >= size }?.let { return it }
+    return ByteBuffer.allocateDirect(size.coerceAtLeast(INITIAL_DIRECT_BUFFER_SIZE)).also(directBuffer::set)
+}
+
 private fun LargeDynamicMappedBuffer.Mapping.parseZip64CentralDirectoryRecordsNumberAndOffset(): Pair<Long, Long> {
     var endOfCentralDirectoryOffset = endOffset() - END_OF_CENTRAL_DIR_ZIP64_SIZE
     while (endOfCentralDirectoryOffset >= 0) {

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/jarfs/ZipImplementation.kt
@@ -200,35 +200,26 @@ private val inflateToBuffer: ((Inflater, ByteBuffer) -> Int)? =
         null
     }
 
-private const val INITIAL_DIRECT_BUFFER_SIZE = 1 shl 16
-
-/** Entries above this size are inflated into the heap array, so that a single large entry doesn't keep a large buffer per thread. */
-private const val MAX_DIRECT_BUFFER_SIZE = 1 shl 22
+private const val DIRECT_BUFFER_SIZE = 1 shl 16
 
 private val directBuffer: ThreadLocal<ByteBuffer> = ThreadLocal()
 
 private fun inflateToByteArray(inflater: Inflater, result: ByteArray) {
-    val inflate = inflateToBuffer
-    val buffer = if (inflate != null) directBufferOfAtLeast(result.size) else null
-    if (inflate == null || buffer == null) {
+    val inflate = inflateToBuffer ?: run {
         inflater.inflate(result)
         return
     }
-
-    buffer.clear()
-    buffer.limit(result.size)
-    // A single `inflate` call is not guaranteed to fill the whole buffer.
-    while (buffer.hasRemaining()) {
+    val buffer = directBuffer.get() ?: ByteBuffer.allocateDirect(DIRECT_BUFFER_SIZE).also(directBuffer::set)
+    var offset = 0
+    while (offset < result.size) {
+        buffer.clear()
+        buffer.limit(minOf(DIRECT_BUFFER_SIZE, result.size - offset))
         if (inflate(inflater, buffer) == 0) break
+        buffer.flip()
+        val count = buffer.remaining()
+        buffer.get(result, offset, count)
+        offset += count
     }
-    buffer.flip()
-    buffer.get(result, 0, buffer.remaining())
-}
-
-private fun directBufferOfAtLeast(size: Int): ByteBuffer? {
-    if (size > MAX_DIRECT_BUFFER_SIZE) return null
-    directBuffer.get()?.takeIf { it.capacity() >= size }?.let { return it }
-    return ByteBuffer.allocateDirect(size.coerceAtLeast(INITIAL_DIRECT_BUFFER_SIZE)).also(directBuffer::set)
 }
 
 private fun LargeDynamicMappedBuffer.Mapping.parseZip64CentralDirectoryRecordsNumberAndOffset(): Pair<Long, Long> {

--- a/compiler/tests/org/jetbrains/kotlin/jvm/compiler/io/FastJarFSTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/jvm/compiler/io/FastJarFSTest.kt
@@ -18,7 +18,7 @@ import java.io.PrintStream
 import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
-
+import kotlin.random.Random
 
 abstract class AbstractFastJarFSTest {
 
@@ -137,6 +137,24 @@ class FastJarFSTest : AbstractFastJarFSTest() {
             out.closeEntry()
         }
         assertEquals(data, String(fs.findFileByPath(jarFile.absolutePath + "!/flat.txt")!!.contentsToByteArray()))
+    }
+
+    @Test
+    fun testDeflatedEntryLargerThanInflateBuffer() {
+        val fs = fs ?: return
+        val tmpDir = KotlinTestUtils.tmpDirForTest(testInfo)
+        val jarFile = File(tmpDir, "tmp.jar")
+
+        // Larger than the buffer that the inflater output is read through, so that several `inflate` calls are needed.
+        val data = Random(42).nextBytes(5 * 1024 * 1024)
+        ZipOutputStream(FileOutputStream(jarFile)).use { out ->
+            out.putNextEntry(ZipEntry("big.bin"))
+            out.write(data)
+            out.closeEntry()
+        }
+
+        val file = fs.findFileByPath(jarFile.absolutePath + "!/big.bin") ?: error("Not found big.bin")
+        Assertions.assertArrayEquals(data, file.contentsToByteArray())
     }
 }
 


### PR DESCRIPTION
Previous change in 84a7c369c0 fixed the issue in `setInput`, however a similar problem is still there in the `inflate` call.

On JDK 11+, `Inflater.inflate(byte[])` calls either `inflateBytesBytes` or `inflateBufferBytes`, both of which are native and take `byte[]` as a parameter, and both pin the array with `GetPrimitiveArrayCritical`, which blocks GC until the call is over. This could have resulted in flaky OOMs in tests-different-jdk, because while one thread is inflating zip entries, another thread might fail to allocate because of GCLocker, which leads to OOM.

If we use `Inflater.inflate(ByteBuffer)` instead, we'll end up with `inflateBufferBuffer` which doesn't use `GetPrimitiveArrayCritical` (see sources of `Inflater.c` in the JDK), and GCLocker has no way to interfere.

To avoid allocating a `ByteBuffer` on each entry, cache it in a thread-local variable. Also, fallback to using the old method in case the requested entry is too large (> 4 MB) or if JDK < 11 is used.

Note that the code works as before on JDK < 11, but there's no problem on JDK 8 in tests-different-jdk because on JDK 8, ParallelGC is used by default, while OOMs happen only since JDK 11, where G1 is the default (since JDK 9). ParallelGC has a simpler architecture which apparently doesn't suffer from this problem. Also, we plan to raise the minimal JDK for the compiler soon anyway (KT-88173).

 #KT-69758
 #KTI-3258