### PR TITLE
[KGP] Don't set EXPAND_TYPE_ALIASES on older Build Tools API impls

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildToolsApiJvmCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildToolsApiJvmCompilationIT.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 import org.jetbrains.kotlin.gradle.tasks.USING_JVM_INCREMENTAL_COMPILATION_MESSAGE
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.junit.jupiter.api.DisplayName
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.writeText
 
 @DisplayName("JVM compilation via the Build Tools API")
@@ -25,7 +24,8 @@ class BuildToolsApiJvmCompilationIT : KGPBaseTest() {
     @DisplayName("Build Tools version consistency checker works if the old way of compilation is used together with the build tools API transform")
     fun versionConsistencyDiagnosticWorks(gradleVersion: GradleVersion) {
         project(
-            "simpleProject", gradleVersion, buildOptions = defaultBuildOptions.copy(
+            "simpleProject", gradleVersion,
+            buildOptions = defaultBuildOptions.copy(
                 runViaBuildToolsApi = false,
                 incremental = false,
             ),
@@ -56,7 +56,8 @@ class BuildToolsApiJvmCompilationIT : KGPBaseTest() {
                 kotlin {
                     coreLibrariesVersion = "${TestVersions.Kotlin.STABLE_RELEASE}"
                 }
-                """.trimIndent())
+                """.trimIndent()
+            )
             buildGradle.append( // FIXME: this is a workaround for KT-68107
                 // language=Gradle
                 """
@@ -69,6 +70,31 @@ class BuildToolsApiJvmCompilationIT : KGPBaseTest() {
             )
             build("assemble") {
                 assertNoDiagnostic(KotlinToolingDiagnostics.BuildToolsApiVersionInconsistency)
+            }
+        }
+    }
+
+    @GradleTest
+    @DisplayName("Classpath snapshotting works with a compiler older than the snapshotting options known to KGP")
+    fun classpathSnapshottingWithOlderCompilerVersion(gradleVersion: GradleVersion) {
+        project(
+            "incrementalMultiproject", gradleVersion,
+            buildOptions = defaultBuildOptions.copy(expandTypeAliasesInClasspathSnapshots = true),
+        ) {
+            listOf("lib", "app").forEach { subProjectName ->
+                subProject(subProjectName).buildGradle.append(
+                    // language=Gradle
+                    """
+                    kotlin {
+                        compilerVersion.set("${"2.4.20-RC"}")
+                        coreLibrariesVersion = "${"2.4.20-RC"}"
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            build("assemble") {
+                assertTasksExecuted(":lib:compileKotlin", ":app:compileKotlin")
             }
         }
     }
@@ -146,4 +172,5 @@ class BuildToolsApiJvmCompilationIT : KGPBaseTest() {
             }
         }
     }
+
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/transforms/ClasspathEntrySnapshotTransform.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/transforms/ClasspathEntrySnapshotTransform.kt
@@ -25,6 +25,8 @@ import org.jetbrains.kotlin.compilerRunner.btapi.BuildSessionService
 import org.jetbrains.kotlin.gradle.internal.ClassLoadersCachingBuildService
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.TransformActionUsingKotlinToolingDiagnostics
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import org.jetbrains.kotlin.tooling.core.toKotlinVersion
 import java.io.File
 
 /** Transform to create a snapshot of a classpath entry (directory or jar). */
@@ -71,11 +73,13 @@ internal abstract class ClasspathEntrySnapshotTransform : TransformAction<Classp
     @get:InputArtifact
     abstract val inputArtifact: Provider<FileSystemLocation>
 
+    // workaround for incorrect nullability of `map`
+    private val buildToolsImplVersion: String?
+        get() = parameters.buildToolsImplVersion.orNull.takeIf { it != "null" }
+
     private fun checkVersionConsistency() {
         if (parameters.suppressVersionInconsistencyChecks.get()) return
         val kgpVersion = parameters.kgpVersion.get()
-        val buildToolsImplVersion = parameters.buildToolsImplVersion.orNull
-            .takeIf { it != "null" } // workaround for incorrect nullability of `map`
         if (kgpVersion != buildToolsImplVersion) {
             reportDiagnostic(KotlinToolingDiagnostics.BuildToolsApiVersionInconsistency(kgpVersion, buildToolsImplVersion))
         }
@@ -111,7 +115,10 @@ internal abstract class ClasspathEntrySnapshotTransform : TransformAction<Classp
             .apply {
                 this[GRANULARITY] = granularity
                 this[PARSE_INLINED_LOCAL_CLASSES] = parseInlinedLocalClasses
-                this[EXPAND_TYPE_ALIASES] = expandTypeAliases
+
+                if (supportsExpandTypeAliases()) {
+                    this[EXPAND_TYPE_ALIASES] = expandTypeAliases
+                }
             }.build()
         val snapshot = buildSession.executeOperation(snapshotOperation)
         snapshot.saveSnapshot(snapshotOutputFile)
@@ -135,5 +142,13 @@ internal abstract class ClasspathEntrySnapshotTransform : TransformAction<Classp
             classpathEntryDirOrJar.name == "android.jar"
         ) CLASS_LEVEL
         else CLASS_MEMBER_LEVEL
+    }
+
+    private fun supportsExpandTypeAliases(): Boolean {
+        val implVersionString = buildToolsImplVersion ?: return false
+        val implVersion = KotlinToolingVersion(implVersionString)
+
+        return implVersion.toKotlinVersion()
+            .isAtLeast(EXPAND_TYPE_ALIASES.availableSinceVersion.major, EXPAND_TYPE_ALIASES.availableSinceVersion.minor)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
@@ -170,11 +170,11 @@ internal open class BaseKotlinCompileConfig<TASK : KotlinCompile> : AbstractKotl
             project.kotlinPropertiesProvider.expandTypeAliasesInClasspathSnapshots.map { it && isMultiplatform }
         )
 
-        val suppressVersionInconsistencyChecks = project.kotlinPropertiesProvider.suppressBuildToolsApiVersionConsistencyChecks
-        if (!suppressVersionInconsistencyChecks) {
-            parameters.buildToolsImplVersion.set(classpath.map { configuration -> configuration.findBuildToolsApiImplVersion() })
-        }
-        parameters.suppressVersionInconsistencyChecks.set(suppressVersionInconsistencyChecks)
+        parameters.suppressVersionInconsistencyChecks.set(
+            project.kotlinPropertiesProvider.suppressBuildToolsApiVersionConsistencyChecks
+        )
+
+        parameters.buildToolsImplVersion.set(classpath.map { configuration -> configuration.findBuildToolsApiImplVersion() })
         parameters.buildSessionService.set(buildSessionService)
     }
 


### PR DESCRIPTION
A Build Tools API implementation throws when asked to set an option introduced after its own version, so pinning `kotlin.compilerVersion` to a release older than 2.5.0 broke classpath snapshotting. Skip the option when the resolved kotlin-build-tools-impl predates it, which also requires its version to be always passed to the transform, not only when the consistency check is enabled.

^KT-88018