### PR TITLE
Preparatory commits for KT-88012

### DIFF
--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/LLFirDiagnosticReporter.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/LLFirDiagnosticReporter.kt
@@ -42,7 +42,6 @@ internal class LLFirDiagnosticReporter : PendingDiagnosticReporter() {
 
         val psiDiagnostic = when (diagnostic) {
             is KtPsiDiagnostic -> diagnostic
-            is KtLightDiagnostic -> diagnostic.toPsiDiagnostic()
             else -> error("Unknown diagnostic type ${diagnostic::class.simpleName}")
         }
 
@@ -92,57 +91,4 @@ private fun KtPsiDiagnostic.isInside(element: AbstractKtSourceElement): Boolean 
 private fun KtDiagnostic.isAboutImplicitImport(): Boolean {
     if (this !is KtPsiDiagnostic) return false
     return (element is KtFakePsiSourceElement && (element as KtFakePsiSourceElement).kind == KtFakeSourceElementKind.ImplicitImport)
-}
-
-
-private fun KtLightDiagnostic.toPsiDiagnostic(): KtPsiDiagnostic {
-    val psiSourceElement = element.unwrapToKtPsiSourceElement()
-        ?: error("Diagnostic should be created from PSI in IDE")
-    @Suppress("UNCHECKED_CAST")
-    return when (this) {
-        is KtLightSimpleDiagnostic -> KtPsiSimpleDiagnostic(
-            psiSourceElement,
-            severity,
-            factory,
-            positioningStrategy,
-            context,
-        )
-
-        is KtLightDiagnosticWithParameters1<*> -> KtPsiDiagnosticWithParameters1(
-            psiSourceElement,
-            a,
-            severity,
-            factory as KtDiagnosticFactory1<Any?>,
-            positioningStrategy,
-            context,
-        )
-
-        is KtLightDiagnosticWithParameters2<*, *> -> KtPsiDiagnosticWithParameters2(
-            psiSourceElement,
-            a, b,
-            severity,
-            factory as KtDiagnosticFactory2<Any?, Any?>,
-            positioningStrategy,
-            context,
-        )
-
-        is KtLightDiagnosticWithParameters3<*, *, *> -> KtPsiDiagnosticWithParameters3(
-            psiSourceElement,
-            a, b, c,
-            severity,
-            factory as KtDiagnosticFactory3<Any?, Any?, Any?>,
-            positioningStrategy,
-            context,
-        )
-
-        is KtLightDiagnosticWithParameters4<*, *, *, *> -> KtPsiDiagnosticWithParameters4(
-            psiSourceElement,
-            a, b, c, d,
-            severity,
-            factory as KtDiagnosticFactory4<Any?, Any?, Any?, Any?>,
-            positioningStrategy,
-            context,
-        )
-        else -> error("Unknown diagnostic type ${this::class.simpleName}")
-    }
 }

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/stubBased/deserialization/StubBasedClassDeserialization.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/stubBased/deserialization/StubBasedClassDeserialization.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
 import org.jetbrains.kotlin.analysis.low.level.api.fir.projectStructure.LLFirModuleData
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.builder.FirRegularClassBuilder

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/SourceHelpers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/SourceHelpers.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirSupertypesChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirSupertypesChecker.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.fir.analysis.checkers.declaration
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
+import org.jetbrains.kotlin.KtLightSourceElement
+import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.ClassKind
@@ -35,7 +37,10 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirTypeAliasSymbol
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.StandardClassIds
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.toKtLightSourceElement
+import org.jetbrains.kotlin.toKtPsiSourceElement
 import org.jetbrains.kotlin.util.getChildren
 
 object FirSupertypesChecker : FirClassChecker(MppCheckerKind.Platform) {
@@ -209,15 +214,22 @@ object FirSupertypesChecker : FirClassChecker(MppCheckerKind.Platform) {
 
     private fun FirFunctionTypeParameter.findSourceForParameterName(): KtSourceElement? {
         val name = this.name ?: return null
-        val treeStructure = source.treeStructure
-        val nodes = source.lighterASTNode.getChildren(treeStructure)
-        val node = nodes.find { it.tokenType == KtTokens.IDENTIFIER && treeStructure.toString(it) == name.identifier } ?: return null
+        if (source is KtLightSourceElement) {
+            val treeStructure = source.treeStructure
+            val nodes = source.lighterASTNode.getChildren(treeStructure)
+            val node = nodes.find { it.tokenType == KtTokens.IDENTIFIER && treeStructure.toString(it) == name.identifier } ?: return null
 
-        return node.toKtLightSourceElement(
-            treeStructure,
-            startOffset = node.startOffset,
-            endOffset = node.endOffset
-        )
+            return node.toKtLightSourceElement(
+                treeStructure,
+                startOffset = node.startOffset,
+                endOffset = node.endOffset
+            )
+        } else {
+            val source = source
+            require(source is KtPsiSourceElement)
+            val psi = source.psi.findDescendantOfType<KtParameter> { it.nameAsName == name } ?: return null
+            return psi.nameIdentifier?.toKtPsiSourceElement()
+        }
     }
 
 

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/JvmSupertypeUpdater.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/JvmSupertypeUpdater.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.java
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.*

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/declarations/FirJavaClass.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/declarations/FirJavaClass.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirImplementationDetail
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.builder.FirAnnotationContainerBuilder

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/declarations/FirJavaTypeParameter.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/declarations/FirJavaTypeParameter.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.java.declarations
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirImplementationDetail
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.builder.FirBuilderDsl

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/enhancement/FirAnnotationTypeQualifierResolver.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/enhancement/FirAnnotationTypeQualifierResolver.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.java.enhancement
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirSessionComponent
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/enhancement/SignatureEnhancement.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/enhancement/SignatureEnhancement.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.FirCachesFactory

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/scopes/JavaClassUseSiteMemberScope.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/scopes/JavaClassUseSiteMemberScope.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.FirCachesFactory

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/scopes/JavaOverrideChecker.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/scopes/JavaOverrideChecker.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.SessionHolder
 import org.jetbrains.kotlin.fir.analysis.checkers.classKind

--- a/compiler/fir/plugin-utils/src/org/jetbrains/kotlin/fir/plugin/DeclarationBuildingContext.kt
+++ b/compiler/fir/plugin-utils/src/org/jetbrains/kotlin/fir/plugin/DeclarationBuildingContext.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.builder.buildTypeParameter

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/LookupTagUtils.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/LookupTagUtils.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.resolve
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.builtins.StandardNames
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirFunctionTypeParameter
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/calls/FirReceivers.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/calls/FirReceivers.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.calls
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.SessionAndScopeSessionHolder
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/calls/ImplicitValue.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/calls/ImplicitValue.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.calls
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.expressions.builder.*
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/CallableCopyTypeCalculator.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/CallableCopyTypeCalculator.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.scopes
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.resolvedTypeFromPrototype
 import org.jetbrains.kotlin.fir.types.ConeKotlinType

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirClassAnySynthesizedMemberScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirClassAnySynthesizedMemberScope.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirSessionComponent
 import org.jetbrains.kotlin.fir.caches.FirCache
@@ -24,7 +23,6 @@ import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
 import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
 import org.jetbrains.kotlin.fir.declarations.utils.equalityBoundType
 import org.jetbrains.kotlin.fir.declarations.utils.isData
-import org.jetbrains.kotlin.fir.declarations.utils.isExtension
 import org.jetbrains.kotlin.fir.declarations.utils.isInlineOrValue
 import org.jetbrains.kotlin.fir.languageVersionSettings
 import org.jetbrains.kotlin.fir.render

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirDelegatedMemberScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirDelegatedMemberScope.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.scopes.impl
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.utils.classId

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/TypeUtils.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.SessionHolder
 import org.jetbrains.kotlin.fir.copyWithNewSource

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/fir/DestructuringDeclaration.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/fir/DestructuringDeclaration.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.lightTree.fir
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.builder.AbstractRawFirBuilder
 import org.jetbrains.kotlin.fir.builder.DestructuringContext

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/fir/ValueParameter.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/fir/ValueParameter.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.lightTree.fir
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.*
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.builder.*
 import org.jetbrains.kotlin.fir.copy

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/Destructuring.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/Destructuring.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirVariable

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/CollectionLiteralResolution.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/CollectionLiteralResolution.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.resolve
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.StandardTypes
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.isDeprecationLevelHidden

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/CollectionLiteralResolutionUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/CollectionLiteralResolutionUtils.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.resolve
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.builtins.StandardNames
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.diagnostics.ConeCollectionLiteralAmbiguity
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.expressions.FirCollectionLiteral

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ContextSensitiveResolutionUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ContextSensitiveResolutionUtils.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.declarations.utils.isCompanion
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.expressions.*

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/FirSamResolver.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/FirSamResolver.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.builtins.functions.FunctionTypeKind
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.NullableMap

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolveUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ResolveUtils.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.builtins.functions.FunctionTypeKind
 import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.utils.hasExplicitBackingField

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/VisibilityUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/VisibilityUtils.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.calls
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.FirVisibilityChecker
 import org.jetbrains.kotlin.fir.declarations.*

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/candidate/Candidate.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/candidate/Candidate.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.calls.candidate
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/FirInvokeResolveTowerExtension.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/FirInvokeResolveTowerExtension.kt
@@ -9,7 +9,6 @@ import kotlinx.collections.immutable.toPersistentSet
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.declarations.utils.equalityBoundType
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/FirTowerResolveTask.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/FirTowerResolveTask.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.SessionHolder
 import org.jetbrains.kotlin.fir.declarations.FirTowerDataContext
 import org.jetbrains.kotlin.fir.declarations.fullyExpandedClass

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/TowerLevels.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/tower/TowerLevels.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.resolve.calls.tower
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.hasAnnotationWithClassId

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirCallCompleter.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirCallCompleter.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.KtFakeSourceElementKind.ItLambdaParameter
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.contracts.description.ConeCallsEffectDeclaration
 import org.jetbrains.kotlin.fir.contracts.description.ConeHoldsInEffectDeclaration

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedArgumentsAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/PostponedArgumentsAnalyzer.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.resolve.inference
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.references.builder.buildErrorNamedReference

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirCallCompletionResultsWriterTransformer.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.resolve.transformers
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.builtins.functions.FunctionTypeKind
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.synthetic.FirSyntheticProperty

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSpecificTypeResolverTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSpecificTypeResolverTransformer.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.resolve.transformers
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtRealSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.computeTypeAttributes
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSupertypesResolution.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSupertypesResolution.kt
@@ -11,7 +11,6 @@ import kotlinx.collections.immutable.toPersistentList
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.config.AnalysisFlags
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.utils.classId

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSyntheticCallGenerator.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSyntheticCallGenerator.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.resolve.transformers
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.builtins.StandardNames
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.createCache

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/IntegerLiteralAndOperatorApproximationTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/IntegerLiteralAndOperatorApproximationTransformer.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.transformers
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.SessionAndScopeSessionHolder

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/BodyResolveUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/BodyResolveUtils.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.fir.resolve.transformers.body.resolve
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.KtSourceElementOffsetStrategy
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
@@ -19,7 +18,6 @@ import org.jetbrains.kotlin.fir.expressions.builder.buildVarargArgumentsExpressi
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConePostponedInferenceDiagnostic
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.resolve.substitution.AbstractConeSubstitutor
-import org.jetbrains.kotlin.fir.resolve.substitution.ConeSubstitutor
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.StandardClassIds

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirArrayOfCallTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirArrayOfCallTransformer.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.transformers.body.resolve
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.expressions.*

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/contracts/FirAbstractContractResolveTransformerDispatcher.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/contracts/FirAbstractContractResolveTransformerDispatcher.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.fir.resolve.transformers.contracts
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.contracts.FirLegacyRawContractDescription
 import org.jetbrains.kotlin.fir.contracts.FirRawContractDescription

--- a/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/impl/FirSmartCastExpressionImpl.kt
+++ b/compiler/fir/tree/gen/org/jetbrains/kotlin/fir/expressions/impl/FirSmartCastExpressionImpl.kt
@@ -12,7 +12,6 @@ package org.jetbrains.kotlin.fir.expressions.impl
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.DfaType
 import org.jetbrains.kotlin.fir.MutableOrEmptyList
 import org.jetbrains.kotlin.fir.builder.toMutableOrEmpty

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/EnumClassUtils.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/EnumClassUtils.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.builtins.StandardNames.ENUM_VALUES
 import org.jetbrains.kotlin.builtins.StandardNames.ENUM_VALUE_OF
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.builder.FirRegularClassBuilder
 import org.jetbrains.kotlin.fir.declarations.builder.buildProperty

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirGeneration.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirGeneration.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirVariable

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/impl/FirDefaultPropertyAccessor.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/declarations/impl/FirDefaultPropertyAccessor.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibility
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirImplementationDetail
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.MutableOrEmptyList

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirContractCallBlock.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirContractCallBlock.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.expressions.impl
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.MutableOrEmptyList
 import org.jetbrains.kotlin.fir.builder.toMutableOrEmpty
 import org.jetbrains.kotlin.fir.expressions.*

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirSingleExpressionBlock.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/expressions/impl/FirSingleExpressionBlock.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.fir.expressions.impl
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.MutableOrEmptyList
 import org.jetbrains.kotlin.fir.builder.toMutableOrEmpty
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/ImplementationConfigurator.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/ImplementationConfigurator.kt
@@ -573,7 +573,7 @@ object ImplementationConfigurator : AbstractFirTreeImplementationConfigurator() 
                 value = "originalExpression.source?.fakeElement(KtFakeSourceElementKind.SmartCastExpression)"
                 withGetter = true
             }
-            additionalImports(fakeElementImport, fakeSourceElementKindImport)
+            additionalImports(fakeSourceElementKindImport)
         }
 
         impl(resolvedNamedReference)

--- a/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/importables.kt
+++ b/compiler/fir/tree/tree-generator/src/org/jetbrains/kotlin/fir/tree/generator/importables.kt
@@ -12,12 +12,10 @@ val resolvePhaseExtensionImport = ArbitraryImportable("org.jetbrains.kotlin.fir.
 val resolvedDeclarationStatusImport = ArbitraryImportable("org.jetbrains.kotlin.fir.declarations.impl", "FirResolvedDeclarationStatusImpl")
 
 val constructClassTypeImport = ArbitraryImportable("org.jetbrains.kotlin.fir.types", "constructClassType")
-val constructClassLikeTypeImport = ArbitraryImportable("org.jetbrains.kotlin.fir.types", "constructClassLikeType")
 val toLookupTagImport = ArbitraryImportable("org.jetbrains.kotlin.fir.types", "toLookupTag")
 val coneTypeOrNullImport = ArbitraryImportable("org.jetbrains.kotlin.fir.types", "coneTypeOrNull")
 
 val fakeSourceElementKindImport = ArbitraryImportable("org.jetbrains.kotlin", "KtFakeSourceElementKind")
-val fakeElementImport = ArbitraryImportable("org.jetbrains.kotlin", "fakeElement")
 
 val transformInPlaceImport = ArbitraryImportable(VISITOR_PACKAGE, "transformInplace")
 val transformSingleImport = ArbitraryImportable(VISITOR_PACKAGE, "transformSingle")

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/KtSourceElement.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/KtSourceElement.kt
@@ -1045,6 +1045,15 @@ sealed class KtSourceElement : AbstractKtSourceElement() {
 
     /** Elements of the same source should be considered equal. */
     abstract override fun equals(other: Any?): Boolean
+
+    abstract fun fakeElement(
+        newKind: KtFakeSourceElementKind,
+        offsetStrategy: KtSourceElementOffsetStrategy = KtSourceElementOffsetStrategy.Default,
+    ): KtSourceElement
+
+    abstract fun realElement(): KtSourceElement
+
+    abstract val text: CharSequence
 }
 
 // NB: in certain situations, psi.node could be null (see e.g. KT-44152)
@@ -1196,6 +1205,21 @@ sealed class KtPsiSourceElement(val psi: PsiElement) : KtSourceElement() {
         append(", ").append(startOffset).append("..").append(endOffset)
         append(')')
     }
+
+    override fun fakeElement(newKind: KtFakeSourceElementKind, offsetStrategy: KtSourceElementOffsetStrategy): KtSourceElement {
+        if (kind == newKind) return this
+        return when (offsetStrategy) {
+            is KtSourceElementOffsetStrategy.Default -> KtFakePsiSourceElement(psi, newKind)
+            is KtSourceElementOffsetStrategy.Custom -> KtFakePsiSourceElementWithCustomOffsetStrategy(psi, newKind, offsetStrategy)
+        }
+    }
+
+    override fun realElement(): KtSourceElement {
+        return KtRealPsiSourceElement(psi)
+    }
+
+    override val text: CharSequence
+        get() = psi.text
 }
 
 class KtRealPsiSourceElement(psi: PsiElement) : KtPsiSourceElement(psi) {
@@ -1298,42 +1322,6 @@ sealed class KtSourceElementOffsetStrategy {
     }
 }
 
-fun KtSourceElement.fakeElement(
-    newKind: KtFakeSourceElementKind,
-    offsetStrategy: KtSourceElementOffsetStrategy = KtSourceElementOffsetStrategy.Default,
-): KtSourceElement {
-    if (kind == newKind) return this
-    return when (this) {
-        is KtLightSourceElement -> {
-            val [startOffset, endOffset] = if (offsetStrategy is KtSourceElementOffsetStrategy.Custom) {
-                offsetStrategy.startOffset to offsetStrategy.endOffset
-            } else {
-                startOffset to endOffset
-            }
-
-            KtLightSourceElement(
-                lighterASTNode,
-                startOffset,
-                endOffset,
-                treeStructure,
-                newKind
-            )
-        }
-
-        is KtPsiSourceElement -> when (offsetStrategy) {
-            is KtSourceElementOffsetStrategy.Default -> KtFakePsiSourceElement(psi, newKind)
-            is KtSourceElementOffsetStrategy.Custom -> KtFakePsiSourceElementWithCustomOffsetStrategy(psi, newKind, offsetStrategy)
-        }
-    }
-}
-
-fun KtSourceElement.realElement(): KtSourceElement = when (this) {
-    is KtRealPsiSourceElement -> this
-    is KtLightSourceElement -> KtLightSourceElement(lighterASTNode, startOffset, endOffset, treeStructure, KtRealSourceElementKind)
-    is KtPsiSourceElement -> KtRealPsiSourceElement(psi)
-}
-
-
 class KtLightSourceElement(
     override val lighterASTNode: LighterASTNode,
     override val startOffset: Int,
@@ -1395,22 +1383,45 @@ class KtLightSourceElement(
         append(", ").append(startOffset).append("..").append(endOffset)
         append(')')
     }
+
+    override fun fakeElement(
+        newKind: KtFakeSourceElementKind,
+        offsetStrategy: KtSourceElementOffsetStrategy,
+    ): KtLightSourceElement {
+        if (kind == newKind) return this
+        val [startOffset, endOffset] = if (offsetStrategy is KtSourceElementOffsetStrategy.Custom) {
+            offsetStrategy.startOffset to offsetStrategy.endOffset
+        } else {
+            startOffset to endOffset
+        }
+
+        return KtLightSourceElement(
+            lighterASTNode,
+            startOffset,
+            endOffset,
+            treeStructure,
+            newKind
+        )
+    }
+
+    override fun realElement(): KtSourceElement {
+        return KtLightSourceElement(lighterASTNode, startOffset, endOffset, treeStructure, KtRealSourceElementKind)
+    }
+
+    override val text: CharSequence
+        get() = treeStructure.toString(lighterASTNode)
 }
 
 val AbstractKtSourceElement?.psi: PsiElement? get() = (this as? KtPsiSourceElement)?.psi
-
-val KtSourceElement?.text: CharSequence?
-    get() = when (this) {
-        is KtPsiSourceElement -> psi.text
-        is KtLightSourceElement -> treeStructure.toString(lighterASTNode)
-        else -> null
-    }
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun PsiElement.toKtPsiSourceElement(kind: KtSourceElementKind = KtRealSourceElementKind): KtPsiSourceElement = when (kind) {
     is KtRealSourceElementKind -> KtRealPsiSourceElement(this)
     is KtFakeSourceElementKind -> KtFakePsiSourceElement(this, kind)
 }
+
+val KtSourceElement?.text: CharSequence?
+    get() = this?.text
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun LighterASTNode.toKtLightSourceElement(

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiElement
 
 interface DiagnosticMarker {
     val psiElement: PsiElement
+        get() = error("psiElement should be called only on KtPsiDiagnostic and equivalents")
     val factoryName: String
     val severity: Severity
     val textRanges: List<TextRange>

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.AbstractKtSourceElement
-import org.jetbrains.kotlin.KtLightSourceElement
 import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.utils.exceptions.requireWithAttachment
@@ -192,94 +191,30 @@ data class KtPsiDiagnosticWithParameters4<A, B, C, D>(
     }
 }
 
-// ------------------------------ light tree diagnostics ------------------------------
+// ------------------------------ regular (non-PSI) diagnostics ------------------------------
 
-interface KtLightDiagnostic : DiagnosticMarker {
-    val element: KtLightSourceElement
-
-    @Deprecated("Should not be called", level = DeprecationLevel.HIDDEN)
-    override val psiElement: PsiElement
-        get() = error("psiElement should not be called on KtLightDiagnostic")
-}
-
-data class KtLightSimpleDiagnostic(
-    override val element: KtLightSourceElement,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory0,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtSimpleDiagnostic(), KtLightDiagnostic
-
-data class KtLightDiagnosticWithParameters1<A>(
-    override val element: KtLightSourceElement,
-    override val a: A,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory1<A>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters1<A>(), KtLightDiagnostic
-
-data class KtLightDiagnosticWithParameters2<A, B>(
-    override val element: KtLightSourceElement,
-    override val a: A,
-    override val b: B,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory2<A, B>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters2<A, B>(), KtLightDiagnostic
-
-data class KtLightDiagnosticWithParameters3<A, B, C>(
-    override val element: KtLightSourceElement,
-    override val a: A,
-    override val b: B,
-    override val c: C,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory3<A, B, C>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters3<A, B, C>(), KtLightDiagnostic
-
-data class KtLightDiagnosticWithParameters4<A, B, C, D>(
-    override val element: KtLightSourceElement,
-    override val a: A,
-    override val b: B,
-    override val c: C,
-    override val d: D,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory4<A, B, C, D>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters4<A, B, C, D>(), KtLightDiagnostic
-
-// ------------------------------ offset-based diagnostics ------------------------------
-
-interface KtOffsetsOnlyDiagnostic : DiagnosticMarker {
+interface KtRegularDiagnostic : DiagnosticMarker {
     val element: AbstractKtSourceElement
-
-    @Deprecated("Should not be called", level = DeprecationLevel.HIDDEN)
-    override val psiElement: PsiElement
-        get() = error("psiElement should not be called on KtOffsetsOnlyDiagnostic")
 }
 
-data class KtOffsetsOnlySimpleDiagnostic(
+data class KtRegularSimpleDiagnostic(
     override val element: AbstractKtSourceElement,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory0,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtSimpleDiagnostic(), KtOffsetsOnlyDiagnostic
+) : KtSimpleDiagnostic(), KtRegularDiagnostic
 
-data class KtOffsetsOnlyDiagnosticWithParameters1<A>(
+data class KtRegularDiagnosticWithParameters1<A>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory1<A>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters1<A>(), KtOffsetsOnlyDiagnostic
+) : KtDiagnosticWithParameters1<A>(), KtRegularDiagnostic
 
-data class KtOffsetsOnlyDiagnosticWithParameters2<A, B>(
+data class KtRegularDiagnosticWithParameters2<A, B>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val b: B,
@@ -287,9 +222,9 @@ data class KtOffsetsOnlyDiagnosticWithParameters2<A, B>(
     override val factory: KtDiagnosticFactory2<A, B>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters2<A, B>(), KtOffsetsOnlyDiagnostic
+) : KtDiagnosticWithParameters2<A, B>(), KtRegularDiagnostic
 
-data class KtOffsetsOnlyDiagnosticWithParameters3<A, B, C>(
+data class KtRegularDiagnosticWithParameters3<A, B, C>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val b: B,
@@ -298,9 +233,9 @@ data class KtOffsetsOnlyDiagnosticWithParameters3<A, B, C>(
     override val factory: KtDiagnosticFactory3<A, B, C>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters3<A, B, C>(), KtOffsetsOnlyDiagnostic
+) : KtDiagnosticWithParameters3<A, B, C>(), KtRegularDiagnostic
 
-data class KtOffsetsOnlyDiagnosticWithParameters4<A, B, C, D>(
+data class KtRegularDiagnosticWithParameters4<A, B, C, D>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val b: B,
@@ -310,4 +245,4 @@ data class KtOffsetsOnlyDiagnosticWithParameters4<A, B, C, D>(
     override val factory: KtDiagnosticFactory4<A, B, C, D>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters4<A, B, C, D>(), KtOffsetsOnlyDiagnostic
+) : KtDiagnosticWithParameters4<A, B, C, D>(), KtRegularDiagnostic

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
@@ -8,7 +8,6 @@
 package org.jetbrains.kotlin.diagnostics
 
 import org.jetbrains.kotlin.AbstractKtSourceElement
-import org.jetbrains.kotlin.KtLightSourceElement
 import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.config.AnalysisFlags
@@ -85,14 +84,7 @@ class KtDiagnosticFactory0(
                 positioningStrategy ?: defaultPositioningStrategy,
                 context,
             )
-            is KtLightSourceElement -> KtLightSimpleDiagnostic(
-                element,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtOffsetsOnlySimpleDiagnostic(
+            else -> KtRegularSimpleDiagnostic(
                 element,
                 effectiveSeverity,
                 this,
@@ -127,15 +119,7 @@ class KtDiagnosticFactory1<A>(
                 positioningStrategy ?: defaultPositioningStrategy,
                 context,
             )
-            is KtLightSourceElement -> KtLightDiagnosticWithParameters1(
-                element,
-                a,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtOffsetsOnlyDiagnosticWithParameters1(
+            else -> KtRegularDiagnosticWithParameters1(
                 element,
                 a,
                 effectiveSeverity,
@@ -173,16 +157,7 @@ class KtDiagnosticFactory2<A, B>(
                 positioningStrategy ?: defaultPositioningStrategy,
                 context,
             )
-            is KtLightSourceElement -> KtLightDiagnosticWithParameters2(
-                element,
-                a,
-                b,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtOffsetsOnlyDiagnosticWithParameters2(
+            else -> KtRegularDiagnosticWithParameters2(
                 element,
                 a,
                 b,
@@ -223,17 +198,7 @@ class KtDiagnosticFactory3<A, B, C>(
                 positioningStrategy ?: defaultPositioningStrategy,
                 context,
             )
-            is KtLightSourceElement -> KtLightDiagnosticWithParameters3(
-                element,
-                a,
-                b,
-                c,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtOffsetsOnlyDiagnosticWithParameters3(
+            else -> KtRegularDiagnosticWithParameters3(
                 element,
                 a,
                 b,
@@ -277,18 +242,7 @@ class KtDiagnosticFactory4<A, B, C, D>(
                 positioningStrategy ?: defaultPositioningStrategy,
                 context,
             )
-            is KtLightSourceElement -> KtLightDiagnosticWithParameters4(
-                element,
-                a,
-                b,
-                c,
-                d,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtOffsetsOnlyDiagnosticWithParameters4(
+            else -> KtRegularDiagnosticWithParameters4(
                 element,
                 a,
                 b,

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/util/AnalysisExceptions.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/util/AnalysisExceptions.kt
@@ -10,7 +10,6 @@ import com.intellij.util.diff.FlyweightCapableTreeStructure
 import org.jetbrains.kotlin.KtRealSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.psi
-import org.jetbrains.kotlin.text
 import org.jetbrains.kotlin.utils.exceptions.shouldIjPlatformExceptionBeRethrown
 
 val Throwable.classNameAndMessage get() = "${this::class.qualifiedName}: $message"
@@ -75,14 +74,14 @@ private fun KtSourceElement.isDefinitelyNotInsideFile(fileSource: KtSourceElemen
 private fun reportFileMismatch(source: KtSourceElement, fileSource: KtSourceElement, cause: Throwable): Throwable {
     val thisPsi = source.psi
     val otherPsi = fileSource.psi
-    val comparison = "This:\n\n${source.text?.asQuote}\n\n...is not present in"
+    val comparison = "This:\n\n${source.text.asQuote}\n\n...is not present in"
 
     val expectedFileMessage = if (thisPsi != null && otherPsi != null) {
         val actualPath = thisPsi.containingFile.virtualFile.path
         val expectedPath = otherPsi.containingFile.virtualFile.path
         "$expectedPath, but rather in $actualPath"
     } else {
-        "...${fileSource.text?.asQuote}"
+        "...${fileSource.text.asQuote}"
     }
 
     return IllegalStateException(

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
@@ -505,7 +505,7 @@ private class DebugDiagnosticConsumer(
                 factory.defaultPositioningStrategy,
                 DiagnosticContext.Default,
             )
-            is KtLightSourceElement -> KtLightSimpleDiagnostic(
+            is KtLightSourceElement -> KtRegularSimpleDiagnostic(
                 sourceElement,
                 factory.severity,
                 factory,
@@ -542,7 +542,7 @@ private class DebugDiagnosticConsumer(
                 factory.defaultPositioningStrategy,
                 DiagnosticContext.Default,
             )
-            is KtLightSourceElement -> KtLightDiagnosticWithParameters1(
+            is KtLightSourceElement -> KtRegularDiagnosticWithParameters1(
                 positionedElement,
                 argumentFactory(),
                 factory.severity,

--- a/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/FirAssignmentPluginAssignAltererExtension.kt
+++ b/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/FirAssignmentPluginAssignAltererExtension.kt
@@ -6,9 +6,7 @@
 package org.jetbrains.kotlin.assignment.plugin.k2
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.expressions.builder.buildFunctionCall
 import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpression
@@ -25,7 +23,6 @@ import org.jetbrains.kotlin.fir.types.upperBoundIfFlexible
 import org.jetbrains.kotlin.types.expressions.OperatorConventions.ASSIGN_METHOD
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
-@OptIn(DirectDeclarationsAccess::class)
 class FirAssignmentPluginAssignAltererExtension(
     session: FirSession
 ) : FirAssignExpressionAltererExtension(session) {

--- a/plugins/js-plain-objects/compiler-plugin/js-plain-objects.k2/src/org/jetbrains/kotlinx/jso/compiler/fir/JsPlainObjectsFunctionsGenerator.kt
+++ b/plugins/js-plain-objects/compiler-plugin/js-plain-objects.k2/src/org/jetbrains/kotlinx/jso/compiler/fir/JsPlainObjectsFunctionsGenerator.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.resolve.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.builder.FirAnnotationContainerBuilder

--- a/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/FunctionCallTransformer.kt
+++ b/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/FunctionCallTransformer.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirAnnotationContainer
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirFunctionTarget

--- a/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/AbstractConstructorGeneratorPart.kt
+++ b/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/AbstractConstructorGeneratorPart.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.lombok.generators
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtRealSourceElementKind
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.containingClassForStaticMemberAttr

--- a/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/generators/MemberFunctionWithAnnotatedParametersGenerator.kt
+++ b/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/generators/MemberFunctionWithAnnotatedParametersGenerator.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.plugin.sandbox.fir.generators
 
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationResolvePhase
 import org.jetbrains.kotlin.fir.expressions.FirExpression

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/services/FirReplSnippetResolveExtensionImpl.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/services/FirReplSnippetResolveExtensionImpl.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.scripting.compiler.plugin.services
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceFile
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.utils.isReplSnippetDeclaration

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/services/FirScriptConfigurationExtensionImpl.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/services/FirScriptConfigurationExtensionImpl.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.KtSourceFile
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.builder.Context

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/services/FirScriptResolutionConfigurationExtensionImpl.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/services/FirScriptResolutionConfigurationExtensionImpl.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.scripting.compiler.plugin.services
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirImport
 import org.jetbrains.kotlin.fir.declarations.FirScript


### PR DESCRIPTION
The main purposes of preparatory commits:
* avoid situations when we create LT-based diagnostics on PSI-based code
* encapsulate information about PSI in `KtPsiSourceElement` and avoid LT/PSI "multiplexing" when possible