### PR TITLE
[BTA] Fix forward compatibility issue with new default Enum values

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/CommonCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/CommonCompilerArgumentsImpl.kt
@@ -110,13 +110,18 @@ import org.jetbrains.kotlin.buildtools.api.CompilerArgumentsParseException
 import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.WarningLevel
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.AnnotationDefaultTargetMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.ExplicitApiMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.KotlinVersion
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.ReturnValueCheckerMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.VerifyIrMode
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.AnnotationDefaultTargetMode as CompatArgumentsEnumsAnnotationDefaultTargetMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.ExplicitApiMode as CompatArgumentsEnumsExplicitApiMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.KotlinVersion as CompatArgumentsEnumsKotlinVersion
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.ReturnValueCheckerMode as CompatArgumentsEnumsReturnValueCheckerMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.VerifyIrMode as CompatArgumentsEnumsVerifyIrMode
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments as ArgumentsCommonCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.AnnotationDefaultTargetMode as ApiArgumentsEnumsAnnotationDefaultTargetMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.ExplicitApiMode as ApiArgumentsEnumsExplicitApiMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.KotlinVersion as ApiArgumentsEnumsKotlinVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.ReturnValueCheckerMode as ApiArgumentsEnumsReturnValueCheckerMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.VerifyIrMode as ApiArgumentsEnumsVerifyIrMode
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments as CommonCompilerArguments
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
@@ -128,16 +133,22 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: CommonCompilerArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: CommonCompilerArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: CommonCompilerArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: CommonCompilerArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   override operator fun <V> `get`(key: ArgumentsCommonCompilerArguments.CommonCompilerArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   override operator fun <V> `set`(key: ArgumentsCommonCompilerArguments.CommonCompilerArgument<V>, `value`: V) {
@@ -145,7 +156,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(currentKotlinVersion.major, currentKotlinVersion.minor, currentKotlinVersion.patch)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Deprecated(
@@ -153,6 +164,20 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     level = DeprecationLevel.ERROR,
   )
   override operator fun contains(key: ArgumentsCommonCompilerArguments.CommonCompilerArgument<*>): Boolean = key.id in optionsMap
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsExplicitApiMode if directionToInternal -> CompatArgumentsEnumsExplicitApiMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsExplicitApiMode if !directionToInternal-> ApiArgumentsEnumsExplicitApiMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsAnnotationDefaultTargetMode if directionToInternal -> CompatArgumentsEnumsAnnotationDefaultTargetMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsAnnotationDefaultTargetMode if !directionToInternal-> ApiArgumentsEnumsAnnotationDefaultTargetMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsReturnValueCheckerMode if directionToInternal -> CompatArgumentsEnumsReturnValueCheckerMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsReturnValueCheckerMode if !directionToInternal-> ApiArgumentsEnumsReturnValueCheckerMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsVerifyIrMode if directionToInternal -> CompatArgumentsEnumsVerifyIrMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsVerifyIrMode if !directionToInternal-> ApiArgumentsEnumsVerifyIrMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsKotlinVersion if directionToInternal -> CompatArgumentsEnumsKotlinVersion.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsKotlinVersion if !directionToInternal-> ApiArgumentsEnumsKotlinVersion.entries.first { it.name == this.name }
+    else -> this
+  }
 
   abstract override fun build(): CommonCompilerArgumentsImpl
 
@@ -255,7 +280,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     super.applyCompilerArguments(arguments)
     try { this[P] = arguments.pluginOptions } catch (_: NoSuchMethodError) {  }
     try { this[XX_DEBUG_LEVEL_COMPILER_CHECKS] = arguments.debugLevelCompilerChecks } catch (_: NoSuchMethodError) {  }
-    try { this[XX_EXPLICIT_RETURN_TYPES] = arguments.explicitReturnTypes.let { ExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -XXexplicit-return-types value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[XX_EXPLICIT_RETURN_TYPES] = arguments.explicitReturnTypes.let { CompatArgumentsEnumsExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -XXexplicit-return-types value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[XX_LENIENT_MODE] = arguments.lenientMode } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_ANY_SCRIPTS_IN_SOURCE_ROOTS] = arguments.allowAnyScriptsInSourceRoots } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_CONDITION_IMPLIES_RETURNS_CONTRACTS] = arguments.allowConditionImpliesReturnsContracts } catch (_: NoSuchMethodError) {  }
@@ -263,7 +288,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     try { this[X_ALLOW_HOLDSIN_CONTRACT] = arguments.allowHoldsinContract } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_KOTLIN_PACKAGE] = arguments.allowKotlinPackage } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_REIFIED_TYPE_IN_CATCH] = arguments.allowReifiedTypeInCatch } catch (_: NoSuchMethodError) {  }
-    try { this[X_ANNOTATION_DEFAULT_TARGET] = arguments.annotationDefaultTarget?.let { AnnotationDefaultTargetMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xannotation-default-target value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_ANNOTATION_DEFAULT_TARGET] = arguments.annotationDefaultTarget?.let { CompatArgumentsEnumsAnnotationDefaultTargetMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xannotation-default-target value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_ANNOTATION_TARGET_ALL] = arguments.annotationTargetAll } catch (_: NoSuchMethodError) {  }
     try { this[X_CHECK_PHASE_CONDITIONS] = arguments.checkPhaseConditions } catch (_: NoSuchMethodError) {  }
     try { this[X_COMMON_SOURCES] = arguments.commonSources } catch (_: NoSuchMethodError) {  }
@@ -282,7 +307,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     try { this[X_DUMP_PERF] = arguments.dumpPerf?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_ENABLE_INCREMENTAL_COMPILATION] = arguments.incrementalCompilation } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPECT_ACTUAL_CLASSES] = arguments.expectActualClasses } catch (_: NoSuchMethodError) {  }
-    try { this[X_EXPLICIT_API] = arguments.explicitApi.let { ExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xexplicit-api value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_EXPLICIT_API] = arguments.explicitApi.let { CompatArgumentsEnumsExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xexplicit-api value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENT_DEPENDENCY] = arguments.fragmentDependencies } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENT_REFINES] = arguments.fragmentRefines } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENT_SOURCES] = arguments.fragmentSources } catch (_: NoSuchMethodError) {  }
@@ -313,7 +338,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     try { this[X_REPORT_ALL_WARNINGS] = arguments.reportAllWarnings } catch (_: NoSuchMethodError) {  }
     try { this[X_REPORT_OUTPUT_FILES] = arguments.reportOutputFiles } catch (_: NoSuchMethodError) {  }
     try { this[X_REPORT_PERF] = arguments.reportPerf } catch (_: NoSuchMethodError) {  }
-    try { this[X_RETURN_VALUE_CHECKER] = arguments.returnValueChecker.let { ReturnValueCheckerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xreturn-value-checker value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_RETURN_VALUE_CHECKER] = arguments.returnValueChecker.let { CompatArgumentsEnumsReturnValueCheckerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xreturn-value-checker value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_SEPARATE_KMP_COMPILATION] = arguments.separateKmpCompilationScheme } catch (_: NoSuchMethodError) {  }
     try { this[X_SKIP_METADATA_VERSION_CHECK] = arguments.skipMetadataVersionCheck } catch (_: NoSuchMethodError) {  }
     try { this[X_SKIP_PRERELEASE_CHECK] = arguments.skipPrereleaseCheck } catch (_: NoSuchMethodError) {  }
@@ -327,12 +352,12 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     try { this[X_USE_FIR_LT] = arguments.useFirLT } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_K2] = arguments.getUsingReflection<Boolean>("useK2") } catch (_: NoSuchMethodError) {  }
     try { this[X_VERBOSE_PHASES] = arguments.verbosePhases.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
-    try { this[X_VERIFY_IR] = arguments.verifyIr?.let { VerifyIrMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xverify-ir value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_VERIFY_IR] = arguments.verifyIr?.let { CompatArgumentsEnumsVerifyIrMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xverify-ir value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_VERIFY_IR_VISIBILITY] = arguments.getUsingReflection<Boolean>("verifyIrVisibility") } catch (_: NoSuchMethodError) {  }
     try { this[X_WHEN_GUARDS] = arguments.whenGuards } catch (_: NoSuchMethodError) {  }
-    try { this[API_VERSION] = arguments.apiVersion?.let { KotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -api-version value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[API_VERSION] = arguments.apiVersion?.let { CompatArgumentsEnumsKotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -api-version value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[KOTLIN_HOME] = arguments.kotlinHome?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[LANGUAGE_VERSION] = arguments.languageVersion?.let { KotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -language-version value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[LANGUAGE_VERSION] = arguments.languageVersion?.let { CompatArgumentsEnumsKotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -language-version value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[OPT_IN] = arguments.optIn.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[PROGRESSIVE] = arguments.progressiveMode } catch (_: NoSuchMethodError) {  }
     try { this[SCRIPT] = arguments.script } catch (_: NoSuchMethodError) {  }
@@ -355,8 +380,8 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     public val XX_DEBUG_LEVEL_COMPILER_CHECKS: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("XX_DEBUG_LEVEL_COMPILER_CHECKS")
 
-    public val XX_EXPLICIT_RETURN_TYPES: CommonCompilerArgument<ExplicitApiMode> =
-        CommonCompilerArgument("XX_EXPLICIT_RETURN_TYPES")
+    public val XX_EXPLICIT_RETURN_TYPES: CommonCompilerArgument<CompatArgumentsEnumsExplicitApiMode>
+        = CommonCompilerArgument("XX_EXPLICIT_RETURN_TYPES")
 
     public val XX_LENIENT_MODE: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("XX_LENIENT_MODE")
@@ -379,7 +404,8 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     public val X_ALLOW_REIFIED_TYPE_IN_CATCH: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_ALLOW_REIFIED_TYPE_IN_CATCH")
 
-    public val X_ANNOTATION_DEFAULT_TARGET: CommonCompilerArgument<AnnotationDefaultTargetMode?> =
+    public val X_ANNOTATION_DEFAULT_TARGET:
+        CommonCompilerArgument<CompatArgumentsEnumsAnnotationDefaultTargetMode?> =
         CommonCompilerArgument("X_ANNOTATION_DEFAULT_TARGET")
 
     public val X_ANNOTATION_TARGET_ALL: CommonCompilerArgument<Boolean> =
@@ -436,7 +462,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     public val X_EXPECT_ACTUAL_CLASSES: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_EXPECT_ACTUAL_CLASSES")
 
-    public val X_EXPLICIT_API: CommonCompilerArgument<ExplicitApiMode> =
+    public val X_EXPLICIT_API: CommonCompilerArgument<CompatArgumentsEnumsExplicitApiMode> =
         CommonCompilerArgument("X_EXPLICIT_API")
 
     public val X_FRAGMENT_DEPENDENCY: CommonCompilerArgument<Array<String>?> =
@@ -526,7 +552,8 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     public val X_REPORT_PERF: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_REPORT_PERF")
 
-    public val X_RETURN_VALUE_CHECKER: CommonCompilerArgument<ReturnValueCheckerMode> =
+    public val X_RETURN_VALUE_CHECKER:
+        CommonCompilerArgument<CompatArgumentsEnumsReturnValueCheckerMode> =
         CommonCompilerArgument("X_RETURN_VALUE_CHECKER")
 
     public val X_SEPARATE_KMP_COMPILATION: CommonCompilerArgument<Boolean> =
@@ -568,7 +595,7 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     public val X_VERBOSE_PHASES: CommonCompilerArgument<List<String>> =
         CommonCompilerArgument("X_VERBOSE_PHASES")
 
-    public val X_VERIFY_IR: CommonCompilerArgument<VerifyIrMode?> =
+    public val X_VERIFY_IR: CommonCompilerArgument<CompatArgumentsEnumsVerifyIrMode?> =
         CommonCompilerArgument("X_VERIFY_IR")
 
     public val X_VERIFY_IR_VISIBILITY: CommonCompilerArgument<Boolean> =
@@ -577,13 +604,13 @@ internal abstract class CommonCompilerArgumentsImpl() : CommonToolArgumentsImpl(
     public val X_WHEN_GUARDS: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_WHEN_GUARDS")
 
-    public val API_VERSION: CommonCompilerArgument<KotlinVersion?> =
+    public val API_VERSION: CommonCompilerArgument<CompatArgumentsEnumsKotlinVersion?> =
         CommonCompilerArgument("API_VERSION")
 
     public val KOTLIN_HOME: CommonCompilerArgument<java.nio.`file`.Path?> =
         CommonCompilerArgument("KOTLIN_HOME")
 
-    public val LANGUAGE_VERSION: CommonCompilerArgument<KotlinVersion?> =
+    public val LANGUAGE_VERSION: CommonCompilerArgument<CompatArgumentsEnumsKotlinVersion?> =
         CommonCompilerArgument("LANGUAGE_VERSION")
 
     public val OPT_IN: CommonCompilerArgument<List<String>> = CommonCompilerArgument("OPT_IN")

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/CommonToolArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/CommonToolArgumentsImpl.kt
@@ -41,16 +41,22 @@ internal abstract class CommonToolArgumentsImpl() : ArgumentsCommonToolArguments
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: CommonToolArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: CommonToolArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: CommonToolArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: CommonToolArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   override operator fun <V> `get`(key: ArgumentsCommonToolArguments.CommonToolArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   override operator fun <V> `set`(key: ArgumentsCommonToolArguments.CommonToolArgument<V>, `value`: V) {
@@ -58,7 +64,7 @@ internal abstract class CommonToolArgumentsImpl() : ArgumentsCommonToolArguments
     if (key.availableSinceVersion > KotlinReleaseVersion(currentKotlinVersion.major, currentKotlinVersion.minor, currentKotlinVersion.patch)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Deprecated(
@@ -66,6 +72,10 @@ internal abstract class CommonToolArgumentsImpl() : ArgumentsCommonToolArguments
     level = DeprecationLevel.ERROR,
   )
   override operator fun contains(key: ArgumentsCommonToolArguments.CommonToolArgument<*>): Boolean = key.id in optionsMap
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    else -> this
+  }
 
   abstract override fun build(): CommonToolArgumentsImpl
 

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/JvmCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/JvmCompilerArgumentsImpl.kt
@@ -113,21 +113,32 @@ import org.jetbrains.kotlin.buildtools.api.arguments.Jsr305
 import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.NullabilityAnnotation
 import org.jetbrains.kotlin.buildtools.api.arguments.ProfileCompilerCommand
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.AbiStabilityMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.AssertionsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.CompatqualAnnotationsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JdkRelease
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JspecifyAnnotationsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmDefaultMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.LambdasMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.SamConversionsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.StringConcatMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.WhenExpressionsMode
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArguments
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.AbiStabilityMode as CompatArgumentsEnumsAbiStabilityMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.AssertionsMode as CompatArgumentsEnumsAssertionsMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.CompatqualAnnotationsMode as CompatArgumentsEnumsCompatqualAnnotationsMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.JdkRelease as CompatArgumentsEnumsJdkRelease
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.JspecifyAnnotationsMode as CompatArgumentsEnumsJspecifyAnnotationsMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.JvmDefaultMode as CompatArgumentsEnumsJvmDefaultMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.JvmTarget as CompatArgumentsEnumsJvmTarget
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.LambdasMode as CompatArgumentsEnumsLambdasMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.SamConversionsMode as CompatArgumentsEnumsSamConversionsMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.StringConcatMode as CompatArgumentsEnumsStringConcatMode
+import org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums.WhenExpressionsMode as CompatArgumentsEnumsWhenExpressionsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.AbiStabilityMode as ApiArgumentsEnumsAbiStabilityMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.AssertionsMode as ApiArgumentsEnumsAssertionsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.CompatqualAnnotationsMode as ApiArgumentsEnumsCompatqualAnnotationsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JdkRelease as ApiArgumentsEnumsJdkRelease
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JspecifyAnnotationsMode as ApiArgumentsEnumsJspecifyAnnotationsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmDefaultMode as ApiArgumentsEnumsJvmDefaultMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget as ApiArgumentsEnumsJvmTarget
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.LambdasMode as ApiArgumentsEnumsLambdasMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SamConversionsMode as ApiArgumentsEnumsSamConversionsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.StringConcatMode as ApiArgumentsEnumsStringConcatMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.WhenExpressionsMode as ApiArgumentsEnumsWhenExpressionsMode
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -141,16 +152,22 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: JvmCompilerArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: JvmCompilerArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: JvmCompilerArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: JvmCompilerArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   override operator fun <V> `get`(key: JvmCompilerArguments.JvmCompilerArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   override operator fun <V> `set`(key: JvmCompilerArguments.JvmCompilerArgument<V>, `value`: V) {
@@ -158,7 +175,7 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     if (key.availableSinceVersion > KotlinReleaseVersion(currentKotlinVersion.major, currentKotlinVersion.minor, currentKotlinVersion.patch)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Deprecated(
@@ -166,6 +183,32 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     level = DeprecationLevel.ERROR,
   )
   override operator fun contains(key: JvmCompilerArguments.JvmCompilerArgument<*>): Boolean = key.id in optionsMap
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsAbiStabilityMode if directionToInternal -> CompatArgumentsEnumsAbiStabilityMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsAbiStabilityMode if !directionToInternal-> ApiArgumentsEnumsAbiStabilityMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsAssertionsMode if directionToInternal -> CompatArgumentsEnumsAssertionsMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsAssertionsMode if !directionToInternal-> ApiArgumentsEnumsAssertionsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJdkRelease if directionToInternal -> CompatArgumentsEnumsJdkRelease.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsJdkRelease if !directionToInternal-> ApiArgumentsEnumsJdkRelease.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJspecifyAnnotationsMode if directionToInternal -> CompatArgumentsEnumsJspecifyAnnotationsMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsJspecifyAnnotationsMode if !directionToInternal-> ApiArgumentsEnumsJspecifyAnnotationsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsLambdasMode if directionToInternal -> CompatArgumentsEnumsLambdasMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsLambdasMode if !directionToInternal-> ApiArgumentsEnumsLambdasMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsSamConversionsMode if directionToInternal -> CompatArgumentsEnumsSamConversionsMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsSamConversionsMode if !directionToInternal-> ApiArgumentsEnumsSamConversionsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsStringConcatMode if directionToInternal -> CompatArgumentsEnumsStringConcatMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsStringConcatMode if !directionToInternal-> ApiArgumentsEnumsStringConcatMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsCompatqualAnnotationsMode if directionToInternal -> CompatArgumentsEnumsCompatqualAnnotationsMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsCompatqualAnnotationsMode if !directionToInternal-> ApiArgumentsEnumsCompatqualAnnotationsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsWhenExpressionsMode if directionToInternal -> CompatArgumentsEnumsWhenExpressionsMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsWhenExpressionsMode if !directionToInternal-> ApiArgumentsEnumsWhenExpressionsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJvmDefaultMode if directionToInternal -> CompatArgumentsEnumsJvmDefaultMode.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsJvmDefaultMode if !directionToInternal-> ApiArgumentsEnumsJvmDefaultMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJvmTarget if directionToInternal -> CompatArgumentsEnumsJvmTarget.entries.first { it.name == this.name }
+    is CompatArgumentsEnumsJvmTarget if !directionToInternal-> ApiArgumentsEnumsJvmTarget.entries.first { it.name == this.name }
+    else -> this
+  }
 
   override fun deepCopy(): JvmCompilerArgumentsImpl = JvmCompilerArgumentsImpl().also { newArgs -> newArgs.applyCompilerArguments(toCompilerArguments()) }
 
@@ -264,12 +307,12 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
   @Suppress("DEPRECATION")
   protected fun applyCompilerArguments(arguments: K2JVMCompilerArguments) {
     super.applyCompilerArguments(arguments)
-    try { this[X_ABI_STABILITY] = arguments.abiStability?.let { AbiStabilityMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xabi-stability value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_ABI_STABILITY] = arguments.abiStability?.let { CompatArgumentsEnumsAbiStabilityMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xabi-stability value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_ADD_MODULES] = arguments.additionalJavaModules.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_NO_SOURCE_FILES] = arguments.allowNoSourceFiles } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_UNSTABLE_DEPENDENCIES] = arguments.allowUnstableDependencies } catch (_: NoSuchMethodError) {  }
     try { this[X_ANNOTATIONS_IN_METADATA] = arguments.annotationsInMetadata } catch (_: NoSuchMethodError) {  }
-    try { this[X_ASSERTIONS] = arguments.assertionsMode?.let { AssertionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xassertions value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_ASSERTIONS] = arguments.assertionsMode?.let { CompatArgumentsEnumsAssertionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xassertions value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_BACKEND_THREADS] = arguments.backendThreads.let { it.toInt() } } catch (_: NoSuchMethodError) {  }
     try { this[X_BUILD_FILE] = arguments.buildFile } catch (_: NoSuchMethodError) {  }
     try { this[X_COMPILE_BUILTINS_AS_PART_OF_STDLIB] = arguments.getUsingReflection<Boolean>("expectBuiltinsAsPartOfStdlib") } catch (_: NoSuchMethodError) {  }
@@ -288,13 +331,13 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     try { this[X_JAVA_PACKAGE_PREFIX] = arguments.javaPackagePrefix } catch (_: NoSuchMethodError) {  }
     try { this[X_JAVA_SOURCE_ROOTS] = arguments.javaSourceRoots.mapOrEmpty { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_JAVAC_ARGUMENTS] = arguments.getUsingReflection<Array<String>>("javacArguments") } catch (_: NoSuchMethodError) {  }
-    try { this[X_JDK_RELEASE] = arguments.jdkRelease?.let { JdkRelease.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xjdk-release value: $it") } } catch (_: NoSuchMethodError) {  }
-    try { this[X_JSPECIFY_ANNOTATIONS] = arguments.jspecifyAnnotations?.let { JspecifyAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xjspecify-annotations value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_JDK_RELEASE] = arguments.jdkRelease?.let { CompatArgumentsEnumsJdkRelease.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xjdk-release value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_JSPECIFY_ANNOTATIONS] = arguments.jspecifyAnnotations?.let { CompatArgumentsEnumsJspecifyAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xjspecify-annotations value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_JVM_DEFAULT] = arguments.jvmDefault } catch (_: NoSuchMethodError) {  }
     try { this[X_JVM_ENABLE_PREVIEW] = arguments.enableJvmPreview } catch (_: NoSuchMethodError) {  }
     try { this[X_JVM_EXPOSE_BOXED] = arguments.jvmExposeBoxed } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB] = arguments.getUsingReflection<String?>("klibLibraries")?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[X_LAMBDAS] = arguments.lambdas?.let { LambdasMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xlambdas value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_LAMBDAS] = arguments.lambdas?.let { CompatArgumentsEnumsLambdasMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xlambdas value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_LINK_VIA_SIGNATURES] = arguments.getUsingReflection<Boolean>("linkViaSignatures") } catch (_: NoSuchMethodError) {  }
     try { this[X_MODULE_PATH] = arguments.javaModulePath?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_MULTIFILE_PARTS_INHERIT] = arguments.inheritMultifileParts } catch (_: NoSuchMethodError) {  }
@@ -307,12 +350,12 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     try { this[X_NO_SOURCE_DEBUG_EXTENSION] = arguments.noSourceDebugExtension } catch (_: NoSuchMethodError) {  }
     try { this[X_NO_UNIFIED_NULL_CHECKS] = arguments.noUnifiedNullChecks } catch (_: NoSuchMethodError) {  }
     try { this[X_OUTPUT_BUILTINS_METADATA] = arguments.outputBuiltinsMetadata } catch (_: NoSuchMethodError) {  }
-    try { this[X_SAM_CONVERSIONS] = arguments.samConversions?.let { SamConversionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xsam-conversions value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_SAM_CONVERSIONS] = arguments.samConversions?.let { CompatArgumentsEnumsSamConversionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xsam-conversions value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_SANITIZE_PARENTHESES] = arguments.sanitizeParentheses } catch (_: NoSuchMethodError) {  }
     try { this[X_SCRIPT_RESOLVER_ENVIRONMENT] = arguments.scriptResolverEnvironment.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[X_SERIALIZE_IR] = arguments.getUsingReflection<String>("serializeIr") } catch (_: NoSuchMethodError) {  }
-    try { this[X_STRING_CONCAT] = arguments.stringConcat?.let { StringConcatMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xstring-concat value: $it") } } catch (_: NoSuchMethodError) {  }
-    try { this[X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS] = arguments.supportCompatqualCheckerFrameworkAnnotations?.let { CompatqualAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xsupport-compatqual-checker-framework-annotations value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_STRING_CONCAT] = arguments.stringConcat?.let { CompatArgumentsEnumsStringConcatMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xstring-concat value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS] = arguments.supportCompatqualCheckerFrameworkAnnotations?.let { CompatArgumentsEnumsCompatqualAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xsupport-compatqual-checker-framework-annotations value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[X_SUPPRESS_DEPRECATED_JVM_TARGET_WARNING] = arguments.getUsingReflection<Boolean>("suppressDeprecatedJvmTargetWarning") } catch (_: NoSuchMethodError) {  }
     try { this[X_SUPPRESS_MISSING_BUILTINS_ERROR] = arguments.suppressMissingBuiltinsError } catch (_: NoSuchMethodError) {  }
     try { this[X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE] = arguments.typeEnhancementImprovementsInStrictMode } catch (_: NoSuchMethodError) {  }
@@ -325,15 +368,15 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     try { this[X_USE_TYPE_TABLE] = arguments.useTypeTable } catch (_: NoSuchMethodError) {  }
     try { this[X_VALIDATE_BYTECODE] = arguments.validateBytecode } catch (_: NoSuchMethodError) {  }
     try { this[X_VALUE_CLASSES] = arguments.getUsingReflection<Boolean>("valueClasses") } catch (_: NoSuchMethodError) {  }
-    try { this[X_WHEN_EXPRESSIONS] = arguments.whenExpressionsGeneration?.let { WhenExpressionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xwhen-expressions value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[X_WHEN_EXPRESSIONS] = arguments.whenExpressionsGeneration?.let { CompatArgumentsEnumsWhenExpressionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -Xwhen-expressions value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[CLASSPATH] = arguments.classpath?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[D] = arguments.destination } catch (_: NoSuchMethodError) {  }
     try { this[EXPRESSION] = arguments.expression } catch (_: NoSuchMethodError) {  }
     try { this[INCLUDE_RUNTIME] = arguments.includeRuntime } catch (_: NoSuchMethodError) {  }
     try { this[JAVA_PARAMETERS] = arguments.javaParameters } catch (_: NoSuchMethodError) {  }
     try { this[JDK_HOME] = arguments.jdkHome?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[JVM_DEFAULT] = arguments.jvmDefaultStable?.let { JvmDefaultMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -jvm-default value: $it") } } catch (_: NoSuchMethodError) {  }
-    try { this[JVM_TARGET] = arguments.jvmTarget?.let { JvmTarget.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -jvm-target value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[JVM_DEFAULT] = arguments.jvmDefaultStable?.let { CompatArgumentsEnumsJvmDefaultMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -jvm-default value: $it") } } catch (_: NoSuchMethodError) {  }
+    try { this[JVM_TARGET] = arguments.jvmTarget?.let { CompatArgumentsEnumsJvmTarget.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) } ?: throw CompilerArgumentsParseException("Unknown -jvm-target value: $it") } } catch (_: NoSuchMethodError) {  }
     try { this[MODULE_NAME] = arguments.moduleName } catch (_: NoSuchMethodError) {  }
     try { this[NO_JDK] = arguments.noJdk } catch (_: NoSuchMethodError) {  }
     try { this[NO_REFLECT] = arguments.noReflect } catch (_: NoSuchMethodError) {  }
@@ -366,7 +409,7 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
   public companion object {
     private val knownArguments: MutableSet<String> = mutableSetOf()
 
-    public val X_ABI_STABILITY: JvmCompilerArgument<AbiStabilityMode?> =
+    public val X_ABI_STABILITY: JvmCompilerArgument<CompatArgumentsEnumsAbiStabilityMode?> =
         JvmCompilerArgument("X_ABI_STABILITY")
 
     public val X_ADD_MODULES: JvmCompilerArgument<List<String>> =
@@ -381,7 +424,7 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     public val X_ANNOTATIONS_IN_METADATA: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_ANNOTATIONS_IN_METADATA")
 
-    public val X_ASSERTIONS: JvmCompilerArgument<AssertionsMode?> =
+    public val X_ASSERTIONS: JvmCompilerArgument<CompatArgumentsEnumsAssertionsMode?> =
         JvmCompilerArgument("X_ASSERTIONS")
 
     public val X_BACKEND_THREADS: JvmCompilerArgument<Int> =
@@ -434,10 +477,11 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     public val X_JAVAC_ARGUMENTS: JvmCompilerArgument<Array<String>?> =
         JvmCompilerArgument("X_JAVAC_ARGUMENTS")
 
-    public val X_JDK_RELEASE: JvmCompilerArgument<JdkRelease?> =
+    public val X_JDK_RELEASE: JvmCompilerArgument<CompatArgumentsEnumsJdkRelease?> =
         JvmCompilerArgument("X_JDK_RELEASE")
 
-    public val X_JSPECIFY_ANNOTATIONS: JvmCompilerArgument<JspecifyAnnotationsMode?> =
+    public val X_JSPECIFY_ANNOTATIONS:
+        JvmCompilerArgument<CompatArgumentsEnumsJspecifyAnnotationsMode?> =
         JvmCompilerArgument("X_JSPECIFY_ANNOTATIONS")
 
     public val X_JVM_DEFAULT: JvmCompilerArgument<String?> = JvmCompilerArgument("X_JVM_DEFAULT")
@@ -451,7 +495,8 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     public val X_KLIB: JvmCompilerArgument<List<java.nio.`file`.Path>?> =
         JvmCompilerArgument("X_KLIB")
 
-    public val X_LAMBDAS: JvmCompilerArgument<LambdasMode?> = JvmCompilerArgument("X_LAMBDAS")
+    public val X_LAMBDAS: JvmCompilerArgument<CompatArgumentsEnumsLambdasMode?> =
+        JvmCompilerArgument("X_LAMBDAS")
 
     public val X_LINK_VIA_SIGNATURES: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_LINK_VIA_SIGNATURES")
@@ -488,7 +533,7 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     public val X_OUTPUT_BUILTINS_METADATA: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_OUTPUT_BUILTINS_METADATA")
 
-    public val X_SAM_CONVERSIONS: JvmCompilerArgument<SamConversionsMode?> =
+    public val X_SAM_CONVERSIONS: JvmCompilerArgument<CompatArgumentsEnumsSamConversionsMode?> =
         JvmCompilerArgument("X_SAM_CONVERSIONS")
 
     public val X_SANITIZE_PARENTHESES: JvmCompilerArgument<Boolean> =
@@ -499,11 +544,11 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
 
     public val X_SERIALIZE_IR: JvmCompilerArgument<String> = JvmCompilerArgument("X_SERIALIZE_IR")
 
-    public val X_STRING_CONCAT: JvmCompilerArgument<StringConcatMode?> =
+    public val X_STRING_CONCAT: JvmCompilerArgument<CompatArgumentsEnumsStringConcatMode?> =
         JvmCompilerArgument("X_STRING_CONCAT")
 
     public val X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS:
-        JvmCompilerArgument<CompatqualAnnotationsMode?> =
+        JvmCompilerArgument<CompatArgumentsEnumsCompatqualAnnotationsMode?> =
         JvmCompilerArgument("X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS")
 
     public val X_SUPPRESS_DEPRECATED_JVM_TARGET_WARNING: JvmCompilerArgument<Boolean> =
@@ -540,7 +585,7 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     public val X_VALUE_CLASSES: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_VALUE_CLASSES")
 
-    public val X_WHEN_EXPRESSIONS: JvmCompilerArgument<WhenExpressionsMode?> =
+    public val X_WHEN_EXPRESSIONS: JvmCompilerArgument<CompatArgumentsEnumsWhenExpressionsMode?> =
         JvmCompilerArgument("X_WHEN_EXPRESSIONS")
 
     public val CLASSPATH: JvmCompilerArgument<List<java.nio.`file`.Path>?> =
@@ -559,10 +604,11 @@ internal class JvmCompilerArgumentsImpl() : CommonCompilerArgumentsImpl(), JvmCo
     public val JDK_HOME: JvmCompilerArgument<java.nio.`file`.Path?> =
         JvmCompilerArgument("JDK_HOME")
 
-    public val JVM_DEFAULT: JvmCompilerArgument<JvmDefaultMode?> =
+    public val JVM_DEFAULT: JvmCompilerArgument<CompatArgumentsEnumsJvmDefaultMode?> =
         JvmCompilerArgument("JVM_DEFAULT")
 
-    public val JVM_TARGET: JvmCompilerArgument<JvmTarget?> = JvmCompilerArgument("JVM_TARGET")
+    public val JVM_TARGET: JvmCompilerArgument<CompatArgumentsEnumsJvmTarget?> =
+        JvmCompilerArgument("JVM_TARGET")
 
     public val MODULE_NAME: JvmCompilerArgument<String?> = JvmCompilerArgument("MODULE_NAME")
 

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/AbiStabilityMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/AbiStabilityMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class AbiStabilityMode(
+  public val stringValue: String,
+) {
+  STABLE("stable"),
+  UNSTABLE("unstable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/AnnotationDefaultTargetMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/AnnotationDefaultTargetMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class AnnotationDefaultTargetMode(
+  public val stringValue: String,
+) {
+  FIRST_ONLY("first-only"),
+  FIRST_ONLY_WARN("first-only-warn"),
+  PARAM_PROPERTY("param-property"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/AssertionsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/AssertionsMode.kt
@@ -1,0 +1,19 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class AssertionsMode(
+  public val stringValue: String,
+) {
+  ALWAYS_ENABLE("always-enable"),
+  ALWAYS_DISABLE("always-disable"),
+  JVM("jvm"),
+  LEGACY("legacy"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/CompatqualAnnotationsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/CompatqualAnnotationsMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class CompatqualAnnotationsMode(
+  public val stringValue: String,
+) {
+  ENABLE("enable"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/ExplicitApiMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/ExplicitApiMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class ExplicitApiMode(
+  public val stringValue: String,
+) {
+  STRICT("strict"),
+  WARNING("warning"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JdkRelease.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JdkRelease.kt
@@ -1,0 +1,40 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JdkRelease(
+  public val stringValue: String,
+) {
+  JDK_1_6("1.6"),
+  JDK_1_7("1.7"),
+  JDK_1_8("1.8"),
+  JDK_6("6"),
+  JDK_7("7"),
+  JDK_8("8"),
+  JDK_9("9"),
+  JDK_10("10"),
+  JDK_11("11"),
+  JDK_12("12"),
+  JDK_13("13"),
+  JDK_14("14"),
+  JDK_15("15"),
+  JDK_16("16"),
+  JDK_17("17"),
+  JDK_18("18"),
+  JDK_19("19"),
+  JDK_20("20"),
+  JDK_21("21"),
+  JDK_22("22"),
+  JDK_23("23"),
+  JDK_24("24"),
+  JDK_25("25"),
+  JDK_26("26"),
+  JDK_27("27"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JspecifyAnnotationsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JspecifyAnnotationsMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JspecifyAnnotationsMode(
+  public val stringValue: String,
+) {
+  IGNORE("ignore"),
+  STRICT("strict"),
+  WARN("warn"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JvmDefaultMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JvmDefaultMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JvmDefaultMode(
+  public val stringValue: String,
+) {
+  ENABLE("enable"),
+  NO_COMPATIBILITY("no-compatibility"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JvmTarget.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/JvmTarget.kt
@@ -1,0 +1,36 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JvmTarget(
+  public val stringValue: String,
+) {
+  JVM1_6("1.6"),
+  JVM1_8("1.8"),
+  JVM_9("9"),
+  JVM_10("10"),
+  JVM_11("11"),
+  JVM_12("12"),
+  JVM_13("13"),
+  JVM_14("14"),
+  JVM_15("15"),
+  JVM_16("16"),
+  JVM_17("17"),
+  JVM_18("18"),
+  JVM_19("19"),
+  JVM_20("20"),
+  JVM_21("21"),
+  JVM_22("22"),
+  JVM_23("23"),
+  JVM_24("24"),
+  JVM_25("25"),
+  JVM_26("26"),
+  JVM_27("27"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/KotlinVersion.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/KotlinVersion.kt
@@ -1,0 +1,33 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class KotlinVersion(
+  public val stringValue: String,
+) {
+  V1_0("1.0"),
+  V1_1("1.1"),
+  V1_2("1.2"),
+  V1_3("1.3"),
+  V1_4("1.4"),
+  V1_5("1.5"),
+  V1_6("1.6"),
+  V1_7("1.7"),
+  V1_8("1.8"),
+  V1_9("1.9"),
+  V2_0("2.0"),
+  V2_1("2.1"),
+  V2_2("2.2"),
+  V2_3("2.3"),
+  V2_4("2.4"),
+  V2_5("2.5"),
+  V2_6("2.6"),
+  V2_7("2.7"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/LambdasMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/LambdasMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class LambdasMode(
+  public val stringValue: String,
+) {
+  CLASS("class"),
+  INDY("indy"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/ReturnValueCheckerMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/ReturnValueCheckerMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class ReturnValueCheckerMode(
+  public val stringValue: String,
+) {
+  CHECKER("check"),
+  FULL("full"),
+  DISABLED("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/SamConversionsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/SamConversionsMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class SamConversionsMode(
+  public val stringValue: String,
+) {
+  CLASS("class"),
+  INDY("indy"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/StringConcatMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/StringConcatMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class StringConcatMode(
+  public val stringValue: String,
+) {
+  INDY_WITH_CONSTANTS("indy-with-constants"),
+  INDY("indy"),
+  INLINE("inline"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/VerifyIrMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/VerifyIrMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class VerifyIrMode(
+  public val stringValue: String,
+) {
+  NONE("none"),
+  WARNING("warning"),
+  ERROR("error"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/WhenExpressionsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/enums/WhenExpressionsMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.compat.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class WhenExpressionsMode(
+  public val stringValue: String,
+) {
+  INDY("indy"),
+  INLINE("inline"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaApiOptionsGenerator.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaApiOptionsGenerator.kt
@@ -109,7 +109,7 @@ internal class BtaApiOptionsGenerator(
                 val enumConstants = type.java.enumConstants.filterIsInstance<Enum<*>>()
                 @Suppress("UNCHECKED_CAST")
                 enumConstants as List<WithStringRepresentation>
-                enumsToGenerate[type] = generateEnumTypeBuilder(enumConstants, level)
+                enumsToGenerate[type] = generateEnumTypeBuilder(enumConstants, level, type.toBtaEnumClassName())
                 if (type !in enumsExperimental && experimental) {
                     enumsExperimental[type] = true
                 } else if (type in enumsExperimental && !experimental) {
@@ -180,7 +180,7 @@ internal class BtaApiOptionsGenerator(
             if (enumsExperimental.getOrDefault(type, false)) {
                 typeSpecBuilder.addAnnotation(ANNOTATION_EXPERIMENTAL)
             }
-            writeEnumFile(typeSpecBuilder.build(), type)
+            outputs += writeEnumFile(typeSpecBuilder.build(), type, targetPackage)
         }
     }
 
@@ -205,41 +205,6 @@ internal class BtaApiOptionsGenerator(
             addKdoc("\n\nDeprecated in Kotlin version ${wasDeprecatedInVersion.releaseName}.")
             annotation(ClassName(API_PACKAGE, "DeprecatedCompilerArgument")) {}
         }
-    }
-
-    fun <T> generateEnumTypeBuilder(
-        sourceEnum: Collection<T>,
-        level: KotlinCompilerArgumentsLevel,
-    ): TypeSpec.Builder where T : Enum<*>, T : WithStringRepresentation {
-        val className = sourceEnum.first()::class.toBtaEnumClassName()
-        return TypeSpec.enumBuilder(className).apply {
-            property<String>("stringValue") {
-                initializer("stringValue")
-            }
-            if (btaEnumVersionMap.contains(className)) {
-                addKdoc("$KDOC_SINCE ${btaEnumVersionMap.getValue(className).releaseName}")
-            } else {
-                addKdoc(levelsSince[level.name] ?: error("Level ${level.name} is missing in levelSince map"))
-            }
-            primaryConstructor(FunSpec.constructorBuilder().addParameter("stringValue", String::class).build())
-            val nameAccessor = WithStringRepresentation::stringRepresentation
-            sourceEnum.forEach {
-                addEnumConstant(
-                    it.name.uppercase(),
-                    TypeSpec.anonymousClassBuilder().addSuperclassConstructorParameter("%S", nameAccessor.get(it)).build()
-                )
-            }
-        }
-    }
-
-    fun writeEnumFile(typeSpec: TypeSpec, sourceEnum: KClass<*>) {
-        val className = sourceEnum.toBtaEnumClassName()
-        val enumFileAppendable = createGeneratedFileAppendable()
-        val enumFile = FileSpec.builder(className).apply {
-            addType(typeSpec)
-        }.build()
-        enumFile.writeTo(enumFileAppendable)
-        outputs += Path(enumFile.relativePath) to enumFileAppendable.toString()
     }
 
     fun TypeSpec.Builder.generateGetPutFunctions(parameter: ClassName, level: KotlinCompilerArgumentsLevel, deprecateSet: Boolean = false) {
@@ -375,4 +340,39 @@ private fun TypeSpec.Builder.addToArgumentStringsFun() {
         returns(listTypeNameOf<String>())
         this.addModifiers(KModifier.ABSTRACT)
     }
+}
+
+fun <T> generateEnumTypeBuilder(
+    sourceEnum: Collection<T>,
+    level: KotlinCompilerArgumentsLevel,
+    className: ClassName
+): TypeSpec.Builder where T : Enum<*>, T : WithStringRepresentation {
+    return TypeSpec.enumBuilder(className).apply {
+        property<String>("stringValue") {
+            initializer("stringValue")
+        }
+        if (btaEnumVersionMap.contains(className)) {
+            addKdoc("$KDOC_SINCE ${btaEnumVersionMap.getValue(className).releaseName}")
+        } else {
+            addKdoc(levelsSince[level.name] ?: error("Level ${level.name} is missing in levelSince map"))
+        }
+        primaryConstructor(FunSpec.constructorBuilder().addParameter("stringValue", String::class).build())
+        val nameAccessor = WithStringRepresentation::stringRepresentation
+        sourceEnum.forEach {
+            addEnumConstant(
+                it.name.uppercase(),
+                TypeSpec.anonymousClassBuilder().addSuperclassConstructorParameter("%S", nameAccessor.get(it)).build()
+            )
+        }
+    }
+}
+
+fun writeEnumFile(typeSpec: TypeSpec, sourceEnum: KClass<*>, targetPackage: String): Pair<Path, String> {
+    val className = sourceEnum.toBtaImplEnumClassName(targetPackage)
+    val enumFileAppendable = createGeneratedFileAppendable()
+    val enumFile = FileSpec.builder(className).apply {
+        addType(typeSpec)
+    }.build()
+    enumFile.writeTo(enumFileAppendable)
+    return Path(enumFile.relativePath) to enumFileAppendable.toString()
 }

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaImplOptionsGenerator.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaImplOptionsGenerator.kt
@@ -20,6 +20,7 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.io.path.Path
 import kotlin.reflect.KClass
+import kotlin.reflect.full.allSuperclasses
 
 private const val ARGUMENT_PARSE_DIAGNOSTICS_CLASS = "ArgumentParseDiagnostics"
 
@@ -108,19 +109,20 @@ internal class BtaImplOptionsGenerator(
                 val argumentImplTypeName = ClassName(targetPackage, implClassName, argumentTypeNameString)
                 val constructorSpecBuilder = constructorSpecBuilder()
 
-                val mapProperty = generateOptionsMap()
-                generateOwnGetPutFunctions(argumentImplTypeName, mapProperty, level)
+                generateOptionsMap()
+                generateOwnGetPutFunctions(argumentImplTypeName)
 
                 if (syntheticInterfaces.isEmpty()) {
                     val argumentTypeName = ClassName(API_ARGUMENTS_PACKAGE, apiClassName, argumentTypeNameString)
-                    generateGetPutFunctions(argumentTypeName, mapProperty, level)
+                    generateGetPutFunctions(argumentTypeName, level)
                 } else {
                     syntheticInterfaces.forEach { syntheticInterface ->
                         val argumentTypeName =
                             ClassName(API_ARGUMENTS_PACKAGE, syntheticInterface.name, syntheticInterface.name.removeSuffix("s"))
-                        generateGetPutFunctions(argumentTypeName, mapProperty, level)
+                        generateGetPutFunctions(argumentTypeName, level)
                     }
                 }
+                val mapEnumsFun = generateMapEnumsFunBuilder()
 
                 addType(TypeSpec.companionObjectBuilder().apply {
                     property(
@@ -137,8 +139,12 @@ internal class BtaImplOptionsGenerator(
                         applyCompilerArgumentsFun = applyCompilerArgumentsFun,
                         toCompilerConverterFun = toCompilerConverterFun,
                         toCompilerArgumentsAffectingOutcomeFun = toCompilerArgumentsAffectingOutcomeFun,
+                        mapEnumsFun = mapEnumsFun,
+                        level = level
                     )
                 }.build())
+
+                addFunction(mapEnumsFun.build())
 
                 // Initialize default values for custom arguments
                 defaultsInitializer.build().takeIf { it.isNotEmpty() }?.let { addInitializerBlock(it) }
@@ -210,6 +216,15 @@ internal class BtaImplOptionsGenerator(
         return GeneratorOutputs(ClassName(targetPackage, implClassName), outputs)
     }
 
+    private fun generateMapEnumsFunBuilder(): FunSpec.Builder {
+        return FunSpec.builder("mapEnums").apply {
+            receiver(Any::class.asClassName().copy(nullable = true))
+            returns(Any::class.asClassName().copy(nullable = true))
+            addParameter("directionToInternal", Boolean::class)
+            modifiers.add(KModifier.PRIVATE)
+        }
+    }
+
     private fun constructorSpecBuilder(): FunSpec.Builder = FunSpec.constructorBuilder().apply {
         if (!generateCompatLayer) {
             addParameter(
@@ -245,7 +260,26 @@ internal class BtaImplOptionsGenerator(
         applyCompilerArgumentsFun: FunSpec.Builder,
         toCompilerConverterFun: FunSpec.Builder,
         toCompilerArgumentsAffectingOutcomeFun: FunSpec.Builder,
+        mapEnumsFun: FunSpec.Builder,
+        level: KotlinCompilerArgumentsLevel,
     ) {
+        val enumsToGenerate = mutableMapOf<KClass<*>, TypeSpec.Builder>()
+
+        /**
+         * Marks enum to be generated and returns its name
+         */
+        fun generatedEnumType(type: KClass<*>): ClassName {
+            require(WithStringRepresentation::class in type.allSuperclasses) {
+                "Compiler enum ${type.qualifiedName} must implement ${WithStringRepresentation::class.qualifiedName} to be used with BTA."
+            }
+            val enumConstants = type.java.enumConstants.filterIsInstance<Enum<*>>()
+            @Suppress("UNCHECKED_CAST")
+            enumConstants as List<WithStringRepresentation>
+            enumsToGenerate[type] =
+                generateEnumTypeBuilder(enumConstants, level, type.toBtaImplEnumClassName(targetPackage))
+            return type.toBtaImplEnumClassName(targetPackage)
+        }
+
         arguments.forEach { argument ->
             val name = argument.extractName()
             if (skipXX && name.startsWith("XX_")) return@forEach
@@ -273,11 +307,12 @@ internal class BtaImplOptionsGenerator(
                     val classifier = type.classifier as? KClass<*> ?: error("Type is not a KClass: $type")
                     when {
                         classifier.java.isEnum -> {
-                            val classifier = type.classifier as KClass<*>
-                            classifier.toBtaEnumClassName()
+//                            val classifier = type.classifier as KClass<*>
+//                            classifier.toBtaEnumClassName()
+                            generatedEnumType(classifier)
                         }
                         classifier == List::class && (type.arguments.first().type?.classifier as? KClass<*>)?.java?.isEnum == true -> {
-                            listTypeNameOf((type.arguments.first().type?.classifier as KClass<*>).toBtaEnumClassName())
+                            listTypeNameOf(generatedEnumType(type.arguments.first().type?.classifier as KClass<*>))
                         }
                         else -> {
                             type.asTypeName()
@@ -321,6 +356,23 @@ internal class BtaImplOptionsGenerator(
                 }
             }
         }
+
+        mapEnumsFun.beginControlFlow("return when (this)")
+        enumsToGenerate.forEach { [type, typeSpecBuilder] ->
+            outputs += writeEnumFile(typeSpecBuilder.build(), type, targetPackage)
+            mapEnumsFun.addStatement(
+                "is %T if directionToInternal -> %T.entries.first { it.name == this.name }",
+                type.toBtaEnumClassName(),
+                type.toBtaImplEnumClassName(targetPackage),
+            )
+            mapEnumsFun.addStatement(
+                "is %T if !directionToInternal-> %T.entries.first { it.name == this.name }",
+                type.toBtaImplEnumClassName(targetPackage),
+                type.toBtaEnumClassName(),
+            )
+        }
+        mapEnumsFun.addStatement("else -> this")
+        mapEnumsFun.endControlFlow()
     }
 
     private fun generateCustomRepresentation(
@@ -656,8 +708,6 @@ internal class BtaImplOptionsGenerator(
 
     fun TypeSpec.Builder.generateOwnGetPutFunctions(
         implParameter: ClassName,
-        mapProperty: PropertySpec,
-        level: KotlinCompilerArgumentsLevel,
     ) {
         function("get") {
             val typeParameter = TypeVariableName("V")
@@ -668,15 +718,15 @@ internal class BtaImplOptionsGenerator(
             addModifiers(KModifier.OPERATOR)
             addTypeVariable(typeParameter)
             addParameter("key", implParameter.parameterizedBy(typeParameter))
-            addStatement("return %N[key.id] as %T", mapProperty, typeParameter)
+            addStatement("return optionsMap[key.id] as %T", typeParameter)
         }
         function("set") {
             val typeParameter = TypeVariableName("V")
-            addModifiers(KModifier.OPERATOR, KModifier.PRIVATE)
+            addModifiers(KModifier.OPERATOR)
             addTypeVariable(typeParameter)
             addParameter("key", implParameter.parameterizedBy(typeParameter))
             addParameter("value", typeParameter)
-            addStatement("%N[key.id] = %N", mapProperty, "value")
+            addStatement("optionsMap[key.id] = %N", "value")
         }
 
         function("contains") {
@@ -685,9 +735,22 @@ internal class BtaImplOptionsGenerator(
             addParameter("key", implParameter.parameterizedBy(STAR))
             addStatement("return key.id in optionsMap")
         }
+
+        function("get") {
+            returns(Any::class.asClassName().copy(nullable = true))
+            addModifiers(KModifier.OPERATOR, KModifier.PRIVATE)
+            addParameter("key", String::class)
+            addStatement("return optionsMap[key]?.mapEnums(false)")
+        }
+        function("set") {
+            addModifiers(KModifier.OPERATOR, KModifier.PRIVATE)
+            addParameter("key", String::class)
+            addParameter("value", Any::class.asClassName().copy(nullable = true))
+            addStatement("optionsMap[key] = %N?.mapEnums(true)", "value")
+        }
     }
 
-    fun TypeSpec.Builder.generateGetPutFunctions(parameter: ClassName, mapProperty: PropertySpec, level: KotlinCompilerArgumentsLevel) {
+    fun TypeSpec.Builder.generateGetPutFunctions(parameter: ClassName, level: KotlinCompilerArgumentsLevel) {
         function("get") {
             val typeParameter = TypeVariableName("V")
             annotation<Suppress> {
@@ -701,7 +764,7 @@ internal class BtaImplOptionsGenerator(
             addTypeVariable(typeParameter)
             addParameter("key", parameter.parameterizedBy(typeParameter))
             addStatement($$"check(key.id in optionsMap) { \"Argument ${key.id} is not set and has no default value\" }")
-            addStatement("return %N[key.id] as %T", mapProperty, typeParameter)
+            addStatement("return this[key.id] as %T", typeParameter)
         }
         function("set") {
             if (targetPackage == IMPL_ARGUMENTS_PACKAGE) {
@@ -741,7 +804,7 @@ internal class BtaImplOptionsGenerator(
                     .endControlFlow()
                     .build()
             )
-            addStatement("%N[key.id] = %N", mapProperty, "value")
+            addStatement("this[key.id] = %N", "value")
         }
 
         if (levelsSince[level.name] == KDOC_SINCE_2_3_0) {
@@ -914,15 +977,17 @@ internal class BtaImplOptionsGenerator(
             addStatement("return arguments")
         }
     }
+
+    private val TypeName.isGeneratedEnum: Boolean get() = (this as? ClassName)?.packageName?.startsWith("$targetPackage.enums") ?: false
+    private fun TypeName.isGeneratedEnumList(): Boolean {
+        @OptIn(ExperimentalContracts::class)
+        contract {
+            returns(true) implies (this@isGeneratedEnumList is ParameterizedTypeName)
+        }
+        return this is ParameterizedTypeName && this.rawType == List::class.asTypeName() && this.typeArguments[0].isGeneratedEnum
+    }
 }
 
-private fun TypeName.isGeneratedEnumList(): Boolean {
-    @OptIn(ExperimentalContracts::class)
-    contract {
-        returns(true) implies (this@isGeneratedEnumList is ParameterizedTypeName)
-    }
-    return this is ParameterizedTypeName && this.rawType == List::class.asTypeName() && this.typeArguments[0].isGeneratedEnum
-}
 
 internal fun FunSpec.Builder.addSafeSetStatement(
     wasIntroducedRecently: Boolean,

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/constantsAndUtils.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/constantsAndUtils.kt
@@ -104,8 +104,7 @@ internal fun BtaCompilerArgument<*>.extractName(): String = name.uppercase().rep
 }
 
 internal fun KClass<*>.toBtaEnumClassName(): ClassName = ClassName(API_ENUMS_PACKAGE, simpleName!!)
-
-internal val TypeName.isGeneratedEnum: Boolean get() = (this as? ClassName)?.packageName?.startsWith(API_ENUMS_PACKAGE) ?: false
+internal fun KClass<*>.toBtaImplEnumClassName(targetPackage: String): ClassName = ClassName("$targetPackage.enums", simpleName!!)
 
 internal fun createGeneratedFileAppendable(): StringBuilder = StringBuilder(GeneratorsFileUtil.GENERATED_MESSAGE_PREFIX)
     .appendLine("the README.md file").appendLine(GeneratorsFileUtil.GENERATED_MESSAGE_SUFFIX).appendLine()

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonCompilerArgumentsImpl.kt
@@ -140,15 +140,22 @@ import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.WarningLevel
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.AnnotationDefaultTargetMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.ExplicitApiMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.HeaderMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.KotlinVersion
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.NameBasedDestructuringMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.ReturnValueCheckerMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.VerifyIrMode
 import org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.AnnotationDefaultTargetMode as InternalArgumentsEnumsAnnotationDefaultTargetMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.ExplicitApiMode as InternalArgumentsEnumsExplicitApiMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.HeaderMode as InternalArgumentsEnumsHeaderMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.KotlinVersion as InternalArgumentsEnumsKotlinVersion
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.NameBasedDestructuringMode as InternalArgumentsEnumsNameBasedDestructuringMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.ReturnValueCheckerMode as InternalArgumentsEnumsReturnValueCheckerMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.VerifyIrMode as InternalArgumentsEnumsVerifyIrMode
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments as ArgumentsCommonCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.AnnotationDefaultTargetMode as ApiArgumentsEnumsAnnotationDefaultTargetMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.ExplicitApiMode as ApiArgumentsEnumsExplicitApiMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.HeaderMode as ApiArgumentsEnumsHeaderMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.KotlinVersion as ApiArgumentsEnumsKotlinVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.NameBasedDestructuringMode as ApiArgumentsEnumsNameBasedDestructuringMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.ReturnValueCheckerMode as ApiArgumentsEnumsReturnValueCheckerMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.VerifyIrMode as ApiArgumentsEnumsVerifyIrMode
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments as CommonCompilerArguments
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
@@ -165,17 +172,23 @@ internal abstract class CommonCompilerArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: CommonCompilerArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: CommonCompilerArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: CommonCompilerArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: CommonCompilerArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: ArgumentsCommonCompilerArguments.CommonCompilerArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -183,7 +196,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Deprecated(
@@ -191,6 +204,24 @@ internal abstract class CommonCompilerArgumentsImpl(
     level = DeprecationLevel.ERROR,
   )
   override operator fun contains(key: ArgumentsCommonCompilerArguments.CommonCompilerArgument<*>): Boolean = key.id in optionsMap
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsExplicitApiMode if directionToInternal -> InternalArgumentsEnumsExplicitApiMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsExplicitApiMode if !directionToInternal-> ApiArgumentsEnumsExplicitApiMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsAnnotationDefaultTargetMode if directionToInternal -> InternalArgumentsEnumsAnnotationDefaultTargetMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsAnnotationDefaultTargetMode if !directionToInternal-> ApiArgumentsEnumsAnnotationDefaultTargetMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsHeaderMode if directionToInternal -> InternalArgumentsEnumsHeaderMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsHeaderMode if !directionToInternal-> ApiArgumentsEnumsHeaderMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsNameBasedDestructuringMode if directionToInternal -> InternalArgumentsEnumsNameBasedDestructuringMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsNameBasedDestructuringMode if !directionToInternal-> ApiArgumentsEnumsNameBasedDestructuringMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsReturnValueCheckerMode if directionToInternal -> InternalArgumentsEnumsReturnValueCheckerMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsReturnValueCheckerMode if !directionToInternal-> ApiArgumentsEnumsReturnValueCheckerMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsVerifyIrMode if directionToInternal -> InternalArgumentsEnumsVerifyIrMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsVerifyIrMode if !directionToInternal-> ApiArgumentsEnumsVerifyIrMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsKotlinVersion if directionToInternal -> InternalArgumentsEnumsKotlinVersion.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsKotlinVersion if !directionToInternal-> ApiArgumentsEnumsKotlinVersion.entries.first { it.name == this.name }
+    else -> this
+  }
 
   abstract override fun build(): CommonCompilerArgumentsImpl
 
@@ -321,7 +352,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[XX_LANGUAGE] = arguments.manuallyConfiguredFeatures } catch (_: NoSuchMethodError) {  }
     try { this[XX_DEBUG_LEVEL_COMPILER_CHECKS] = arguments.debugLevelCompilerChecks } catch (_: NoSuchMethodError) {  }
     try { this[XX_DUMP_MODEL] = arguments.dumpArgumentsDir } catch (_: NoSuchMethodError) {  }
-    try { this[XX_EXPLICIT_RETURN_TYPES] = arguments.explicitReturnTypes.let { ExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::explicitReturnTypes, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -XXexplicit-return-types value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[XX_EXPLICIT_RETURN_TYPES] = arguments.explicitReturnTypes.let { InternalArgumentsEnumsExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::explicitReturnTypes, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -XXexplicit-return-types value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[XX_LENIENT_MODE] = arguments.lenientMode } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_ANY_SCRIPTS_IN_SOURCE_ROOTS] = arguments.allowAnyScriptsInSourceRoots } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_CONDITION_IMPLIES_RETURNS_CONTRACTS] = arguments.allowConditionImpliesReturnsContracts } catch (_: NoSuchMethodError) {  }
@@ -330,7 +361,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_ALLOW_KOTLIN_PACKAGE] = arguments.allowKotlinPackage } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_REIFIED_TYPE_IN_CATCH] = arguments.allowReifiedTypeInCatch } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_RETURNS_RESULT_OF] = arguments.allowReturnsResultOf } catch (_: NoSuchMethodError) {  }
-    try { this[X_ANNOTATION_DEFAULT_TARGET] = arguments.annotationDefaultTarget?.let { AnnotationDefaultTargetMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::annotationDefaultTarget, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xannotation-default-target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_ANNOTATION_DEFAULT_TARGET] = arguments.annotationDefaultTarget?.let { InternalArgumentsEnumsAnnotationDefaultTargetMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::annotationDefaultTarget, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xannotation-default-target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_ANNOTATION_TARGET_ALL] = arguments.annotationTargetAll } catch (_: NoSuchMethodError) {  }
     try { this[X_CALLABLE_REFERENCES_TO_CONTEXTUAL] = arguments.callableReferencesToContextual } catch (_: NoSuchMethodError) {  }
     try { this[X_CHECK_PHASE_CONDITIONS] = arguments.checkPhaseConditions } catch (_: NoSuchMethodError) {  }
@@ -361,7 +392,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_EQUALITY_BOUNDS] = arguments.equalityBounds } catch (_: NoSuchMethodError) {  }
     try { this[X_ESCAPING_FUNCTIONS] = arguments.escapingFunctions.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPECT_ACTUAL_CLASSES] = arguments.expectActualClasses } catch (_: NoSuchMethodError) {  }
-    try { this[X_EXPLICIT_API] = arguments.explicitApi.let { ExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::explicitApi, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xexplicit-api value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_EXPLICIT_API] = arguments.explicitApi.let { InternalArgumentsEnumsExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::explicitApi, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xexplicit-api value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPLICIT_BACKING_FIELDS] = arguments.explicitBackingFields } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPLICIT_CONTEXT_ARGUMENTS] = arguments.explicitContextArguments } catch (_: NoSuchMethodError) {  }
     try { this[X_FIR_AGGRESSIVE_PRUNING] = arguments.firAggressivePruning } catch (_: NoSuchMethodError) {  }
@@ -371,7 +402,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_FRAGMENT_SOURCES] = arguments.fragmentSources } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENTS] = arguments.fragments } catch (_: NoSuchMethodError) {  }
     try { this[X_HEADER_MODE] = arguments.headerMode } catch (_: NoSuchMethodError) {  }
-    try { this[X_HEADER_MODE_TYPE] = arguments.headerModeType.let { HeaderMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::headerModeType, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xheader-mode-type value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_HEADER_MODE_TYPE] = arguments.headerModeType.let { InternalArgumentsEnumsHeaderMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::headerModeType, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xheader-mode-type value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_IGNORE_CONST_OPTIMIZATION_ERRORS] = arguments.ignoreConstOptimizationErrors } catch (_: NoSuchMethodError) {  }
     try { this[X_INLINE_CLASSES] = arguments.inlineClasses } catch (_: NoSuchMethodError) {  }
     try { this[X_INTELLIJ_PLUGIN_ROOT] = arguments.intellijPluginRoot } catch (_: NoSuchMethodError) {  }
@@ -382,7 +413,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_METADATA_VERSION] = arguments.metadataVersion } catch (_: NoSuchMethodError) {  }
     try { this[X_MULTI_DOLLAR_INTERPOLATION] = arguments.multiDollarInterpolation } catch (_: NoSuchMethodError) {  }
     try { this[X_MULTI_PLATFORM] = arguments.multiPlatform } catch (_: NoSuchMethodError) {  }
-    try { this[X_NAME_BASED_DESTRUCTURING] = arguments.nameBasedDestructuring?.let { NameBasedDestructuringMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::nameBasedDestructuring, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xname-based-destructuring value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_NAME_BASED_DESTRUCTURING] = arguments.nameBasedDestructuring?.let { InternalArgumentsEnumsNameBasedDestructuringMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::nameBasedDestructuring, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xname-based-destructuring value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_NESTED_TYPE_ALIASES] = arguments.nestedTypeAliases } catch (_: NoSuchMethodError) {  }
     try { this[X_NEW_INFERENCE] = arguments.newInference } catch (_: NoSuchMethodError) {  }
     try { this[X_NO_CHECK_ACTUAL] = arguments.noCheckActual } catch (_: NoSuchMethodError) {  }
@@ -402,7 +433,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_REPORT_ALL_WARNINGS] = arguments.reportAllWarnings } catch (_: NoSuchMethodError) {  }
     try { this[X_REPORT_OUTPUT_FILES] = arguments.reportOutputFiles } catch (_: NoSuchMethodError) {  }
     try { this[X_REPORT_PERF] = arguments.reportPerf } catch (_: NoSuchMethodError) {  }
-    try { this[X_RETURN_VALUE_CHECKER] = arguments.returnValueChecker.let { ReturnValueCheckerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::returnValueChecker, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xreturn-value-checker value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_RETURN_VALUE_CHECKER] = arguments.returnValueChecker.let { InternalArgumentsEnumsReturnValueCheckerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::returnValueChecker, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xreturn-value-checker value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_SEPARATE_KMP_COMPILATION] = arguments.separateKmpCompilationScheme } catch (_: NoSuchMethodError) {  }
     try { this[X_SKIP_METADATA_VERSION_CHECK] = arguments.skipMetadataVersionCheck } catch (_: NoSuchMethodError) {  }
     try { this[X_SKIP_PRERELEASE_CHECK] = arguments.skipPrereleaseCheck } catch (_: NoSuchMethodError) {  }
@@ -415,13 +446,13 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_USE_FIR_IC] = arguments.useFirIC } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_FIR_LT] = arguments.useFirLT } catch (_: NoSuchMethodError) {  }
     try { this[X_VERBOSE_PHASES] = arguments.verbosePhases.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
-    try { this[X_VERIFY_IR] = arguments.verifyIr?.let { VerifyIrMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::verifyIr, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xverify-ir value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_VERIFY_IR] = arguments.verifyIr?.let { InternalArgumentsEnumsVerifyIrMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::verifyIr, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xverify-ir value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_VERIFY_IR_NESTED_OFFSETS] = arguments.getUsingReflection<Boolean>("verifyIrNestedOffsets") } catch (_: NoSuchMethodError) {  }
     try { this[X_VERIFY_IR_VISIBILITY] = arguments.getUsingReflection<Boolean>("verifyIrVisibility") } catch (_: NoSuchMethodError) {  }
     try { this[X_WHEN_GUARDS] = arguments.whenGuards } catch (_: NoSuchMethodError) {  }
-    try { this[API_VERSION] = arguments.apiVersion?.let { KotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::apiVersion, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -api-version value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[API_VERSION] = arguments.apiVersion?.let { InternalArgumentsEnumsKotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::apiVersion, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -api-version value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[KOTLIN_HOME] = arguments.kotlinHome?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[LANGUAGE_VERSION] = arguments.languageVersion?.let { KotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::languageVersion, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -language-version value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[LANGUAGE_VERSION] = arguments.languageVersion?.let { InternalArgumentsEnumsKotlinVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::languageVersion, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -language-version value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[OPT_IN] = arguments.optIn.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[PROGRESSIVE] = arguments.progressiveMode } catch (_: NoSuchMethodError) {  }
     try { this[SCRIPT] = arguments.script } catch (_: NoSuchMethodError) {  }
@@ -561,7 +592,8 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val XX_DUMP_MODEL: CommonCompilerArgument<String?> =
         CommonCompilerArgument("XX_DUMP_MODEL")
 
-    public val XX_EXPLICIT_RETURN_TYPES: CommonCompilerArgument<ExplicitApiMode> =
+    public val XX_EXPLICIT_RETURN_TYPES:
+        CommonCompilerArgument<InternalArgumentsEnumsExplicitApiMode> =
         CommonCompilerArgument("XX_EXPLICIT_RETURN_TYPES")
 
     public val XX_LENIENT_MODE: CommonCompilerArgument<Boolean> =
@@ -588,7 +620,8 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_ALLOW_RETURNS_RESULT_OF: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_ALLOW_RETURNS_RESULT_OF")
 
-    public val X_ANNOTATION_DEFAULT_TARGET: CommonCompilerArgument<AnnotationDefaultTargetMode?> =
+    public val X_ANNOTATION_DEFAULT_TARGET:
+        CommonCompilerArgument<InternalArgumentsEnumsAnnotationDefaultTargetMode?> =
         CommonCompilerArgument("X_ANNOTATION_DEFAULT_TARGET")
 
     public val X_ANNOTATION_TARGET_ALL: CommonCompilerArgument<Boolean> =
@@ -681,7 +714,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_EXPECT_ACTUAL_CLASSES: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_EXPECT_ACTUAL_CLASSES")
 
-    public val X_EXPLICIT_API: CommonCompilerArgument<ExplicitApiMode> =
+    public val X_EXPLICIT_API: CommonCompilerArgument<InternalArgumentsEnumsExplicitApiMode> =
         CommonCompilerArgument("X_EXPLICIT_API")
 
     public val X_EXPLICIT_BACKING_FIELDS: CommonCompilerArgument<Boolean> =
@@ -711,7 +744,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_HEADER_MODE: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_HEADER_MODE")
 
-    public val X_HEADER_MODE_TYPE: CommonCompilerArgument<HeaderMode> =
+    public val X_HEADER_MODE_TYPE: CommonCompilerArgument<InternalArgumentsEnumsHeaderMode> =
         CommonCompilerArgument("X_HEADER_MODE_TYPE")
 
     public val X_IGNORE_CONST_OPTIMIZATION_ERRORS: CommonCompilerArgument<Boolean> =
@@ -744,7 +777,8 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_MULTI_PLATFORM: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_MULTI_PLATFORM")
 
-    public val X_NAME_BASED_DESTRUCTURING: CommonCompilerArgument<NameBasedDestructuringMode?> =
+    public val X_NAME_BASED_DESTRUCTURING:
+        CommonCompilerArgument<InternalArgumentsEnumsNameBasedDestructuringMode?> =
         CommonCompilerArgument("X_NAME_BASED_DESTRUCTURING")
 
     public val X_NESTED_TYPE_ALIASES: CommonCompilerArgument<Boolean> =
@@ -801,7 +835,8 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_REPORT_PERF: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_REPORT_PERF")
 
-    public val X_RETURN_VALUE_CHECKER: CommonCompilerArgument<ReturnValueCheckerMode> =
+    public val X_RETURN_VALUE_CHECKER:
+        CommonCompilerArgument<InternalArgumentsEnumsReturnValueCheckerMode> =
         CommonCompilerArgument("X_RETURN_VALUE_CHECKER")
 
     public val X_SEPARATE_KMP_COMPILATION: CommonCompilerArgument<Boolean> =
@@ -841,7 +876,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_VERBOSE_PHASES: CommonCompilerArgument<List<String>> =
         CommonCompilerArgument("X_VERBOSE_PHASES")
 
-    public val X_VERIFY_IR: CommonCompilerArgument<VerifyIrMode?> =
+    public val X_VERIFY_IR: CommonCompilerArgument<InternalArgumentsEnumsVerifyIrMode?> =
         CommonCompilerArgument("X_VERIFY_IR")
 
     public val X_VERIFY_IR_NESTED_OFFSETS: CommonCompilerArgument<Boolean> =
@@ -853,13 +888,13 @@ internal abstract class CommonCompilerArgumentsImpl(
     public val X_WHEN_GUARDS: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_WHEN_GUARDS")
 
-    public val API_VERSION: CommonCompilerArgument<KotlinVersion?> =
+    public val API_VERSION: CommonCompilerArgument<InternalArgumentsEnumsKotlinVersion?> =
         CommonCompilerArgument("API_VERSION")
 
     public val KOTLIN_HOME: CommonCompilerArgument<java.nio.`file`.Path?> =
         CommonCompilerArgument("KOTLIN_HOME")
 
-    public val LANGUAGE_VERSION: CommonCompilerArgument<KotlinVersion?> =
+    public val LANGUAGE_VERSION: CommonCompilerArgument<InternalArgumentsEnumsKotlinVersion?> =
         CommonCompilerArgument("LANGUAGE_VERSION")
 
     public val OPT_IN: CommonCompilerArgument<List<String>> = CommonCompilerArgument("OPT_IN")

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonJsAndWasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonJsAndWasmArgumentsImpl.kt
@@ -56,11 +56,15 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerKlibArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsMainCallMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapEmbedSources
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapNamesPolicy
 import org.jetbrains.kotlin.cli.common.arguments.CommonJsAndWasmCompilerArguments
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JsIrDiagnosticMode as InternalArgumentsEnumsJsIrDiagnosticMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JsMainCallMode as InternalArgumentsEnumsJsMainCallMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.SourceMapEmbedSources as InternalArgumentsEnumsSourceMapEmbedSources
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.SourceMapNamesPolicy as InternalArgumentsEnumsSourceMapNamesPolicy
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode as ApiArgumentsEnumsJsIrDiagnosticMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsMainCallMode as ApiArgumentsEnumsJsMainCallMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapEmbedSources as ApiArgumentsEnumsSourceMapEmbedSources
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapNamesPolicy as ApiArgumentsEnumsSourceMapNamesPolicy
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -80,17 +84,23 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: CommonJsAndWasmArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: CommonJsAndWasmArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: CommonJsAndWasmArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: CommonJsAndWasmArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: CommonJsAndWasmArguments.CommonJsAndWasmArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -98,14 +108,14 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: CommonJsAndWasmCompilerKlibArguments.CommonJsAndWasmCompilerKlibArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -113,14 +123,14 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: CommonJsAndWasmCompilerLinkingArguments.CommonJsAndWasmCompilerLinkingArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -128,7 +138,19 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
+  }
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsJsIrDiagnosticMode if directionToInternal -> InternalArgumentsEnumsJsIrDiagnosticMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJsIrDiagnosticMode if !directionToInternal-> ApiArgumentsEnumsJsIrDiagnosticMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJsMainCallMode if directionToInternal -> InternalArgumentsEnumsJsMainCallMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJsMainCallMode if !directionToInternal-> ApiArgumentsEnumsJsMainCallMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsSourceMapEmbedSources if directionToInternal -> InternalArgumentsEnumsSourceMapEmbedSources.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsSourceMapEmbedSources if !directionToInternal-> ApiArgumentsEnumsSourceMapEmbedSources.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsSourceMapNamesPolicy if directionToInternal -> InternalArgumentsEnumsSourceMapNamesPolicy.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsSourceMapNamesPolicy if !directionToInternal-> ApiArgumentsEnumsSourceMapNamesPolicy.entries.first { it.name == this.name }
+    else -> this
   }
 
   abstract override fun build(): CommonJsAndWasmArgumentsImpl
@@ -178,7 +200,7 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     try { this[X_INCLUDE] = arguments.includes?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_DCE] = arguments.irDce } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_DCE_PRINT_REACHABILITY_INFO] = arguments.irDcePrintReachabilityInfo } catch (_: NoSuchMethodError) {  }
-    try { this[X_IR_DCE_RUNTIME_DIAGNOSTIC] = arguments.irDceRuntimeDiagnostic?.let { JsIrDiagnosticMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irDceRuntimeDiagnostic, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xir-dce-runtime-diagnostic value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_IR_DCE_RUNTIME_DIAGNOSTIC] = arguments.irDceRuntimeDiagnostic?.let { InternalArgumentsEnumsJsIrDiagnosticMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irDceRuntimeDiagnostic, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xir-dce-runtime-diagnostic value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_MODULE_NAME] = arguments.irModuleName } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_PER_MODULE_OUTPUT_NAME] = arguments.irPerModuleOutputName } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_PRODUCE_JS] = arguments.irProduceJs } catch (_: NoSuchMethodError) {  }
@@ -189,12 +211,12 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     try { this[IR_OUTPUT_DIR] = arguments.outputDir?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[IR_OUTPUT_NAME] = arguments.moduleName } catch (_: NoSuchMethodError) {  }
     try { this[LIBRARIES] = arguments.libraries?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[MAIN] = arguments.main?.let { JsMainCallMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::main, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -main value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[MAIN] = arguments.main?.let { InternalArgumentsEnumsJsMainCallMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::main, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -main value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[NOPACK] = arguments.nopack } catch (_: NoSuchMethodError) {  }
     try { this[SOURCE_MAP] = arguments.sourceMap } catch (_: NoSuchMethodError) {  }
     try { this[SOURCE_MAP_BASE_DIRS] = arguments.sourceMapBaseDirs?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[SOURCE_MAP_EMBED_SOURCES] = arguments.sourceMapEmbedSources?.let { SourceMapEmbedSources.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::sourceMapEmbedSources, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -source-map-embed-sources value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[SOURCE_MAP_NAMES_POLICY] = arguments.sourceMapNamesPolicy?.let { SourceMapNamesPolicy.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::sourceMapNamesPolicy, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -source-map-names-policy value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[SOURCE_MAP_EMBED_SOURCES] = arguments.sourceMapEmbedSources?.let { InternalArgumentsEnumsSourceMapEmbedSources.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::sourceMapEmbedSources, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -source-map-embed-sources value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[SOURCE_MAP_NAMES_POLICY] = arguments.sourceMapNamesPolicy?.let { InternalArgumentsEnumsSourceMapNamesPolicy.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::sourceMapNamesPolicy, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -source-map-names-policy value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[SOURCE_MAP_PREFIX] = arguments.sourceMapPrefix } catch (_: NoSuchMethodError) {  }
     internalArguments.addAll(arguments.internalArguments.map { it.stringRepresentation })
   }
@@ -259,7 +281,8 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     public val X_IR_DCE_PRINT_REACHABILITY_INFO: CommonJsAndWasmArgument<Boolean> =
         CommonJsAndWasmArgument("X_IR_DCE_PRINT_REACHABILITY_INFO")
 
-    public val X_IR_DCE_RUNTIME_DIAGNOSTIC: CommonJsAndWasmArgument<JsIrDiagnosticMode?> =
+    public val X_IR_DCE_RUNTIME_DIAGNOSTIC:
+        CommonJsAndWasmArgument<InternalArgumentsEnumsJsIrDiagnosticMode?> =
         CommonJsAndWasmArgument("X_IR_DCE_RUNTIME_DIAGNOSTIC")
 
     public val X_IR_MODULE_NAME: CommonJsAndWasmArgument<String?> =
@@ -292,7 +315,8 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     public val LIBRARIES: CommonJsAndWasmArgument<List<java.nio.`file`.Path>?> =
         CommonJsAndWasmArgument("LIBRARIES")
 
-    public val MAIN: CommonJsAndWasmArgument<JsMainCallMode?> = CommonJsAndWasmArgument("MAIN")
+    public val MAIN: CommonJsAndWasmArgument<InternalArgumentsEnumsJsMainCallMode?> =
+        CommonJsAndWasmArgument("MAIN")
 
     public val NOPACK: CommonJsAndWasmArgument<Boolean> = CommonJsAndWasmArgument("NOPACK")
 
@@ -301,10 +325,12 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     public val SOURCE_MAP_BASE_DIRS: CommonJsAndWasmArgument<List<java.nio.`file`.Path>?> =
         CommonJsAndWasmArgument("SOURCE_MAP_BASE_DIRS")
 
-    public val SOURCE_MAP_EMBED_SOURCES: CommonJsAndWasmArgument<SourceMapEmbedSources?> =
+    public val SOURCE_MAP_EMBED_SOURCES:
+        CommonJsAndWasmArgument<InternalArgumentsEnumsSourceMapEmbedSources?> =
         CommonJsAndWasmArgument("SOURCE_MAP_EMBED_SOURCES")
 
-    public val SOURCE_MAP_NAMES_POLICY: CommonJsAndWasmArgument<SourceMapNamesPolicy?> =
+    public val SOURCE_MAP_NAMES_POLICY:
+        CommonJsAndWasmArgument<InternalArgumentsEnumsSourceMapNamesPolicy?> =
         CommonJsAndWasmArgument("SOURCE_MAP_NAMES_POLICY")
 
     public val SOURCE_MAP_PREFIX: CommonJsAndWasmArgument<String?> =

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonKlibBasedArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonKlibBasedArgumentsImpl.kt
@@ -41,11 +41,15 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsKlibArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsLinkingArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.DuplicatedUniqueNameStrategy
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.KlibIrInlinerMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageLogLevel
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageMode
 import org.jetbrains.kotlin.cli.common.arguments.CommonKlibBasedCompilerArguments
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.DuplicatedUniqueNameStrategy as InternalArgumentsEnumsDuplicatedUniqueNameStrategy
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.KlibIrInlinerMode as InternalArgumentsEnumsKlibIrInlinerMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.PartialLinkageLogLevel as InternalArgumentsEnumsPartialLinkageLogLevel
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.PartialLinkageMode as InternalArgumentsEnumsPartialLinkageMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.DuplicatedUniqueNameStrategy as ApiArgumentsEnumsDuplicatedUniqueNameStrategy
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.KlibIrInlinerMode as ApiArgumentsEnumsKlibIrInlinerMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageLogLevel as ApiArgumentsEnumsPartialLinkageLogLevel
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageMode as ApiArgumentsEnumsPartialLinkageMode
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -65,17 +69,23 @@ internal abstract class CommonKlibBasedArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: CommonKlibBasedArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: CommonKlibBasedArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: CommonKlibBasedArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: CommonKlibBasedArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: CommonKlibBasedArguments.CommonKlibBasedArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -83,14 +93,14 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: CommonKlibBasedArgumentsKlibArguments.CommonKlibBasedArgumentsKlibArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -98,14 +108,14 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: CommonKlibBasedArgumentsLinkingArguments.CommonKlibBasedArgumentsLinkingArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -113,7 +123,19 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
+  }
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsDuplicatedUniqueNameStrategy if directionToInternal -> InternalArgumentsEnumsDuplicatedUniqueNameStrategy.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsDuplicatedUniqueNameStrategy if !directionToInternal-> ApiArgumentsEnumsDuplicatedUniqueNameStrategy.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsKlibIrInlinerMode if directionToInternal -> InternalArgumentsEnumsKlibIrInlinerMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsKlibIrInlinerMode if !directionToInternal-> ApiArgumentsEnumsKlibIrInlinerMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsPartialLinkageMode if directionToInternal -> InternalArgumentsEnumsPartialLinkageMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsPartialLinkageMode if !directionToInternal-> ApiArgumentsEnumsPartialLinkageMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsPartialLinkageLogLevel if directionToInternal -> InternalArgumentsEnumsPartialLinkageLogLevel.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsPartialLinkageLogLevel if !directionToInternal-> ApiArgumentsEnumsPartialLinkageLogLevel.entries.first { it.name == this.name }
+    else -> this
   }
 
   abstract override fun build(): CommonKlibBasedArgumentsImpl
@@ -144,14 +166,14 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     super.applyCompilerArguments(arguments)
     try { this[X_FAKE_OVERRIDE_VALIDATOR] = arguments.getUsingReflection<Boolean>("fakeOverrideValidator") } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_ABI_VERSION] = arguments.customKlibAbiVersion } catch (_: NoSuchMethodError) {  }
-    try { this[X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY] = arguments.duplicatedUniqueNameStrategy?.let { DuplicatedUniqueNameStrategy.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::duplicatedUniqueNameStrategy, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xklib-duplicated-unique-name-strategy value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY] = arguments.duplicatedUniqueNameStrategy?.let { InternalArgumentsEnumsDuplicatedUniqueNameStrategy.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::duplicatedUniqueNameStrategy, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xklib-duplicated-unique-name-strategy value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS] = arguments.enableSignatureClashChecks } catch (_: NoSuchMethodError) {  }
-    try { this[X_KLIB_IR_INLINER] = arguments.irInlinerBeforeKlibSerialization.let { KlibIrInlinerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irInlinerBeforeKlibSerialization, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xklib-ir-inliner value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_KLIB_IR_INLINER] = arguments.irInlinerBeforeKlibSerialization.let { InternalArgumentsEnumsKlibIrInlinerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irInlinerBeforeKlibSerialization, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xklib-ir-inliner value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_NORMALIZE_ABSOLUTE_PATH] = arguments.getUsingReflection<Boolean>("normalizeAbsolutePath") } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_RELATIVE_PATH_BASE] = arguments.relativePathBases.mapOrEmpty { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT] = arguments.klibZipFileAccessorCacheLimit.let { it.toInt() } } catch (_: NoSuchMethodError) {  }
-    try { this[X_PARTIAL_LINKAGE] = arguments.partialLinkageMode?.let { PartialLinkageMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::partialLinkageMode, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xpartial-linkage value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[X_PARTIAL_LINKAGE_LOGLEVEL] = arguments.partialLinkageLogLevel?.let { PartialLinkageLogLevel.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::partialLinkageLogLevel, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xpartial-linkage-loglevel value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_PARTIAL_LINKAGE] = arguments.partialLinkageMode?.let { InternalArgumentsEnumsPartialLinkageMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::partialLinkageMode, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xpartial-linkage value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_PARTIAL_LINKAGE_LOGLEVEL] = arguments.partialLinkageLogLevel?.let { InternalArgumentsEnumsPartialLinkageLogLevel.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::partialLinkageLogLevel, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xpartial-linkage-loglevel value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_SKIP_LIBRARY_SPECIAL_COMPATIBILITY_CHECKS] = arguments.skipLibrarySpecialCompatibilityChecks } catch (_: NoSuchMethodError) {  }
     internalArguments.addAll(arguments.internalArguments.map { it.stringRepresentation })
   }
@@ -190,13 +212,13 @@ internal abstract class CommonKlibBasedArgumentsImpl(
         CommonKlibBasedArgument("X_KLIB_ABI_VERSION")
 
     public val X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY:
-        CommonKlibBasedArgument<DuplicatedUniqueNameStrategy?> =
+        CommonKlibBasedArgument<InternalArgumentsEnumsDuplicatedUniqueNameStrategy?> =
         CommonKlibBasedArgument("X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY")
 
     public val X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS: CommonKlibBasedArgument<Boolean> =
         CommonKlibBasedArgument("X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS")
 
-    public val X_KLIB_IR_INLINER: CommonKlibBasedArgument<KlibIrInlinerMode> =
+    public val X_KLIB_IR_INLINER: CommonKlibBasedArgument<InternalArgumentsEnumsKlibIrInlinerMode> =
         CommonKlibBasedArgument("X_KLIB_IR_INLINER")
 
     public val X_KLIB_NORMALIZE_ABSOLUTE_PATH: CommonKlibBasedArgument<Boolean> =
@@ -208,10 +230,11 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     public val X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT: CommonKlibBasedArgument<Int> =
         CommonKlibBasedArgument("X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT")
 
-    public val X_PARTIAL_LINKAGE: CommonKlibBasedArgument<PartialLinkageMode?> =
-        CommonKlibBasedArgument("X_PARTIAL_LINKAGE")
+    public val X_PARTIAL_LINKAGE: CommonKlibBasedArgument<InternalArgumentsEnumsPartialLinkageMode?>
+        = CommonKlibBasedArgument("X_PARTIAL_LINKAGE")
 
-    public val X_PARTIAL_LINKAGE_LOGLEVEL: CommonKlibBasedArgument<PartialLinkageLogLevel?> =
+    public val X_PARTIAL_LINKAGE_LOGLEVEL:
+        CommonKlibBasedArgument<InternalArgumentsEnumsPartialLinkageLogLevel?> =
         CommonKlibBasedArgument("X_PARTIAL_LINKAGE_LOGLEVEL")
 
     public val X_SKIP_LIBRARY_SPECIAL_COMPATIBILITY_CHECKS: CommonKlibBasedArgument<Boolean> =

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonToolArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonToolArgumentsImpl.kt
@@ -64,17 +64,23 @@ internal abstract class CommonToolArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: CommonToolArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: CommonToolArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: CommonToolArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: CommonToolArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: ArgumentsCommonToolArguments.CommonToolArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -82,7 +88,7 @@ internal abstract class CommonToolArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Deprecated(
@@ -90,6 +96,10 @@ internal abstract class CommonToolArgumentsImpl(
     level = DeprecationLevel.ERROR,
   )
   override operator fun contains(key: ArgumentsCommonToolArguments.CommonToolArgument<*>): Boolean = key.id in optionsMap
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    else -> this
+  }
 
   abstract override fun build(): CommonToolArgumentsImpl
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JsArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JsArgumentsImpl.kt
@@ -51,12 +51,15 @@ import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgumen
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsEcmaVersion
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArgumentsAllErrors
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JsEcmaVersion as InternalArgumentsEnumsJsEcmaVersion
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JsIrDiagnosticMode as InternalArgumentsEnumsJsIrDiagnosticMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JsModuleKind as InternalArgumentsEnumsJsModuleKind
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsEcmaVersion as ApiArgumentsEnumsJsEcmaVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode as ApiArgumentsEnumsJsIrDiagnosticMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind as ApiArgumentsEnumsJsModuleKind
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -80,17 +83,23 @@ internal class JsArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: JsArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: JsArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: JsArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: JsArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: JsCompilerArguments.JsCompilerArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -98,14 +107,14 @@ internal class JsArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: JsCompilerKlibArguments.JsCompilerKlibArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -113,14 +122,14 @@ internal class JsArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: JsCompilerLinkingArguments.JsCompilerLinkingArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -128,7 +137,17 @@ internal class JsArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
+  }
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsJsIrDiagnosticMode if directionToInternal -> InternalArgumentsEnumsJsIrDiagnosticMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJsIrDiagnosticMode if !directionToInternal-> ApiArgumentsEnumsJsIrDiagnosticMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJsModuleKind if directionToInternal -> InternalArgumentsEnumsJsModuleKind.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJsModuleKind if !directionToInternal-> ApiArgumentsEnumsJsModuleKind.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJsEcmaVersion if directionToInternal -> InternalArgumentsEnumsJsEcmaVersion.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJsEcmaVersion if !directionToInternal-> ApiArgumentsEnumsJsEcmaVersion.entries.first { it.name == this.name }
+    else -> this
   }
 
   override fun deepCopy(): JsArgumentsImpl = JsArgumentsImpl(argumentValidationErrors.toSet(), restrictedArgViolations.toList(), argumentParseDiagnostics.copy()).also { newArgs -> newArgs.applyCompilerArguments(toCompilerArguments()) }
@@ -192,13 +211,13 @@ internal class JsArgumentsImpl(
     try { this[X_IR_PER_FILE] = arguments.irPerFile } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_PER_MODULE] = arguments.irPerModule } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_SAFE_EXTERNAL_BOOLEAN] = arguments.irSafeExternalBoolean } catch (_: NoSuchMethodError) {  }
-    try { this[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] = arguments.irSafeExternalBooleanDiagnostic?.let { JsIrDiagnosticMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irSafeExternalBooleanDiagnostic, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xir-safe-external-boolean-diagnostic value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] = arguments.irSafeExternalBooleanDiagnostic?.let { InternalArgumentsEnumsJsIrDiagnosticMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irSafeExternalBooleanDiagnostic, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xir-safe-external-boolean-diagnostic value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_OPTIMIZE_GENERATED_JS] = arguments.optimizeGeneratedJs } catch (_: NoSuchMethodError) {  }
     try { this[X_PLATFORM_ARGUMENTS_IN_MAIN_FUNCTION] = arguments.platformArgumentsProviderJsExpression } catch (_: NoSuchMethodError) {  }
     try { this[X_SUSPEND_LAMBDA_EXPORTING] = arguments.allowExportingSuspendLambdas } catch (_: NoSuchMethodError) {  }
     try { this[X_TYPED_ARRAYS] = arguments.getUsingReflection<Boolean>("typedArrays") } catch (_: NoSuchMethodError) {  }
-    try { this[MODULE_KIND] = arguments.moduleKind?.let { JsModuleKind.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::moduleKind, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -module-kind value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[TARGET] = arguments.target?.let { JsEcmaVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::target, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[MODULE_KIND] = arguments.moduleKind?.let { InternalArgumentsEnumsJsModuleKind.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::moduleKind, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -module-kind value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[TARGET] = arguments.target?.let { InternalArgumentsEnumsJsEcmaVersion.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::target, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     internalArguments.addAll(arguments.internalArguments.map { it.stringRepresentation })
   }
 
@@ -306,7 +325,8 @@ internal class JsArgumentsImpl(
     public val X_IR_SAFE_EXTERNAL_BOOLEAN: JsArgument<Boolean> =
         JsArgument("X_IR_SAFE_EXTERNAL_BOOLEAN")
 
-    public val X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC: JsArgument<JsIrDiagnosticMode?> =
+    public val X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC:
+        JsArgument<InternalArgumentsEnumsJsIrDiagnosticMode?> =
         JsArgument("X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC")
 
     public val X_OPTIMIZE_GENERATED_JS: JsArgument<Boolean> = JsArgument("X_OPTIMIZE_GENERATED_JS")
@@ -319,8 +339,9 @@ internal class JsArgumentsImpl(
 
     public val X_TYPED_ARRAYS: JsArgument<Boolean> = JsArgument("X_TYPED_ARRAYS")
 
-    public val MODULE_KIND: JsArgument<JsModuleKind?> = JsArgument("MODULE_KIND")
+    public val MODULE_KIND: JsArgument<InternalArgumentsEnumsJsModuleKind?> =
+        JsArgument("MODULE_KIND")
 
-    public val TARGET: JsArgument<JsEcmaVersion?> = JsArgument("TARGET")
+    public val TARGET: JsArgument<InternalArgumentsEnumsJsEcmaVersion?> = JsArgument("TARGET")
   }
 }

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
@@ -120,22 +120,34 @@ import org.jetbrains.kotlin.buildtools.api.arguments.Jsr305
 import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.NullabilityAnnotation
 import org.jetbrains.kotlin.buildtools.api.arguments.ProfileCompilerCommand
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.AbiStabilityMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.AssertionsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.CompatqualAnnotationsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JdkRelease
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JspecifyAnnotationsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmDefaultMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.LambdasMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.SamConversionsMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.StringConcatMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.ValhallaSupportMode
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.WhenExpressionsMode
 import org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArgumentsAllErrors
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.AbiStabilityMode as InternalArgumentsEnumsAbiStabilityMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.AssertionsMode as InternalArgumentsEnumsAssertionsMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.CompatqualAnnotationsMode as InternalArgumentsEnumsCompatqualAnnotationsMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JdkRelease as InternalArgumentsEnumsJdkRelease
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JspecifyAnnotationsMode as InternalArgumentsEnumsJspecifyAnnotationsMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JvmDefaultMode as InternalArgumentsEnumsJvmDefaultMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.JvmTarget as InternalArgumentsEnumsJvmTarget
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.LambdasMode as InternalArgumentsEnumsLambdasMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.SamConversionsMode as InternalArgumentsEnumsSamConversionsMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.StringConcatMode as InternalArgumentsEnumsStringConcatMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.ValhallaSupportMode as InternalArgumentsEnumsValhallaSupportMode
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.WhenExpressionsMode as InternalArgumentsEnumsWhenExpressionsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.AbiStabilityMode as ApiArgumentsEnumsAbiStabilityMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.AssertionsMode as ApiArgumentsEnumsAssertionsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.CompatqualAnnotationsMode as ApiArgumentsEnumsCompatqualAnnotationsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JdkRelease as ApiArgumentsEnumsJdkRelease
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JspecifyAnnotationsMode as ApiArgumentsEnumsJspecifyAnnotationsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmDefaultMode as ApiArgumentsEnumsJvmDefaultMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget as ApiArgumentsEnumsJvmTarget
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.LambdasMode as ApiArgumentsEnumsLambdasMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SamConversionsMode as ApiArgumentsEnumsSamConversionsMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.StringConcatMode as ApiArgumentsEnumsStringConcatMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.ValhallaSupportMode as ApiArgumentsEnumsValhallaSupportMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.WhenExpressionsMode as ApiArgumentsEnumsWhenExpressionsMode
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -155,17 +167,23 @@ internal class JvmCompilerArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: JvmCompilerArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: JvmCompilerArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: JvmCompilerArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: JvmCompilerArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: JvmCompilerArguments.JvmCompilerArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -173,7 +191,7 @@ internal class JvmCompilerArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Deprecated(
@@ -181,6 +199,34 @@ internal class JvmCompilerArgumentsImpl(
     level = DeprecationLevel.ERROR,
   )
   override operator fun contains(key: JvmCompilerArguments.JvmCompilerArgument<*>): Boolean = key.id in optionsMap
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsAbiStabilityMode if directionToInternal -> InternalArgumentsEnumsAbiStabilityMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsAbiStabilityMode if !directionToInternal-> ApiArgumentsEnumsAbiStabilityMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsAssertionsMode if directionToInternal -> InternalArgumentsEnumsAssertionsMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsAssertionsMode if !directionToInternal-> ApiArgumentsEnumsAssertionsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJdkRelease if directionToInternal -> InternalArgumentsEnumsJdkRelease.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJdkRelease if !directionToInternal-> ApiArgumentsEnumsJdkRelease.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJspecifyAnnotationsMode if directionToInternal -> InternalArgumentsEnumsJspecifyAnnotationsMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJspecifyAnnotationsMode if !directionToInternal-> ApiArgumentsEnumsJspecifyAnnotationsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsLambdasMode if directionToInternal -> InternalArgumentsEnumsLambdasMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsLambdasMode if !directionToInternal-> ApiArgumentsEnumsLambdasMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsSamConversionsMode if directionToInternal -> InternalArgumentsEnumsSamConversionsMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsSamConversionsMode if !directionToInternal-> ApiArgumentsEnumsSamConversionsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsStringConcatMode if directionToInternal -> InternalArgumentsEnumsStringConcatMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsStringConcatMode if !directionToInternal-> ApiArgumentsEnumsStringConcatMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsCompatqualAnnotationsMode if directionToInternal -> InternalArgumentsEnumsCompatqualAnnotationsMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsCompatqualAnnotationsMode if !directionToInternal-> ApiArgumentsEnumsCompatqualAnnotationsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsValhallaSupportMode if directionToInternal -> InternalArgumentsEnumsValhallaSupportMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsValhallaSupportMode if !directionToInternal-> ApiArgumentsEnumsValhallaSupportMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsWhenExpressionsMode if directionToInternal -> InternalArgumentsEnumsWhenExpressionsMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsWhenExpressionsMode if !directionToInternal-> ApiArgumentsEnumsWhenExpressionsMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJvmDefaultMode if directionToInternal -> InternalArgumentsEnumsJvmDefaultMode.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJvmDefaultMode if !directionToInternal-> ApiArgumentsEnumsJvmDefaultMode.entries.first { it.name == this.name }
+    is ApiArgumentsEnumsJvmTarget if directionToInternal -> InternalArgumentsEnumsJvmTarget.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsJvmTarget if !directionToInternal-> ApiArgumentsEnumsJvmTarget.entries.first { it.name == this.name }
+    else -> this
+  }
 
   override fun deepCopy(): JvmCompilerArgumentsImpl = JvmCompilerArgumentsImpl(argumentValidationErrors.toSet(), restrictedArgViolations.toList(), argumentParseDiagnostics.copy()).also { newArgs -> newArgs.applyCompilerArguments(toCompilerArguments()) }
 
@@ -284,12 +330,12 @@ internal class JvmCompilerArgumentsImpl(
   @Suppress("DEPRECATION")
   protected fun applyCompilerArguments(arguments: K2JVMCompilerArguments) {
     super.applyCompilerArguments(arguments)
-    try { this[X_ABI_STABILITY] = arguments.abiStability?.let { AbiStabilityMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::abiStability, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xabi-stability value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_ABI_STABILITY] = arguments.abiStability?.let { InternalArgumentsEnumsAbiStabilityMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::abiStability, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xabi-stability value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_ADD_MODULES] = arguments.additionalJavaModules.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_NO_SOURCE_FILES] = arguments.allowNoSourceFiles } catch (_: NoSuchMethodError) {  }
     try { this[X_ALLOW_UNSTABLE_DEPENDENCIES] = arguments.allowUnstableDependencies } catch (_: NoSuchMethodError) {  }
     try { this[X_ANNOTATIONS_IN_METADATA] = arguments.annotationsInMetadata } catch (_: NoSuchMethodError) {  }
-    try { this[X_ASSERTIONS] = arguments.assertionsMode?.let { AssertionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::assertionsMode, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xassertions value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_ASSERTIONS] = arguments.assertionsMode?.let { InternalArgumentsEnumsAssertionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::assertionsMode, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xassertions value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_BACKEND_THREADS] = arguments.backendThreads.let { it.toInt() } } catch (_: NoSuchMethodError) {  }
     try { this[X_BUILD_FILE] = arguments.buildFile } catch (_: NoSuchMethodError) {  }
     try { this[X_COMPILE_BUILTINS_AS_PART_OF_STDLIB] = arguments.getUsingReflection<Boolean>("expectBuiltinsAsPartOfStdlib") } catch (_: NoSuchMethodError) {  }
@@ -310,13 +356,13 @@ internal class JvmCompilerArgumentsImpl(
     try { this[X_JAVA_PACKAGE_PREFIX] = arguments.javaPackagePrefix } catch (_: NoSuchMethodError) {  }
     try { this[X_JAVA_SOURCE_ROOTS] = arguments.javaSourceRoots.mapOrEmpty { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_JAVAC_ARGUMENTS] = arguments.getUsingReflection<Array<String>>("javacArguments") } catch (_: NoSuchMethodError) {  }
-    try { this[X_JDK_RELEASE] = arguments.jdkRelease?.let { JdkRelease.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jdkRelease, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xjdk-release value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[X_JSPECIFY_ANNOTATIONS] = arguments.jspecifyAnnotations?.let { JspecifyAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jspecifyAnnotations, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xjspecify-annotations value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_JDK_RELEASE] = arguments.jdkRelease?.let { InternalArgumentsEnumsJdkRelease.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jdkRelease, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xjdk-release value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_JSPECIFY_ANNOTATIONS] = arguments.jspecifyAnnotations?.let { InternalArgumentsEnumsJspecifyAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jspecifyAnnotations, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xjspecify-annotations value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_JVM_DEFAULT] = arguments.jvmDefault } catch (_: NoSuchMethodError) {  }
     try { this[X_JVM_ENABLE_PREVIEW] = arguments.enableJvmPreview } catch (_: NoSuchMethodError) {  }
     try { this[X_JVM_EXPOSE_BOXED] = arguments.jvmExposeBoxed } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB] = arguments.getUsingReflection<String?>("klibLibraries")?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[X_LAMBDAS] = arguments.lambdas?.let { LambdasMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::lambdas, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xlambdas value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_LAMBDAS] = arguments.lambdas?.let { InternalArgumentsEnumsLambdasMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::lambdas, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xlambdas value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_LINK_VIA_SIGNATURES] = arguments.getUsingReflection<Boolean>("linkViaSignatures") } catch (_: NoSuchMethodError) {  }
     try { this[X_MODULE_PATH] = arguments.javaModulePath?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_MULTIFILE_PARTS_INHERIT] = arguments.inheritMultifileParts } catch (_: NoSuchMethodError) {  }
@@ -329,12 +375,12 @@ internal class JvmCompilerArgumentsImpl(
     try { this[X_NO_SOURCE_DEBUG_EXTENSION] = arguments.noSourceDebugExtension } catch (_: NoSuchMethodError) {  }
     try { this[X_NO_UNIFIED_NULL_CHECKS] = arguments.noUnifiedNullChecks } catch (_: NoSuchMethodError) {  }
     try { this[X_OUTPUT_BUILTINS_METADATA] = arguments.outputBuiltinsMetadata } catch (_: NoSuchMethodError) {  }
-    try { this[X_SAM_CONVERSIONS] = arguments.samConversions?.let { SamConversionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::samConversions, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xsam-conversions value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_SAM_CONVERSIONS] = arguments.samConversions?.let { InternalArgumentsEnumsSamConversionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::samConversions, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xsam-conversions value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_SANITIZE_PARENTHESES] = arguments.sanitizeParentheses } catch (_: NoSuchMethodError) {  }
     try { this[X_SCRIPT_RESOLVER_ENVIRONMENT] = arguments.scriptResolverEnvironment.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[X_SERIALIZE_IR] = arguments.getUsingReflection<String>("serializeIr") } catch (_: NoSuchMethodError) {  }
-    try { this[X_STRING_CONCAT] = arguments.stringConcat?.let { StringConcatMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::stringConcat, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xstring-concat value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS] = arguments.supportCompatqualCheckerFrameworkAnnotations?.let { CompatqualAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::supportCompatqualCheckerFrameworkAnnotations, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xsupport-compatqual-checker-framework-annotations value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_STRING_CONCAT] = arguments.stringConcat?.let { InternalArgumentsEnumsStringConcatMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::stringConcat, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xstring-concat value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS] = arguments.supportCompatqualCheckerFrameworkAnnotations?.let { InternalArgumentsEnumsCompatqualAnnotationsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::supportCompatqualCheckerFrameworkAnnotations, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xsupport-compatqual-checker-framework-annotations value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_SUPPRESS_DEPRECATED_JVM_TARGET_WARNING] = arguments.getUsingReflection<Boolean>("suppressDeprecatedJvmTargetWarning") } catch (_: NoSuchMethodError) {  }
     try { this[X_SUPPRESS_MISSING_BUILTINS_ERROR] = arguments.suppressMissingBuiltinsError } catch (_: NoSuchMethodError) {  }
     try { this[X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE] = arguments.typeEnhancementImprovementsInStrictMode } catch (_: NoSuchMethodError) {  }
@@ -346,18 +392,18 @@ internal class JvmCompilerArgumentsImpl(
     try { this[X_USE_METADATA_ON_INCREMENTAL_CLASSPATH] = arguments.useMetadataOnIncrementalClasspath } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_OLD_CLASS_FILES_READING] = arguments.useOldClassFilesReading } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_TYPE_TABLE] = arguments.useTypeTable } catch (_: NoSuchMethodError) {  }
-    try { this[X_VALHALLA_SUPPORT] = arguments.valhallaSupport?.let { ValhallaSupportMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::valhallaSupport, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xvalhalla-support value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_VALHALLA_SUPPORT] = arguments.valhallaSupport?.let { InternalArgumentsEnumsValhallaSupportMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::valhallaSupport, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xvalhalla-support value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_VALIDATE_BYTECODE] = arguments.validateBytecode } catch (_: NoSuchMethodError) {  }
     try { this[X_VALUE_CLASSES] = arguments.getUsingReflection<Boolean>("valueClasses") } catch (_: NoSuchMethodError) {  }
-    try { this[X_WHEN_EXPRESSIONS] = arguments.whenExpressionsGeneration?.let { WhenExpressionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::whenExpressionsGeneration, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xwhen-expressions value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_WHEN_EXPRESSIONS] = arguments.whenExpressionsGeneration?.let { InternalArgumentsEnumsWhenExpressionsMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::whenExpressionsGeneration, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xwhen-expressions value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[CLASSPATH] = arguments.classpath?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[D] = arguments.destination } catch (_: NoSuchMethodError) {  }
     try { this[EXPRESSION] = arguments.expression } catch (_: NoSuchMethodError) {  }
     try { this[INCLUDE_RUNTIME] = arguments.includeRuntime } catch (_: NoSuchMethodError) {  }
     try { this[JAVA_PARAMETERS] = arguments.javaParameters } catch (_: NoSuchMethodError) {  }
     try { this[JDK_HOME] = arguments.jdkHome?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[JVM_DEFAULT] = arguments.jvmDefaultStable?.let { JvmDefaultMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jvmDefaultStable, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -jvm-default value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[JVM_TARGET] = arguments.jvmTarget?.let { JvmTarget.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jvmTarget, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -jvm-target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[JVM_DEFAULT] = arguments.jvmDefaultStable?.let { InternalArgumentsEnumsJvmDefaultMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jvmDefaultStable, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -jvm-default value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[JVM_TARGET] = arguments.jvmTarget?.let { InternalArgumentsEnumsJvmTarget.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::jvmTarget, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -jvm-target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[MODULE_NAME] = arguments.moduleName } catch (_: NoSuchMethodError) {  }
     try { this[NO_JDK] = arguments.noJdk } catch (_: NoSuchMethodError) {  }
     try { this[NO_REFLECT] = arguments.noReflect } catch (_: NoSuchMethodError) {  }
@@ -498,7 +544,7 @@ internal class JvmCompilerArgumentsImpl(
   public companion object {
     private val knownArguments: MutableSet<String> = mutableSetOf()
 
-    public val X_ABI_STABILITY: JvmCompilerArgument<AbiStabilityMode?> =
+    public val X_ABI_STABILITY: JvmCompilerArgument<InternalArgumentsEnumsAbiStabilityMode?> =
         JvmCompilerArgument("X_ABI_STABILITY")
 
     public val X_ADD_MODULES: JvmCompilerArgument<List<String>> =
@@ -513,7 +559,7 @@ internal class JvmCompilerArgumentsImpl(
     public val X_ANNOTATIONS_IN_METADATA: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_ANNOTATIONS_IN_METADATA")
 
-    public val X_ASSERTIONS: JvmCompilerArgument<AssertionsMode?> =
+    public val X_ASSERTIONS: JvmCompilerArgument<InternalArgumentsEnumsAssertionsMode?> =
         JvmCompilerArgument("X_ASSERTIONS")
 
     public val X_BACKEND_THREADS: JvmCompilerArgument<Int> =
@@ -571,10 +617,11 @@ internal class JvmCompilerArgumentsImpl(
     public val X_JAVAC_ARGUMENTS: JvmCompilerArgument<Array<String>?> =
         JvmCompilerArgument("X_JAVAC_ARGUMENTS")
 
-    public val X_JDK_RELEASE: JvmCompilerArgument<JdkRelease?> =
+    public val X_JDK_RELEASE: JvmCompilerArgument<InternalArgumentsEnumsJdkRelease?> =
         JvmCompilerArgument("X_JDK_RELEASE")
 
-    public val X_JSPECIFY_ANNOTATIONS: JvmCompilerArgument<JspecifyAnnotationsMode?> =
+    public val X_JSPECIFY_ANNOTATIONS:
+        JvmCompilerArgument<InternalArgumentsEnumsJspecifyAnnotationsMode?> =
         JvmCompilerArgument("X_JSPECIFY_ANNOTATIONS")
 
     public val X_JVM_DEFAULT: JvmCompilerArgument<String?> = JvmCompilerArgument("X_JVM_DEFAULT")
@@ -588,7 +635,8 @@ internal class JvmCompilerArgumentsImpl(
     public val X_KLIB: JvmCompilerArgument<List<java.nio.`file`.Path>?> =
         JvmCompilerArgument("X_KLIB")
 
-    public val X_LAMBDAS: JvmCompilerArgument<LambdasMode?> = JvmCompilerArgument("X_LAMBDAS")
+    public val X_LAMBDAS: JvmCompilerArgument<InternalArgumentsEnumsLambdasMode?> =
+        JvmCompilerArgument("X_LAMBDAS")
 
     public val X_LINK_VIA_SIGNATURES: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_LINK_VIA_SIGNATURES")
@@ -625,7 +673,7 @@ internal class JvmCompilerArgumentsImpl(
     public val X_OUTPUT_BUILTINS_METADATA: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_OUTPUT_BUILTINS_METADATA")
 
-    public val X_SAM_CONVERSIONS: JvmCompilerArgument<SamConversionsMode?> =
+    public val X_SAM_CONVERSIONS: JvmCompilerArgument<InternalArgumentsEnumsSamConversionsMode?> =
         JvmCompilerArgument("X_SAM_CONVERSIONS")
 
     public val X_SANITIZE_PARENTHESES: JvmCompilerArgument<Boolean> =
@@ -636,11 +684,11 @@ internal class JvmCompilerArgumentsImpl(
 
     public val X_SERIALIZE_IR: JvmCompilerArgument<String> = JvmCompilerArgument("X_SERIALIZE_IR")
 
-    public val X_STRING_CONCAT: JvmCompilerArgument<StringConcatMode?> =
+    public val X_STRING_CONCAT: JvmCompilerArgument<InternalArgumentsEnumsStringConcatMode?> =
         JvmCompilerArgument("X_STRING_CONCAT")
 
     public val X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS:
-        JvmCompilerArgument<CompatqualAnnotationsMode?> =
+        JvmCompilerArgument<InternalArgumentsEnumsCompatqualAnnotationsMode?> =
         JvmCompilerArgument("X_SUPPORT_COMPATQUAL_CHECKER_FRAMEWORK_ANNOTATIONS")
 
     public val X_SUPPRESS_DEPRECATED_JVM_TARGET_WARNING: JvmCompilerArgument<Boolean> =
@@ -674,7 +722,7 @@ internal class JvmCompilerArgumentsImpl(
     public val X_USE_TYPE_TABLE: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_USE_TYPE_TABLE")
 
-    public val X_VALHALLA_SUPPORT: JvmCompilerArgument<ValhallaSupportMode?> =
+    public val X_VALHALLA_SUPPORT: JvmCompilerArgument<InternalArgumentsEnumsValhallaSupportMode?> =
         JvmCompilerArgument("X_VALHALLA_SUPPORT")
 
     public val X_VALIDATE_BYTECODE: JvmCompilerArgument<Boolean> =
@@ -683,7 +731,7 @@ internal class JvmCompilerArgumentsImpl(
     public val X_VALUE_CLASSES: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_VALUE_CLASSES")
 
-    public val X_WHEN_EXPRESSIONS: JvmCompilerArgument<WhenExpressionsMode?> =
+    public val X_WHEN_EXPRESSIONS: JvmCompilerArgument<InternalArgumentsEnumsWhenExpressionsMode?> =
         JvmCompilerArgument("X_WHEN_EXPRESSIONS")
 
     public val CLASSPATH: JvmCompilerArgument<List<java.nio.`file`.Path>?> =
@@ -702,10 +750,11 @@ internal class JvmCompilerArgumentsImpl(
     public val JDK_HOME: JvmCompilerArgument<java.nio.`file`.Path?> =
         JvmCompilerArgument("JDK_HOME")
 
-    public val JVM_DEFAULT: JvmCompilerArgument<JvmDefaultMode?> =
+    public val JVM_DEFAULT: JvmCompilerArgument<InternalArgumentsEnumsJvmDefaultMode?> =
         JvmCompilerArgument("JVM_DEFAULT")
 
-    public val JVM_TARGET: JvmCompilerArgument<JvmTarget?> = JvmCompilerArgument("JVM_TARGET")
+    public val JVM_TARGET: JvmCompilerArgument<InternalArgumentsEnumsJvmTarget?> =
+        JvmCompilerArgument("JVM_TARGET")
 
     public val MODULE_NAME: JvmCompilerArgument<String?> = JvmCompilerArgument("MODULE_NAME")
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/MetadataArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/MetadataArgumentsImpl.kt
@@ -40,11 +40,12 @@ import org.jetbrains.kotlin.buildtools.api.CompilerArgumentsParseException
 import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.MetadataTargetPlatform
 import org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2MetadataCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArgumentsAllErrors
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.MetadataTargetPlatform as InternalArgumentsEnumsMetadataTargetPlatform
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.MetadataTargetPlatform as ApiArgumentsEnumsMetadataTargetPlatform
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -64,17 +65,23 @@ internal class MetadataArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: MetadataArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: MetadataArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: MetadataArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: MetadataArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: MetadataArguments.MetadataArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -82,7 +89,13 @@ internal class MetadataArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
+  }
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsMetadataTargetPlatform if directionToInternal -> InternalArgumentsEnumsMetadataTargetPlatform.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsMetadataTargetPlatform if !directionToInternal-> ApiArgumentsEnumsMetadataTargetPlatform.entries.first { it.name == this.name }
+    else -> this
   }
 
   override fun deepCopy(): MetadataArgumentsImpl = MetadataArgumentsImpl(argumentValidationErrors.toSet(), restrictedArgViolations.toList(), argumentParseDiagnostics.copy()).also { newArgs -> newArgs.applyCompilerArguments(toCompilerArguments()) }
@@ -117,7 +130,7 @@ internal class MetadataArgumentsImpl(
     try { this[X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT] = arguments.klibZipFileAccessorCacheLimit.let { it.toInt() } } catch (_: NoSuchMethodError) {  }
     try { this[X_LEGACY_METADATA_JAR_K2] = arguments.legacyMetadataJar } catch (_: NoSuchMethodError) {  }
     try { this[X_REFINES_PATHS] = arguments.refinesPaths.mapOrEmpty { Path(it) } } catch (_: NoSuchMethodError) {  }
-    try { this[X_TARGET_PLATFORM] = arguments.targetPlatform.map { MetadataTargetPlatform.entries.firstOrNull { entry -> entry.stringValue == it } ?: throw CompilerArgumentsParseException("Unknown -Xtarget-platform value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_TARGET_PLATFORM] = arguments.targetPlatform.map { InternalArgumentsEnumsMetadataTargetPlatform.entries.firstOrNull { entry -> entry.stringValue == it } ?: throw CompilerArgumentsParseException("Unknown -Xtarget-platform value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[CLASSPATH] = arguments.classpath?.split(File.pathSeparator)?.map { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[D] = arguments.destination } catch (_: NoSuchMethodError) {  }
     try { this[MODULE_NAME] = arguments.moduleName } catch (_: NoSuchMethodError) {  }
@@ -191,7 +204,8 @@ internal class MetadataArgumentsImpl(
     public val X_REFINES_PATHS: MetadataArgument<List<java.nio.`file`.Path>> =
         MetadataArgument("X_REFINES_PATHS")
 
-    public val X_TARGET_PLATFORM: MetadataArgument<List<MetadataTargetPlatform>> =
+    public val X_TARGET_PLATFORM:
+        MetadataArgument<List<InternalArgumentsEnumsMetadataTargetPlatform>> =
         MetadataArgument("X_TARGET_PLATFORM")
 
     public val CLASSPATH: MetadataArgument<List<java.nio.`file`.Path>?> =

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
@@ -51,10 +51,11 @@ import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgumen
 import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerKlibArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerLinkingArguments
-import org.jetbrains.kotlin.buildtools.api.arguments.enums.WasmTarget
 import org.jetbrains.kotlin.cli.common.arguments.KotlinWasmCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArgumentsAllErrors
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.enums.WasmTarget as InternalArgumentsEnumsWasmTarget
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.WasmTarget as ApiArgumentsEnumsWasmTarget
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -78,17 +79,23 @@ internal class WasmArgumentsImpl(
   @Suppress("UNCHECKED_CAST")
   public operator fun <V> `get`(key: WasmArgument<V>): V = optionsMap[key.id] as V
 
-  private operator fun <V> `set`(key: WasmArgument<V>, `value`: V) {
+  public operator fun <V> `set`(key: WasmArgument<V>, `value`: V) {
     optionsMap[key.id] = `value`
   }
 
   public operator fun contains(key: WasmArgument<*>): Boolean = key.id in optionsMap
 
+  private operator fun `get`(key: String): Any? = optionsMap[key]?.mapEnums(false)
+
+  private operator fun `set`(key: String, `value`: Any?) {
+    optionsMap[key] = `value`?.mapEnums(true)
+  }
+
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: WasmCompilerArguments.WasmCompilerArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -96,14 +103,14 @@ internal class WasmArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: WasmCompilerKlibArguments.WasmCompilerKlibArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -111,14 +118,14 @@ internal class WasmArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
   }
 
   @Suppress("UNCHECKED_CAST")
   @UseFromImplModuleRestricted
   override operator fun <V> `get`(key: WasmCompilerLinkingArguments.WasmCompilerLinkingArgument<V>): V {
     check(key.id in optionsMap) { "Argument ${key.id} is not set and has no default value" }
-    return optionsMap[key.id] as V
+    return this[key.id] as V
   }
 
   @UseFromImplModuleRestricted
@@ -126,7 +133,13 @@ internal class WasmArgumentsImpl(
     if (key.availableSinceVersion > KotlinReleaseVersion(2, 5, 0)) {
       throw IllegalStateException("${key.id} is available only since ${key.availableSinceVersion}")
     }
-    optionsMap[key.id] = `value`
+    this[key.id] = `value`
+  }
+
+  private fun Any?.mapEnums(directionToInternal: Boolean): Any? = when (this) {
+    is ApiArgumentsEnumsWasmTarget if directionToInternal -> InternalArgumentsEnumsWasmTarget.entries.first { it.name == this.name }
+    is InternalArgumentsEnumsWasmTarget if !directionToInternal-> ApiArgumentsEnumsWasmTarget.entries.first { it.name == this.name }
+    else -> this
   }
 
   override fun deepCopy(): WasmArgumentsImpl = WasmArgumentsImpl(argumentValidationErrors.toSet(), restrictedArgViolations.toList(), argumentParseDiagnostics.copy()).also { newArgs -> newArgs.applyCompilerArguments(toCompilerArguments()) }
@@ -191,7 +204,7 @@ internal class WasmArgumentsImpl(
     try { this[X_WASM_KCLASS_FQN] = arguments.wasmKClassFqn } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_NO_JSTAG] = arguments.wasmNoJsTag } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_SOURCE_MAP_INCLUDE_MAPPINGS_FROM_UNAVAILABLE_SOURCES] = arguments.includeUnavailableSourcesIntoSourceMap } catch (_: NoSuchMethodError) {  }
-    try { this[X_WASM_TARGET] = arguments.wasmTarget?.let { WasmTarget.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::wasmTarget, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xwasm-target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
+    try { this[X_WASM_TARGET] = arguments.wasmTarget?.let { InternalArgumentsEnumsWasmTarget.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::wasmTarget, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xwasm-target value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_USE_NEW_EXCEPTION_PROPOSAL] = arguments.wasmUseNewExceptionProposal } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_USE_STACK_SWITCHING_PROPOSAL] = arguments.wasmUseStackSwitchingProposal } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS] = arguments.wasmUseTrapsInsteadOfExceptions } catch (_: NoSuchMethodError) {  }
@@ -308,7 +321,8 @@ internal class WasmArgumentsImpl(
     public val X_WASM_SOURCE_MAP_INCLUDE_MAPPINGS_FROM_UNAVAILABLE_SOURCES: WasmArgument<Boolean> =
         WasmArgument("X_WASM_SOURCE_MAP_INCLUDE_MAPPINGS_FROM_UNAVAILABLE_SOURCES")
 
-    public val X_WASM_TARGET: WasmArgument<WasmTarget?> = WasmArgument("X_WASM_TARGET")
+    public val X_WASM_TARGET: WasmArgument<InternalArgumentsEnumsWasmTarget?> =
+        WasmArgument("X_WASM_TARGET")
 
     public val X_WASM_USE_NEW_EXCEPTION_PROPOSAL: WasmArgument<Boolean?> =
         WasmArgument("X_WASM_USE_NEW_EXCEPTION_PROPOSAL")

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/AbiStabilityMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/AbiStabilityMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class AbiStabilityMode(
+  public val stringValue: String,
+) {
+  STABLE("stable"),
+  UNSTABLE("unstable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/AnnotationDefaultTargetMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/AnnotationDefaultTargetMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class AnnotationDefaultTargetMode(
+  public val stringValue: String,
+) {
+  FIRST_ONLY("first-only"),
+  FIRST_ONLY_WARN("first-only-warn"),
+  PARAM_PROPERTY("param-property"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/AssertionsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/AssertionsMode.kt
@@ -1,0 +1,19 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class AssertionsMode(
+  public val stringValue: String,
+) {
+  ALWAYS_ENABLE("always-enable"),
+  ALWAYS_DISABLE("always-disable"),
+  JVM("jvm"),
+  LEGACY("legacy"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/CompatqualAnnotationsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/CompatqualAnnotationsMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class CompatqualAnnotationsMode(
+  public val stringValue: String,
+) {
+  ENABLE("enable"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/DuplicatedUniqueNameStrategy.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/DuplicatedUniqueNameStrategy.kt
@@ -1,0 +1,19 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class DuplicatedUniqueNameStrategy(
+  public val stringValue: String,
+) {
+  DENY("deny"),
+  ALLOW_ALL_WITH_WARNING("allow-all-with-warning"),
+  ALLOW_FIRST_WITH_WARNING("allow-first-with-warning"),
+  ALLOW_ALL("allow-all"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/ExplicitApiMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/ExplicitApiMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class ExplicitApiMode(
+  public val stringValue: String,
+) {
+  STRICT("strict"),
+  WARNING("warning"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/HeaderMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/HeaderMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class HeaderMode(
+  public val stringValue: String,
+) {
+  ANY("any"),
+  COMPILATION("compilation"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JdkRelease.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JdkRelease.kt
@@ -1,0 +1,40 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JdkRelease(
+  public val stringValue: String,
+) {
+  JDK_1_6("1.6"),
+  JDK_1_7("1.7"),
+  JDK_1_8("1.8"),
+  JDK_6("6"),
+  JDK_7("7"),
+  JDK_8("8"),
+  JDK_9("9"),
+  JDK_10("10"),
+  JDK_11("11"),
+  JDK_12("12"),
+  JDK_13("13"),
+  JDK_14("14"),
+  JDK_15("15"),
+  JDK_16("16"),
+  JDK_17("17"),
+  JDK_18("18"),
+  JDK_19("19"),
+  JDK_20("20"),
+  JDK_21("21"),
+  JDK_22("22"),
+  JDK_23("23"),
+  JDK_24("24"),
+  JDK_25("25"),
+  JDK_26("26"),
+  JDK_27("27"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsEcmaVersion.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsEcmaVersion.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class JsEcmaVersion(
+  public val stringValue: String,
+) {
+  ES5("es5"),
+  ES2015("es2015"),
+  ES2020("es2020"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsIrDiagnosticMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsIrDiagnosticMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class JsIrDiagnosticMode(
+  public val stringValue: String,
+) {
+  LOG("log"),
+  EXCEPTION("exception"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsMainCallMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsMainCallMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class JsMainCallMode(
+  public val stringValue: String,
+) {
+  CALL("call"),
+  NO_CALL("noCall"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsModuleKind.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JsModuleKind.kt
@@ -1,0 +1,20 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class JsModuleKind(
+  public val stringValue: String,
+) {
+  PLAIN("plain"),
+  AMD("amd"),
+  COMMONJS("commonjs"),
+  UMD("umd"),
+  ES("es"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JspecifyAnnotationsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JspecifyAnnotationsMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JspecifyAnnotationsMode(
+  public val stringValue: String,
+) {
+  IGNORE("ignore"),
+  STRICT("strict"),
+  WARN("warn"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JvmDefaultMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JvmDefaultMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JvmDefaultMode(
+  public val stringValue: String,
+) {
+  ENABLE("enable"),
+  NO_COMPATIBILITY("no-compatibility"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JvmTarget.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/JvmTarget.kt
@@ -1,0 +1,36 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class JvmTarget(
+  public val stringValue: String,
+) {
+  JVM1_6("1.6"),
+  JVM1_8("1.8"),
+  JVM_9("9"),
+  JVM_10("10"),
+  JVM_11("11"),
+  JVM_12("12"),
+  JVM_13("13"),
+  JVM_14("14"),
+  JVM_15("15"),
+  JVM_16("16"),
+  JVM_17("17"),
+  JVM_18("18"),
+  JVM_19("19"),
+  JVM_20("20"),
+  JVM_21("21"),
+  JVM_22("22"),
+  JVM_23("23"),
+  JVM_24("24"),
+  JVM_25("25"),
+  JVM_26("26"),
+  JVM_27("27"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/KlibIrInlinerMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/KlibIrInlinerMode.kt
@@ -1,0 +1,19 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class KlibIrInlinerMode(
+  public val stringValue: String,
+) {
+  INTRAMODULE("intra-module"),
+  FULL("full"),
+  DISABLED("disabled"),
+  DEFAULT("default"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/KotlinVersion.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/KotlinVersion.kt
@@ -1,0 +1,33 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class KotlinVersion(
+  public val stringValue: String,
+) {
+  V1_0("1.0"),
+  V1_1("1.1"),
+  V1_2("1.2"),
+  V1_3("1.3"),
+  V1_4("1.4"),
+  V1_5("1.5"),
+  V1_6("1.6"),
+  V1_7("1.7"),
+  V1_8("1.8"),
+  V1_9("1.9"),
+  V2_0("2.0"),
+  V2_1("2.1"),
+  V2_2("2.2"),
+  V2_3("2.3"),
+  V2_4("2.4"),
+  V2_5("2.5"),
+  V2_6("2.6"),
+  V2_7("2.7"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/LambdasMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/LambdasMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class LambdasMode(
+  public val stringValue: String,
+) {
+  CLASS("class"),
+  INDY("indy"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/MetadataTargetPlatform.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/MetadataTargetPlatform.kt
@@ -1,0 +1,20 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class MetadataTargetPlatform(
+  public val stringValue: String,
+) {
+  JVM("JVM"),
+  JS("JS"),
+  WASM_JS("WasmJs"),
+  WASM_WASI("WasmWasi"),
+  NATIVE("Native"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/NameBasedDestructuringMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/NameBasedDestructuringMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class NameBasedDestructuringMode(
+  public val stringValue: String,
+) {
+  ONLY_SYNTAX("only-syntax"),
+  NAME_MISMATCH("name-mismatch"),
+  COMPLETE("complete"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/PartialLinkageLogLevel.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/PartialLinkageLogLevel.kt
@@ -1,0 +1,19 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class PartialLinkageLogLevel(
+  public val stringValue: String,
+) {
+  SILENT("silent"),
+  INFO("info"),
+  WARNING("warning"),
+  ERROR("error"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/PartialLinkageMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/PartialLinkageMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class PartialLinkageMode(
+  public val stringValue: String,
+) {
+  ENABLE("enable"),
+  DISABLE("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/ReturnValueCheckerMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/ReturnValueCheckerMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class ReturnValueCheckerMode(
+  public val stringValue: String,
+) {
+  CHECKER("check"),
+  FULL("full"),
+  DISABLED("disable"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/SamConversionsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/SamConversionsMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class SamConversionsMode(
+  public val stringValue: String,
+) {
+  CLASS("class"),
+  INDY("indy"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/SourceMapEmbedSources.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/SourceMapEmbedSources.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class SourceMapEmbedSources(
+  public val stringValue: String,
+) {
+  ALWAYS("always"),
+  NEVER("never"),
+  INLINING("inlining"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/SourceMapNamesPolicy.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/SourceMapNamesPolicy.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class SourceMapNamesPolicy(
+  public val stringValue: String,
+) {
+  NO("no"),
+  SIMPLE_NAMES("simple-names"),
+  FULLY_QUALIFIED_NAMES("fully-qualified-names"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/StringConcatMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/StringConcatMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class StringConcatMode(
+  public val stringValue: String,
+) {
+  INDY_WITH_CONSTANTS("indy-with-constants"),
+  INDY("indy"),
+  INLINE("inline"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/ValhallaSupportMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/ValhallaSupportMode.kt
@@ -1,0 +1,19 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class ValhallaSupportMode(
+  public val stringValue: String,
+) {
+  NONE("none"),
+  PRIMITIVES("primitives"),
+  PRIMITIVES_AND_FULL_VALUE_CLASSES("primitivesAndFullValueClasses"),
+  ALL_VALUES("allValues"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/VerifyIrMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/VerifyIrMode.kt
@@ -1,0 +1,18 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class VerifyIrMode(
+  public val stringValue: String,
+) {
+  NONE("none"),
+  WARNING("warning"),
+  ERROR("error"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/WasmTarget.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/WasmTarget.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.4.20
+ */
+public enum class WasmTarget(
+  public val stringValue: String,
+) {
+  WASM_JS("wasm-js"),
+  WASM_WASI("wasm-wasi"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/WhenExpressionsMode.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/enums/WhenExpressionsMode.kt
@@ -1,0 +1,17 @@
+// This file was generated automatically. See the README.md file
+// DO NOT MODIFY IT MANUALLY.
+
+package org.jetbrains.kotlin.buildtools.`internal`.arguments.enums
+
+import kotlin.String
+
+/**
+ * @since 2.3.0
+ */
+public enum class WhenExpressionsMode(
+  public val stringValue: String,
+) {
+  INDY("indy"),
+  INLINE("inline"),
+  ;
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
@@ -99,12 +99,13 @@ internal class JsDtsGenerationOperationImpl private constructor(
         this[USE_UNKNOWN_INSTEAD_ANY] =
             linkingOperation.compilerArguments[JsArgumentsImpl.X_DTS_USE_UNKNOWN_INSTEAD_ANY]
 
-        this[MODULE_KIND] = linkingOperation.compilerArguments[JsArgumentsImpl.MODULE_KIND]
-            ?: JsModuleKind.ES.takeIf {
-                val target = linkingOperation.compilerArguments[JsArgumentsImpl.TARGET]
-                target != null && target >= JsEcmaVersion.ES2015
-            }
-            ?: JsModuleKind.UMD
+        this[MODULE_KIND] =
+            linkingOperation.compilerArguments[JsArgumentsImpl.MODULE_KIND]?.let { from -> JsModuleKind.entries.first { it.name == from.name } }
+                ?: JsModuleKind.ES.takeIf {
+                    val target =
+                        linkingOperation.compilerArguments[JsArgumentsImpl.TARGET]?.let { from -> JsEcmaVersion.entries.first { it.name == from.name } }
+                    target != null && target >= JsEcmaVersion.ES2015
+                } ?: JsModuleKind.UMD
 
         this[GRANULARITY] = when {
             linkingOperation.compilerArguments[JsArgumentsImpl.X_IR_PER_FILE] -> JsDtsGranularity.PER_FILE
@@ -155,7 +156,8 @@ internal class JsDtsGenerationOperationImpl private constructor(
                 } ?: JsModuleKind.UMD
         )
         val COMPILE_LONG_AS_BIG_INT: Option<Boolean> = Option("COMPILE_LONG_AS_BIG_INT", defaultArgsReference.compileLongAsBigInt ?: false)
-        val IMPLEMENT_INTERFACES: Option<Boolean> = Option("IMPLEMENT_INTERFACES", defaultArgsReference.allowImplementableInterfacesExporting)
+        val IMPLEMENT_INTERFACES: Option<Boolean> =
+            Option("IMPLEMENT_INTERFACES", defaultArgsReference.allowImplementableInterfacesExporting)
         val EXPORT_SUSPEND_LAMBDAS: Option<Boolean> = Option("EXPORT_SUSPEND_LAMBDAS", defaultArgsReference.allowExportingSuspendLambdas)
         val USE_UNKNOWN_INSTEAD_ANY: Option<Boolean> = Option("USE_UNKNOWN_INSTEAD_ANY", defaultArgsReference.useUnknownInsteadAny)
         val DATA_CLASS_COPY_RESPECTS_CONSTRUCTOR_VISIBILITY: Option<Boolean> =


### PR DESCRIPTION
The solution is to generate a mirrored set of enums in impl package, so that when a new enum value is added, the impl can operate on it even when loaded from a previous version of the API (which doesn't have the new value).

It is expected that when the old API tries to read a value that only exists in the new impl, it will cause an error.
The new value is not representable using the old API enum class.

^KT-88756 Verification Pending