### PR TITLE
Fix group generation in compilation of nested `when` expressions

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testComposableCallInWhenConditionNestedInWhenResult.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testComposableCallInWhenConditionNestedInWhenResult.txt
@@ -1,0 +1,52 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.*
+
+val a = true
+val c = false
+
+@Composable fun Test() {
+    val enabled = a && (GetTrue() || c)
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+val a: Boolean = true
+val c: Boolean = false
+@Composable
+@FunctionKeyMeta(key = -1794342280, startOffset = 124, endOffset = 202)
+fun Test(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Test):Test.kt")
+  if (%composer.shouldExecute(%changed != 0, %changed and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    val enabled = when {
+      a -> {
+        %composer.startReplaceGroup(<>)
+        sourceInformation(%composer, "<GetTru...>")
+        val tmp0_group = GetTrue(%composer, 0) || c
+        %composer.endReplaceGroup()
+        tmp0_group
+      }
+      else -> {
+        %composer.startReplaceGroup(<>)
+        %composer.endReplaceGroup()
+        false
+      }
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Test(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=false].txt
@@ -38,12 +38,17 @@ TestKt {
     file: Test.kt
     contentOf$lambda$0(Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 11 }
+        ReplaceGroup { key: <key>, line: 12 }
+        ReplaceGroup { key: <key>, line: 13 }
         ReplaceGroup { key: <key>, line: 13 }
         ReplaceGroup { key: <key>, line: 13 }
         ReplaceGroup { key: <key>, line: 14 }
         ReplaceGroup { key: <key>, line: 14 }
+        ReplaceGroup { key: <key>, line: 14 }
         ReplaceGroup { key: <key>, line: 15 }
         ReplaceGroup { key: <key>, line: 15 }
+        ReplaceGroup { key: <key>, line: 15 }
+        ReplaceGroup { key: <key>, line: 16 }
         ReplaceGroup { key: <key>, line: 18 }
         ReplaceGroup { key: <key>, line: 18 }
 }
@@ -59,12 +64,17 @@ TestKt {
     file: Test.kt
     contentOf$lambda$0(Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 11 }
+        ReplaceGroup { key: <key>, line: 12 }
+        ReplaceGroup { key: <key>, line: 13 }
         ReplaceGroup { key: <key>, line: 13 }
         ReplaceGroup { key: <key>, line: 13 }
         ReplaceGroup { key: <key>, line: 14 }
         ReplaceGroup { key: <key>, line: 14 }
+        ReplaceGroup { key: <key>, line: 14 }
         ReplaceGroup { key: <key>, line: 15 }
         ReplaceGroup { key: <key>, line: 15 }
+        ReplaceGroup { key: <key>, line: 15 }
+        ReplaceGroup { key: <key>, line: 16 }
         ReplaceGroup { key: <key>, line: 18 }
         ReplaceGroup { key: <key>, line: 18 }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=true].txt
@@ -31,12 +31,17 @@ private fun contentOf(
 ComposeStackTrace -> $$compose:
     1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda_412467906_$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):16:16 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
     1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
@@ -44,12 +49,17 @@ ComposeStackTrace -> $$compose:
 ComposeStackTrace -> $$compose:
     1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda_412467906_$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):16:16 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
     1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
@@ -2818,4 +2818,29 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             }
         """
     )
+
+    /**
+     * This is a regression test against a bug that caused groups to be generated incorrectly
+     * whenever a `when` expression had a result that was computed by another `when` expression, and
+     * the inner `when` expression had a `@Composable` call in one of its conditions.
+     * For more details, see https://issuetracker.google.com/issues/546101628.
+     */
+    @Test
+    fun testComposableCallInWhenConditionNestedInWhenResult() = verifyGoldenComposeIrTransform(
+        source = """
+            import androidx.compose.runtime.*
+
+            val a = true
+            val c = false
+
+            @Composable fun Test() {
+                val enabled = a && (GetTrue() || c)
+            }
+        """,
+        extra = """
+            import androidx.compose.runtime.Composable
+
+            @Composable fun GetTrue(): Boolean = true
+        """
+    )
 }

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
@@ -600,6 +600,25 @@ class CompositionTests {
             }
         }
     }
+
+    /**
+     * This is a regression test against a bug that caused groups to be generated incorrectly
+     * whenever a `when` expression had a result that was computed by another `when` expression, and
+     * the inner `when` expression had a `@Composable` call in one of its conditions.
+     * For more details, see https://issuetracker.google.com/issues/546101628.
+     */
+    @Test
+    fun testComposableCallInWhenConditionNestedInWhenResult() = compositionTest {
+        val eligible = mutableStateOf(true)
+
+        compose {
+            val enabled = eligible.value && (getCondition() || false)
+            val one = remember { 1 }
+        }
+
+        eligible.value = false
+        advance()
+    }
 }
 
 @Composable

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -3943,12 +3943,12 @@ class ComposableFunctionBodyTransformer(
                     resultScopes.add(resultScope)
 
                     // the first condition is always executed so if it has a composable call in it,
-                    // it doesn't necessitate a group. However, non-skipping group optimization is
-                    // enabled, we need a wrapping group if any conditions have a composable call.
+                    // it doesn't necessitate a group.
                     needsWrappingGroup = needsWrappingGroup || ((index != 0) && condScope.hasComposableCalls)
 
-                    if (resultScope.hasComposableCalls && !it.result.isGroupBalanced())
+                    if (resultScope.hasComposableCalls) {
                         resultsWithCalls++
+                    }
 
                     transformed.branches.add(
                         IrBranchImpl(
@@ -4043,14 +4043,6 @@ class ComposableFunctionBodyTransformer(
                 transformed.asCoalescableGroup(whenScope)
             else -> transformed
         }
-    }
-
-    // Returns true if the number of groups added are required to be fix and a group is inserted  to balance the groups if they are not.
-    // Currently this is only guaranteed for IrWhen nodes when the group non-skipping group optimization is enabled. This avoids
-    // inserting a redundant group to balance an already balanced set of groups.
-    private fun IrExpression.isGroupBalanced(): Boolean = when (this) {
-        is IrWhen -> FeatureFlag.OptimizeNonSkippingGroups.enabled
-        else -> false
     }
 
     sealed class Scope(val name: String) {


### PR DESCRIPTION
Relnote: "Fixed a bug that caused miscompilation whenever a `when` expression had a result that was computed by another `when` expression, and the inner `when` expression had a `@Composable` call in one of its conditions."

Test: Test cases added to CompositionTests and ControlFlowTransformTests
Bug: 546101628