### PR TITLE
[Gradle] Add integration tests for KMP test execution, aggregation, and failure reporting

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestReportIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestReportIT.kt
@@ -7,13 +7,15 @@ package org.jetbrains.kotlin.gradle.mpp
 
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.testFederation.SmokeTest
 import org.junit.jupiter.api.DisplayName
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @MppGradlePluginTests
-@DisplayName("Tests for Multiplatform test reporting")
+@SmokeTest
+@DisplayName("Tests for KMP test reporting")
 class MppTestReportIT : KGPBaseTest() {
 
     @DisplayName("Aggregated test report contains results from multiple targets (:allTests)")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestReportIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestReportIT.kt
@@ -72,4 +72,61 @@ class MppTestReportIT : KGPBaseTest() {
             )
         }
     }
+
+    @DisplayName("Test failure details, stack trace anti-drift, and HTML report (:jvmTest)")
+    @GradleTest
+    fun testTestFailureReportingAndStackTrace(gradleVersion: GradleVersion) {
+        project(
+            "base-kotlin-multiplatform-library",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
+        ) {
+            buildScriptInjection {
+                kotlinMultiplatform.jvm()
+                kotlinMultiplatform.sourceSets.getByName("commonTest").dependencies {
+                    implementation(kotlin("test"))
+                }
+            }
+
+            val testClass = "FailingTest"
+            val testPackage = "org.example.project"
+            val testSource = """
+                package $testPackage
+
+                import kotlin.test.Test
+
+                class $testClass {
+                    @Test
+                    fun failing() {
+                        throw IllegalStateException("boom")
+                    }
+                }
+            """.trimIndent()
+
+            val throwingLine = testSource.lines().indexOfFirst { "throw" in it } + 1
+
+            kotlinSourcesDir("commonTest").source("$testPackage/$testClass.kt") {
+                testSource
+            }
+
+            buildAndFail(":jvmTest") {
+                assertTasksFailed(":jvmTest")
+            }
+
+            val testCases = readTestCases(":jvmTest")
+            val failingTestCase = testCases.single { it.className == "$testPackage.$testClass" && it.name.startsWith("failing") }
+            val failure = failingTestCase.failure
+            assertNotNull(failure, "Expected failure information for test case")
+            assertEquals("java.lang.IllegalStateException", failure.type)
+            assertEquals("java.lang.IllegalStateException: boom", failure.message)
+            assertNotNull(failure.stackTrace, "Expected stack trace in test failure")
+            assertTrue(
+                failure.stackTrace.contains("$testPackage.$testClass.failing($testClass.kt:$throwingLine)"),
+                "Expected stack trace to contain '$testPackage.$testClass.failing($testClass.kt:$throwingLine)', but was:\n${failure.stackTrace}"
+            )
+
+            val htmlReport = testClassHtmlReport(":jvmTest", "$testPackage.$testClass", gradleVersion, targetName = "jvm")
+            assertFileExists(htmlReport)
+        }
+    }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestReportIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppTestReportIT.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.mpp
+
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@MppGradlePluginTests
+@DisplayName("Tests for Multiplatform test reporting")
+class MppTestReportIT : KGPBaseTest() {
+
+    @DisplayName("Aggregated test report contains results from multiple targets (:allTests)")
+    @GradleTest
+    fun testAllTestsReportAggregation(gradleVersion: GradleVersion) {
+        project(
+            "base-kotlin-multiplatform-library",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
+        ) {
+            buildScriptInjection {
+                kotlinMultiplatform.jvm()
+                kotlinMultiplatform.js {
+                    nodejs()
+                }
+                kotlinMultiplatform.sourceSets.getByName("commonTest").dependencies {
+                    implementation(kotlin("test"))
+                }
+            }
+
+            kotlinSourcesDir("commonTest").source("org/example/project/SampleTest.kt") {
+                """
+                package org.example.project
+
+                import kotlin.test.Test
+                import kotlin.test.assertTrue
+
+                class SampleTest {
+                    @Test
+                    fun testOne() {
+                        assertTrue(true)
+                    }
+
+                    @Test
+                    fun testTwo() {
+                        assertTrue(true)
+                    }
+                }
+                """.trimIndent()
+            }
+
+            build(":allTests") {
+                assertTasksExecuted(":jvmTest", ":jsNodeTest", ":allTests")
+            }
+
+            assertFileInProjectExists("build/reports/tests/allTests/index.html")
+            assertExecutedTestCases(
+                ":jvmTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+            assertExecutedTestCases(
+                ":jsNodeTest",
+                "org.example.project.SampleTest#testOne",
+                "org.example.project.SampleTest#testTwo",
+            )
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
@@ -142,6 +142,7 @@ fun GradleProject.readTestCases(
     taskName: String,
     subprojectName: String? = null,
 ): List<TestCaseResult> {
+    val simpleTaskName = taskName.removePrefix(":").substringAfterLast(':')
     val testReportDir = testResultsAndReportsDirs(taskName, subprojectName).first
 
     if (!Files.exists(testReportDir)) {
@@ -157,9 +158,10 @@ fun GradleProject.readTestCases(
             else -> root.getChildren("testcase")
         }
         testCases.map { testCaseElement ->
-            val className = testCaseElement.getAttributeValue("classname")
+            val rawClassName = testCaseElement.getAttributeValue("classname")
                 ?: testCaseElement.getAttributeValue("className")
                 ?: ""
+            val className = rawClassName.removePrefix("$simpleTaskName.")
             val name = testCaseElement.getAttributeValue("name") ?: ""
             val failureElement = testCaseElement.getChild("failure") ?: testCaseElement.getChild("error")
             val failure = failureElement?.let {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
@@ -142,7 +142,7 @@ fun GradleProject.readTestCases(
     taskName: String,
     subprojectName: String? = null,
 ): List<TestCaseResult> {
-    val simpleTaskName = taskName.removePrefix(":").substringAfterLast(':')
+    val simpleTaskName = taskName.substringAfterLast(':')
     val testReportDir = testResultsAndReportsDirs(taskName, subprojectName).first
 
     if (!Files.exists(testReportDir)) {


### PR DESCRIPTION
### Summary
- Added dedicated, lightweight integration tests covering KMP test aggregation (`:allTests`) and test failure reporting fidelity (`:jvmTest`)

### Changes
`MppTestReportIT.kt`:
- Added `testAllTestsReportAggregation`: Verifies `:allTests` execution across multiple targets (`jvm` + `js(Node)`), aggregate HTML report generation (`build/reports/tests/allTests/index.html`), and XML test case verification.
- Added `testTestFailureReportingAndStackTrace`: Verifies `:jvmTest` failure handling, structured XML metadata (failure.type, failure.message), anti-drift dynamic line number resolution in stack traces, and target HTML report generation.

`testAssertions.kt`:
- Normalized test class name parsing in `readTestCases` to handle Gradle 9+ non-JVM task name prefixes.

^KQA-3437