### PR TITLE
[Gradle] Refactor external Android target test suites to use shared helper

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/AllTestsExternalAndroidTargetIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/AllTestsExternalAndroidTargetIT.kt
@@ -5,8 +5,6 @@
 
 package org.jetbrains.kotlin.gradle.android.externalAndroidTarget
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
-import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
 
@@ -21,28 +19,17 @@ class AllTestsExternalAndroidTargetIT : KGPBaseTest() {
         androidVersion: String,
         jdkVersion: JdkVersions.ProvidedJdk,
     ) {
-        project(
-            "empty",
+        externalAndroidLibraryProject(
             gradleVersion = gradleVersion,
-            buildOptions = defaultBuildOptions.copy(androidVersion = androidVersion),
-            buildJdk = jdkVersion.location,
+            androidVersion = androidVersion,
+            jdkVersion = jdkVersion,
+            namespace = "org.jetbrains.sample.alltests",
+            withJava = true,
+            androidLibraryConfiguration = {
+                withHostTest {}
+                withDeviceTest {}
+            },
         ) {
-            plugins {
-                kotlin("multiplatform")
-                id("com.android.kotlin.multiplatform.library")
-            }
-            buildScriptInjection {
-                kotlinMultiplatform.apply {
-                    targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach { target ->
-                        target.compileSdk = 34
-                        target.namespace = "org.jetbrains.sample.alltests"
-                        target.withJava()
-                        target.withHostTest {}
-                        target.withDeviceTest {}
-                    }
-                }
-            }
-
             projectPath.source("src/androidMain/kotlin/AndroidMain.kt") {
                 """
                 class AndroidMain

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/AndroidJvmLibDependencyResolutionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/AndroidJvmLibDependencyResolutionIT.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.gradle.android.externalAndroidTarget
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -482,23 +481,15 @@ class AndroidJvmLibDependencyResolutionIT : KGPBaseTest() {
         jdkVersion: JdkVersions.ProvidedJdk,
         namespace: String,
         configureKmp: KotlinMultiplatformExtension.() -> Unit = {},
-    ): TestProject = project(
-        "empty",
+    ): TestProject = externalAndroidLibraryProject(
         gradleVersion = gradleVersion,
-        buildOptions = defaultBuildOptions.copy(androidVersion = androidVersion),
-        buildJdk = jdkVersion.location,
+        androidVersion = androidVersion,
+        jdkVersion = jdkVersion,
+        namespace = namespace,
     ) {
-        plugins {
-            kotlin("multiplatform")
-            id("com.android.kotlin.multiplatform.library")
-        }
         projectPath.resolve("gradle.properties").toFile().appendText("\nkotlin.mpp.applyDefaultHierarchyTemplate=false\n")
         buildScriptInjection {
             kotlinMultiplatform.apply {
-                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach { target ->
-                    target.compileSdk = 34
-                    target.namespace = namespace
-                }
                 jvm()
                 macosArm64()
                 val commonMain = sourceSets.getByName("commonMain")
@@ -518,22 +509,14 @@ class AndroidJvmLibDependencyResolutionIT : KGPBaseTest() {
         jdkVersion: JdkVersions.ProvidedJdk,
         namespace: String,
         configureKmp: KotlinMultiplatformExtension.() -> Unit = {},
-    ): TestProject = project(
-        "empty",
+    ): TestProject = externalAndroidLibraryProject(
         gradleVersion = gradleVersion,
-        buildOptions = defaultBuildOptions.copy(androidVersion = androidVersion),
-        buildJdk = jdkVersion.location,
+        androidVersion = androidVersion,
+        jdkVersion = jdkVersion,
+        namespace = namespace,
     ) {
-        plugins {
-            kotlin("multiplatform")
-            id("com.android.kotlin.multiplatform.library")
-        }
         buildScriptInjection {
             kotlinMultiplatform.apply {
-                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach { target ->
-                    target.compileSdk = 34
-                    target.namespace = namespace
-                }
                 configureKmp()
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/ComposeCompilerPluginExternalAndroidTargetIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/ComposeCompilerPluginExternalAndroidTargetIT.kt
@@ -5,14 +5,12 @@
 
 package org.jetbrains.kotlin.gradle.android.externalAndroidTarget
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.logging.LogLevel
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.gradle.testbase.*
-import org.gradle.kotlin.dsl.kotlin
 import org.junit.jupiter.api.condition.OS
 import kotlin.io.path.listDirectoryEntries
 
@@ -31,26 +29,21 @@ class ComposeCompilerPluginExternalAndroidTargetIT : KGPBaseTest() {
         androidVersion: String,
         jdkVersion: JdkVersions.ProvidedJdk,
     ) {
-        val testProject = project(
-            "empty",
+        val testProject = externalAndroidLibraryProject(
             gradleVersion = gradleVersion,
-            buildOptions = defaultBuildOptions.copy(androidVersion = androidVersion),
-            buildJdk = jdkVersion.location,
-        ) {
-            plugins {
-                kotlin("multiplatform")
-                id("com.android.kotlin.multiplatform.library")
+            androidVersion = androidVersion,
+            jdkVersion = jdkVersion,
+            namespace = "org.jetbrains.sample.compose.android",
+            additionalPlugins = {
                 id("org.jetbrains.kotlin.plugin.compose")
-            }
-
+            },
+            androidLibraryConfiguration = {
+                withHostTest {}
+                withDeviceTest {}
+            },
+        ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
-                    targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach { target ->
-                        target.compileSdk = 34
-                        target.namespace = "org.jetbrains.sample.compose.android"
-                        target.withHostTest {}
-                        target.withDeviceTest {}
-                    }
                     iosArm64()
                     sourceSets.getByName("commonMain").dependencies {
                         implementation("org.jetbrains.compose.runtime:runtime:1.9.1")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/ExplicitApiExternalAndroidTargetIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/externalAndroidTarget/ExplicitApiExternalAndroidTargetIT.kt
@@ -5,9 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.android.externalAndroidTarget
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.logging.LogLevel
-import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
 
@@ -29,6 +27,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -64,6 +63,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -116,6 +116,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -166,6 +167,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -218,6 +220,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -268,6 +271,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -317,6 +321,7 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
             androidVersion = androidVersion,
             jdkVersion = jdkVersion,
             namespace = "org.jetbrains.sample",
+            withJava = true,
         ) {
             buildScriptInjection {
                 kotlinMultiplatform.apply {
@@ -355,34 +360,6 @@ class ExplicitApiExternalAndroidTargetIT : KGPBaseTest() {
                 assertOutputDoesNotContain("Return type must be specified in explicit API mode")
             }
         }
-    }
-
-    private fun externalAndroidLibraryProject(
-        gradleVersion: GradleVersion,
-        androidVersion: String,
-        jdkVersion: JdkVersions.ProvidedJdk,
-        namespace: String,
-        configureProject: TestProject.() -> Unit = {},
-    ): TestProject = project(
-        "empty",
-        gradleVersion = gradleVersion,
-        buildOptions = defaultBuildOptions.copy(androidVersion = androidVersion),
-        buildJdk = jdkVersion.location,
-    ) {
-        plugins {
-            kotlin("multiplatform")
-            id("com.android.kotlin.multiplatform.library")
-        }
-        buildScriptInjection {
-            kotlinMultiplatform.apply {
-                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach { target ->
-                    target.compileSdk = 34
-                    target.namespace = namespace
-                    target.withJava()
-                }
-            }
-        }
-        configureProject()
     }
 
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testProjectsBuildScriptInjectionDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testProjectsBuildScriptInjectionDsl.kt
@@ -9,6 +9,7 @@ import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.kotlin
+import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.util.GradleVersion
 import java.io.File
 
@@ -18,6 +19,7 @@ fun KGPBaseTest.externalAndroidLibraryProject(
     jdkVersion: JdkVersions.ProvidedJdk,
     namespace: String = "org.jetbrains.sample.androidlibrary",
     withJava: Boolean = false,
+    additionalPlugins: PluginDependenciesSpec.() -> Unit = {},
     androidLibraryConfiguration: KotlinMultiplatformAndroidLibraryTarget.() -> Unit = {},
     configureProject: TestProject.() -> Unit = {},
 ): TestProject = project(
@@ -29,6 +31,7 @@ fun KGPBaseTest.externalAndroidLibraryProject(
     plugins {
         kotlin("multiplatform")
         id("com.android.kotlin.multiplatform.library")
+        additionalPlugins()
     }
     buildScriptInjection {
         kotlinMultiplatform.apply {


### PR DESCRIPTION
### Summary
- refactored external Android target integration test suites to reuse the shared `externalAndroidLibraryProject` helper from `testProjectsBuildScriptInjectionDsl.kt`, eliminating duplicate test setup across test classes.
- stacked on https://github.com/JetBrains/kotlin/pull/7637

^KQA-3438