### PR TITLE
AI: update JetBrains MCP tool names for IDEA 2026.2.1

### DIFF
--- a/.ai/guidelines.md
+++ b/.ai/guidelines.md
@@ -96,7 +96,7 @@ Use other similar tools only if it is not possible to use the JetBrains IDE MCP,
 - MCP changes integrate with IDE's undo history
 
 **IDE capabilities:**
-- `search_in_files_by_text` uses IntelliJ indexes — faster than grep on large codebases
+- `search_text` uses IntelliJ indexes — faster than grep on large codebases
 - `rename_refactoring` understands code structure and updates all references correctly
 - `get_symbol_info` provides type info, documentation, and declarations
 - `get_file_problems` runs IntelliJ inspections beyond syntax checking
@@ -108,13 +108,13 @@ If there are many options for the JetBrains IDE MCP server, ask the user what MC
 
 ### Tool mapping
 
-| Instead of      | Use JetBrains MCP                                     |
-|-----------------|-------------------------------------------------------|
-| `Read`          | `get_file_text_by_path`                               |
-| `Edit`, `Write` | `replace_text_in_file`, `create_new_file`             |
-| `Grep`          | `search_in_files_by_text`, `search_in_files_by_regex` |
-| `Glob`          | `find_files_by_name_keyword`, `find_files_by_glob`    |
-| `Task(Explore)` | `list_directory_tree`, `search_in_files_by_text`      |
+| Instead of      | Use JetBrains MCP                    |
+|-----------------|--------------------------------------|
+| `Read`          | `read_file`                          |
+| `Edit`, `Write` | `apply_patch`, `create_new_file`     |
+| `Grep`          | `search_text`, `search_regex`        |
+| `Glob`          | `search_file`                        |
+| `Task(Explore)` | `list_directory_tree`, `search_text` |
 
 ### Additional MCP tools
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,12 +2,10 @@
   "permissions": {
     "defaultMode": "plan",
     "allow": [
+      "mcp__jetbrains__apply_patch",
       "mcp__jetbrains__create_new_file",
-      "mcp__jetbrains__find_files_by_glob",
-      "mcp__jetbrains__find_files_by_name_keyword",
       "mcp__jetbrains__get_all_open_file_paths",
       "mcp__jetbrains__get_file_problems",
-      "mcp__jetbrains__get_file_text_by_path",
       "mcp__jetbrains__get_project_dependencies",
       "mcp__jetbrains__get_project_modules",
       "mcp__jetbrains__get_repositories",
@@ -15,15 +13,13 @@
       "mcp__jetbrains__get_symbol_info",
       "mcp__jetbrains__list_directory_tree",
       "mcp__jetbrains__open_file_in_editor",
+      "mcp__jetbrains__read_file",
       "mcp__jetbrains__reformat_file",
       "mcp__jetbrains__rename_refactoring",
-      "mcp__jetbrains__replace_text_in_file",
-      "mcp__jetbrains__search_in_files_by_regex",
-      "mcp__jetbrains__search_in_files_by_text",
+      "mcp__jetbrains__search_file",
+      "mcp__jetbrains__search_regex",
       "mcp__jetbrains__search_symbol",
-      "mcp__jetbrains__read_file",
-      "mcp__jetbrains__search_text",
-      "mcp__jetbrains__search_file"
+      "mcp__jetbrains__search_text"
     ]
   }
 }

--- a/.claude/skills/analysis-api-mark-internal-apis/SKILL.md
+++ b/.claude/skills/analysis-api-mark-internal-apis/SKILL.md
@@ -173,7 +173,7 @@ Tools to run the search:
 | `@LLFirInternals`         | Only inside `analysis/low-level-api-fir/` (own tests/testFixtures, no usages outside)   | **Keep.** No change. This is precisely what `@LLFirInternals` is for: making a `src/` declaration accessible to LL FIR's own tests. |
 | `@LLFirInternals`         | Anywhere outside `analysis/low-level-api-fir/`                                          | **Upgrade.** Replace the `@LLFirInternals` line with `@KaImplementationDetail`. Swap imports accordingly.                           |
 
-Apply edits with `mcp__idea__replace_text_in_file`. **Import housekeeping:** when removing or replacing an annotation,
+Apply edits with `mcp__idea__apply_patch`. **Import housekeeping:** when removing or replacing an annotation,
 also remove the corresponding import if no other declaration in the file still uses it. When adding `@KaImplementationDetail`,
 ensure `import org.jetbrains.kotlin.analysis.api.KaImplementationDetail` is present.
 

--- a/.claude/skills/build-bump-gradle-version/SKILL.md
+++ b/.claude/skills/build-bump-gradle-version/SKILL.md
@@ -35,8 +35,7 @@ It is one of three Gradle-version skills; make sure you're in the right one:
 
 **Tooling:** per the project `CLAUDE.md`, use JetBrains IDE MCP tools for every read and write on
 project files — `mcp__idea__read_file`, `mcp__idea__search_text` / `mcp__idea__search_regex`,
-`mcp__idea__get_symbol_info`, and whichever edit tool this MCP server exposes
-(`mcp__idea__replace_text_in_file` or `mcp__idea__apply_patch`) — not `Read`/`Edit`/`Grep`/`Glob`,
+`mcp__idea__get_symbol_info`, and `mcp__idea__apply_patch` for edits — not `Read`/`Edit`/`Grep`/`Glob`,
 which bypass the IDE's view of open buffers. Use the default `Bash` tool for Gradle commands (never
 `execute_terminal_command`). After editing any file, run `mcp__idea__get_file_problems` with
 `errorsOnly: false` and fix warnings attributable to your change.

--- a/.claude/skills/build-tools-bump-gradle-api/SKILL.md
+++ b/.claude/skills/build-tools-bump-gradle-api/SKILL.md
@@ -15,7 +15,7 @@ This skill walks through bumping `GradlePluginVariant.GRADLE_COMMON_COMPILE_API_
 — the Gradle API version that the Kotlin Gradle plugins' common source set is compiled against.
 
 **IMPORTANT**: This project uses JetBrains MCP tools for all file operations. Use
-`mcp__idea__*` tools (read_file, replace_text_in_file, search_in_files_by_text, etc.)
+`mcp__idea__*` tools (read_file, apply_patch, search_text, etc.)
 instead of standard Read/Edit/Grep/Glob tools.
 
 ---
@@ -43,7 +43,7 @@ change the constant inside the `companion object`:
 const val GRADLE_COMMON_COMPILE_API_VERSION = "<NEW_VERSION>"
 ```
 
-Use `mcp__idea__replace_text_in_file` to make this change.
+Use `mcp__idea__apply_patch` to make this change.
 
 ---
 
@@ -107,7 +107,7 @@ If errors appear, approach them methodically:
 2. **Understand the API change**: Use `mcp__idea__get_symbol_info` to look up what
    replaced a removed or changed API. Check the Gradle release notes for the target version.
 
-3. **Apply fixes**: Use `mcp__idea__replace_text_in_file` to update code.
+3. **Apply fixes**: Use `mcp__idea__apply_patch` to update code.
 
 4. **Re-run compilation** after each round of fixes until it's clean.
 

--- a/.claude/skills/build-tools-bump-gradle-in-tests/SKILL.md
+++ b/.claude/skills/build-tools-bump-gradle-in-tests/SKILL.md
@@ -72,7 +72,7 @@ Per the project `CLAUDE.md`, use JetBrains IDE MCP tools for every read and
 write on these project files. Specifically:
 
 - Read with `mcp__idea__read_file` or `mcp__idea__get_symbol_info`.
-- Edit with `mcp__idea__replace_text_in_file`.
+- Edit with `mcp__idea__apply_patch`.
 - After each edit, run `mcp__idea__get_file_problems` with `errorsOnly: false`
   and fix any warning attributable to the change.
 

--- a/.claude/skills/disable-generation-check/SKILL.md
+++ b/.claude/skills/disable-generation-check/SKILL.md
@@ -16,7 +16,7 @@ Ask the user whether they want to **disable** the generation check (for branchin
 
 For each `GeneratorsFileUtil.writeFileIfContentChanged(...)` call in the 2 files below, ensure it has `forbidGenerationOnTeamcity = false`. Depending on the current state, either add the parameter or swap `true` to `false`.
 
-Use `replace_text_in_file` with `forbidGenerationOnTeamcity = true` -> `forbidGenerationOnTeamcity = false` as a `replaceAll` replacement in each file. If no match is found (first-time application), add the parameter instead — see the "First-time" examples below.
+Use `apply_patch` to swap `forbidGenerationOnTeamcity = true` -> `forbidGenerationOnTeamcity = false` in each file, with one hunk per call site. If no match is found (first-time application), add the parameter instead — see the "First-time" examples below.
 
 ### Files and call sites
 
@@ -38,7 +38,7 @@ GeneratorsFileUtil.writeFileIfContentChanged(versionsFilePath.toFile(), sortedVe
 
 ### How to apply
 
-Use JetBrains MCP `replace_text_in_file` for each replacement. All replacements are independent — make them in parallel.
+Use JetBrains MCP `apply_patch`, one call per file covering all its call sites. The two files are independent — patch them in parallel.
 
 ### Commit pattern (disable)
 ```
@@ -51,7 +51,7 @@ Use JetBrains MCP `replace_text_in_file` for each replacement. All replacements 
 
 After branching is complete, re-enable the check by swapping `false` to `true` in all call sites across the 2 files.
 
-Use `replace_text_in_file` with `forbidGenerationOnTeamcity = false` -> `forbidGenerationOnTeamcity = true` as a `replaceAll` replacement in each of the 2 files.
+Use `apply_patch` to swap `forbidGenerationOnTeamcity = false` -> `forbidGenerationOnTeamcity = true` in each of the 2 files, with one hunk per call site.
 
 ### Commit pattern (revert)
 ```
@@ -68,7 +68,7 @@ The `DisableCacheInKotlinVersion` generator uses a rolling deprecation cycle: N 
 
 Find all usages of `DisableCacheInKotlinVersion.\`<old_version>\`` and replace with the next version constant (e.g. `2_3_20` → `2_4_0`). There are typically 3 usages — 2 in string templates and 1 in Kotlin code. The existing `@Suppress("DEPRECATION")` annotations handle the WARNING level on N-1 constants.
 
-Use `replace_text_in_file` with `replaceAll: true` to swap all occurrences at once.
+Use a single `apply_patch` call with one hunk per occurrence to swap them all at once.
 
 ### Commit pattern (bump version in tests)
 ```


### PR DESCRIPTION
The IDE's MCP server renamed six tools, so the guidelines and the permission allow-list pointed at tools that no longer exist: get_file_text_by_path -> read_file, replace_text_in_file -> apply_patch, search_in_files_by_text -> search_text, search_in_files_by_regex -> search_regex, and both find_files_by_name_keyword and find_files_by_glob -> search_file. The new names are verified against `tools/list` of IntelliJ IDEA MCP Server 2026.2.1, which offers 51 tools; every mcp__idea__* and mcp__jetbrains__* name left in the repo exists there.

`apply_patch` takes a patch instead of a search/replace pair, so the disable-generation-check skill needed rewording rather than a rename: what used to be a `replaceAll` replacement is now one call per file with one hunk per call site.

Also allow-list `search_regex`, which would otherwise prompt on every call, and drop the six dead allow-list entries.