### PR TITLE
[Native] Preparations to switch to KlibLoader on 2nd compilation stage, part 3

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/js/JsIrLoweringPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/js/JsIrLoweringPipelinePhase.kt
@@ -61,7 +61,7 @@ object JsIrLoweringPipelinePhase : PipelinePhase<WebLoadedIrPipelineArtifact, Js
         deserializer.clear()
         // Sort dependencies after IR linkage.
         val sortedModuleDependencies = deserializer.moduleDependencyTracker.reverseTopoOrder(moduleDependencies = moduleDependencies)
-        val allModules = sortedModuleDependencies.all
+        val allModules = sortedModuleDependencies.allDependencies
         allModules.forEach { module ->
             if (shouldGeneratePolyfills) {
                 collectNativeImplementations(context, module)

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/JsIrLinkerLoader.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/JsIrLinkerLoader.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.common.linkage.partial.partialLinkageConfig
 import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
 import org.jetbrains.kotlin.backend.common.serialization.checkIsFunctionInterface
 import org.jetbrains.kotlin.backend.common.serialization.encodings.BinarySymbolData
-import org.jetbrains.kotlin.backend.common.serialization.kotlinLibrary
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.cli.common.diagnosticsCollector
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -51,12 +50,8 @@ internal class LoadedJsIr(
         val unorderedModuleFragments: List<IrModuleFragment> = loadedFragments.values.toList()
 
         val orderedAndIndexedModuleFragments: Map<IrModuleFragment, Int> = linker.moduleDependencyTracker.reverseTopoOrder(
-            IrModuleDependencies(
-                all = unorderedModuleFragments,
-                stdlib = unorderedModuleFragments.firstOrNull { it.kotlinLibrary?.isAnyPlatformStdlib == true },
-                included = unorderedModuleFragments.last(),
-            )
-        ).all.mapIndexed { index, moduleFragment -> moduleFragment to index }.toMap()
+            IrModuleDependencies(unorderedModuleFragments)
+        ).allDependencies.mapIndexed { index, moduleFragment -> moduleFragment to index }.toMap()
 
         val orderedLoadedFragments: Map<KotlinLibraryFile, IrModuleFragment> = loadedFragments.entries
             .map { [libraryFile, moduleFragment] -> libraryFile to moduleFragment }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
@@ -97,7 +97,7 @@ fun linkIr(irModuleInfo: IrModuleInfo, configuration: CompilerConfiguration): Pa
     // Sort dependencies after IR linkage.
     val sortedModuleDependencies = irLinker.moduleDependencyTracker.reverseTopoOrder(moduleDependencies)
 
-    val allModules = sortedModuleDependencies.all
+    val allModules = sortedModuleDependencies.allDependencies
     allModules.forEach { it.patchDeclarationParents() }
 
     irLinker.postProcess(irBuiltIns, inOrAfterLinkageStep = true)

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/IrModuleInfo.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/IrModuleInfo.kt
@@ -24,16 +24,22 @@ data class IrModuleInfo(
 /**
  * The dependencies of [IrModuleInfo]
  *
- * @property all All the dependencies.
- *   If [stdlib] is not null, then it is expected as the very first element in [all].
- *   If [included] is not null, then it is expected as the very last element in [all].
- * @property stdlib The standard library dependency (if any).
- * @property included The "included library" dependency (if any).
+ * @property allDependencies All the dependencies.
  * @property fragmentNames The mapping from [IrModuleFragment] to its name. Used only in Kotlin/JS.
  */
 data class IrModuleDependencies(
-    val all: List<IrModuleFragment>,
-    val stdlib: IrModuleFragment?,
-    val included: IrModuleFragment?,
+    val allDependencies: List<IrModuleFragment>,
     val fragmentNames: Map<IrModuleFragment, String> = emptyMap()
-)
+) {
+    init {
+        val extraFragments = fragmentNames.keys - allDependencies.toSet()
+        require(extraFragments.isEmpty()) {
+            buildString {
+                appendLine("The set of module fragments in 'fragmentNames' is wider than in 'allDependencies'.")
+                appendLine()
+                appendLine("Extra fragments in 'fragmentNames' (${extraFragments.size}):")
+                extraFragments.map { it.name }.sorted().joinTo(this, separator = "\n") { "- $it" }
+            }
+        }
+    }
+}

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrModuleDependencyTracker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrModuleDependencyTracker.kt
@@ -55,7 +55,7 @@ class IrModuleDependencyTrackerImpl : IrModuleDependencyTracker {
     override fun reverseTopoOrder(moduleDependencies: IrModuleDependencies): IrModuleDependencies {
         val modulesToSort = moduleDependencies.allDependencies.toSet()
 
-        val untrackedModules = trackedModules.keys - modulesToSort
+        val untrackedModules = modulesToSort - trackedModules.keys
         check(untrackedModules.isEmpty()) {
             "The following modules are not being tracked in ${this::class}: ${untrackedModules.joinToString { it.name.asString() }}"
         }

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrModuleDependencyTracker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrModuleDependencyTracker.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.backend.common.serialization
 import org.jetbrains.kotlin.backend.common.IrModuleDependencies
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.utils.DFS
-import org.jetbrains.kotlin.utils.addIfNotNull
 
 interface IrModuleDependencyTracker {
     fun addModuleForTracking(module: IrModuleFragment)
@@ -54,7 +53,7 @@ class IrModuleDependencyTrackerImpl : IrModuleDependencyTracker {
     }
 
     override fun reverseTopoOrder(moduleDependencies: IrModuleDependencies): IrModuleDependencies {
-        val modulesToSort = moduleDependencies.all.toSet()
+        val modulesToSort = moduleDependencies.allDependencies.toSet()
 
         val untrackedModules = trackedModules.keys - modulesToSort
         check(untrackedModules.isEmpty()) {
@@ -67,15 +66,7 @@ class IrModuleDependencyTrackerImpl : IrModuleDependencyTracker {
         val sortedModules: List<IrModuleFragment> = DFS.topologicalOrder(modulesToSort) { module -> trackedModules.getValue(module) }
             .filter { it in modulesToSort } // Avoid accidentally adding dependencies that were not in [IrModuleDependencies.all].
             .reversed()
-            .let { sortedModules ->
-                // The stdlib and included libraries are special. They need to be at the fixed places.
-                buildList {
-                    addIfNotNull(moduleDependencies.stdlib)
-                    sortedModules.filterTo(this) { it != moduleDependencies.stdlib && it != moduleDependencies.included }
-                    addIfNotNull(moduleDependencies.included)
-                }
-            }
 
-        return moduleDependencies.copy(all = sortedModules)
+        return moduleDependencies.copy(allDependencies = sortedModules)
     }
 }

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/KotlinIrLinker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/KotlinIrLinker.kt
@@ -85,6 +85,9 @@ abstract class KotlinIrLinker(
     private val moduleDeserializersByPackageName = mutableMapOf<FqName, MutableList<IrModuleDeserializer>>()
     private val moduleDeserializersWithUnknownPackageNames = mutableListOf<IrModuleDeserializer>()
 
+    val allModuleDeserializers: List<IrModuleDeserializer>
+        get() = deserializersForModules.values.toList()
+
     abstract val irMangler: KotlinMangler.IrMangler
 
     abstract val fakeOverrideBuilder: IrLinkerFakeOverrideProvider

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/KotlinIrLinker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/KotlinIrLinker.kt
@@ -88,6 +88,9 @@ abstract class KotlinIrLinker(
     val allModuleDeserializers: List<IrModuleDeserializer>
         get() = deserializersForModules.values.toList()
 
+    val allModuleFragments: List<IrModuleFragment>
+        get() = deserializersForModules.values.map { it.moduleFragment }
+
     abstract val irMangler: KotlinMangler.IrMangler
 
     abstract val fakeOverrideBuilder: IrLinkerFakeOverrideProvider

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
@@ -65,32 +65,20 @@ private fun deserializeDependencies(
     filesToLoad: Set<String>?,
     mapping: (KotlinLibrary) -> ModuleDescriptor
 ): IrModuleDependencies {
-    val all: MutableList<IrModuleFragment> = mutableListOf()
-    var stdlib: IrModuleFragment? = null
-    var included: IrModuleFragment? = null
-
-    klibs.all.forEach { klib: KotlinLibrary ->
+    val dependencies = klibs.all.map { klib: KotlinLibrary ->
         val descriptor: ModuleDescriptor = mapping(klib)
-        val module: IrModuleFragment = when {
+        when {
             klibs.included == null -> irLinker.deserializeIrModuleHeader(descriptor, klib, { DeserializationStrategy.EXPLICITLY_EXPORTED })
             filesToLoad != null && klib == klibs.included -> irLinker.deserializeDirtyFiles(descriptor, klib, filesToLoad)
             filesToLoad != null && klib != klibs.included -> irLinker.deserializeHeadersWithInlineBodies(descriptor, klib)
             klib == klibs.included -> irLinker.deserializeIrModuleHeader(descriptor, klib, { DeserializationStrategy.ALL })
             else -> irLinker.deserializeIrModuleHeader(descriptor, klib, { DeserializationStrategy.EXPLICITLY_EXPORTED })
         }
-
-        all += module
-        when {
-            klib.isAnyPlatformStdlib -> stdlib = module
-            klib == klibs.included -> included = module
-        }
     }
 
     return IrModuleDependencies(
-        all = all,
-        stdlib = stdlib,
-        included = included,
-        fragmentNames = all.getUniqueNameForEachFragment(),
+        allDependencies = dependencies,
+        fragmentNames = dependencies.getUniqueNameForEachFragment(),
     )
 }
 
@@ -170,9 +158,7 @@ fun loadIrForSingleModule(
     val isStdlibCompilation = mainFragment == stdlibFragment
 
     val moduleDependencies = IrModuleDependencies(
-        all = deserializedFragments,
-        stdlib = stdlibFragment.takeIf { !isStdlibCompilation },
-        included = mainFragment,
+        allDependencies = deserializedFragments,
         fragmentNames = deserializedFragments.getUniqueNameForEachFragment(),
     )
 
@@ -238,7 +224,7 @@ private fun getIrModuleInfoForKlib(
     irLinker.postProcess(irBuiltIns, inOrAfterLinkageStep = true)
 
     return IrModuleInfo(
-        module = moduleDependencies.included!!,
+        module = moduleDependencies.allDependencies.single { it.kotlinLibrary == klibs.included },
         dependencies = moduleDependencies,
         bultins = irBuiltIns,
         symbolTable = symbolTable,

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/lower/serialization/ir/JsIrLinker.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/lower/serialization/ir/JsIrLinker.kt
@@ -94,11 +94,6 @@ class JsIrLinker(
         }
     }
 
-    val modules
-        get() = deserializersForModules.values
-            .map { it.moduleFragment }
-
-
     fun moduleDeserializer(moduleDescriptor: ModuleDescriptor): IrModuleDeserializer {
         return deserializersForModules[moduleDescriptor.name.asString()] ?: error("Deserializer for $moduleDescriptor not found")
     }

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/CInteropModuleDeserializerFactory.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/CInteropModuleDeserializerFactory.kt
@@ -9,10 +9,18 @@ import org.jetbrains.kotlin.backend.common.serialization.IrModuleDeserializer
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.library.KotlinLibrary
 
-interface CInteropModuleDeserializerFactory {
+interface CInteropModuleDeserializerFactory<D> where D : IrModuleDeserializer, D : CInteropModuleDeserializer {
     fun createIrModuleDeserializer(
         moduleFragment: IrModuleFragment,
         klib: KotlinLibrary,
         linker: KonanIrLinker,
-    ): IrModuleDeserializer
+    ): D
+}
+
+interface CInteropModuleDeserializer {
+    /**
+     * Whether there are any declarations that were actually loaded and linked from the
+     * C-interop library represented by the current module deserializer.
+     */
+    fun hasAnyLinkedIrDeclarations(): Boolean
 }

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
@@ -119,6 +119,7 @@ class KonanIrLinker(
 
     private val String.isForwardDeclarationModuleName: Boolean get() = this == KlibResolvedModuleDescriptorsFactoryImpl.Companion.FORWARD_DECLARATIONS_MODULE_NAME.asString()
 
+    // TODO(KT-61096): Drop it in favor of KotlinIrLinker.allModuleDeserializers
     val modules: Map<Path, IrModuleFragment>
         get() = mutableMapOf<Path, IrModuleFragment>().apply {
             deserializersForModules

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
@@ -36,7 +36,7 @@ class KonanIrLinker(
     symbolTable: SymbolTable,
     friendModules: Map<String, Collection<String>>,
     private val forwardModuleDescriptor: ModuleDescriptor?,
-    private val cInteropModuleDeserializerFactory: CInteropModuleDeserializerFactory,
+    private val cInteropModuleDeserializerFactory: CInteropModuleDeserializerFactory<*>,
     exportedDependencies: List<ModuleDescriptor>,
     partialLinkageConfig: PartialLinkageConfig,
     irDiagnosticReporter: IrDiagnosticReporter,

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
@@ -25,10 +25,8 @@ import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isNativeStdlib
 import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
-import org.jetbrains.kotlin.library.metadata.impl.KlibResolvedModuleDescriptorsFactoryImpl
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.library.metadata.klibModuleOriginOrNull
-import java.nio.file.Path
 
 class KonanIrLinker(
     private val currentModule: ModuleDescriptor,
@@ -116,17 +114,4 @@ class KonanIrLinker(
             }
         }
     }
-
-    private val String.isForwardDeclarationModuleName: Boolean get() = this == KlibResolvedModuleDescriptorsFactoryImpl.Companion.FORWARD_DECLARATIONS_MODULE_NAME.asString()
-
-    // TODO(KT-61096): Drop it in favor of KotlinIrLinker.allModuleDeserializers
-    val modules: Map<Path, IrModuleFragment>
-        get() = mutableMapOf<Path, IrModuleFragment>().apply {
-            deserializersForModules
-                .filter { !it.key.isForwardDeclarationModuleName && it.value.moduleFragment.descriptor !== currentModule }
-                .forEach {
-                    val klib = it.value.klib
-                    this[klib.path] = it.value.moduleFragment
-                }
-        }
 }

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/JsIrLoweringFacade.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/JsIrLoweringFacade.kt
@@ -97,7 +97,7 @@ class JsIrLoweringFacade(
         (val irModuleFragment = module, val moduleDependencies = dependencies, val _ = bultins, val _ = symbolTable, val _ = deserializer) = inputArtifact.cliArtifact.moduleInfo
 
         irModuleFragment.resolveTestPaths()
-        moduleDependencies.all.forEach { it.resolveTestPaths() }
+        moduleDependencies.allDependencies.forEach { it.resolveTestPaths() }
 
         val cliInputArtifact = inputArtifact.cliArtifact as? WebLoadedIrPipelineArtifact
             ?: testInfraError("JsIrLoweringFacade expects WebLoadedIrPipelineArtifact")

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.library.isExplicitlySpecifiedByUserInCLIArgument
 import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.native.resolve.KonanLibrariesResolveSupport
 import org.jetbrains.kotlin.utils.KotlinNativePaths
 import java.nio.file.Files
@@ -383,11 +384,12 @@ class NativeSecondStageCompilationConfig(
 
     internal val produceStaticFramework get() = configuration.staticFramework
 
-    private val resolve = KonanLibrariesResolveSupport(
-            configuration, target, distribution, resolveManifestDependenciesLenient = true
-    )
-
-    val resolvedLibraries get() = resolve.resolvedLibraries
+    val resolvedLibraries: KotlinLibraryResolveResult = KonanLibrariesResolveSupport(
+            configuration = configuration,
+            target = target,
+            distribution = distribution,
+            resolveManifestDependenciesLenient = true
+    ).resolvedLibraries
 
     /**
      * Returns the list of libraries in reverse topological order.

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.backend.common.IrBuiltInsForLinker
+import org.jetbrains.kotlin.backend.common.IrModuleDependencies
 import org.jetbrains.kotlin.backend.common.linkage.issues.checkNoUnboundSymbols
 import org.jetbrains.kotlin.backend.common.linkage.partial.partialLinkageConfig
 import org.jetbrains.kotlin.backend.common.phaser.KotlinBackendIrHolder
@@ -85,6 +86,9 @@ internal fun LinkKlibsContext.linkKlibs(
     deserializeDependencies(moduleDescriptor, irLinker)
     ensureCStructsAndEnumsAreLoadedForCaching(irLinker, libraryToCacheModule)
 
+    // Get the list of all dependencies (including potentially unused platform libraries).
+    val originalModuleDependencies = IrModuleDependencies(irLinker.allModuleDeserializers.map { it.moduleFragment })
+
     @OptIn(InternalSymbolFinderAPI::class)
     val irBuiltIns = IrBuiltInsForLinker(irLinker, config.configuration.languageVersionSettings)
     val symbols = BackendNativeSymbols(this, irBuiltIns, config.configuration)
@@ -102,7 +106,7 @@ internal fun LinkKlibsContext.linkKlibs(
     // so to make the pipeline more deterministic, the files are to be sorted.
     // This concerns in the first place global initializers order for the eager initialization strategy,
     // where the files are being initialized in order one by one.
-    modules.values.forEach { module -> module.files.sortBy { it.fileEntry.name } }
+    originalModuleDependencies.allDependencies.forEach { module -> module.files.sortBy { it.fileEntry.name } }
 
     if (stdlibIsBeingCached) {
         val maxArity = 255 // See [BuiltInFictitiousFunctionClassFactory].

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -120,7 +120,14 @@ internal fun LinkKlibsContext.linkKlibs(
 
     return if (libraryToCache == null) {
         val mainModule = IrModuleFragmentImpl(moduleDescriptor)
-        LinkKlibsOutput(modules, mainModule, irBuiltIns, symbols, symbolTable, irLinker)
+        LinkKlibsOutput(
+                irModules = modules,
+                irModule = mainModule,
+                irBuiltIns = irBuiltIns,
+                symbols = symbols,
+                symbolTable = symbolTable,
+                irLinker = irLinker
+        )
     } else {
         val libraryPath: Path = libraryToCache.klib.path
         val libraryModule = modules[libraryPath] ?: error("No module for the library being cached: $libraryPath")

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlin.backend.common.linkage.issues.checkNoUnboundSymbols
 import org.jetbrains.kotlin.backend.common.linkage.partial.partialLinkageConfig
 import org.jetbrains.kotlin.backend.common.phaser.KotlinBackendIrHolder
 import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
-import org.jetbrains.kotlin.backend.common.serialization.IrModuleDeserializer
 import org.jetbrains.kotlin.backend.common.serialization.kotlinLibrary
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
@@ -220,12 +219,12 @@ private fun generateImplForCStructsAndEnums(linker: KonanIrLinker, builtIns: IrB
 internal class KonanCInteropModuleDeserializerFactory(
         private val cachedLibraries: CachedLibraries,
         private val deserializationConfiguration: DeserializationConfiguration,
-) : CInteropModuleDeserializerFactory {
+) : CInteropModuleDeserializerFactory<KonanInteropModuleDeserializer> {
     override fun createIrModuleDeserializer(
             moduleFragment: IrModuleFragment,
             klib: KotlinLibrary,
             linker: KonanIrLinker,
-    ): IrModuleDeserializer = KonanInteropModuleDeserializer(
+    ) = KonanInteropModuleDeserializer(
             deserializationConfiguration,
             moduleFragment,
             klib,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isHeader
 import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
 import org.jetbrains.kotlin.library.metadata.KlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.impl.KlibResolvedModuleDescriptorsFactoryImpl
 import org.jetbrains.kotlin.library.metadata.impl.isForwardDeclarationModule
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.library.metadata.kotlinLibrary
@@ -87,7 +88,7 @@ internal fun LinkKlibsContext.linkKlibs(
     ensureCStructsAndEnumsAreLoadedForCaching(irLinker, libraryToCacheModule)
 
     // Get the list of all dependencies (including potentially unused platform libraries).
-    val originalModuleDependencies = IrModuleDependencies(irLinker.allModuleDeserializers.map { it.moduleFragment })
+    val originalModuleDependencies = IrModuleDependencies(irLinker.allModuleFragments)
 
     @OptIn(InternalSymbolFinderAPI::class)
     val irBuiltIns = IrBuiltInsForLinker(irLinker, config.configuration.languageVersionSettings)
@@ -99,8 +100,6 @@ internal fun LinkKlibsContext.linkKlibs(
     generateImplForCStructsAndEnums(irLinker, irBuiltIns, symbols)
 
     config.configuration.checkNoUnboundSymbols(symbolTable, "at the end of IR linkage process")
-
-    val modules = irLinker.modules
 
     // IR linker deserializes files in the order they lie on the disk, which might be inconvenient,
     // so to make the pipeline more deterministic, the files are to be sorted.
@@ -118,10 +117,14 @@ internal fun LinkKlibsContext.linkKlibs(
         }
     }
 
+    val irModulesForLinkKlibsOutput: Map<Path, IrModuleFragment> = originalModuleDependencies.allDependencies
+            .filter { it.name != KlibResolvedModuleDescriptorsFactoryImpl.FORWARD_DECLARATIONS_MODULE_NAME && it.descriptor !== moduleDescriptor }
+            .associateBy { it.kotlinLibrary!!.path }
+
     return if (libraryToCache == null) {
         val mainModule = IrModuleFragmentImpl(moduleDescriptor)
         LinkKlibsOutput(
-                irModules = modules,
+                irModules = irModulesForLinkKlibsOutput,
                 irModule = mainModule,
                 irBuiltIns = irBuiltIns,
                 symbols = symbols,
@@ -130,9 +133,9 @@ internal fun LinkKlibsContext.linkKlibs(
         )
     } else {
         val libraryPath: Path = libraryToCache.klib.path
-        val libraryModule = modules[libraryPath] ?: error("No module for the library being cached: $libraryPath")
+        val libraryModule = irModulesForLinkKlibsOutput[libraryPath] ?: error("No module for the library being cached: $libraryPath")
         LinkKlibsOutput(
-                irModules = modules.filterKeys { it != libraryPath },
+                irModules = irModulesForLinkKlibsOutput.filterKeys { it != libraryPath },
                 irModule = libraryModule,
                 irBuiltIns = irBuiltIns,
                 symbols = symbols,
@@ -214,7 +217,8 @@ private fun ensureCStructsAndEnumsAreLoadedForCaching(linker: KonanIrLinker, lib
 
 private fun generateImplForCStructsAndEnums(linker: KonanIrLinker, builtIns: IrBuiltIns, symbols: BackendNativeSymbols) {
     val implGen = IrImplementationGeneratorForCStructsAndEnums(builtIns, symbols)
-    for (module in linker.modules.values) {
+    for (deserializer in linker.allModuleDeserializers) {
+        val module = deserializer.moduleFragment
         if (module.kotlinLibrary?.isCInteropLibrary() == true) {
             for (file in module.files) {
                 for (declaration in file.declarations) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -678,7 +678,7 @@ private fun ObjCExportCodeGenerator.generateUnitContinuationToRetainedCompletion
 
 private val ObjCExportBlockCodeGenerator.mappedFunctionNClasses: List<IrClass>
     get() {
-        val stdlibModule = context.irLinker.modules.values.firstOrNull { it.kotlinLibrary?.isNativeStdlib == true }
+        val stdlibModule = context.irLinker.allModuleFragments.firstOrNull { it.kotlinLibrary?.isNativeStdlib == true }
                 ?: error("stdlib module not found")
         val functionFiles = stdlibModule.files.filter { it.isFunctionInterfaceFile }
         val functionN = functionFiles.flatMap { it.declarations.filterIsInstance<IrClass>() }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanInteropModuleDeserializer.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanInteropModuleDeserializer.kt
@@ -59,7 +59,7 @@ internal class KonanInteropModuleDeserializer(
         override val klib: KotlinLibrary,
         private val isLibraryCached: Boolean,
         private val linker: KonanIrLinker,
-) : IrModuleDeserializer(moduleFragment, klib.versions.abiVersion ?: KotlinAbiVersion.CURRENT) {
+) : IrModuleDeserializer(moduleFragment, klib.versions.abiVersion ?: KotlinAbiVersion.CURRENT), CInteropModuleDeserializer {
     init {
         require(klib.isCInteropLibrary())
     }
@@ -83,6 +83,10 @@ internal class KonanInteropModuleDeserializer(
             super.onNewClass(clazz)
             linker.fakeOverrideBuilder.enqueueClass(clazz, clazz.symbol.signature!!, CompatibilityMode.CURRENT)
         }
+    }
+
+    override fun hasAnyLinkedIrDeclarations(): Boolean {
+        return declarationTracker.deserializedDeclarations.isNotEmpty()
     }
 
     private val transformer = CInteropKlibMetadata2IRTransformer(

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/converters/NativeDeserializerFacade.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/converters/NativeDeserializerFacade.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.common.IrModuleInfo
 import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
 import org.jetbrains.kotlin.backend.common.serialization.IrModuleDeserializer
+import org.jetbrains.kotlin.backend.common.serialization.kotlinLibrary
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureDescriptor
 import org.jetbrains.kotlin.backend.konan.serialization.CInteropModuleDeserializerFactory
 import org.jetbrains.kotlin.backend.konan.serialization.KonanIrLinker
@@ -34,10 +35,8 @@ import org.jetbrains.kotlin.ir.util.ExternalDependenciesGenerator
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.konan.config.konanIncludedLibraries
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.isNativeStdlib
 import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
 import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
-import org.jetbrains.kotlin.library.metadata.impl.isForwardDeclarationModule
 import org.jetbrains.kotlin.library.metadata.kotlinLibrary
 import org.jetbrains.kotlin.library.uniqueName
 import org.jetbrains.kotlin.native.pipeline.NativeLoadedIrArtifact
@@ -138,7 +137,7 @@ class NativeDeserializerFacade(
         val sortedModuleDependencies = irLinker.moduleDependencyTracker.reverseTopoOrder(moduleDependencies)
 
         return IrModuleInfo(
-            module = sortedModuleDependencies.included!!,
+            module = sortedModuleDependencies.allDependencies.single { it.kotlinLibrary == mainLibrary },
             dependencies = sortedModuleDependencies,
             bultins = irBuiltIns,
             symbolTable = symbolTable,
@@ -155,31 +154,15 @@ class NativeDeserializerFacade(
         irLinker: KonanIrLinker,
         mainModuleLib: KotlinLibrary?,
         mapping: (KotlinLibrary) -> ModuleDescriptor,
-    ): IrModuleDependencies {
-        val all: MutableList<IrModuleFragment> = mutableListOf()
-        var stdlib: IrModuleFragment? = null
-        var included: IrModuleFragment? = null
-
-        libraries.forEach { klib: KotlinLibrary ->
+    ): IrModuleDependencies = IrModuleDependencies(
+        libraries.map { klib: KotlinLibrary ->
             val descriptor: ModuleDescriptor = mapping(klib)
-            val module: IrModuleFragment = if (klib != mainModuleLib)
+            if (klib != mainModuleLib)
                 irLinker.deserializeIrModuleHeader(descriptor, klib, { DeserializationStrategy.EXPLICITLY_EXPORTED })
             else
                 irLinker.deserializeIrModuleHeader(descriptor, klib, { DeserializationStrategy.ALL }, descriptor.name.asString())
-
-            all += module
-            when {
-                klib.isNativeStdlib -> stdlib = module
-                klib == mainModuleLib -> included = module
-            }
         }
-
-        return IrModuleDependencies(
-            all = all,
-            stdlib = stdlib,
-            included = included,
-        )
-    }
+    )
 
     companion object {
         @OptIn(K1Deprecation::class)

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/converters/NativeDeserializerFacade.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/converters/NativeDeserializerFacade.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.backend.common.IrModuleDependencies
 import org.jetbrains.kotlin.backend.common.IrModuleInfo
 import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
-import org.jetbrains.kotlin.backend.common.serialization.IrModuleDeserializer
 import org.jetbrains.kotlin.backend.common.serialization.kotlinLibrary
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureDescriptor
 import org.jetbrains.kotlin.backend.konan.serialization.CInteropModuleDeserializerFactory
@@ -170,12 +169,12 @@ class NativeDeserializerFacade(
     }
 }
 
-object CInteropModuleDeserializerFactoryMock : CInteropModuleDeserializerFactory {
+object CInteropModuleDeserializerFactoryMock : CInteropModuleDeserializerFactory<Nothing> {
     override fun createIrModuleDeserializer(
         moduleFragment: IrModuleFragment,
         klib: KotlinLibrary,
         linker: KonanIrLinker,
-    ): IrModuleDeserializer {
+    ): Nothing {
         TODO("TODO (KT-85312): Implement IR deserialization for C-interop libraries in tests")
     }
 }


### PR DESCRIPTION
[KT-61096](https://youtrack.jetbrains.com/issue/KT-61096) [KLIB Resolve] Drop KLIB resolve inside the Kotlin/Native compiler
[KT-81624](https://youtrack.jetbrains.com/issue/KT-81624) [KLIB Resolve] Kotlin/Native: -no-default-libs may lead to the final binary depending on a lot of system frameworks