### PR TITLE
[KGP] Default classpath metadata to the jvm multiplatform IC property

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/CommonCodeWithPlatformSymbolsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/CommonCodeWithPlatformSymbolsIT.kt
@@ -45,6 +45,11 @@ abstract class CommonCodeWithPlatformSymbolsITBase(
         else -> copy(enableJvmUnsafeIncrementalCompilationForMultiplatform = enabled)
     }
 
+    private fun BuildOptions.withoutJvmClasspathMetadata(): BuildOptions = when (platformType) {
+        KotlinPlatformType.jvm -> copy(jvmClasspathMetadata = false)
+        else -> this
+    }
+
     private val platformSourceSet = "${platformType.name}Main"
 
     @GradleTest
@@ -54,7 +59,7 @@ abstract class CommonCodeWithPlatformSymbolsITBase(
         project(
             "kt-62686-mpp-source-set-boundary",
             gradleVersion,
-            buildOptions = defaultBuildOptions.withUnsafeOptimizationsForMultiplatform(true)
+            buildOptions = defaultBuildOptions.withUnsafeOptimizationsForMultiplatform(true).withoutJvmClasspathMetadata()
         ) {
             buildScriptInjection(setupBuildScript)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
@@ -645,7 +645,7 @@ internal class PropertiesProvider private constructor(private val project: Proje
      * giving each non-leaf fragment an isolated dependency view while jvmMain keeps the full JVM classpath.
      */
     val enableJvmClasspathMetadata: Provider<Boolean>
-        get() = booleanProvider(PropertyNames.KOTLIN_INTERNAL_JVM_CLASSPATH_METADATA).orElse(false)
+        get() = booleanProvider(PropertyNames.KOTLIN_INTERNAL_JVM_CLASSPATH_METADATA).orElse(enableJvmUnsafeOptimizationsForMultiplatform)
 
     val enableKlibsCrossCompilation: Boolean
         get() = booleanProperty(PropertyNames.KOTLIN_NATIVE_ENABLE_KLIBS_CROSSCOMPILATION) ?: true


### PR DESCRIPTION
`enableJvmClasspathMetadata` defaulted to `false`, so opting into `kotlin.internal.jvm.enableUnsafeOptimizationsForMultiplatform` alone left common sources compiled incrementally without the isolated fragment dependency view that keeps them from resolving against platform declarations - the KT-62686 problem the classpath metadata exists to prevent.

Default it to the value of that property instead, so that enabling incremental compilation of common sources also enables the mechanism that makes it correct. The internal classpath metadata property still wins when set explicitly, so it remains a kill switch for turning the metadata off on its own.

^KT-88763 Fixed