### PR TITLE
[Build] Fix test performance regression on jvmCodegenTests and klib compatibility tests

### DIFF
--- a/compiler/fir/fir2ir/build.gradle.kts
+++ b/compiler/fir/fir2ir/build.gradle.kts
@@ -109,6 +109,8 @@ projectTests {
         "aggregateTests",
         defineJDKEnvVariables = environment,
         skipInLocalBuild = true,
+        maxHeapSize = testMaxHeapSizeLarge,
+        garbageCollector = GarbageCollector.Parallel
     ) {
         configure {
             excludeTags("FirPsiCodegenTest")

--- a/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/generalTestTask.kt
+++ b/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/generalTestTask.kt
@@ -152,16 +152,10 @@ internal fun Project.createGeneralTestTask(
             "-Djna.nosys=true"
         )
 
-        val effectiveGC = effectiveGC.orNull
-        if (effectiveGC != null) {
-            jvmArgs(
-                when (effectiveGC) {
-                    GarbageCollector.G1 -> "-XX:+UseG1GC"
-                    GarbageCollector.Parallel -> "-XX:+UseParallelGC"
-                },
-                "-XX:MaxHeapFreeRatio=30",
-                "-XX:MinHeapFreeRatio=10",
-            )
+        when (effectiveGC.orNull) {
+            GarbageCollector.G1 -> jvmArgs("-XX:+UseG1GC")
+            GarbageCollector.Parallel -> jvmArgs("-XX:+UseParallelGC")
+            null -> Unit
         }
 
         val nativeMemoryTracking = project.providers.gradleProperty("kotlin.build.test.process.NativeMemoryTracking")


### PR DESCRIPTION
The previous changes, providing static Xmx values reduced the available memory (Xmx) for this tests to 2g (default). A heap of this size causes a significant GC overhead.