### PR TITLE
[Stdlib] Enable return-value-checker=full in all compilations

### DIFF
--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -56,10 +56,6 @@ fun KotlinCommonCompilerOptions.mainCompilationOptions() {
     }
 }
 
-fun KotlinCommonCompilerOptions.addReturnValueCheckerInfo() {
-    freeCompilerArgs.add("-Xreturn-value-checker=full")
-}
-
 /**
  * Between making a language feature stable and the next bootstrap, we need to keep providing the compiler argument.
  * But this produces a warning
@@ -96,6 +92,10 @@ kotlin {
 
     explicitApi()
 
+    compilerOptions {
+        freeCompilerArgs.add("-Xreturn-value-checker=full")
+    }
+
     metadata {
         compilations {
             all {
@@ -111,7 +111,6 @@ kotlin {
                             )
                         )
                         mainCompilationOptions()
-                        addReturnValueCheckerInfo()
                         suppressRedundantCliArgumentWarning()
                     }
                 }
@@ -162,7 +161,6 @@ kotlin {
                             )
                         )
                         mainCompilationOptions()
-                        addReturnValueCheckerInfo()
                     }
                 }
                 defaultSourceSet {
@@ -192,7 +190,6 @@ kotlin {
                             )
                         )
                         mainCompilationOptions()
-                        addReturnValueCheckerInfo()
                     }
                 }
             }
@@ -213,7 +210,6 @@ kotlin {
                             )
                         )
                         mainCompilationOptions()
-                        addReturnValueCheckerInfo()
                     }
                 }
             }
@@ -284,7 +280,6 @@ kotlin {
                             diagnosticNamesArg,
                         )
                     )
-                    compilerOptions.addReturnValueCheckerInfo()
                 }
             }
         }
@@ -319,7 +314,6 @@ kotlin {
             val main = getByName("main") {
                 compileTaskProvider.configure {
                     compilerOptions.mainCompilationOptions()
-                    compilerOptions.addReturnValueCheckerInfo()
                     compilerOptions.freeCompilerArgs.add("-Xir-module-name=$KOTLIN_WASM_STDLIB_NAME")
                 }
             }
@@ -353,9 +347,6 @@ kotlin {
                     "-nostdlib",
                 )
             )
-        }
-        nativeTarget.compilations["main"].compileTaskProvider.configure {
-            compilerOptions.addReturnValueCheckerInfo()
         }
     }
 

--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -96,8 +96,14 @@ kotlin {
 
     explicitApi()
 
-    compilerOptions {
-        addReturnValueCheckerInfo()
+    targets.all {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    addReturnValueCheckerInfo()
+                }
+            }
+        }
     }
 
     metadata {

--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -49,6 +49,7 @@ fun KotlinCommonCompilerOptions.mainCompilationOptions() {
     freeCompilerArgs.add("-Xcontext-parameters")
     freeCompilerArgs.add("-Xname-based-destructuring=complete")
     freeCompilerArgs.add("-Xcollection-literals")
+    addReturnValueCheckerInfo()
     if (!kotlinBuildProperties.disableWerror) allWarningsAsErrors = true
 
     if (this is KotlinJvmCompilerOptions) {
@@ -121,7 +122,6 @@ kotlin {
                             )
                         )
                         mainCompilationOptions()
-                        addReturnValueCheckerInfo()
                         suppressRedundantCliArgumentWarning()
                     }
                 }
@@ -140,6 +140,7 @@ kotlin {
                                 diagnosticNamesArg
                             )
                         )
+                        addReturnValueCheckerInfo()
                         suppressRedundantCliArgumentWarning()
                     }
                 }

--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.support.serviceOf
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
@@ -1057,16 +1058,36 @@ tasks.withType<Kotlin2JsCompile>().configureEach {
 }
 
 tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    doFirst {
+    val problems = serviceOf<Problems>()
+    val expectedRvcMode = "full"
+    doFirst("ensure return-value-checker is enabled") {
+        val reporter = problems.reporter
+
         val rvcModes = compilerOptions.freeCompilerArgs.orNull.orEmpty().filter { "return-value-checker" in it }
-        if (rvcModes.isEmpty()) {
-            logger.warn("[$path] return-value-check not configured")
-        } else if (rvcModes.size > 1) {
-            logger.warn("[$path] return-value-checker is configured multiple times: $rvcModes")
-        } else {
-            val rvcMode = rvcModes.single()
-            if (!rvcMode.endsWith("=full", ignoreCase = true)) {
-                logger.warn("[$path] return-value-checker incorrect mode $rvcMode")
+        val rvcMode = rvcModes.singleOrNull()
+
+        if (rvcMode == null) {
+            reporter.report(
+                ProblemId.create(
+                    "missing-rvc-mode",
+                    "return-value-checker not set",
+                    ProblemGroup.create("return-value-checker", "return-value-checker")
+                )
+            ) {
+                details("$path has invalid return-value-checker mode. All values: $rvcModes")
+                solution("""Enable return-value-checker""")
+            }
+        } else if (!rvcMode.endsWith("=$expectedRvcMode", ignoreCase = true)) {
+            logger.warn("$path has incorrect return-value-checker mode. Expected: $expectedRvcMode, but actual arg is: $rvcMode")
+            reporter.report(
+                ProblemId.create(
+                    "incorrect-rvc-mode",
+                    "incorrect return-value-checker mode",
+                    ProblemGroup.create("return-value-checker", "return-value-checker")
+                )
+            ) {
+                details("$path has incorrect return-value-checker mode. Expected: $expectedRvcMode, but actual arg is: $rvcMode")
+                solution("""Enable return-value-checker=$expectedRvcMode""")
             }
         }
     }

--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinWasmWasiTargetDsl
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrLink
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 import org.jetbrains.kotlin.library.KOTLIN_JS_STDLIB_NAME
 import org.jetbrains.kotlin.library.KOTLIN_WASM_STDLIB_NAME
@@ -1053,4 +1054,20 @@ for (name in listOf("sources", "distSources")) {
 // Disabling IC for JS tasks as they may produce false-positive compilation failure
 tasks.withType<Kotlin2JsCompile>().configureEach {
     incremental = false
+}
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+    doFirst {
+        val rvcModes = compilerOptions.freeCompilerArgs.orNull.orEmpty().filter { "return-value-checker" in it }
+        if (rvcModes.isEmpty()) {
+            logger.warn("[$path] return-value-check not configured")
+        } else if (rvcModes.size > 1) {
+            logger.warn("[$path] return-value-checker is configured multiple times: $rvcModes")
+        } else {
+            val rvcMode = rvcModes.single()
+            if (!rvcMode.endsWith("=full", ignoreCase = true)) {
+                logger.warn("[$path] return-value-checker incorrect mode $rvcMode")
+            }
+        }
+    }
 }

--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -56,6 +56,10 @@ fun KotlinCommonCompilerOptions.mainCompilationOptions() {
     }
 }
 
+fun KotlinCommonCompilerOptions.addReturnValueCheckerInfo() {
+    freeCompilerArgs.add("-Xreturn-value-checker=full")
+}
+
 /**
  * Between making a language feature stable and the next bootstrap, we need to keep providing the compiler argument.
  * But this produces a warning
@@ -93,7 +97,7 @@ kotlin {
     explicitApi()
 
     compilerOptions {
-        freeCompilerArgs.add("-Xreturn-value-checker=full")
+        addReturnValueCheckerInfo()
     }
 
     metadata {
@@ -111,6 +115,7 @@ kotlin {
                             )
                         )
                         mainCompilationOptions()
+                        addReturnValueCheckerInfo()
                         suppressRedundantCliArgumentWarning()
                     }
                 }

--- a/libraries/stdlib/jdk7/test/AbstractPathTest.kt
+++ b/libraries/stdlib/jdk7/test/AbstractPathTest.kt
@@ -19,6 +19,7 @@ abstract class AbstractPathTest {
         return this
     }
 
+    @IgnorableReturnValue
     fun Path.cleanupRecursively(): Path {
         cleanUpActions.add(this to { it.deleteRecursively() })
         return this
@@ -35,6 +36,7 @@ abstract class AbstractPathTest {
         }
     }
 
+    @IgnorableReturnValue
     fun Path.tryCreateSymbolicLinkTo(original: Path): Path? {
         return try {
             this.createSymbolicLinkPointingTo(original)

--- a/libraries/stdlib/jdk7/test/FileVisitorBuilderTest.kt
+++ b/libraries/stdlib/jdk7/test/FileVisitorBuilderTest.kt
@@ -81,7 +81,7 @@ class FileVisitorBuilderTest : AbstractPathTest() {
     @Test
     fun overrideInAlreadyBuilt() {
         val builder: FileVisitorBuilder
-        fileVisitor { builder = this }
+        val _ = fileVisitor { builder = this }
         assertFailsWith<IllegalStateException> {
             builder.onVisitFile { _, _ -> FileVisitResult.CONTINUE }
         }

--- a/libraries/stdlib/jdk7/test/PathExtensionsTest.kt
+++ b/libraries/stdlib/jdk7/test/PathExtensionsTest.kt
@@ -638,8 +638,8 @@ class PathExtensionsTest : AbstractPathTest() {
 
         // The default value of these depends on the current operating system, so just check that
         // they don't throw an exception.
-        file.isExecutable()
-        file.isHidden()
+        val _ = file.isExecutable()
+        val _ = file.isHidden()
     }
 
     @Test
@@ -654,8 +654,8 @@ class PathExtensionsTest : AbstractPathTest() {
         assertTrue(file.isWritable())
         assertTrue(file.isSameFileAs(file))
 
-        file.isExecutable()
-        file.isHidden()
+        val _ = file.isExecutable()
+        val _ = file.isHidden()
     }
 
     @Test
@@ -670,7 +670,7 @@ class PathExtensionsTest : AbstractPathTest() {
         assertFalse(file.isWritable())
         assertTrue(file.isSameFileAs(file))
 
-        file.isExecutable()
+        val _ = file.isExecutable()
         // This function will either throw an exception or return false,
         // depending on the operating system.
         try {

--- a/libraries/stdlib/jdk7/test/PathRecursiveFunctionsTest.kt
+++ b/libraries/stdlib/jdk7/test/PathRecursiveFunctionsTest.kt
@@ -5,6 +5,7 @@
 
 package kotlin.jdk7.test
 
+import org.junit.jupiter.api.assertThrows
 import java.nio.file.*
 import kotlin.io.path.*
 import kotlin.jdk7.test.PathTreeWalkTest.Companion.createTestFiles
@@ -376,12 +377,16 @@ class PathRecursiveFunctionsTest : AbstractPathTest() {
                 assertEquals("1/3", source.relativePathString(src))
                 OnErrorResult.SKIP_SUBTREE
             }) { source, target ->
-                try {
-                    source.copyToIgnoringExistingDirectory(target, followLinks = false)
-                } catch (exception: Throwable) {
-                    assertIs<java.nio.file.AccessDeniedException>(exception)
+                @IgnorableReturnValue
+                fun copySourceToTarget() = source.copyToIgnoringExistingDirectory(target, followLinks = false)
+
+                if (source.relativePathString(src) == "7.txt") {
+                    val exception = assertFailsWith<java.nio.file.AccessDeniedException> {
+                        copySourceToTarget()
+                    }
                     assertEquals(source.toString(), exception.file)
-                    assertEquals("7.txt", source.relativePathString(src))
+                } else {
+                    copySourceToTarget()
                 }
                 CopyActionResult.CONTINUE
             }
@@ -702,7 +707,7 @@ class PathRecursiveFunctionsTest : AbstractPathTest() {
             if (source.name == "2") {
                 nested.copyToRecursively(target, followLinks = false)
             } else {
-                source.copyToIgnoringExistingDirectory(target, followLinks = false)
+                val _ = source.copyToIgnoringExistingDirectory(target, followLinks = false)
             }
             CopyActionResult.CONTINUE
         }
@@ -717,7 +722,7 @@ class PathRecursiveFunctionsTest : AbstractPathTest() {
         val dst = createTempDirectory().cleanupRecursively().resolve("dst")
 
         src.copyToRecursively(dst, followLinks = false) { source, target ->
-            source.copyToIgnoringExistingDirectory(target, followLinks = false)
+            val _ = source.copyToIgnoringExistingDirectory(target, followLinks = false)
             if (source.name == "3" || source.name == "9.txt") {
                 CopyActionResult.SKIP_SUBTREE
             } else {
@@ -740,7 +745,7 @@ class PathRecursiveFunctionsTest : AbstractPathTest() {
         val dst = createTempDirectory().cleanupRecursively().resolve("dst")
 
         src.copyToRecursively(dst, followLinks = false) { source, target ->
-            source.copyToIgnoringExistingDirectory(target, followLinks = false)
+            val _ = source.copyToIgnoringExistingDirectory(target, followLinks = false)
             if (source.name == "3" || source.name == "9.txt") {
                 CopyActionResult.TERMINATE
             } else {
@@ -765,7 +770,7 @@ class PathRecursiveFunctionsTest : AbstractPathTest() {
             assertTrue(source.name == "3" || source.name == "9.txt")
             OnErrorResult.TERMINATE
         }) { source, target ->
-            source.copyToIgnoringExistingDirectory(target, followLinks = false)
+            val _ = source.copyToIgnoringExistingDirectory(target, followLinks = false)
             if (source.name == "3" || source.name == "9.txt") throw IllegalArgumentException()
             CopyActionResult.CONTINUE
         }

--- a/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
+++ b/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
@@ -5,9 +5,9 @@
 
 package kotlin.jdk7.test
 
+import org.junit.jupiter.api.assertThrows
 import test.testOnJvm8
 import test.testOnJvm9AndAbove
-import java.lang.NullPointerException
 import java.nio.file.*
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException
@@ -256,12 +256,10 @@ class PathRecursiveFunctionsZipTest : AbstractPathTest() {
 
         withZip("Archive2.zip", listOf("normal", "//")) { root, zipRoot ->
             // Fails in jvm8, succeeds in jvm9+
-            try {
+            assertFailsWith<FileSystemLoopException> {
                 zipRoot.walkIncludeDirectories().toList()
                 // ["/", "//", "normal"] in jvm9-10
                 // ["/", "/normal"] in jvm11
-            } catch (exception: Exception) {
-                assertIs<FileSystemLoopException>(exception)
             }
 
             val target = root.resolve("UnzipArchive2")
@@ -277,12 +275,10 @@ class PathRecursiveFunctionsZipTest : AbstractPathTest() {
             val aFile = zipRoot.resolve("a")
             val aDir = zipRoot.resolve("a/")
             // Fails in jvm8, succeeds in jvm9+
-            try {
+            assertFailsWith<FileSystemLoopException> {
                 zipRoot.walkIncludeDirectories().toList()
                 // ["/", "/a", "/a/"] in jvm9-10
                 // ["/", "/a"] in jvm11
-            } catch (exception: Exception) {
-                assertIs<FileSystemLoopException>(exception)
             }
             testWalkMaybeFailsWith<FileSystemLoopException>(aFile, setOf(aFile))
             testWalkMaybeFailsWith<FileSystemLoopException>(aDir, setOf(aFile))

--- a/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
+++ b/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
@@ -144,6 +144,7 @@ class PathRecursiveFunctionsZipTest : AbstractPathTest() {
         }
     }
 
+    @IgnorableReturnValue
     private inline fun <reified T> testDeleteMaybeFailsWith(path: Path): Boolean {
         return try {
             testDeleteSucceeds(path)

--- a/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
+++ b/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
@@ -5,7 +5,6 @@
 
 package kotlin.jdk7.test
 
-import org.junit.jupiter.api.assertThrows
 import test.testOnJvm8
 import test.testOnJvm9AndAbove
 import java.nio.file.*

--- a/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
+++ b/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
@@ -254,11 +254,15 @@ class PathRecursiveFunctionsZipTest : AbstractPathTest() {
         }
 
         withZip("Archive2.zip", listOf("normal", "//")) { root, zipRoot ->
-            // Fails in jvm8, succeeds in jvm9+
-            assertFailsWith<FileSystemLoopException> {
-                zipRoot.walkIncludeDirectories().toList()
+            testOnJvm8 {
+                assertFailsWith<FileSystemLoopException> {
+                    zipRoot.walkIncludeDirectories().toList()
+                }
+            }
+            testOnJvm9AndAbove {
                 // ["/", "//", "normal"] in jvm9-10
                 // ["/", "/normal"] in jvm11
+                val _ = zipRoot.walkIncludeDirectories().toList()
             }
 
             val target = root.resolve("UnzipArchive2")
@@ -273,11 +277,15 @@ class PathRecursiveFunctionsZipTest : AbstractPathTest() {
         withZip("Archive3.zip", listOf("a/", "a//")) { root, zipRoot ->
             val aFile = zipRoot.resolve("a")
             val aDir = zipRoot.resolve("a/")
-            // Fails in jvm8, succeeds in jvm9+
-            assertFailsWith<FileSystemLoopException> {
-                zipRoot.walkIncludeDirectories().toList()
+            testOnJvm8 {
+                assertFailsWith<FileSystemLoopException> {
+                    zipRoot.walkIncludeDirectories().toList()
+                }
+            }
+            testOnJvm9AndAbove {
                 // ["/", "/a", "/a/"] in jvm9-10
                 // ["/", "/a"] in jvm11
+                val _ = zipRoot.walkIncludeDirectories().toList()
             }
             testWalkMaybeFailsWith<FileSystemLoopException>(aFile, setOf(aFile))
             testWalkMaybeFailsWith<FileSystemLoopException>(aDir, setOf(aFile))

--- a/libraries/stdlib/js/test/core/PromiseTest.kt
+++ b/libraries/stdlib/js/test/core/PromiseTest.kt
@@ -53,7 +53,7 @@ class PromiseTest {
             }
         )
 
-        p.then {
+        val _ = p.then {
             ps
         }.then {
             assertStaticAndRuntimeTypeIs<String>(it)

--- a/libraries/stdlib/jvm/test/collections/ListBuilderTest.kt
+++ b/libraries/stdlib/jvm/test/collections/ListBuilderTest.kt
@@ -66,7 +66,7 @@ class ListBuilderTest {
             override fun get(index: Int): String = "element"
         }
 
-        buildList {
+        val _ = buildList {
             repeat(builderSize) { add("element") }
 
             assertFails { addAll(giantList) }

--- a/libraries/stdlib/jvm/test/collections/MapBuilderTest.kt
+++ b/libraries/stdlib/jvm/test/collections/MapBuilderTest.kt
@@ -33,7 +33,7 @@ class MapBuilderTest {
             }
         }
 
-        buildMap {
+        val _ = buildMap {
             repeat(builderSize) { put(-it, "value") }
 
             assertFails { putAll(giantMap) }

--- a/libraries/stdlib/jvm/test/io/FileTreeWalks.kt
+++ b/libraries/stdlib/jvm/test/io/FileTreeWalks.kt
@@ -446,9 +446,9 @@ class FileTreeWalkTest {
         try {
             val subDir1 = createTempDirectory(prefix = "d1_", directory = dir)
             val subDir2 = createTempDirectory(prefix = "d2_", directory = dir)
-            createTempDirectory(prefix = "d1_", directory = subDir1)
-            createTempFile(prefix = "f1_", directory = subDir1)
-            createTempDirectory(prefix = "d1_", directory = subDir2)
+            val _ = createTempDirectory(prefix = "d1_", directory = subDir1)
+            val _ = createTempFile(prefix = "f1_", directory = subDir1)
+            val _ = createTempDirectory(prefix = "d1_", directory = subDir2)
             assertEquals(6, dirAsFile.walkTopDown().count())
         } finally {
             dirAsFile.deleteRecursively()
@@ -456,7 +456,7 @@ class FileTreeWalkTest {
         dirAsFile.mkdir()
         try {
             val it = dirAsFile.walkTopDown().iterator()
-            it.next()
+            val _ = it.next()
             assertFailsWith<NoSuchElementException>("Second call to next() should fail.") { it.next() }
         } finally {
             dirAsFile.delete()

--- a/libraries/stdlib/jvm/test/io/Files.kt
+++ b/libraries/stdlib/jvm/test/io/Files.kt
@@ -68,9 +68,9 @@ class FilesTest {
     @Test fun listFilesWithFilter() {
         val dir = createTempDirectory("temp")
 
-        createTempFile(prefix = "temp1", suffix = ".kt", directory = dir)
-        createTempFile(prefix = "temp2", suffix = ".java", directory = dir)
-        createTempFile(prefix = "temp3", suffix = ".kt", directory = dir)
+        val _ = createTempFile(prefix = "temp1", suffix = ".kt", directory = dir)
+        val _ = createTempFile(prefix = "temp2", suffix = ".java", directory = dir)
+        val _ = createTempFile(prefix = "temp3", suffix = ".kt", directory = dir)
 
         // This line works only with Kotlin File.listFiles(filter)
         val result = dir.toFile().listFiles { it -> it.name.endsWith(".kt") } // todo ambiguity on SAM
@@ -577,12 +577,12 @@ class FilesTest {
         try {
             val subDir1 = createTempDirectory(prefix = "d1_", directory = srcPath)
             val subDir2 = createTempDirectory(prefix = "d2_", directory = srcPath)
-            createTempDirectory(prefix = "d1_", directory = subDir1)
+            val _ = createTempDirectory(prefix = "d1_", directory = subDir1)
             val file1 = createTempFile(prefix = "f1_", directory = srcPath).toFile()
             val file2 = createTempFile(prefix = "f2_", directory = subDir1).toFile()
             file1.writeText("hello")
             file2.writeText("wazzup")
-            createTempDirectory(prefix = "d1_", directory = subDir2)
+            val _ = createTempDirectory(prefix = "d1_", directory = subDir2)
 
             assertTrue(src.copyRecursively(dst))
             check()

--- a/libraries/stdlib/jvm/test/numbers/BuiltinCompanionJVMTest.kt
+++ b/libraries/stdlib/jvm/test/numbers/BuiltinCompanionJVMTest.kt
@@ -67,6 +67,6 @@ class BuiltinCompanionJVMTest {
 
     @Test fun stringTest() {
         val s = String
-        s.CASE_INSENSITIVE_ORDER
+        val _ = s.CASE_INSENSITIVE_ORDER
     }
 }

--- a/libraries/stdlib/jvm/test/properties/delegation/lazy/LazyValuesJVMTest.kt
+++ b/libraries/stdlib/jvm/test/properties/delegation/lazy/LazyValuesJVMTest.kt
@@ -16,8 +16,8 @@ class SynchronizedLazyValTest {
     }
 
     @Test fun doTest() {
-        synchronized(this) {
-            kotlin.concurrent.thread { a } // not available in js
+        val _ = synchronized(this) {
+            kotlin.concurrent.thread { val _ = a } // not available in js
             result = 1
             a
         }

--- a/libraries/stdlib/jvm/test/properties/delegation/lazy/LazyValuesJVMTest.kt
+++ b/libraries/stdlib/jvm/test/properties/delegation/lazy/LazyValuesJVMTest.kt
@@ -17,7 +17,7 @@ class SynchronizedLazyValTest {
 
     @Test fun doTest() {
         val _ = synchronized(this) {
-            kotlin.concurrent.thread { val _ = a } // not available in js
+            val _ = kotlin.concurrent.thread { val _ = a } // not available in js
             result = 1
             a
         }

--- a/libraries/stdlib/jvm/test/random/RandomSerializationTest.kt
+++ b/libraries/stdlib/jvm/test/random/RandomSerializationTest.kt
@@ -19,10 +19,10 @@ class RandomSerializationTest {
     }
 
     private fun discardSomeValues(instance: Random) {
-        instance.nextInt()
-        instance.nextDouble()
-        instance.nextLong()
-        instance.nextBytes(64)
+        val _ = instance.nextInt()
+        val _ = instance.nextDouble()
+        val _ = instance.nextLong()
+        val _ = instance.nextBytes(64)
     }
 
     private fun testRandomsHaveSameState(first: Random, second: Random) {
@@ -64,7 +64,7 @@ class RandomSerializationTest {
         )
 
         checkEquivalentToSerialized(
-                instance = Random(0).apply { repeat(64) { nextLong() } }, // advance state by discarding values
+                instance = Random(0).apply { repeat(64) { val _ = nextLong() } }, // advance state by discarding values
                 serializedHex = "ac ed 00 05 73 72 00 1a 6b 6f 74 6c 69 6e 2e 72 61 6e 64 6f 6d 2e 58 6f 72 57 6f 77 52 61 6e 64 6f 6d 00 00 00 00 00 00 00 00 02 00 06 49 00 06 61 64 64 65 6e 64 49 00 01 76 49 00 01 77 49 00 01 78 49 00 01 79 49 00 01 7a 78 70 04 25 d3 c0 be 0e 05 94 fd be 13 de a4 17 b2 90 b0 de a4 64 9c 72 81 64"
         )
 

--- a/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt
+++ b/libraries/stdlib/jvm/test/utils/LazyJVMTest.kt
@@ -27,7 +27,12 @@ class LazyJVMTest {
 
         val threads = 3
         val barrier = CyclicBarrier(threads)
-        val accessThreads = List(threads) { thread { barrier.await(); lazy.value } }
+        val accessThreads = List(threads) {
+            thread {
+                barrier.await()
+                val _ = lazy.value
+            }
+        }
         accessThreads.forEach { it.join() }
 
         assertEquals(1, counter.get())
@@ -59,7 +64,7 @@ class LazyJVMTest {
         val lazy1 = lazy(lock, initializer)
         val lazy2 = lazy(lock, initializer)
 
-        val accessThreads = listOf(lazy1, lazy2).map { thread { it.value } }
+        val accessThreads = listOf(lazy1, lazy2).map { thread { val _ = it.value } }
         accessThreads.forEach { it.join() }
 
         assertEquals(2, counter.get())
@@ -108,7 +113,12 @@ class LazyJVMTest {
         val lazy = lazy(LazyThreadSafetyMode.PUBLICATION, initializer)
 
         val barrier = CyclicBarrier(threads)
-        val accessThreads = List(threads) { thread { barrier.await(); lazy.value } }
+        val accessThreads = List(threads) {
+            thread {
+                barrier.await()
+                val _ = lazy.value
+            }
+        }
         val result = run { while (!lazy.isInitialized()) Thread.sleep(1); lazy.value }
         accessThreads.forEach { it.join() }
 

--- a/libraries/stdlib/jvm/testLongRunning/collections/IndexOverflowJVMTest.kt
+++ b/libraries/stdlib/jvm/testLongRunning/collections/IndexOverflowJVMTest.kt
@@ -30,12 +30,12 @@ class IndexOverflowJVMTest {
             }
         }
 
-        fun assertIndexOverflow(f: () -> Unit) {
+        fun assertIndexOverflow(f: () -> Any) {
             val ex = assertFailsWith<ArithmeticException>(block = f)
             assertTrue(ex.message!!.contains("index", ignoreCase = true))
         }
 
-        fun assertCountOverflow(f: () -> Unit) {
+        fun assertCountOverflow(f: () -> Any) {
             val ex = assertFailsWith<ArithmeticException>(block = f)
             assertTrue(ex.message!!.contains("count", ignoreCase = true))
         }

--- a/libraries/stdlib/test/collections/ArrayDequeTest.kt
+++ b/libraries/stdlib/test/collections/ArrayDequeTest.kt
@@ -584,11 +584,11 @@ class ArrayDequeTest {
 
             repeat(times = 2) {
                 if (expectedIterator.hasNext()) {
-                    expectedIterator.next()
-                    actualIterator.next()
+                    val _ = expectedIterator.next()
+                    val _ = actualIterator.next()
                 } else if (expectedIterator.hasPrevious()) {
-                    expectedIterator.previous()
-                    actualIterator.previous()
+                    val _ = expectedIterator.previous()
+                    val _ = actualIterator.previous()
                 }
                 if (dequeSize > it) {
                     expectedIterator.remove()

--- a/libraries/stdlib/test/collections/ArraysTest.kt
+++ b/libraries/stdlib/test/collections/ArraysTest.kt
@@ -361,9 +361,9 @@ class ArraysTest {
         val a = arrayOf(b)
         b[0] = a
         b[1] = b
-        a.toString()
+        val _ = a.toString()
         assertTrue(true, "toString does not cycle")
-        a.contentToString()
+        val _ = a.contentToString()
         assertTrue(true, "contentToString does not cycle")
         val result = a.contentDeepToString()
         assertEquals("[[[...], [...]]]", result)
@@ -1005,7 +1005,7 @@ class ArraysTest {
 
     @Test fun copyRangeInto() {
         fun <T> doTest(
-            copyInto: T.(T, Int, Int, Int) -> T,
+            copyInto: T.(T, Int, Int, Int) -> Unit,
             assertTEquals: (T, T, String) -> Unit,
             toStringT: T.() -> String,
             dest: T, newValues: T,
@@ -1361,7 +1361,7 @@ class ArraysTest {
             )
         }
     }
-    
+
     @Test
     fun runningFoldIndexed() {
         for (size in 0 until 4) {
@@ -1681,6 +1681,7 @@ class ArraysTest {
         assertArrayNotSameButEquals(arrayOf("3", "2", "1"), (arrayOf("1", "2", "3") as Array<out String>).reversedArray())
     }
 
+    @Suppress("RETURN_VALUE_NOT_USED_COERCION")
     @Test fun onEach() {
         var count = 0
         val data = intArrayOf(1, 2, 3)
@@ -1706,6 +1707,7 @@ class ArraysTest {
         assertEquals(listOf('1', '2', '3'), mutableListOf<Char>().apply { charArrayOf('1', '2', '3').onEach { add(it) } })
     }
 
+    @Suppress("RETURN_VALUE_NOT_USED_COERCION")
     @Test fun onEachIndexed() {
         assertEquals(listOf(1, 3, 5), mutableListOf<Int>().apply { intArrayOf(1, 2, 3).onEachIndexed { i, e -> add(i + e) } })
         assertEquals(listOf(1, 3, 5), mutableListOf<Int>().apply { byteArrayOf(1, 2, 3).onEachIndexed { i, e -> add(i + e) } })
@@ -1966,8 +1968,8 @@ class ArraysTest {
         expect(2) { iter.nextIndex() }
         expect(1) { iter.previousIndex() }
         expect(3) {
-            iter.next()
-            iter.previous()
+            val _ = iter.next()
+            val _ = iter.previous()
             iter.next()
         }
 
@@ -1999,8 +2001,8 @@ class ArraysTest {
         expect(2) { iter.nextIndex() }
         expect(1) { iter.previousIndex() }
         expect("c") {
-            iter.next()
-            iter.previous()
+            val _ = iter.next()
+            val _ = iter.previous()
             iter.next()
         }
 

--- a/libraries/stdlib/test/collections/CollectionTest.kt
+++ b/libraries/stdlib/test/collections/CollectionTest.kt
@@ -1231,7 +1231,7 @@ class CollectionTest {
 
     @Test fun toStringContainingThis() = testExceptOn(TestPlatform.Js) {
         // resulting string is platform-dependent, but shouldn't throw
-        arrayOf<Any>("a", "b", "c").apply { this[1] = this }.toString()
+        val _ = arrayOf<Any>("a", "b", "c").apply { this[1] = this }.toString()
 
         assertEquals(
             "[a, (this Collection), c]",

--- a/libraries/stdlib/test/collections/ComparisonDSL.kt
+++ b/libraries/stdlib/test/collections/ComparisonDSL.kt
@@ -27,11 +27,11 @@ public class CompareContext<out T>(public val expected: T, public val actual: T)
         assertEquals(expected.getter(), actual.getter(), message)
     }
 
-    public fun propertyFails(getter: T.() -> Unit) {
+    public fun propertyFails(getter: T.() -> Any?) {
         assertFailEquals({ expected.getter() }, { actual.getter() })
     }
 
-    public inline fun <reified E : Throwable> propertyFailsWith(crossinline getter: T.() -> Unit) {
+    public inline fun <reified E : Throwable> propertyFailsWith(crossinline getter: T.() -> Any?) {
         assertFailsWith<E> { expected.getter() }
         assertFailsWith<E> { actual.getter() }
     }
@@ -40,7 +40,7 @@ public class CompareContext<out T>(public val expected: T, public val actual: T)
         compare(expected.getter(), actual.getter(), block)
     }
 
-    private fun assertFailEquals(expected: () -> Unit, actual: () -> Unit) {
+    private fun assertFailEquals(expected: () -> Any?, actual: () -> Any?) {
         val expectedFail = assertFails(expected)
         val actualFail = assertFails(actual)
         //assertEquals(expectedFail != null, actualFail != null)

--- a/libraries/stdlib/test/collections/ConcurrentModificationTest.kt
+++ b/libraries/stdlib/test/collections/ConcurrentModificationTest.kt
@@ -30,7 +30,7 @@ class ConcurrentModificationTest {
 
             val iterator = collection.createIterator()
 
-            iteratorOp.precedingFunction?.invoke(iterator)
+            val _ = iteratorOp.precedingFunction?.invoke(iterator)
             collectionOp.function.invoke(collection)
 
             val message = "listOp: ${collectionOp.description}, iteratorOp: ${iteratorOp.description}"
@@ -125,9 +125,9 @@ class ConcurrentModificationTest {
             CollectionOperation("retainAll(emptyList())") { retainAll(emptyList()) },
 
             CollectionOperation("clear()") { clear() },
-            CollectionOperation("iterator.remove()") { iterator().apply { next(); remove() } },
+            CollectionOperation("iterator.remove()") { iterator().apply { val _ = next(); remove() } },
         ).also { ops ->
-            ops + ops.map {
+            val _ = ops + ops.map {
                 CollectionOperation("subList(1, size)." + it.description, it.throwsCME) { it.function.invoke(subList(1, size)) }
             }
         }
@@ -145,7 +145,7 @@ class ConcurrentModificationTest {
         }
 
         testThrowsCME { action ->
-            buildList(4) {
+            val _ = buildList(4) {
                 addAll(listOf("a", "b", "c", "d"))
                 action(this)
             }
@@ -170,7 +170,7 @@ class ConcurrentModificationTest {
         }
 
         testThrowsCME { action ->
-            buildList(10) {
+            val _ = buildList(10) {
                 addAll(listOf("a", "b", "c", "d"))
                 action(this)
             }
@@ -257,6 +257,7 @@ class ConcurrentModificationTest {
     }
 
     @Test
+    @Suppress("RETURN_VALUE_NOT_USED", "RETURN_VALUE_NOT_USED_COERCION")
     fun subList() {
         if (TestPlatform.current == TestPlatform.Js) return
 
@@ -309,7 +310,7 @@ class ConcurrentModificationTest {
         }
 
         testThrowsCME { action ->
-            buildList {
+            val _ = buildList {
                 addAll(listOf("a", "b", "c", "d"))
                 val subList = subList(0, size)
                 add("e")
@@ -359,7 +360,7 @@ class ConcurrentModificationTest {
             CollectionOperation("retainAll(emptyList())") { retainAll(emptyList()) },
 
             CollectionOperation("clear()") { clear() },
-            CollectionOperation("iterator.remove()") { iterator().apply { next(); remove() } },
+            CollectionOperation("iterator.remove()") { iterator().apply { val _ = next(); remove() } },
         )
 
         fun testThrowsCME(withMutableSet: WithCollection<MutableSet<String>>) {
@@ -389,7 +390,7 @@ class ConcurrentModificationTest {
         }
 
         testThrowsCME { action ->
-            buildSet(10) {
+            val _ = buildSet(10) {
                 addAll(elements)
                 action(this)
             }
@@ -428,7 +429,7 @@ class ConcurrentModificationTest {
             CollectionOperation("putAll(non-existing)") { putAll(mapOf("e" to "e", "f" to "f")) },
 
             CollectionOperation("clear()") { clear() },
-            CollectionOperation("iterator.remove()") { iterator().apply { next(); remove() } },
+            CollectionOperation("iterator.remove()") { iterator().apply { val _ = next(); remove() } },
         )
 
         fun testThrowsCME(withMutableMap: WithCollection<MutableMap<String, String>>) {
@@ -461,7 +462,7 @@ class ConcurrentModificationTest {
             }
         }
         testThrowsCME { action ->
-            buildMap(10) {
+            val _ = buildMap(10) {
                 putAll(entries)
                 action(this)
             }
@@ -494,14 +495,16 @@ private class CollectionOperation<C>(
 
 private class IteratorOperation<I>(
     val description: String,
-    val precedingFunction: (I.() -> Unit)? = null,
+    val precedingFunction: (I.() -> Any?)? = null,
     val function: I.() -> Unit
 )
 
 private fun <E> iteratorOperations() = listOf<IteratorOperation<MutableIterator<E>>>(
-    IteratorOperation("next()") { next() },
+    IteratorOperation("next()") { val _ = next() },
     IteratorOperation("remove()", { next() }) { remove() }
 )
+
+@Suppress("RETURN_VALUE_NOT_USED_COERCION")
 private val listIteratorOperations = listOf<IteratorOperation<MutableListIterator<String>>>(
     IteratorOperation("next()") { next() },
     IteratorOperation("remove()", { next() }) { remove() },

--- a/libraries/stdlib/test/collections/ContainerBuilderTest.kt
+++ b/libraries/stdlib/test/collections/ContainerBuilderTest.kt
@@ -32,7 +32,7 @@ class ContainerBuilderTest {
 
         "clear()"                               to { clear() },
 
-        "iterator().apply { next() }.remove()"  to { iterator().apply { next() }.remove() }
+        "iterator().apply { next() }.remove()"  to { iterator().apply { val _ = next() }.remove() }
     )
 
     private fun <E> mutableListOperations(present: E, absent: E) = mutableCollectionOperations(present, absent) + listOf<Pair<String, MutableList<E>.() -> Unit>>(
@@ -41,9 +41,9 @@ class ContainerBuilderTest {
         "addAll(0, emptyList())"                        to { addAll(0, emptyList()) },
         "removeAt(0)"                                   to { removeAt(0) },
         "set(0, present)"                               to { set(0, present) },
-        "listIterator().apply { next() }.remove()"      to { listIterator().apply { next() }.remove() },
-        "listIterator(0).apply { next() }.remove()"     to { listIterator(0).apply { next() }.remove() },
-        "listIterator().apply { next() }.set(present)"  to { listIterator().apply { next() }.set(present) },
+        "listIterator().apply { next() }.remove()"      to { listIterator().apply { val _ = next() }.remove() },
+        "listIterator(0).apply { next() }.remove()"     to { listIterator(0).apply { val _ = next() }.remove() },
+        "listIterator().apply { next() }.set(present)"  to { listIterator().apply { val _ = next() }.set(present) },
         "listIterator().add(present)"                   to { listIterator().add(present) }
     )
 
@@ -146,7 +146,7 @@ class ContainerBuilderTest {
 
     @Test
     fun listBuilderSubList() {
-        buildList<Char> {
+        val _ = buildList<Char> {
             addAll(listOf('a', 'b', 'c', 'd', 'e'))
 
             val subList = subList(1, 4)

--- a/libraries/stdlib/test/collections/HashMapCompactTest.kt
+++ b/libraries/stdlib/test/collections/HashMapCompactTest.kt
@@ -90,7 +90,7 @@ class HashMapCompactTest {
 
     @Test
     fun kt68298() {
-        buildMap { performOperations() }
+        val _ = buildMap { performOperations() }
         HashMap<IntWrapper, String?>().performOperations()
         LinkedHashMap<IntWrapper, String?>().performOperations()
     }

--- a/libraries/stdlib/test/collections/MapTest.kt
+++ b/libraries/stdlib/test/collections/MapTest.kt
@@ -532,7 +532,7 @@ class MapTest {
         doTest("HashMap", mapLetterToIndex.toMap(HashMap()), "c", 2)
         doTest("LinkedHashMap", mapLetterToIndex.toMap(LinkedHashMap()), "d", 3)
 
-        buildMap {
+        val _ = buildMap {
             putAll(mapLetterToIndex)
             doTest("MapBuilder", this, "z", 25)
         }
@@ -579,7 +579,7 @@ class MapTest {
             doTest("HashMap", mapLetterToIndex.toMap(HashMap()), key, value)
             doTest("LinkedHashMap", mapLetterToIndex.toMap(LinkedHashMap()), key, value)
 
-            buildMap {
+            val _ = buildMap {
                 putAll(mapLetterToIndex)
                 doTest("MapBuilder", this, key, value)
             }
@@ -628,7 +628,7 @@ class MapTest {
             }
         }
 
-        buildMap {
+        val _ = buildMap {
             this["a"] = 1
             this["b"] = 2
             this["c"] = 3
@@ -834,20 +834,20 @@ class MapTest {
     @Test fun minBySelectorEvaluateOnce() {
         val source = listOf(1, 2, 3).associateWith { it }
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
     @Test fun maxBySelectorEvaluateOnce() {
         val source = listOf(1, 2, 3).associateWith { it }
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -1062,7 +1062,7 @@ class MapTest {
             map.entries.removeAll(copiedEntries)
             assertEquals(0, map.size)
 
-            copiedKeyValues.zip(copiedEntries) { pair, entry ->
+            val _ = copiedKeyValues.zip(copiedEntries) { pair, entry ->
                 assertEquals(pair, entry.toPair())
             }
 
@@ -1072,7 +1072,7 @@ class MapTest {
         }
 
         testDetachedCopyBehavior(mutableMapOf("a" to 1, "b" to 2))
-        buildMap {
+        val _ = buildMap {
             put("a", 1); put("b", 2)
             testDetachedCopyBehavior(this)
         }

--- a/libraries/stdlib/test/collections/MutableCollectionsTest.kt
+++ b/libraries/stdlib/test/collections/MutableCollectionsTest.kt
@@ -43,7 +43,7 @@ class MutableCollectionTest {
     private fun <T> forAllStandardMutableLists(data: List<T>, block: (MutableList<T>) -> Unit) {
         block(data.toMutableList())
         block(ArrayDeque(data))
-        buildList {
+        val _ = buildList {
             addAll(data)
             block(this)
         }

--- a/libraries/stdlib/test/collections/ReversedViewsTest.kt
+++ b/libraries/stdlib/test/collections/ReversedViewsTest.kt
@@ -224,7 +224,7 @@ class ReversedViewsTest {
         compare(copyIter, iter) {
             propertyFailsWith<IllegalStateException> { remove() }
             propertyEquals {
-                next()
+                val _ = next()
                 remove()
             }
             propertyEquals { previousIndex() }
@@ -237,7 +237,7 @@ class ReversedViewsTest {
 
         compare(copyIter, iter) {
             propertyEquals {
-                next()
+                val _ = next()
                 remove()
             }
             propertyEquals { previousIndex() }
@@ -339,6 +339,6 @@ class ReversedViewsTest {
 
 private fun Iterator<*>.seekEnd() {
     while (hasNext()) {
-        next()
+        val _ = next()
     }
 }

--- a/libraries/stdlib/test/collections/SequenceTest.kt
+++ b/libraries/stdlib/test/collections/SequenceTest.kt
@@ -30,7 +30,7 @@ public class SequenceTest {
         TriggerSequence(source).let { s ->
             val result = operation(s)
             assertFalse(s.iterated, "Source should not be iterated before the result is")
-            result.iterator().hasNext()
+            val _ = result.iterator().hasNext()
             assertTrue(s.iterated, "Source should be iterated after the result is iterated")
         }
     }
@@ -532,6 +532,7 @@ public class SequenceTest {
         }
     }
 
+    @Suppress("RETURN_VALUE_NOT_USED")
     @Test fun makeSequenceOneTimeConstrained() {
         val sequence = sequenceOf(1, 2, 3, 4)
         sequence.toList()
@@ -547,9 +548,8 @@ public class SequenceTest {
 
     }
 
-    private fun <T, C : MutableCollection<in T>> Sequence<T>.takeWhileTo(result: C, predicate: (T) -> Boolean): C {
+    private fun <T, C : MutableCollection<in T>> Sequence<T>.takeWhileTo(result: C, predicate: (T) -> Boolean) {
         for (element in this) if (predicate(element)) result.add(element) else break
-        return result
     }
 
     @Test fun sequenceExtensions() {

--- a/libraries/stdlib/test/collections/UnsignedArraysTest.kt
+++ b/libraries/stdlib/test/collections/UnsignedArraysTest.kt
@@ -1057,6 +1057,7 @@ class UnsignedArraysTest {
     }
 
     @Test
+    @Suppress("RETURN_VALUE_NOT_USED_COERCION")
     fun onEach() {
         assertEquals(listOf<UInt>(1u, 2u, 3u), mutableListOf<UInt>().apply { uintArrayOf(1u, 2u, 3u).onEach { add(it) } })
         assertEquals(listOf<UByte>(1u, 2u, 3u), mutableListOf<UByte>().apply { ubyteArrayOf(1u, 2u, 3u).onEach { add(it) } })
@@ -1065,6 +1066,7 @@ class UnsignedArraysTest {
     }
 
     @Test
+    @Suppress("RETURN_VALUE_NOT_USED_COERCION")
     fun onEachIndexed() {
         assertEquals(listOf<UInt>(1u, 3u, 5u), mutableListOf<UInt>().apply { uintArrayOf(1u, 2u, 3u).onEachIndexed { i, e -> add(i.toUInt() + e) } })
         assertEquals(listOf<UInt>(1u, 3u, 5u), mutableListOf<UInt>().apply { ubyteArrayOf(1u, 2u, 3u).onEachIndexed { i, e -> add(i.toUByte() + e) } })

--- a/libraries/stdlib/test/coroutines/CoroutineContextTest.kt
+++ b/libraries/stdlib/test/coroutines/CoroutineContextTest.kt
@@ -221,7 +221,7 @@ class CoroutineContextTest {
             assertSame(e, context[key])
         }
         val set = mutableSetOf<CoroutineContext.Element>()
-        context.fold(set) { s, e -> s.apply { add(e) } }
+        val _ = context.fold(set) { s, e -> s.apply { add(e) } }
         assertEquals(set, es.toSet())
         when (es.size) {
             0 -> assertSame(context, EmptyCoroutineContext)

--- a/libraries/stdlib/test/generated/minmax/MinMaxArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -134,17 +134,17 @@ class MinMaxArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = arrayOf("a", "bcd", "e")
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -152,10 +152,10 @@ class MinMaxArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = arrayOf("a", "bcd", "e")
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -212,19 +212,19 @@ class MinMaxArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxByteArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxByteArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxByteArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = byteArrayOf(1, 2, Byte.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxByteArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = byteArrayOf(1, 2, Byte.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxByteArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxCharArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxCharArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxCharArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = charArrayOf('a', 'b', Char.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxCharArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = charArrayOf('a', 'b', Char.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxCharArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxCharSequenceTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxCharSequenceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxCharSequenceTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = StringBuilder(charArrayOf('a', 'b', Char.MAX_VALUE).concatToString())
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxCharSequenceTest {
     fun maxBySelectorEvaluateOnce() {
         val source = StringBuilder(charArrayOf('a', 'b', Char.MAX_VALUE).concatToString())
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxCharSequenceTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxDoubleArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxDoubleArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -110,17 +110,17 @@ class MinMaxDoubleArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = doubleArrayOf(1.0, 2.0, Double.POSITIVE_INFINITY)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -128,10 +128,10 @@ class MinMaxDoubleArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = doubleArrayOf(1.0, 2.0, Double.POSITIVE_INFINITY)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -188,19 +188,19 @@ class MinMaxDoubleArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxFloatArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxFloatArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -110,17 +110,17 @@ class MinMaxFloatArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = floatArrayOf(1.0F, 2.0F, Float.POSITIVE_INFINITY)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -128,10 +128,10 @@ class MinMaxFloatArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = floatArrayOf(1.0F, 2.0F, Float.POSITIVE_INFINITY)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -188,19 +188,19 @@ class MinMaxFloatArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxIntArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxIntArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxIntArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = intArrayOf(1, 2, Int.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxIntArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = intArrayOf(1, 2, Int.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxIntArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxIterableTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxIterableTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -134,17 +134,17 @@ class MinMaxIterableTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = listOf("a", "bcd", "e")
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -152,10 +152,10 @@ class MinMaxIterableTest {
     fun maxBySelectorEvaluateOnce() {
         val source = listOf("a", "bcd", "e")
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -212,19 +212,19 @@ class MinMaxIterableTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxLongArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxLongArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxLongArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = longArrayOf(1, 2, Long.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxLongArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = longArrayOf(1, 2, Long.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxLongArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxSequenceTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxSequenceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -134,17 +134,17 @@ class MinMaxSequenceTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = sequenceOf("a", "bcd", "e")
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -152,10 +152,10 @@ class MinMaxSequenceTest {
     fun maxBySelectorEvaluateOnce() {
         val source = sequenceOf("a", "bcd", "e")
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -212,19 +212,19 @@ class MinMaxSequenceTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxShortArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxShortArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxShortArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = shortArrayOf(1, 2, Short.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxShortArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = shortArrayOf(1, 2, Short.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxShortArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxUByteArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxUByteArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxUByteArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = ubyteArrayOf(1U, 2U, UByte.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxUByteArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = ubyteArrayOf(1U, 2U, UByte.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxUByteArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxUIntArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxUIntArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxUIntArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = uintArrayOf(1U, 2U, UInt.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxUIntArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = uintArrayOf(1U, 2U, UInt.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxUIntArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxULongArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxULongArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxULongArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = ulongArrayOf(1UL, 2UL, ULong.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxULongArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = ulongArrayOf(1UL, 2UL, ULong.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxULongArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/generated/minmax/MinMaxUShortArrayTest.kt
+++ b/libraries/stdlib/test/generated/minmax/MinMaxUShortArrayTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -92,17 +92,17 @@ class MinMaxUShortArrayTest {
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = ushortArrayOf(1U, 2U, UShort.MAX_VALUE)
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(3, c)
     }
 
@@ -110,10 +110,10 @@ class MinMaxUShortArrayTest {
     fun maxBySelectorEvaluateOnce() {
         val source = ushortArrayOf(1U, 2U, UShort.MAX_VALUE)
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(3, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(3, c)
     }
     
@@ -170,19 +170,19 @@ class MinMaxUShortArrayTest {
         assertNull(empty.minOfOrNull { it.toString() })
         assertNull(empty.maxOfOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minOf { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { it.toString() } }
 
 
         assertNull(empty.minOfOrNull { 0.0 })
         assertNull(empty.maxOfOrNull { 0.0 })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0 } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0 } }
 
 
         assertNull(empty.minOfOrNull { 0.0F })
         assertNull(empty.maxOfOrNull { 0.0F })
         assertFailsWith<NoSuchElementException> { empty.minOf { 0.0F } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { 0.0F } }
 
 
     }

--- a/libraries/stdlib/test/js/MapJsTest.kt
+++ b/libraries/stdlib/test/js/MapJsTest.kt
@@ -12,9 +12,9 @@ import test.collections.behaviors.*
 class ComplexMapJsTest : MapJsTest() {
     // Helper function with generic parameter to force to use ComlpexHashMap
     fun <K : kotlin.Comparable<K>> doTest() {
-        HashMap<K, Int>()
-        HashMap<K, Int>(3)
-        HashMap<K, Int>(3, 0.5f)
+        val _ = HashMap<K, Int>()
+        val _ = HashMap<K, Int>(3)
+        val _ = HashMap<K, Int>(3, 0.5f)
         @Suppress("UNCHECKED_CAST")
         val map = HashMap<K, Int>(createTestMap() as HashMap<K, Int>)
 
@@ -35,9 +35,9 @@ class ComplexMapJsTest : MapJsTest() {
 
 class PrimitiveMapJsTest : MapJsTest() {
     @Test override fun constructors() {
-        HashMap<String, Int>()
-        HashMap<String, Int>(3)
-        HashMap<String, Int>(3, 0.5f)
+        val _ = HashMap<String, Int>()
+        val _ = HashMap<String, Int>(3)
+        val _ = HashMap<String, Int>(3, 0.5f)
 
         val map = HashMap<String, Int>(createTestMap())
 
@@ -76,9 +76,9 @@ class PrimitiveMapJsTest : MapJsTest() {
 
 class LinkedHashMapJsTest : LinkedMapJsTest() {
     @Test override fun constructors() {
-        LinkedHashMap<String, Int>()
-        LinkedHashMap<String, Int>(3)
-        LinkedHashMap<String, Int>(3, 0.5f)
+        val _ = LinkedHashMap<String, Int>()
+        val _ = LinkedHashMap<String, Int>(3)
+        val _ = LinkedHashMap<String, Int>(3, 0.5f)
 
         val map = LinkedHashMap<String, Int>(createTestMap())
 

--- a/libraries/stdlib/test/js/SetJsTest.kt
+++ b/libraries/stdlib/test/js/SetJsTest.kt
@@ -12,9 +12,9 @@ import test.collections.behaviors.*
 class ComplexSetJsTest : SetJsTest() {
     // Helper function with generic parameter to force to use ComlpexHashMap
     fun <T> doTest() {
-        HashSet<T>()
-        HashSet<T>(3)
-        HashSet<T>(3, 0.5f)
+        val _ = HashSet<T>()
+        val _ = HashSet<T>(3)
+        val _ = HashSet<T>(3, 0.5f)
 
         @Suppress("UNCHECKED_CAST")
         val set = HashSet<T>(data as HashSet<T>)
@@ -40,9 +40,9 @@ class PrimitiveSetJsTest : SetJsTest() {
     override fun createEmptyMutableSetWithNullableValues(): MutableSet<String?> = HashSet()
     @Test
     override fun constructors() {
-        HashSet<String>()
-        HashSet<String>(3)
-        HashSet<String>(3, 0.5f)
+        val _ = HashSet<String>()
+        val _ = HashSet<String>(3)
+        val _ = HashSet<String>(3, 0.5f)
 
         val set = HashSet<String>(data)
 
@@ -67,9 +67,9 @@ class LinkedHashSetJsTest : SetJsTest() {
     override fun createEmptyMutableSetWithNullableValues(): MutableSet<String?> = LinkedHashSet()
     @Test
     override fun constructors() {
-        LinkedHashSet<String>()
-        LinkedHashSet<String>(3)
-        LinkedHashSet<String>(3, 0.5f)
+        val _ = LinkedHashSet<String>()
+        val _ = LinkedHashSet<String>(3)
+        val _ = LinkedHashSet<String>(3, 0.5f)
 
         val set = LinkedHashSet<String>(data)
 

--- a/libraries/stdlib/test/numbers/BuiltinCompanionTest.kt
+++ b/libraries/stdlib/test/numbers/BuiltinCompanionTest.kt
@@ -12,7 +12,7 @@ class BuiltinCompanionTest {
     @Test
     fun intTest() {
         val i = Int
-        i.MAX_VALUE
+        val _ = i.MAX_VALUE
 
         assertSame(Int, i)
     }
@@ -20,7 +20,7 @@ class BuiltinCompanionTest {
     @Test
     fun doubleTest() {
         val d = Double
-        d.NaN
+        val _ = d.NaN
 
         assertSame(Double, d)
     }
@@ -28,7 +28,7 @@ class BuiltinCompanionTest {
     @Test
     fun floatTest() {
         val f = Float
-        f.NEGATIVE_INFINITY
+        val _ = f.NEGATIVE_INFINITY
 
         assertSame(Float, f)
     }
@@ -36,7 +36,7 @@ class BuiltinCompanionTest {
     @Test
     fun longTest() {
         val l = Long
-        l.MAX_VALUE
+        val _ = l.MAX_VALUE
 
         assertSame(Long, l)
     }
@@ -44,7 +44,7 @@ class BuiltinCompanionTest {
     @Test
     fun shortTest() {
         val s = Short
-        s.MIN_VALUE
+        val _ = s.MIN_VALUE
 
         assertSame(Short, s)
     }
@@ -52,7 +52,7 @@ class BuiltinCompanionTest {
     @Test
     fun byteTest() {
         val b = Byte
-        b.MAX_VALUE
+        val _ = b.MAX_VALUE
 
         assertSame(Byte, b)
     }
@@ -60,7 +60,7 @@ class BuiltinCompanionTest {
     @Test
     fun charTest() {
         val ch = Char
-        ch.MIN_SURROGATE
+        val _ = ch.MIN_SURROGATE
 
         assertSame(Char, ch)
     }

--- a/libraries/stdlib/test/properties/delegation/lazy/LazyValuesTest.kt
+++ b/libraries/stdlib/test/properties/delegation/lazy/LazyValuesTest.kt
@@ -2,6 +2,7 @@
  * Copyright 2010-2018 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
+@file:Suppress("RETURN_VALUE_NOT_USED")
 
 package test.properties.delegation.lazy
 

--- a/libraries/stdlib/test/ranges/RangeTest.kt
+++ b/libraries/stdlib/test/ranges/RangeTest.kt
@@ -473,9 +473,11 @@ public class RangeTest {
         assertTrue(("empty"..<"empty").isEmpty())
     }
 
-    private fun assertFailsWithIllegalArgument(f: () -> Unit) = assertFailsWith<IllegalArgumentException> { f() }
+    @IgnorableReturnValue
+    private fun assertFailsWithIllegalArgument(f: () -> Any?) = assertFailsWith<IllegalArgumentException> { f() }
 
-    @Test fun illegalProgressionCreation() {
+    @Test
+    fun illegalProgressionCreation() {
         // create Progression explicitly with increment = 0
         assertFailsWithIllegalArgument { IntProgression.fromClosedRange(0, 5, 0) }
         assertFailsWithIllegalArgument { LongProgression.fromClosedRange(0, 5, 0) }

--- a/libraries/stdlib/test/ranges/URangeTest.kt
+++ b/libraries/stdlib/test/ranges/URangeTest.kt
@@ -253,7 +253,8 @@ public class URangeTest {
         (10UL downTo 1UL).let { checkHashCode(it, it.first, it.last, it.step) }
     }
 
-    private fun assertFailsWithIllegalArgument(f: () -> Unit) = assertFailsWith<IllegalArgumentException> { f() }
+    @IgnorableReturnValue
+    private fun assertFailsWithIllegalArgument(f: () -> Any?) = assertFailsWith<IllegalArgumentException> { f() }
 
     @Test
     fun illegalProgressionCreation() {

--- a/libraries/stdlib/test/text/BytesHexFormatTest.kt
+++ b/libraries/stdlib/test/text/BytesHexFormatTest.kt
@@ -436,7 +436,7 @@ class BytesHexFormatTest {
         assertSame(HexFormat.Default.bytes, emptyFormat.bytes)
         assertSame(HexFormat.Default.number, emptyFormat.number)
 
-        val bytesFormat = HexFormat { bytes }
+        val bytesFormat = HexFormat { val _ = bytes }
         assertNotSame(HexFormat.Default.bytes, bytesFormat.bytes)
         assertSame(HexFormat.Default.number, bytesFormat.number)
 

--- a/libraries/stdlib/test/text/RegexTest.kt
+++ b/libraries/stdlib/test/text/RegexTest.kt
@@ -379,7 +379,7 @@ class RegexTest {
             assertEquals(input.substring(match.range), match.value)
         }
 
-        matches.zipWithNext { [_, m1], [_, m2] ->
+        val _ = matches.zipWithNext { [_, m1], [_, m2] ->
             assertEquals(m2.range, assertNotNull(m1.next()).range)
         }
         assertNull(matches.last().second.next())

--- a/libraries/stdlib/test/time/DurationTest.kt
+++ b/libraries/stdlib/test/time/DurationTest.kt
@@ -934,7 +934,7 @@ class DurationTest {
 
         for (valid in validDefaultFormat) {
             assertNotNull(Duration.parseOrNull(valid), "Should parse valid ordering: $valid")
-            Duration.parse(valid)  // should not throw
+            val _ = Duration.parse(valid)  // should not throw
         }
 
         val invalidDefaultFormat = listOf(
@@ -969,7 +969,7 @@ class DurationTest {
 
         for (valid in validIsoFormat) {
             assertNotNull(Duration.parseIsoStringOrNull(valid), "Should parse valid ISO ordering: $valid")
-            Duration.parseIsoString(valid)  // should not throw
+            val _ = Duration.parseIsoString(valid)  // should not throw
         }
 
         val invalidIsoFormat = listOf(

--- a/libraries/stdlib/test/time/InstantIsoStringsTest.kt
+++ b/libraries/stdlib/test/time/InstantIsoStringsTest.kt
@@ -26,7 +26,7 @@ class InstantIsoStringsTest {
         fun assertMonthBoundariesAreCorrect(year: Int, month: Int, lastDayOfMonth: Int) {
             val validString = "${localDateToString(year, month, lastDayOfMonth)}T23:59:59Z"
             val invalidString = "${localDateToString(year, month, lastDayOfMonth + 1)}T23:59:59Z"
-            Instant.parse(validString) // shouldn't throw
+            val _ = Instant.parse(validString) // shouldn't throw
             assertNotNull(Instant.parseOrNull(validString))
             assertInvalidFormat(invalidString) { Instant.parse(invalidString) }
             assertNull(Instant.parseOrNull(invalidString))

--- a/libraries/stdlib/test/time/MeasureTimeTest.kt
+++ b/libraries/stdlib/test/time/MeasureTimeTest.kt
@@ -13,6 +13,7 @@ import kotlin.time.Duration.Companion.nanoseconds
 class MeasureTimeTest {
 
     companion object {
+        @IgnorableReturnValue
         fun longRunningCalc(): String = buildString {
             repeat(10) {
                 while (Random.nextDouble() >= 0.001);

--- a/libraries/stdlib/test/time/TimeMarkTest.kt
+++ b/libraries/stdlib/test/time/TimeMarkTest.kt
@@ -258,7 +258,7 @@ class TimeMarkTest {
     fun longTimeMarkInfinities() {
         for (unit in units) {
             val timeSource = LongTimeSource(unit).apply {
-                markNow() // fix zero reading
+                val _ = markNow() // fix zero reading
                 reading = Long.MIN_VALUE + 1
             }
 

--- a/libraries/stdlib/test/utils/KotlinVersionTest.kt
+++ b/libraries/stdlib/test/utils/KotlinVersionTest.kt
@@ -28,7 +28,7 @@ class KotlinVersionTest {
             for (place in 0..2) {
                 val [major, minor, patch] = IntArray(3) { index -> if (index == place) component else 0 }
                 if (component in 0..KotlinVersion.MAX_COMPONENT_VALUE) {
-                    KotlinVersion(major, minor, patch)
+                    val _ = KotlinVersion(major, minor, patch)
                 } else {
                     assertFailsWith<IllegalArgumentException>("Expected $major.$minor.$patch to be invalid version") {
                         KotlinVersion(major, minor, patch)
@@ -71,4 +71,3 @@ class KotlinVersionTest {
         }
     }
 }
-

--- a/libraries/stdlib/test/utils/LazyTest.kt
+++ b/libraries/stdlib/test/utils/LazyTest.kt
@@ -19,7 +19,7 @@ class LazyTest {
         assertEquals(1, callCount)
         assertTrue(lazyInt.isInitialized())
 
-        lazyInt.value
+        val _ = lazyInt.value
         assertEquals(1, callCount)
     }
 

--- a/libraries/stdlib/test/utils/TODOTest.kt
+++ b/libraries/stdlib/test/utils/TODOTest.kt
@@ -33,18 +33,17 @@ class TODOTest {
         }
     }
 
-    private fun assertNotImplemented(block: () -> Unit) {
+    private fun assertNotImplemented(block: () -> Any?) {
         assertFailsWith<NotImplementedError>(block = block)
     }
 
-    private fun assertNotImplementedWithMessage(message: String, block: () -> Unit) {
+    private fun assertNotImplementedWithMessage(message: String, block: () -> Any?) {
         val e = assertFailsWith<NotImplementedError>(block = block)
         assertTrue(message in e.message!!)
     }
 
 
     @Test
-    @Suppress("RETURN_VALUE_NOT_USED", "RETURN_VALUE_NOT_USED_COERCION")
     fun usage() {
         val inst = PartiallyImplementedClass()
 

--- a/libraries/stdlib/test/utils/TODOTest.kt
+++ b/libraries/stdlib/test/utils/TODOTest.kt
@@ -44,6 +44,7 @@ class TODOTest {
 
 
     @Test
+    @Suppress("RETURN_VALUE_NOT_USED", "RETURN_VALUE_NOT_USED_COERCION")
     fun usage() {
         val inst = PartiallyImplementedClass()
 

--- a/libraries/tools/kotlin-stdlib-gen/src/generators/test/MinMaxTestGenerator.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/generators/test/MinMaxTestGenerator.kt
@@ -228,17 +228,17 @@ $assertions
         assertNull(empty.minByOrNull { it.toString() })
         assertNull(empty.maxByOrNull { it.toString() })
         assertFailsWith<NoSuchElementException> { empty.minBy { it.toString() } }
-        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxBy { it.toString() } }
     }
 
     @Test 
     fun minBySelectorEvaluateOnce() {
         val source = ${containerOf(defaultElements)}
         var c = 0
-        source.minBy { c++ }
+        val _ = source.minBy { c++ }
         assertEquals(${defaultElements.size}, c)
         c = 0
-        source.minByOrNull { c++ }
+        val _ = source.minByOrNull { c++ }
         assertEquals(${defaultElements.size}, c)
     }
 
@@ -246,10 +246,10 @@ $assertions
     fun maxBySelectorEvaluateOnce() {
         val source = ${containerOf(defaultElements)}
         var c = 0
-        source.maxBy { c++ }
+        val _ = source.maxBy { c++ }
         assertEquals(${defaultElements.size}, c)
         c = 0
-        source.maxByOrNull { c++ }
+        val _ = source.maxByOrNull { c++ }
         assertEquals(${defaultElements.size}, c)
     }
     
@@ -314,7 +314,7 @@ $assertions
         assertNull(empty.minOfOrNull { $selector })
         assertNull(empty.maxOfOrNull { $selector })
         assertFailsWith<NoSuchElementException> { empty.minOf { $selector } }
-        assertFailsWith<NoSuchElementException> { empty.maxOf { $selector } }                       
+        assertFailsWith<NoSuchElementException> { empty.maxOf { $selector } }
 """)
             }
             writer.appendLine("""


### PR DESCRIPTION
Fully enable RVC in all compilations, not just main.

Remove build.gradle.kts custom logic for enabling RVC per compilation.

Context:
I am investigating the requirements for a KGP DSL option. One option is to just migrate code.
stdlib is not a typical Kotlin library, but the difficulty in migrating was a point of discussion. This commit demonstrates the required effort to migrate and what KGP DSL is missing. ^KT-87602