### PR TITLE
[Stdlib] Rework binarySearch kdoc and samples to reflect typical usage

### DIFF
--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -282,14 +282,14 @@ class Collections {
         @Sample
         fun binarySearchFindOrInsert() {
             /**
-             * If the value is found, returns its index.
-             * Otherwise, inserts the value at the right position and returns its index.
+             * If the element is found, returns its index.
+             * Otherwise, inserts the element at the right position and returns its index.
              */
-            fun findOrInsert(list: MutableList<Char>, value: Char): Int {
-                val index = list.binarySearch(value)
-                if (index < 0) { // value not found
+            fun findOrInsert(list: MutableList<Char>, element: Char): Int {
+                val index = list.binarySearch(element)
+                if (index < 0) { // element not found
                     val insertionIndex = index.inv() // same as -(index + 1)
-                    list.add(insertionIndex, value)
+                    list.add(insertionIndex, element)
                     return insertionIndex
                 }
                 return index
@@ -317,8 +317,8 @@ class Collections {
         }
 
         @Sample
-        fun binarySearchRepeatingValues() {
-            // If multiple equal values are present, binarySearch could return any one of them.
+        fun binarySearchRepeatingElements() {
+            // If multiple equal elements are present, binarySearch could return any one of them.
             val list2b = mutableListOf('a', 'b', 'b', 'c', 'd', 'e')
             assertPrints(list2b.binarySearch('b'), "2") // could be either 1 or 2
             val list5b = mutableListOf('a', 'b', 'b', 'b', 'b', 'b', 'c', 'd', 'e')
@@ -372,15 +372,15 @@ class Collections {
 
         @Sample
         fun binarySearchWithComparisonFunctionLowerBoundUpperBound() {
-            // first index such that list[index] >= value, or list.size() if such index doesn't exist
-            fun <T : Comparable<T>> List<T?>.lowerBound(value: T?): Int =
-                binarySearch { if (it != null && value != null && it < value) -1 else 1 }.inv()
+            // first index such that list[index] >= element, or list.size() if such index doesn't exist
+            fun <T : Comparable<T>> List<T?>.lowerBound(element: T?): Int =
+                binarySearch { if (it != null && element != null && it < element) -1 else 1 }.inv()
 
-            // first index such that list[index] > value, or list.size() if such index doesn't exist
-            fun <T : Comparable<T>> List<T?>.upperBound(value: T?): Int =
-                binarySearch { if (it == null || (value != null && it <= value)) -1 else 1 }.inv()
+            // first index such that list[index] > element, or list.size() if such index doesn't exist
+            fun <T : Comparable<T>> List<T?>.upperBound(element: T?): Int =
+                binarySearch { if (it == null || (element != null && it <= element)) -1 else 1 }.inv()
 
-            // [lowerBound, upperBound) is a semi-interval of all the entries of the value in the list
+            // [lowerBound, upperBound) is a semi-interval of all the entries of the element in the list
 
             val lst1 = mutableListOf('a', 'b', 'b', 'c', 'd', 'e')
             val lst2 = mutableListOf('a',           'c', 'd', 'e')

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -273,6 +273,35 @@ class Collections {
         }
 
         @Sample
+        fun binarySearchFoundNotFound() {
+            val list = mutableListOf('a', 'b', 'c', 'd', 'e')
+            assertPrints(list.binarySearch('d') >= 0, "true") // found
+            assertPrints(list.binarySearch('f') >= 0, "false") // not found
+        }
+
+        @Sample
+        fun binarySearchFindOrInsert() {
+            /**
+             * If the value is found, returns its index.
+             * Otherwise, inserts the value at the right position and returns its index.
+             */
+            fun findOrInsert(list: MutableList<Char>, value: Char): Int {
+                val index = list.binarySearch(value)
+                if (index < 0) { // value not found
+                    val insertionIndex = index.inv() // same as -(index + 1)
+                    list.add(insertionIndex, value)
+                    return insertionIndex
+                }
+                return index
+            }
+
+            val index1 = findOrInsert(mutableListOf('a', 'b', 'c', 'd', 'e'), 'd')
+            assertPrints(index1, "3")
+            val index2 = findOrInsert(mutableListOf('a', 'b', 'c', 'e'), 'd')
+            assertPrints(index2, "3")
+        }
+
+        @Sample
         fun binarySearchOnComparable() {
             val list = mutableListOf('a', 'b', 'c', 'd', 'e')
             assertPrints(list.binarySearch('d'), "3")
@@ -280,11 +309,20 @@ class Collections {
             list.remove('d')
 
             val invertedInsertionPoint = list.binarySearch('d')
-            val actualInsertionPoint = -(invertedInsertionPoint + 1)
+            val actualInsertionPoint = invertedInsertionPoint.inv() // same as -(invertedInsertionPoint + 1)
             assertPrints(actualInsertionPoint, "3")
 
             list.add(actualInsertionPoint, 'd')
             assertPrints(list, "[a, b, c, d, e]")
+        }
+
+        @Sample
+        fun binarySearchRepeatingValues() {
+            // If multiple equal values are present, binarySearch could return any one of them.
+            val list2b = mutableListOf('a', 'b', 'b', 'c', 'd', 'e')
+            assertPrints(list2b.binarySearch('b'), "2") // could be either 1 or 2
+            val list5b = mutableListOf('a', 'b', 'b', 'b', 'b', 'b', 'c', 'd', 'e')
+            assertPrints(list5b.binarySearch('b'), "4") // could be either 1, 2, 3, 4 or 5
         }
 
         @Sample

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -283,7 +283,7 @@ class Collections {
         fun binarySearchFindOrInsert() {
             /**
              * If the element is found, returns its index.
-             * Otherwise, inserts the element at the right position and returns its index.
+             * Otherwise, inserts the element at the correct position and returns its index.
              */
             fun findOrInsert(list: MutableList<Char>, element: Char): Int {
                 val index = list.binarySearch(element)
@@ -386,7 +386,6 @@ class Collections {
             val lst2 = mutableListOf('a',           'c', 'd', 'e')
             val lst3 = mutableListOf('a', 'b', 'c')
             val lst4 = mutableListOf(null, null, 'a', 'b', 'c')
-            val lst5 = mutableListOf('a', 'b', 'c')
 
             assertPrints(lst1.lowerBound('b'), "1")
             assertPrints(lst1.upperBound('b'), "3")

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -319,10 +319,10 @@ class Collections {
         @Sample
         fun binarySearchRepeatingElements() {
             // If multiple equal elements are present, binarySearch could return any one of them.
-            val list2b = mutableListOf('a', 'b', 'b', 'c', 'd', 'e')
-            assertPrints(list2b.binarySearch('b'), "2") // could be either 1 or 2
-            val list5b = mutableListOf('a', 'b', 'b', 'b', 'b', 'b', 'c', 'd', 'e')
-            assertPrints(list5b.binarySearch('b'), "4") // could be either 1, 2, 3, 4 or 5
+            val list1 = mutableListOf('a', 'b', 'b')
+            assertPrints(list1.binarySearch('b'), "1") // could be either 1 or 2
+            val list2 = mutableListOf('a', 'b', 'b', 'c', 'd')
+            assertPrints(list2.binarySearch('b'), "2") // could be either 1 or 2
         }
 
         @Sample

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -308,11 +308,11 @@ class Collections {
 
             list.remove('d')
 
-            val invertedInsertionPoint = list.binarySearch('d')
-            val actualInsertionPoint = invertedInsertionPoint.inv() // same as -(invertedInsertionPoint + 1)
-            assertPrints(actualInsertionPoint, "3")
+            val invertedInsertionIndex = list.binarySearch('d')
+            val actualInsertionIndex = invertedInsertionIndex.inv() // same as -(invertedInsertionIndex + 1)
+            assertPrints(actualInsertionIndex, "3")
 
-            list.add(actualInsertionPoint, 'd')
+            list.add(actualInsertionIndex, 'd')
             assertPrints(list, "[a, b, c, d, e]")
         }
 

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -371,6 +371,36 @@ class Collections {
         }
 
         @Sample
+        fun binarySearchWithComparisonFunctionLowerBoundUpperBound() {
+            // first index such that list[index] >= value, or list.size() if such index doesn't exist
+            fun <T : Comparable<T>> List<T?>.lowerBound(value: T?): Int =
+                binarySearch { if (it != null && value != null && it < value) -1 else 1 }.inv()
+
+            // first index such that list[index] > value, or list.size() if such index doesn't exist
+            fun <T : Comparable<T>> List<T?>.upperBound(value: T?): Int =
+                binarySearch { if (it == null || (value != null && it <= value)) -1 else 1 }.inv()
+
+            // [lowerBound, upperBound) is a semi-interval of all the entries of the value in the list
+
+            val lst1 = mutableListOf('a', 'b', 'b', 'c', 'd', 'e')
+            val lst2 = mutableListOf('a',           'c', 'd', 'e')
+            val lst3 = mutableListOf('a', 'b', 'c')
+            val lst4 = mutableListOf(null, null, 'a', 'b', 'c')
+            val lst5 = mutableListOf('a', 'b', 'c')
+
+            assertPrints(lst1.lowerBound('b'), "1")
+            assertPrints(lst1.upperBound('b'), "3")
+            assertPrints(lst2.lowerBound('b'), "1")
+            assertPrints(lst2.upperBound('b'), "1")
+            assertPrints(lst3.lowerBound(null), "0")
+            assertPrints(lst3.upperBound(null), "0")
+            assertPrints(lst4.lowerBound(null), "0")
+            assertPrints(lst4.upperBound(null), "2")
+            assertPrints(lst4.lowerBound('d'), "3")
+            assertPrints(lst4.upperBound('d'), "3")
+        }
+
+        @Sample
         fun add() {
             val list = mutableListOf('a', 'b', 'c')
             assertTrue(list.add('c'))

--- a/libraries/stdlib/samples/test/samples/collections/collections.kt
+++ b/libraries/stdlib/samples/test/samples/collections/collections.kt
@@ -395,8 +395,8 @@ class Collections {
             assertPrints(lst3.upperBound(null), "0")
             assertPrints(lst4.lowerBound(null), "0")
             assertPrints(lst4.upperBound(null), "2")
-            assertPrints(lst4.lowerBound('d'), "3")
-            assertPrints(lst4.upperBound('d'), "3")
+            assertPrints(lst4.lowerBound('d'), "5")
+            assertPrints(lst4.upperBound('d'), "5")
         }
 
         @Sample

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -314,16 +314,16 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
 
 /**
  * Searches this list or its range for the provided [element] using the binary search algorithm.
- * The list is expected to be sorted into ascending order according to the Comparable natural ordering of its elements,
- * otherwise the result is undefined.
+ * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of its elements,
+ * otherwise the result is unspecified.
  *
- * If the list contains multiple elements equal to the specified [element], there is no guarantee which one will be found.
+ * If the list contains multiple elements equal to [element], there is no guarantee which one will be found.
  *
  * `null` value is considered to be less than any non-null value.
  *
  * @return the index of the element, if it is contained in the list within the specified range;
- * otherwise, the inverted insertion point `(-insertion point - 1)`.
- * The insertion point is defined as the index at which the element should be inserted,
+ * otherwise, the inverted insertion index `(-insertion index - 1)`.
+ * The insertion index is defined as the index at which the element should be inserted,
  * so that the list (or the specified subrange of the list) still remains sorted.
  * Thus, if the returned index is `>= 0`, then the value is present;
  * otherwise the value could be inserted at `index.inv()`

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -324,8 +324,13 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
  * @return the index of the element, if it is contained in the list within the specified range;
  * otherwise, the inverted insertion point `(-insertion point - 1)`.
  * The insertion point is defined as the index at which the element should be inserted,
- * so that the list (or the specified subrange of list) still remains sorted.
+ * so that the list (or the specified subrange of the list) still remains sorted.
+ * Thus, if the returned index is `>= 0`, then the value is present;
+ * otherwise the value could be inserted at `index.inv()`
+ * @sample samples.collections.Collections.Lists.binarySearchFoundNotFound
+ * @sample samples.collections.Collections.Lists.binarySearchFindOrInsert
  * @sample samples.collections.Collections.Lists.binarySearchOnComparable
+ * @sample samples.collections.Collections.Lists.binarySearchRepeatingValues
  * @sample samples.collections.Collections.Lists.binarySearchWithBoundaries
  */
 public fun <T : Comparable<T>> List<T?>.binarySearch(element: T?, fromIndex: Int = 0, toIndex: Int = size): Int {

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -319,6 +319,9 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
  *
  * If the list contains multiple elements equal to [element], there is no guarantee which one will be found.
  *
+ * If you need to find the first or the last occurrence of an element,
+ * refer to the [binarySearch] with a custom comparison function.
+ *
  * `null` value is considered to be less than any non-null value.
  *
  * @return the index of the element, if it is contained in the list within the specified range;
@@ -437,6 +440,7 @@ public inline fun <T, K : Comparable<K>> List<T>.binarySearchBy(
  * The insertion point is defined as the index at which the element should be inserted,
  * so that the list (or the specified subrange of list) still remains sorted.
  * @sample samples.collections.Collections.Lists.binarySearchWithComparisonFunction
+ * @sample samples.collections.Collections.Lists.binarySearchWithComparisonFunctionLowerBoundUpperBound
  */
 public fun <T> List<T>.binarySearch(fromIndex: Int = 0, toIndex: Int = size, comparison: (T) -> Int): Int {
     rangeCheck(size, fromIndex, toIndex)

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -333,7 +333,7 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
  * @sample samples.collections.Collections.Lists.binarySearchFoundNotFound
  * @sample samples.collections.Collections.Lists.binarySearchFindOrInsert
  * @sample samples.collections.Collections.Lists.binarySearchOnComparable
- * @sample samples.collections.Collections.Lists.binarySearchRepeatingValues
+ * @sample samples.collections.Collections.Lists.binarySearchRepeatingElements
  * @sample samples.collections.Collections.Lists.binarySearchWithBoundaries
  */
 public fun <T : Comparable<T>> List<T?>.binarySearch(element: T?, fromIndex: Int = 0, toIndex: Int = size): Int {

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -328,8 +328,8 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
  * otherwise, the inverted insertion index `(-insertion index - 1)`.
  * The insertion index is defined as the index at which the element should be inserted,
  * so that the list (or the specified subrange of the list) still remains sorted.
- * Thus, if the returned index is `>= 0`, then the value is present at this index;
- * otherwise, the value could be inserted at `index.inv()` to maintain the sorted order.
+ * Thus, if the returned index is `>= 0`, then the element is present at this index;
+ * otherwise, the element could be inserted at `index.inv()` to maintain the sorted order.
  * @sample samples.collections.Collections.Lists.binarySearchFoundNotFound
  * @sample samples.collections.Collections.Lists.binarySearchFindOrInsert
  * @sample samples.collections.Collections.Lists.binarySearchOnComparable
@@ -359,17 +359,22 @@ public fun <T : Comparable<T>> List<T?>.binarySearch(element: T?, fromIndex: Int
 
 /**
  * Searches this list or its range for the provided [element] using the binary search algorithm.
- * The list is expected to be sorted into ascending order according to the specified [comparator],
- * otherwise the result is undefined.
+ * The list is expected to be sorted in ascending order according to the specified [comparator];
+ * otherwise, the result is undefined.
  *
  * If the list contains multiple elements equal to the specified [element], there is no guarantee which one will be found.
+ *
+ * If you need to find the first or the last occurrence of an element,
+ * refer to the [binarySearch] with a custom comparison function.
  *
  * `null` value is considered to be less than any non-null value.
  *
  * @return the index of the element, if it is contained in the list within the specified range;
- * otherwise, the inverted insertion point `(-insertion point - 1)`.
- * The insertion point is defined as the index at which the element should be inserted,
- * so that the list (or the specified subrange of list) still remains sorted according to the specified [comparator].
+ * otherwise, the inverted insertion index `(-insertion index - 1)`.
+ * The insertion index is defined as the index at which the element should be inserted,
+ * so that the list (or the specified subrange of the list) still remains sorted according to the specified [comparator].
+ * Thus, if the returned index is `>= 0`, then the element is present at this index;
+ * otherwise, the element could be inserted at `index.inv()` to maintain the sorted order.
  * @sample samples.collections.Collections.Lists.binarySearchWithComparator
  */
 public fun <T> List<T>.binarySearch(element: T, comparator: Comparator<in T>, fromIndex: Int = 0, toIndex: Int = size): Int {
@@ -396,17 +401,22 @@ public fun <T> List<T>.binarySearch(element: T, comparator: Comparator<in T>, fr
 /**
  * Searches this list or its range for an element having the key returned by the specified [selector] function
  * equal to the provided [key] value using the binary search algorithm.
- * The list is expected to be sorted into ascending order according to the Comparable natural ordering of keys of its elements.
- * otherwise the result is undefined.
+ * The list is expected to be sorted into ascending order according to the Comparable natural ordering of keys of its elements;
+ * otherwise, the result is undefined.
  *
  * If the list contains multiple elements with the specified [key], there is no guarantee which one will be found.
+ *
+ * If you need to find the first or the last occurrence of an element,
+ * refer to the [binarySearch] with a custom comparison function.
  *
  * `null` value is considered to be less than any non-null value.
  *
  * @return the index of the element with the specified [key], if it is contained in the list within the specified range;
- * otherwise, the inverted insertion point `(-insertion point - 1)`.
- * The insertion point is defined as the index at which the element should be inserted,
- * so that the list (or the specified subrange of list) still remains sorted.
+ * otherwise, the inverted insertion index `(-insertion index - 1)`.
+ * The insertion index is defined as the index at which the element should be inserted,
+ * so that the list (or the specified subrange of the list) still remains sorted.
+ * Thus, if the returned index is `>= 0`, then the element is present at this index;
+ * otherwise, the element could be inserted at `index.inv()` to maintain the sorted order.
  * @sample samples.collections.Collections.Lists.binarySearchByKey
  */
 public inline fun <T, K : Comparable<K>> List<T>.binarySearchBy(
@@ -431,14 +441,19 @@ public inline fun <T, K : Comparable<K>> List<T>.binarySearchBy(
  *
  * If the list contains multiple elements for which [comparison] returns zero, there is no guarantee which one will be found.
  *
+ * If you need to find the first or the last occurrence of an element,
+ * use this [binarySearch] with a custom comparison function. See sample for an example.
+ *
  * @param comparison function that returns zero when called on the list element being searched.
  * On the elements coming before the target element, the function must return negative values;
  * on the elements coming after the target element, the function must return positive values.
  *
  * @return the index of the found element, if it is contained in the list within the specified range;
- * otherwise, the inverted insertion point `(-insertion point - 1)`.
- * The insertion point is defined as the index at which the element should be inserted,
+ * otherwise, the inverted insertion index `(-insertion index - 1)`.
+ * The insertion index is defined as the index at which the element should be inserted,
  * so that the list (or the specified subrange of list) still remains sorted.
+ * Thus, if the returned index is `>= 0`, then the element is present at this index;
+ * otherwise, the element could be inserted at `index.inv()` to maintain the sorted order.
  * @sample samples.collections.Collections.Lists.binarySearchWithComparisonFunction
  * @sample samples.collections.Collections.Lists.binarySearchWithComparisonFunctionLowerBoundUpperBound
  */

--- a/libraries/stdlib/src/kotlin/collections/Collections.kt
+++ b/libraries/stdlib/src/kotlin/collections/Collections.kt
@@ -314,8 +314,8 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
 
 /**
  * Searches this list or its range for the provided [element] using the binary search algorithm.
- * The list is expected to be sorted in a non-descending order according to the Comparable natural ordering of its elements,
- * otherwise the result is unspecified.
+ * The list is expected to be sorted in ascending order according to the Comparable natural ordering of its elements;
+ * otherwise, the result is undefined.
  *
  * If the list contains multiple elements equal to [element], there is no guarantee which one will be found.
  *
@@ -328,8 +328,8 @@ internal fun <T> List<T>.optimizeReadOnlyList() = when (size) {
  * otherwise, the inverted insertion index `(-insertion index - 1)`.
  * The insertion index is defined as the index at which the element should be inserted,
  * so that the list (or the specified subrange of the list) still remains sorted.
- * Thus, if the returned index is `>= 0`, then the value is present;
- * otherwise the value could be inserted at `index.inv()`
+ * Thus, if the returned index is `>= 0`, then the value is present at this index;
+ * otherwise, the value could be inserted at `index.inv()` to maintain the sorted order.
  * @sample samples.collections.Collections.Lists.binarySearchFoundNotFound
  * @sample samples.collections.Collections.Lists.binarySearchFindOrInsert
  * @sample samples.collections.Collections.Lists.binarySearchOnComparable


### PR DESCRIPTION
- Add more typical flow samples
- Add a sample for lowerBound / upperBound binary search
- Rename insertion point into insertion index for clarity
- Promote .inv() function instead of -(returnedValue - 1)

Original review ID: KT-MR-24966