### PR TITLE
Generators: do not log unchanged kotlin-compiler-arguments.json

### DIFF
--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/serialization/json/jsonSerializer.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/serialization/json/jsonSerializer.kt
@@ -22,5 +22,5 @@ fun main(args: Array<String>) {
 
     val jsonArguments = format.encodeToString(kotlinCompilerArguments)
 
-    GeneratorsFileUtil.writeFileIfContentChanged(destinationFile, jsonArguments)
+    GeneratorsFileUtil.writeFileIfContentChanged(destinationFile, jsonArguments, logNotChanged = false)
 }


### PR DESCRIPTION
To avoid this message on every clean build:

    Not changed: /home/udalov/kotlin/compiler/arguments/resources/kotlin-compiler-arguments.json