### PR TITLE
[Gradle] Use internal workaround for prototyping isolated project support in JS in more places

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -10,7 +10,6 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
@@ -33,10 +32,7 @@ import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.wasm.npm.WasmNpmResolverPlugin
 import org.jetbrains.kotlin.gradle.tasks.registerTask
-import org.jetbrains.kotlin.gradle.utils.dashSeparatedName
-import org.jetbrains.kotlin.gradle.utils.decamelize
-import org.jetbrains.kotlin.gradle.utils.newInstance
-import org.jetbrains.kotlin.gradle.utils.property
+import org.jetbrains.kotlin.gradle.utils.*
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.capitalizeAsciiOnly
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 import org.jetbrains.kotlin.utils.addIfNotNull
@@ -380,26 +376,6 @@ internal constructor(
 
     internal companion object {
         private val DECAMELIZE_REGEX = "([A-Z])".toRegex()
-
-        /** Check whether [Project.getIsolated] is available. */
-        private val isIsolatedProjectAvailable: Boolean
-            get() = GradleVersion.current() >= GradleVersion.version("8.8")
-
-        /** Check if this [Project] is the root project (in an isolated-project-friendly way, if possible). */
-        private fun Project.isRootProject(): Boolean =
-            if (isIsolatedProjectAvailable) {
-                isolated == isolated.rootProject
-            } else {
-                this == rootProject
-            }
-
-        /** Get the root project name (in an isolated-project-friendly way, if possible). */
-        private fun Project.rootProjectName(): String =
-            if (isIsolatedProjectAvailable) {
-                isolated.rootProject.name
-            } else {
-                rootProject.name
-            }
 
         internal fun buildNpmProjectName(
             project: Project,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/d8/D8Plugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/d8/D8Plugin.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.targets.web.HasPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.tasks.registerTask
+import org.jetbrains.kotlin.gradle.utils.isRootProject
 
 @ExperimentalWasmDsl
 abstract class D8Plugin internal constructor() : Plugin<Project> {
@@ -22,7 +23,7 @@ abstract class D8Plugin internal constructor() : Plugin<Project> {
 
         val spec = project.extensions.createD8EnvSpec()
 
-        if (project == project.rootProject) {
+        if (project.isRootProject()) {
             @Suppress("DEPRECATION")
             project.extensions.create(
                 D8RootExtension.EXTENSION_NAME,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/web/nodejs/NodeJsRootPluginApplier.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/web/nodejs/NodeJsRootPluginApplier.kt
@@ -15,6 +15,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.TasksRequirements
 import org.jetbrains.kotlin.gradle.targets.js.npm.*
@@ -45,8 +47,8 @@ internal class NodeJsRootPluginApplier(
 ) {
 
     fun apply(project: Project) {
-        check(project == project.rootProject) {
-            "${this::class.java.name} can be applied only to root project"
+        checkIsJsToolingProject(project) {
+            "Cannot register ${this::class.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
         }
 
         project.plugins.apply(BasePlugin::class.java)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/web/yarn/BaseYarnRootExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/web/yarn/BaseYarnRootExtension.kt
@@ -18,6 +18,8 @@ import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.logging.kotlinInfo
 import org.jetbrains.kotlin.gradle.targets.js.AbstractSettings
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnv
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NpmApiExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.Platform
@@ -41,8 +43,8 @@ abstract class BaseYarnRootExtension internal constructor(
 ) : AbstractSettings<YarnEnv>(), NpmApiExtension<YarnEnvironment, Yarn> {
 
     init {
-        check(project == project.rootProject) {
-            "Yarn plugin can be applied only to the root project, but was applied to ${project.path}"
+        checkIsJsToolingProject(project) {
+            "Cannot register ${BaseYarnRootExtension::class.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/isolatedProjects.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/isolatedProjects.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.utils
+
+import org.gradle.api.Project
+import org.gradle.util.GradleVersion
+
+/** Get the root project name (in an isolated-project-friendly way, if possible). */
+internal fun Project.rootProjectName(): String =
+    if (isIsolatedProjectAvailable) {
+        isolated.rootProject.name
+    } else {
+        rootProject.name
+    }
+
+/** Check if this [Project] is the root project (in an isolated-project-friendly way, if possible). */
+internal fun Project.isRootProject(): Boolean =
+    if (isIsolatedProjectAvailable) {
+        isolated == isolated.rootProject
+    } else {
+        this == rootProject
+    }
+
+/** Check whether [Project.getIsolated] is available. */
+private val isIsolatedProjectAvailable: Boolean
+    get() = GradleVersion.current() >= GradleVersion.version("8.8")


### PR DESCRIPTION
The initial commit bd5e3d78f2c17d34802435ef22a799c2236dc479 missed some places that broke Isolated Projects.
In this commit we replace more usages of `rootProject` with `jsToolingProject()`.

Also, extract shared IP utils to a common util file.

The only intended purpose is to help prototype IP support in kotlin git KT-88136. Must be removed after KT-80311.

^KT-88136