### PR TITLE
[IR] Remove unused IrClass.addSimpleDelegatingConstructor()

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
@@ -719,41 +719,6 @@ fun ir2stringWhole(ir: IrElement?): String {
     return strWriter.toString()
 }
 
-@Suppress("unused") // Used in rhizomedb
-fun IrClass.addSimpleDelegatingConstructor(
-    superConstructor: IrConstructor,
-    irBuiltIns: IrBuiltIns,
-    isPrimary: Boolean = false,
-    origin: IrDeclarationOrigin? = null
-): IrConstructor =
-    addConstructor {
-        val klass = this@addSimpleDelegatingConstructor
-        this.startOffset = klass.startOffset
-        this.endOffset = klass.endOffset
-        this.origin = origin ?: klass.origin
-        this.visibility = superConstructor.visibility
-        this.isPrimary = isPrimary
-    }.also { constructor ->
-        constructor.parameters = superConstructor.parameters.memoryOptimizedMap { parameter ->
-            parameter.copyTo(constructor)
-        }
-
-        constructor.body = factory.createBlockBody(
-            startOffset, endOffset,
-            listOf(
-                IrDelegatingConstructorCallImpl(
-                    startOffset, endOffset, irBuiltIns.unitType,
-                    superConstructor.symbol, 0
-                ).apply {
-                    constructor.parameters.forEach { parameter ->
-                        arguments[parameter.indexInParameters] = IrGetValueImpl(startOffset, endOffset, parameter.type, parameter.symbol)
-                    }
-                },
-                IrInstanceInitializerCallImpl(startOffset, endOffset, this.symbol, irBuiltIns.unitType)
-            )
-        )
-    }
-
 val IrCall.isSuspend get() = symbol.owner.isSuspend
 val IrFunctionReference.isSuspend get() = (symbol.owner as? IrSimpleFunction)?.isSuspend == true
 


### PR DESCRIPTION
Removed unused declaration IrClass.addSimpleDelegatingConstructor
Its only usage was in Fleet, and the declaration has been copied there in scope of https://jetbrains.team/p/ij/repositories/ultimate/revision/d13dae25e0ceed09ebbc4305e4426d8fceb73348

^[KT-70048](https://youtrack.jetbrains.com/issue/KT-70048) Fixed