### PR TITLE
Add 'readLenient' function to 'KotlinModuleMetadata'.

### DIFF
--- a/libraries/kotlinx-metadata/jvm/api/kotlin-metadata-jvm.api
+++ b/libraries/kotlinx-metadata/jvm/api/kotlin-metadata-jvm.api
@@ -1011,6 +1011,8 @@ public final class kotlin/metadata/jvm/KotlinModuleMetadata {
 	public final fun getKmModule ()Lkotlin/metadata/jvm/KmModule;
 	public final fun getVersion ()Lkotlin/metadata/jvm/JvmMetadataVersion;
 	public static final fun read ([B)Lkotlin/metadata/jvm/KotlinModuleMetadata;
+	public static final fun readLenient ([B)Lkotlin/metadata/jvm/KotlinModuleMetadata;
+	public static final fun readStrict ([B)Lkotlin/metadata/jvm/KotlinModuleMetadata;
 	public final fun setKmModule (Lkotlin/metadata/jvm/KmModule;)V
 	public final fun setVersion (Lkotlin/metadata/jvm/JvmMetadataVersion;)V
 	public final fun write ()[B
@@ -1018,6 +1020,8 @@ public final class kotlin/metadata/jvm/KotlinModuleMetadata {
 
 public final class kotlin/metadata/jvm/KotlinModuleMetadata$Companion {
 	public final fun read ([B)Lkotlin/metadata/jvm/KotlinModuleMetadata;
+	public final fun readLenient ([B)Lkotlin/metadata/jvm/KotlinModuleMetadata;
+	public final fun readStrict ([B)Lkotlin/metadata/jvm/KotlinModuleMetadata;
 }
 
 public abstract interface annotation class kotlin/metadata/jvm/UnstableMetadataApi : java/lang/annotation/Annotation {

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinClassMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinClassMetadata.kt
@@ -422,7 +422,7 @@ public sealed class KotlinClassMetadata {
             throw IllegalArgumentException("This $name cannot be written because it represents metadata read in lenient mode")
         }
 
-        private fun checkMetadataVersionForWrite(version: JvmMetadataVersion) {
+        internal fun checkMetadataVersionForWrite(version: JvmMetadataVersion) {
             require(version.major >= 1 && (version.major > 1 || version.minor >= 4)) {
                 "This version of kotlinx-metadata-jvm doesn't support writing Kotlin metadata of version earlier than 1.4. " +
                         "Please change the version from $version to at least [1, 4]."

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinClassMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinClassMetadata.kt
@@ -386,7 +386,7 @@ public sealed class KotlinClassMetadata {
          * or equivalent [KotlinClassHeader] can be used.
          *
          * This method can read only supported metadata versions (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for definition).
-         * It will throw an exception if the metadata version is greater than what kotlinx-metadata-jvm understands.
+         * It will throw an exception if the metadata version is greater than what kotlin-metadata-jvm understands.
          * It is suitable when your tooling cannot tolerate reading potentially incomplete or incorrect information due to version differences.
          * It is also the only method that allows metadata transformation and `KotlinClassMetadata.write` subsequent calls.
          *
@@ -424,11 +424,11 @@ public sealed class KotlinClassMetadata {
 
         internal fun checkMetadataVersionForWrite(version: JvmMetadataVersion) {
             require(version.major >= 1 && (version.major > 1 || version.minor >= 4)) {
-                "This version of kotlinx-metadata-jvm doesn't support writing Kotlin metadata of version earlier than 1.4. " +
+                "This version of kotlin-metadata-jvm doesn't support writing Kotlin metadata of version earlier than 1.4. " +
                         "Please change the version from $version to at least [1, 4]."
             }
             require(version <= JvmMetadataVersion.HIGHEST_ALLOWED_TO_WRITE) {
-                "kotlinx-metadata-jvm cannot write metadata for future compiler versions. Requested to write version $version, but highest known version is ${JvmMetadataVersion.HIGHEST_ALLOWED_TO_WRITE}"
+                "kotlin-metadata-jvm cannot write metadata for future compiler versions. Requested to write version $version, but highest known version is ${JvmMetadataVersion.HIGHEST_ALLOWED_TO_WRITE}"
             }
         }
 

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -57,6 +57,11 @@ public class KotlinModuleMetadata internal constructor(
     public fun write(): ByteArray {
         throwIfNotWriteable(isAllowedToWrite, "module")
         checkMetadataVersionForWrite(version)
+        return writeImpl()
+    }
+
+    // internal for testing
+    internal fun writeImpl(): ByteArray {
         val b = JvmModuleProtoBuf.Module.newBuilder()
         kmModule.packageParts.forEach { [fqName, packageParts] ->
             PackageParts(fqName).apply {

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -101,7 +101,11 @@ public class KotlinModuleMetadata internal constructor(
      * Collection of methods for reading and writing [KotlinModuleMetadata].
      */
     public companion object {
-        @Deprecated(level = DeprecationLevel.ERROR, message = "Use readStrict instead", replaceWith = ReplaceWith("readStrict(bytes)"))
+        @Deprecated(
+            level = DeprecationLevel.WARNING,
+            message = "read() throws an error if metadata version is too high. Use either readStrict() if you want to retain this behavior, or readLenient() if you want to try to read newer metadata.",
+            replaceWith = ReplaceWith("readStrict(bytes)")
+        )
         @JvmStatic
         @UnstableMetadataApi
         public fun read(bytes: ByteArray): KotlinModuleMetadata {

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -40,7 +40,7 @@ public class KotlinModuleMetadata internal constructor(
      */
     public var version: JvmMetadataVersion,
 
-    internal val isAllowedToWrite: Boolean,
+    private val isAllowedToWrite: Boolean,
 ) {
     public constructor(
         kmModule: KmModule,
@@ -96,24 +96,11 @@ public class KotlinModuleMetadata internal constructor(
      * Collection of methods for reading and writing [KotlinModuleMetadata].
      */
     public companion object {
-        /**
-         * Parses the given byte array with the .kotlin_module file content and returns the [KotlinModuleMetadata] instance,
-         * or `null` if this byte array encodes a module with an unsupported metadata version.
-         *
-         * This method can read only supported metadata versions (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for definition).
-         * It will throw an exception if the metadata version is greater than what kotlinx-metadata-jvm understands.
-         * It is suitable when your tooling cannot tolerate reading potentially incomplete or incorrect information due to version differences.
-         * It is also the only method that allows metadata transformation and `KotlinClassMetadata.write` subsequent calls.
-         *
-         * @throws IllegalArgumentException if an error happened while parsing the given byte array,
-         * which means that it is either not the content of a `.kotlin_module` file, or it has been corrupted.
-         *
-         * @see JvmMetadataVersion.LATEST_STABLE_SUPPORTED
-         */
+        @Deprecated(level = DeprecationLevel.ERROR, message = "Use readStrict instead", replaceWith = ReplaceWith("readStrict"))
         @JvmStatic
         @UnstableMetadataApi
         public fun read(bytes: ByteArray): KotlinModuleMetadata {
-            return readLenient(bytes, false)
+            return readMetadataImpl(bytes, lenient = false)
         }
 
         /**
@@ -133,7 +120,7 @@ public class KotlinModuleMetadata internal constructor(
         @JvmStatic
         @UnstableMetadataApi
         public fun readStrict(bytes: ByteArray): KotlinModuleMetadata {
-            return readLenient(bytes, false)
+            return readMetadataImpl(bytes, lenient = false)
         }
 
         /**
@@ -141,7 +128,6 @@ public class KotlinModuleMetadata internal constructor(
          * or `null` if this byte array encodes a module with an unsupported metadata version.
          *
          * This method makes best effort to read unsupported metadata versions.
-         * If [annotationData] version is greater than [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] + 1, this method still attempts to read it and may ignore parts of the metadata it does not understand.
          * Keep in mind that this method will still throw an exception if metadata is changed in an unpredictable way.
          * Because obtained metadata can be incomplete, its [KotlinClassMetadata.write] method will throw an exception.
          * This method still cannot read metadata produced by pre-1.0 compilers.
@@ -152,7 +138,12 @@ public class KotlinModuleMetadata internal constructor(
          * @see JvmMetadataVersion.LATEST_STABLE_SUPPORTED
          */
         @JvmStatic
-        public fun readLenient(bytes: ByteArray, lenient: Boolean): KotlinModuleMetadata {
+        @UnstableMetadataApi
+        public fun readLenient(bytes: ByteArray): KotlinModuleMetadata {
+            return readMetadataImpl(bytes, lenient = true)
+        }
+
+        private fun readMetadataImpl(bytes: ByteArray, lenient: Boolean): KotlinModuleMetadata {
             return wrapIntoMetadataExceptionWhenNeeded {
                 val result = ModuleMapping.loadModuleMapping(
                     bytes, "KotlinModuleMetadata", skipMetadataVersionCheck = lenient,

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -13,6 +13,8 @@ import org.jetbrains.kotlin.metadata.jvm.JvmModuleProtoBuf
 import org.jetbrains.kotlin.metadata.jvm.deserialization.ModuleMapping
 import org.jetbrains.kotlin.metadata.jvm.deserialization.PackageParts
 import org.jetbrains.kotlin.metadata.jvm.deserialization.serializeToByteArray
+import kotlin.metadata.jvm.KotlinClassMetadata.Companion.checkMetadataVersionForWrite
+import kotlin.metadata.jvm.KotlinClassMetadata.Companion.throwIfNotWriteable
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion as CompilerMetadataVersion
 
 /**
@@ -25,7 +27,7 @@ import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion as Compiler
  *  and `@OptionalExpectation` declarations ([KmModule.optionalAnnotationClasses]).
  */
 @UnstableMetadataApi
-public class KotlinModuleMetadata public constructor(
+public class KotlinModuleMetadata internal constructor(
     /**
      * [KmModule] representation of this metadata.
      *
@@ -37,7 +39,14 @@ public class KotlinModuleMetadata public constructor(
      * Version of this metadata.
      */
     public var version: JvmMetadataVersion,
+
+    internal val isAllowedToWrite: Boolean,
 ) {
+    public constructor(
+        kmModule: KmModule,
+        version: JvmMetadataVersion,
+    ) : this(kmModule, version, true)
+
     /**
      * Encodes and writes this metadata of the Kotlin module file.
      *
@@ -46,6 +55,8 @@ public class KotlinModuleMetadata public constructor(
      * @throws IllegalArgumentException if [kmModule] is not correct and cannot be written or if [version] is not supported for writing.
      */
     public fun write(): ByteArray {
+        throwIfNotWriteable(isAllowedToWrite, "module")
+        checkMetadataVersionForWrite(version)
         val b = JvmModuleProtoBuf.Module.newBuilder()
         kmModule.packageParts.forEach { [fqName, packageParts] ->
             PackageParts(fqName).apply {
@@ -89,23 +100,70 @@ public class KotlinModuleMetadata public constructor(
          * Parses the given byte array with the .kotlin_module file content and returns the [KotlinModuleMetadata] instance,
          * or `null` if this byte array encodes a module with an unsupported metadata version.
          *
+         * This method can read only supported metadata versions (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for definition).
+         * It will throw an exception if the metadata version is greater than what kotlinx-metadata-jvm understands.
+         * It is suitable when your tooling cannot tolerate reading potentially incomplete or incorrect information due to version differences.
+         * It is also the only method that allows metadata transformation and `KotlinClassMetadata.write` subsequent calls.
+         *
          * @throws IllegalArgumentException if an error happened while parsing the given byte array,
          * which means that it is either not the content of a `.kotlin_module` file, or it has been corrupted.
+         *
+         * @see JvmMetadataVersion.LATEST_STABLE_SUPPORTED
          */
         @JvmStatic
         @UnstableMetadataApi
         public fun read(bytes: ByteArray): KotlinModuleMetadata {
+            return readLenient(bytes, false)
+        }
+
+        /**
+         * Parses the given byte array with the .kotlin_module file content and returns the [KotlinModuleMetadata] instance,
+         * or `null` if this byte array encodes a module with an unsupported metadata version.
+         *
+         * This method can read only supported metadata versions (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for definition).
+         * It will throw an exception if the metadata version is greater than what kotlinx-metadata-jvm understands.
+         * It is suitable when your tooling cannot tolerate reading potentially incomplete or incorrect information due to version differences.
+         * It is also the only method that allows metadata transformation and `KotlinClassMetadata.write` subsequent calls.
+         *
+         * @throws IllegalArgumentException if an error happened while parsing the given byte array,
+         * which means that it is either not the content of a `.kotlin_module` file, or it has been corrupted.
+         *
+         * @see JvmMetadataVersion.LATEST_STABLE_SUPPORTED
+         */
+        @JvmStatic
+        @UnstableMetadataApi
+        public fun readStrict(bytes: ByteArray): KotlinModuleMetadata {
+            return readLenient(bytes, false)
+        }
+
+        /**
+         * Parses the given byte array with the .kotlin_module file content and returns the [KotlinModuleMetadata] instance,
+         * or `null` if this byte array encodes a module with an unsupported metadata version.
+         *
+         * This method makes best effort to read unsupported metadata versions.
+         * If [annotationData] version is greater than [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] + 1, this method still attempts to read it and may ignore parts of the metadata it does not understand.
+         * Keep in mind that this method will still throw an exception if metadata is changed in an unpredictable way.
+         * Because obtained metadata can be incomplete, its [KotlinClassMetadata.write] method will throw an exception.
+         * This method still cannot read metadata produced by pre-1.0 compilers.
+         *
+         * @throws IllegalArgumentException if an error happened while parsing the given byte array,
+         * which means that it is either not the content of a `.kotlin_module` file, or it has been corrupted.
+         *
+         * @see JvmMetadataVersion.LATEST_STABLE_SUPPORTED
+         */
+        @JvmStatic
+        public fun readLenient(bytes: ByteArray, lenient: Boolean): KotlinModuleMetadata {
             return wrapIntoMetadataExceptionWhenNeeded {
                 val result = ModuleMapping.loadModuleMapping(
-                    bytes, "KotlinModuleMetadata", skipMetadataVersionCheck = false,
+                    bytes, "KotlinModuleMetadata", skipMetadataVersionCheck = lenient,
                     isJvmPackageNameSupported = true
-                ) { throwIfNotCompatible(it, lenient = false /* TODO */) }
+                ) { throwIfNotCompatible(it, lenient = lenient) }
                 when (result) {
                     ModuleMapping.EMPTY, ModuleMapping.CORRUPTED ->
                         throw IllegalArgumentException("Data is not the content of a .kotlin_module file, or it has been corrupted.")
                 }
                 val module = readModuleMetadataImpl(result)
-                KotlinModuleMetadata(module, JvmMetadataVersion(result.version.toArray()))
+                KotlinModuleMetadata(module, JvmMetadataVersion(result.version.toArray()), isAllowedToWrite = !lenient)
             }
         }
     }

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -119,7 +119,7 @@ public class KotlinModuleMetadata internal constructor(
          * This method can read only supported metadata versions (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for definition).
          * It will throw an exception if the metadata version is greater than what kotlin-metadata-jvm understands.
          * It is suitable when your tooling cannot tolerate reading potentially incomplete or incorrect information due to version differences.
-         * It is also the only method that allows metadata transformation and `KotlinClassMetadata.write` subsequent calls.
+         * It is also the only method that allows metadata transformation and `KotlinModuleMetadata.write` subsequent calls.
          *
          * @throws IllegalArgumentException if an error happened while parsing the given byte array,
          * which means that it is either not the content of a `.kotlin_module` file, or it has been corrupted.
@@ -138,7 +138,7 @@ public class KotlinModuleMetadata internal constructor(
          *
          * This method makes best effort to read unsupported metadata versions.
          * Keep in mind that this method will still throw an exception if metadata is changed in an unpredictable way.
-         * Because obtained metadata can be incomplete, its [KotlinClassMetadata.write] method will throw an exception.
+         * Because obtained metadata can be incomplete, its [KotlinModuleMetadata.write] method will throw an exception.
          * This method still cannot read metadata produced by pre-1.0 compilers.
          *
          * @throws IllegalArgumentException if an error happened while parsing the given byte array,

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -101,7 +101,7 @@ public class KotlinModuleMetadata internal constructor(
      * Collection of methods for reading and writing [KotlinModuleMetadata].
      */
     public companion object {
-        @Deprecated(level = DeprecationLevel.ERROR, message = "Use readStrict instead", replaceWith = ReplaceWith("readStrict"))
+        @Deprecated(level = DeprecationLevel.ERROR, message = "Use readStrict instead", replaceWith = ReplaceWith("readStrict(bytes)"))
         @JvmStatic
         @UnstableMetadataApi
         public fun read(bytes: ByteArray): KotlinModuleMetadata {

--- a/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
+++ b/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinModuleMetadata.kt
@@ -108,7 +108,7 @@ public class KotlinModuleMetadata internal constructor(
          * or `null` if this byte array encodes a module with an unsupported metadata version.
          *
          * This method can read only supported metadata versions (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for definition).
-         * It will throw an exception if the metadata version is greater than what kotlinx-metadata-jvm understands.
+         * It will throw an exception if the metadata version is greater than what kotlin-metadata-jvm understands.
          * It is suitable when your tooling cannot tolerate reading potentially incomplete or incorrect information due to version differences.
          * It is also the only method that allows metadata transformation and `KotlinClassMetadata.write` subsequent calls.
          *

--- a/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
@@ -88,7 +88,7 @@ class DifferentVersionsTest {
         val resource = DifferentVersionsTest::class.java.classLoader.getResource(path) ?: error("No resource found named '$path'.")
         val md = KotlinModuleMetadata.readStrict(resource.readBytes())
         md.version = JvmMetadataVersion(md.version.major, md.version.minor + 2, md.version.patch)
-        val futureVersion = md.write() // TODO this fails because I can't write far-future metadata
+        val futureVersion = md.writeImpl()
 
         assertFailsWith<IllegalArgumentException> { KotlinModuleMetadata.readStrict(futureVersion) }
         assertIs<KotlinModuleMetadata>(KotlinModuleMetadata.readLenient(futureVersion))

--- a/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.metadata.jvm.JvmMetadataVersion
 import kotlin.metadata.jvm.KotlinModuleMetadata
+import kotlin.metadata.jvm.UnstableMetadataApi
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -81,7 +82,7 @@ class DifferentVersionsTest {
         assertIs<KotlinClassMetadata.Class>(KotlinClassMetadata.readLenient(md))
     }
 
-    @Suppress("OPT_IN_USAGE")
+    @OptIn(UnstableMetadataApi::class)
     @Test
     fun readModuleMetadataStrictSemanticsFlag() {
         val path = "META-INF/kotlin-stdlib.kotlin_module"

--- a/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
@@ -91,6 +91,6 @@ class DifferentVersionsTest {
         val futureVersion = md.write() // TODO this fails because I can't write far-future metadata
 
         assertFailsWith<IllegalArgumentException> { KotlinModuleMetadata.readStrict(futureVersion) }
-        assertIs<KotlinModuleMetadata>(KotlinModuleMetadata.readStrict(futureVersion))
+        assertIs<KotlinModuleMetadata>(KotlinModuleMetadata.readLenient(futureVersion))
     }
 }

--- a/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/DifferentVersionsTest.kt
@@ -9,12 +9,15 @@ import kotlin.metadata.jvm.KotlinClassMetadata
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.metadata.jvm.JvmMetadataVersion
+import kotlin.metadata.jvm.KotlinModuleMetadata
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
 class DifferentVersionsTest {
-    val metadata = DifferentVersionsTest::class.java.getMetadata()
+    private val metadata = DifferentVersionsTest::class.java.getMetadata()
 
     fun Metadata.changeVersion(newVersion: IntArray) = Metadata(
         kind, newVersion,
@@ -76,5 +79,18 @@ class DifferentVersionsTest {
         val md = metadata.changeVersion(MetadataVersion.INSTANCE_NEXT.toArray()).addFlag(1 shl 1)
         assertIs<KotlinClassMetadata.Class>(KotlinClassMetadata.readStrict(md))
         assertIs<KotlinClassMetadata.Class>(KotlinClassMetadata.readLenient(md))
+    }
+
+    @Suppress("OPT_IN_USAGE")
+    @Test
+    fun readModuleMetadataStrictSemanticsFlag() {
+        val path = "META-INF/kotlin-stdlib.kotlin_module"
+        val resource = DifferentVersionsTest::class.java.classLoader.getResource(path) ?: error("No resource found named '$path'.")
+        val md = KotlinModuleMetadata.readStrict(resource.readBytes())
+        md.version = JvmMetadataVersion(md.version.major, md.version.minor + 2, md.version.patch)
+        val futureVersion = md.write() // TODO this fails because I can't write far-future metadata
+
+        assertFailsWith<IllegalArgumentException> { KotlinModuleMetadata.readStrict(futureVersion) }
+        assertIs<KotlinModuleMetadata>(KotlinModuleMetadata.readStrict(futureVersion))
     }
 }

--- a/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/MetadataSmokeTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/MetadataSmokeTest.kt
@@ -185,8 +185,7 @@ class MetadataSmokeTest {
         assertFailsWith<IllegalArgumentException> { KotlinClassMetadata.MultiFileClassFacade(listOf("A"), mv, 0).write() }
         assertFailsWith<IllegalArgumentException> { KotlinClassMetadata.MultiFileClassPart(KmPackage(), "A", mv, 0).write() }
         assertFailsWith<IllegalArgumentException> { KotlinClassMetadata.SyntheticClass(null, mv, 0).write() }
-
-        KotlinModuleMetadata(KmModule(), mv).write()
+        assertFailsWith<IllegalArgumentException> { KotlinModuleMetadata(KmModule(), mv).write() }
     }
 
     @Test

--- a/libraries/reflect/build.gradle.kts
+++ b/libraries/reflect/build.gradle.kts
@@ -148,6 +148,7 @@ class KotlinModuleShadowTransformer(private val logger: Logger) : ResourceTransf
             context.relocators.fold(content) { acc, relocator -> relocator.applyToSourceContent(acc) }
 
         logger.info("Transforming ${context.path}")
+        @Suppress("DEPRECATION") // KT-88445
         val metadata = KotlinModuleMetadata.read(context.inputStream.readBytes())
         val module = metadata.kmModule
 

--- a/libraries/tools/abi-comparator/src/main/kotlin/org/jetbrains/kotlin/abicmp/tasks/ModuleMetadataTask.kt
+++ b/libraries/tools/abi-comparator/src/main/kotlin/org/jetbrains/kotlin/abicmp/tasks/ModuleMetadataTask.kt
@@ -44,4 +44,4 @@ class ModuleMetadataTask(
 }
 
 @OptIn(UnstableMetadataApi::class)
-private fun ByteArray.toKmModule() = KotlinModuleMetadata.read(this).kmModule
+private fun ByteArray.toKmModule() = KotlinModuleMetadata.readStrict(this).kmModule

--- a/libraries/tools/kotlinp/jvm/src/org/jetbrains/kotlin/kotlinp/jvm/utils.kt
+++ b/libraries/tools/kotlinp/jvm/src/org/jetbrains/kotlin/kotlinp/jvm/utils.kt
@@ -91,7 +91,7 @@ internal fun readMetadata(metadata: Metadata): KotlinClassMetadata {
 
 @OptIn(UnstableMetadataApi::class)
 internal fun readModuleFile(file: File): KotlinModuleMetadata? =
-    runCatching { KotlinModuleMetadata.read(file.readBytes()) }.getOrNull()
+    runCatching { KotlinModuleMetadata.readLenient(file.readBytes()) }.getOrNull()
 
 internal fun readBuiltInsFile(file: File): KotlinCommonMetadata? =
     KotlinCommonMetadata.read(file.readBytes())

--- a/libraries/tools/kotlinp/jvm/testFixtures/org/jetbrains/kotlin/kotlinp/jvm/test/CompareMetadataHandler.kt
+++ b/libraries/tools/kotlinp/jvm/testFixtures/org/jetbrains/kotlin/kotlinp/jvm/test/CompareMetadataHandler.kt
@@ -58,8 +58,8 @@ class CompareMetadataHandler(
                     }
                 }
                 path.endsWith(".kotlin_module") -> {
-                    val moduleFile = KotlinModuleMetadata.read(outputFile.asByteArray())
-                    val moduleFile2 = KotlinModuleMetadata.read(moduleFile.write())
+                    val moduleFile = KotlinModuleMetadata.readStrict(outputFile.asByteArray())
+                    val moduleFile2 = KotlinModuleMetadata.readStrict(moduleFile.write())
                     for ([sb, moduleFileToRender] in listOf(dump to moduleFile, dump2 to moduleFile2)) {
                         sb.appendFileName(path)
                         sb.append(kotlinp.printModuleFile(moduleFileToRender))

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/KotlinModuleMetadataVersionBasedSkippingTransformer.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/KotlinModuleMetadataVersionBasedSkippingTransformer.kt
@@ -47,6 +47,7 @@ class KotlinModuleMetadataVersionBasedSkippingTransformer : ResourceTransformer 
     @OptIn(UnstableMetadataApi::class)
     override fun transform(context: TransformerContext) {
         val metadataBytes = context.inputStream.readBytes()
+        @Suppress("DEPRECATION") // KT-88445
         val version = KotlinModuleMetadata.read(metadataBytes).version
         if (version >= pivotVersionAsMetadataVersion) {
             logger.info("Skipping ${context.path}, because its version $version is >= than $pivotVersionAsMetadataVersion")


### PR DESCRIPTION
Replaces https://github.com/JetBrains/kotlin/pull/6956.