### PR TITLE
Compiler: drop KtPsiDiagnostic in favor of regular diagnostics (KT-88012)

### DIFF
--- a/analysis/analysis-api-fir-diagnostics/analysis-api-fir-diagnostics-generator/src/org/jetbrains/kotlin/analysis/api/fir/generator/rendererrs/FirDiagnosticToKaDiagnosticConverterRenderer.kt
+++ b/analysis/analysis-api-fir-diagnostics/analysis-api-fir-diagnostics-generator/src/org/jetbrains/kotlin/analysis/api/fir/generator/rendererrs/FirDiagnosticToKaDiagnosticConverterRenderer.kt
@@ -60,7 +60,7 @@ object FirDiagnosticToKaDiagnosticConverterRenderer : AbstractDiagnosticsDataCla
 
     private fun SmartPrinter.printDiagnosticParameters(diagnostic: HLDiagnostic) {
         printCustomParameters(diagnostic)
-        println("firDiagnostic as KtPsiDiagnostic,")
+        println("firDiagnostic as KtDiagnosticWithSource,")
         println("token,")
     }
 
@@ -88,7 +88,7 @@ object FirDiagnosticToKaDiagnosticConverterRenderer : AbstractDiagnosticsDataCla
     }
 
     override val defaultImports = listOf(
-        "org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic",
+        "org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource",
         "org.jetbrains.kotlin.fir.builder.FirSyntaxErrors",
         "org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors",
         "org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors",

--- a/analysis/analysis-api-fir-diagnostics/analysis-api-fir-diagnostics-generator/src/org/jetbrains/kotlin/analysis/api/fir/generator/rendererrs/KaDiagnosticClassImplementationRenderer.kt
+++ b/analysis/analysis-api-fir-diagnostics/analysis-api-fir-diagnostics-generator/src/org/jetbrains/kotlin/analysis/api/fir/generator/rendererrs/KaDiagnosticClassImplementationRenderer.kt
@@ -40,7 +40,7 @@ object KaDiagnosticClassImplementationRenderer : AbstractDiagnosticsDataClassRen
         for (parameter in diagnostic.parameters) {
             printParameter(parameter, diagnosticList)
         }
-        println("firDiagnostic: KtPsiDiagnostic,")
+        println("firDiagnostic: KtDiagnosticWithSource,")
         println("token: KaLifetimeToken,")
     }
 
@@ -61,7 +61,7 @@ object KaDiagnosticClassImplementationRenderer : AbstractDiagnosticsDataClassRen
     }
 
     override val defaultImports = listOf(
-        "org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic",
+        "org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource",
         "org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken",
     )
 

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.analysis.api.fir.components.toKaWhenMissingCase
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors
@@ -279,45 +279,45 @@ internal val KT_DIAGNOSTIC_CONVERTER: KaDiagnosticConverter = KaDiagnosticConver
 private fun KaDiagnosticConverterBuilder.addConversions0() {
     add(FirErrors.TOO_MANY_CHARACTERS_IN_CHARACTER_LITERAL) { firDiagnostic ->
         TooManyCharactersInCharacterLiteralImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.WRAPPED_LHS_IN_ASSIGNMENT.warningFactory) { firDiagnostic ->
         WrappedLhsInAssignmentWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.AMBIGUOUS_LABEL) { firDiagnostic ->
         AmbiguousLabelImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.CALL_TO_JS_NON_MODULE_WITH_MODULE_SYSTEM) { firDiagnostic ->
         CallToJsNonModuleWithModuleSystemImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MANY_LAMBDA_EXPRESSION_ARGUMENTS) { firDiagnostic ->
         ManyLambdaExpressionArgumentsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPARE_TO_TYPE_MISMATCH) { firDiagnostic ->
         CompareToTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONST_VAL_WITH_NON_CONST_INITIALIZER) { firDiagnostic ->
         ConstValWithNonConstInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -326,19 +326,19 @@ private fun KaDiagnosticConverterBuilder.addConversions0() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PACKAGE_CANNOT_BE_IMPORTED) { firDiagnostic ->
         PackageCannotBeImportedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_WRONG_TARGET) { firDiagnostic ->
         JsNoRuntimeWrongTargetImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -347,7 +347,7 @@ private fun KaDiagnosticConverterBuilder.addConversions0() {
 private fun KaDiagnosticConverterBuilder.addConversions1() {
     add(FirErrors.ENUM_CLASS_CONSTRUCTOR_CALL) { firDiagnostic ->
         EnumClassConstructorCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -357,7 +357,7 @@ private fun KaDiagnosticConverterBuilder.addConversions1() {
             firDiagnostic.b,
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -366,7 +366,7 @@ private fun KaDiagnosticConverterBuilder.addConversions1() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -375,13 +375,13 @@ private fun KaDiagnosticConverterBuilder.addConversions1() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_ENUM_CONSTRUCTOR) { firDiagnostic ->
         ExpectedEnumConstructorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -390,13 +390,13 @@ private fun KaDiagnosticConverterBuilder.addConversions1() {
 private fun KaDiagnosticConverterBuilder.addConversions2() {
     add(FirErrors.WRONG_LONG_SUFFIX) { firDiagnostic ->
         WrongLongSuffixImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPLICIT_NOTHING_RETURN_TYPE) { firDiagnostic ->
         ImplicitNothingReturnTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -404,19 +404,19 @@ private fun KaDiagnosticConverterBuilder.addConversions2() {
         ArrayEqualityOperatorCanBeReplacedWithContentEqualsImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.INLINE_EXTERNAL_DECLARATION) { firDiagnostic ->
         InlineExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NON_ABSTRACT_MEMBER_OF_EXTERNAL_INTERFACE) { firDiagnostic ->
         NonAbstractMemberOfExternalInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -425,7 +425,7 @@ private fun KaDiagnosticConverterBuilder.addConversions2() {
 private fun KaDiagnosticConverterBuilder.addConversions3() {
     add(FirErrors.DSL_MARKER_PROPAGATES_TO_MANY) { firDiagnostic ->
         DslMarkerPropagatesToManyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -434,31 +434,31 @@ private fun KaDiagnosticConverterBuilder.addConversions3() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROPERTY_INITIALIZER_NO_BACKING_FIELD) { firDiagnostic ->
         PropertyInitializerNoBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ENUM_ENTRY_AS_TYPE) { firDiagnostic ->
         EnumEntryAsTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INLINE_PROPERTY_WITH_BACKING_FIELD_DEPRECATION.warningFactory) { firDiagnostic ->
         InlinePropertyWithBackingFieldDeprecationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_ACCESS_TO_ENUM_ENTRY_PROPERTY_AS_REFERENCE) { firDiagnostic ->
         DeprecatedAccessToEnumEntryPropertyAsReferenceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -468,7 +468,7 @@ private fun KaDiagnosticConverterBuilder.addConversions4() {
     add(FirErrors.LATEINIT_INTRINSIC_CALL_ON_NON_ACCESSIBLE_PROPERTY) { firDiagnostic ->
         LateinitIntrinsicCallOnNonAccessiblePropertyImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -478,13 +478,13 @@ private fun KaDiagnosticConverterBuilder.addConversions4() {
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firSymbolBuilder.buildSymbol(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CAN_BE_VAL_DELAYED_INITIALIZATION) { firDiagnostic ->
         CanBeValDelayedInitializationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -493,14 +493,14 @@ private fun KaDiagnosticConverterBuilder.addConversions4() {
 private fun KaDiagnosticConverterBuilder.addConversions5() {
     add(FirErrors.INNER_ON_TOP_LEVEL_SCRIPT_CLASS.warningFactory) { firDiagnostic ->
         InnerOnTopLevelScriptClassWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROTECTED_CONSTRUCTOR_NOT_IN_SUPER_CALL) { firDiagnostic ->
         ProtectedConstructorNotInSuperCallImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -510,25 +510,25 @@ private fun KaDiagnosticConverterBuilder.addConversions5() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL) { firDiagnostic ->
         IllegalRestrictedSuspendingFunctionCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_LOCAL_FUNCTION) { firDiagnostic ->
         InvalidVersioningOnLocalFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.WRONG_JS_EXPORT_TARGET_VISIBILITY) { firDiagnostic ->
         WrongJsExportTargetVisibilityImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -537,19 +537,19 @@ private fun KaDiagnosticConverterBuilder.addConversions5() {
 private fun KaDiagnosticConverterBuilder.addConversions6() {
     add(FirJsErrors.JS_MODULE_PROHIBITED_ON_NON_NATIVE) { firDiagnostic ->
         JsModuleProhibitedOnNonNativeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CLASS_LITERAL_LHS_NOT_A_CLASS) { firDiagnostic ->
         ClassLiteralLhsNotAClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNUSED_EXPRESSION) { firDiagnostic ->
         UnusedExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -557,14 +557,14 @@ private fun KaDiagnosticConverterBuilder.addConversions6() {
         RepeatedAnnotationWithContainerImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.WRONG_EXPORTED_DECLARATION) { firDiagnostic ->
         WrongExportedDeclarationImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -572,7 +572,7 @@ private fun KaDiagnosticConverterBuilder.addConversions6() {
         UncheckedCastToExternalInterfaceImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -581,14 +581,14 @@ private fun KaDiagnosticConverterBuilder.addConversions6() {
 private fun KaDiagnosticConverterBuilder.addConversions7() {
     add(FirErrors.EXPLICIT_DELEGATION_CALL_REQUIRED) { firDiagnostic ->
         ExplicitDelegationCallRequiredImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONFLICTING_PROJECTION) { firDiagnostic ->
         ConflictingProjectionImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -599,7 +599,7 @@ private fun KaDiagnosticConverterBuilder.addConversions7() {
             firDiagnostic.c.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -607,7 +607,7 @@ private fun KaDiagnosticConverterBuilder.addConversions7() {
         ReturnTypeMismatchByDelegationImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -616,13 +616,13 @@ private fun KaDiagnosticConverterBuilder.addConversions7() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.ENUM_CLASS_IN_EXTERNAL_DECLARATION_WARNING) { firDiagnostic ->
         EnumClassInExternalDeclarationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -631,13 +631,13 @@ private fun KaDiagnosticConverterBuilder.addConversions7() {
 private fun KaDiagnosticConverterBuilder.addConversions8() {
     add(FirErrors.OTHER_ERROR) { firDiagnostic ->
         OtherErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSUPPORTED_ARRAY_LITERAL_OUTSIDE_OF_ANNOTATION.errorFactory) { firDiagnostic ->
         UnsupportedArrayLiteralOutsideOfAnnotationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -645,43 +645,43 @@ private fun KaDiagnosticConverterBuilder.addConversions8() {
         DeprecatedModifierForTargetImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ASSIGNING_SINGLE_ELEMENT_TO_VARARG_IN_NAMED_FORM_ANNOTATION.warningFactory) { firDiagnostic ->
         AssigningSingleElementToVarargInNamedFormAnnotationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_OR_BE_ABSTRACT) { firDiagnostic ->
         MustBeInitializedOrBeAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROPERTY_WITH_EXPLICIT_FIELD_AND_ACCESSORS) { firDiagnostic ->
         PropertyWithExplicitFieldAndAccessorsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_TAILREC_FUNCTION) { firDiagnostic ->
         ExpectedTailrecFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REIFIED_TYPE_PARAMETER_IN_OVERRIDE) { firDiagnostic ->
         ReifiedTypeParameterInOverrideImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_IN_INTERFACE) { firDiagnostic ->
         SynchronizedInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -690,7 +690,7 @@ private fun KaDiagnosticConverterBuilder.addConversions8() {
 private fun KaDiagnosticConverterBuilder.addConversions9() {
     add(FirErrors.OPT_IN_MARKER_ON_OVERRIDE_WARNING) { firDiagnostic ->
         OptInMarkerOnOverrideWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -698,7 +698,7 @@ private fun KaDiagnosticConverterBuilder.addConversions9() {
         WrongSetterParameterTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -707,13 +707,13 @@ private fun KaDiagnosticConverterBuilder.addConversions9() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.ENUM_JVM_RECORD) { firDiagnostic ->
         EnumJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -723,13 +723,13 @@ private fun KaDiagnosticConverterBuilder.addConversions10() {
     add(FirErrors.MISSING_DEPENDENCY_CLASS_IN_LAMBDA_RECEIVER) { firDiagnostic ->
         MissingDependencyClassInLambdaReceiverImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROJECTION_IN_TYPE_OF_ANNOTATION_MEMBER.warningFactory) { firDiagnostic ->
         ProjectionInTypeOfAnnotationMemberWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -737,13 +737,13 @@ private fun KaDiagnosticConverterBuilder.addConversions10() {
         PropertyTypeMismatchOnInheritanceImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEFAULT_VALUE_NOT_ALLOWED_IN_OVERRIDE) { firDiagnostic ->
         DefaultValueNotAllowedInOverrideImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -753,33 +753,33 @@ private fun KaDiagnosticConverterBuilder.addConversions11() {
     add(FirErrors.CONFLICTING_PROJECTION_IN_CALLABLE_REFERENCE_WARNING) { firDiagnostic ->
         ConflictingProjectionInCallableReferenceWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPRESSION_OF_NULLABLE_TYPE_IN_CLASS_LITERAL_LHS_WARNING) { firDiagnostic ->
         ExpressionOfNullableTypeInClassLiteralLhsWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INITIALIZATION_BEFORE_DECLARATION) { firDiagnostic ->
         InitializationBeforeDeclarationImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.THROWS_IN_ANNOTATION.warningFactory) { firDiagnostic ->
         ThrowsInAnnotationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.INLINE_CLASS_IN_EXTERNAL_DECLARATION) { firDiagnostic ->
         InlineClassInExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -789,31 +789,31 @@ private fun KaDiagnosticConverterBuilder.addConversions12() {
     add(FirErrors.REDUNDANT_ANNOTATION) { firDiagnostic ->
         RedundantAnnotationImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CANNOT_EXTEND_IDENTITY_CLASSES) { firDiagnostic ->
         ValueClassCannotExtendIdentityClassesImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_PROJECTION_USAGE) { firDiagnostic ->
         IllegalProjectionUsageImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_NON_OPTIONAL_PARAMETER_POSITION) { firDiagnostic ->
         InvalidNonOptionalParameterPositionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.NO_REFLECTION_IN_CLASS_PATH) { firDiagnostic ->
         NoReflectionInClassPathImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -822,13 +822,13 @@ private fun KaDiagnosticConverterBuilder.addConversions12() {
 private fun KaDiagnosticConverterBuilder.addConversions13() {
     add(FirErrors.BREAK_OR_CONTINUE_JUMPS_ACROSS_FUNCTION_BOUNDARY) { firDiagnostic ->
         BreakOrContinueJumpsAcrossFunctionBoundaryImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_VALUE_CLASS_CONSTRUCTOR_PROPERTY_PARAMETER) { firDiagnostic ->
         AbstractValueClassConstructorPropertyParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -836,13 +836,13 @@ private fun KaDiagnosticConverterBuilder.addConversions13() {
         WrongNumberOfTypeArgumentsInLocalClassInLhsWarningImpl(
             firDiagnostic.a,
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NEXT_MISSING) { firDiagnostic ->
         NextMissingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -850,7 +850,7 @@ private fun KaDiagnosticConverterBuilder.addConversions13() {
         FunctionTypeOfTooLargeArityImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -859,7 +859,7 @@ private fun KaDiagnosticConverterBuilder.addConversions13() {
 private fun KaDiagnosticConverterBuilder.addConversions14() {
     add(FirErrors.ACTUAL_TYPE_ALIAS_TO_NOTHING) { firDiagnostic ->
         ActualTypeAliasToNothingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -867,13 +867,13 @@ private fun KaDiagnosticConverterBuilder.addConversions14() {
         InvalidDefaultValueDependencyImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.CONCURRENT_HASH_MAP_CONTAINS_OPERATOR_ERROR) { firDiagnostic ->
         ConcurrentHashMapContainsOperatorErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -882,13 +882,13 @@ private fun KaDiagnosticConverterBuilder.addConversions14() {
 private fun KaDiagnosticConverterBuilder.addConversions15() {
     add(FirErrors.DATA_CLASS_INVISIBLE_COPY_USAGE.warningFactory) { firDiagnostic ->
         DataClassInvisibleCopyUsageWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_CONST_VAL_USED_IN_CONSTANT_EXPRESSION) { firDiagnostic ->
         NonConstValUsedInConstantExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -897,43 +897,43 @@ private fun KaDiagnosticConverterBuilder.addConversions15() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXTENSION_PROPERTY_MUST_HAVE_ACCESSORS_OR_BE_ABSTRACT) { firDiagnostic ->
         ExtensionPropertyMustHaveAccessorsOrBeAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LATEINIT_INTRINSIC_CALL_ON_NON_LATEINIT) { firDiagnostic ->
         LateinitIntrinsicCallOnNonLateinitImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPECHECKER_HAS_RUN_INTO_RECURSIVE_PROBLEM) { firDiagnostic ->
         TypecheckerHasRunIntoRecursiveProblemImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANONYMOUS_INITIALIZER_IN_INTERFACE) { firDiagnostic ->
         AnonymousInitializerInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_SERIALIZABLE_LAMBDA_ON_INLINED_FUNCTION_LITERALS.errorFactory) { firDiagnostic ->
         JvmSerializableLambdaOnInlinedFunctionLiteralsErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.OVERRIDING_EXTERNAL_FUN_WITH_OPTIONAL_PARAMS) { firDiagnostic ->
         OverridingExternalFunWithOptionalParamsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -942,7 +942,7 @@ private fun KaDiagnosticConverterBuilder.addConversions15() {
 private fun KaDiagnosticConverterBuilder.addConversions16() {
     add(FirErrors.DUPLICATE_PARAMETER_NAME_IN_FUNCTION_TYPE) { firDiagnostic ->
         DuplicateParameterNameInFunctionTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -951,13 +951,13 @@ private fun KaDiagnosticConverterBuilder.addConversions16() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCONSISTENT_BACKING_FIELD_TYPE) { firDiagnostic ->
         InconsistentBackingFieldTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -965,19 +965,19 @@ private fun KaDiagnosticConverterBuilder.addConversions16() {
         TypealiasAsCallableQualifierInImportWarningImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_IN_ANNOTATION.errorFactory) { firDiagnostic ->
         SynchronizedInAnnotationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_STATIC_NOT_IN_OBJECT) { firDiagnostic ->
         JsStaticNotInObjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -986,14 +986,14 @@ private fun KaDiagnosticConverterBuilder.addConversions16() {
 private fun KaDiagnosticConverterBuilder.addConversions17() {
     add(FirErrors.NO_CONSTRUCTOR) { firDiagnostic ->
         NoConstructorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INSTANCE_ACCESS_BEFORE_SUPER_CALL) { firDiagnostic ->
         InstanceAccessBeforeSuperCallImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1003,31 +1003,31 @@ private fun KaDiagnosticConverterBuilder.addConversions17() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.GENERIC_THROWABLE_SUBCLASS) { firDiagnostic ->
         GenericThrowableSubclassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS) { firDiagnostic ->
         ActualFunctionWithDefaultArgumentsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_STATIC_ON_CONST_OR_JVM_FIELD) { firDiagnostic ->
         JvmStaticOnConstOrJvmFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.UPPER_BOUND_CANNOT_BE_ARRAY) { firDiagnostic ->
         UpperBoundCannotBeArrayImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1036,14 +1036,14 @@ private fun KaDiagnosticConverterBuilder.addConversions17() {
 private fun KaDiagnosticConverterBuilder.addConversions18() {
     add(FirErrors.NO_GET_METHOD) { firDiagnostic ->
         NoGetMethodImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_ALL_UNDER_IMPORT_FROM_SINGLETON) { firDiagnostic ->
         CannotAllUnderImportFromSingletonImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1052,14 +1052,14 @@ private fun KaDiagnosticConverterBuilder.addConversions18() {
 private fun KaDiagnosticConverterBuilder.addConversions19() {
     add(FirErrors.REPEATED_ANNOTATION_WARNING) { firDiagnostic ->
         RepeatedAnnotationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.HAS_NEXT_FUNCTION_TYPE_MISMATCH) { firDiagnostic ->
         HasNextFunctionTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1069,7 +1069,7 @@ private fun KaDiagnosticConverterBuilder.addConversions19() {
             firDiagnostic.b.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1077,7 +1077,7 @@ private fun KaDiagnosticConverterBuilder.addConversions19() {
         AbstractPropertyInNonAbstractClassImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1088,20 +1088,20 @@ private fun KaDiagnosticConverterBuilder.addConversions20() {
         JavaClassInheritsKtPrivateClassImpl(
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CYCLIC_INHERITANCE_HIERARCHY) { firDiagnostic ->
         CyclicInheritanceHierarchyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXTENSION_IN_CLASS_REFERENCE_NOT_ALLOWED) { firDiagnostic ->
         ExtensionInClassReferenceNotAllowedImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1109,32 +1109,32 @@ private fun KaDiagnosticConverterBuilder.addConversions20() {
         OverridingIgnorableWithMustUseImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_FIELD_VISIBILITY_MUST_BE_LESS_PERMISSIVE) { firDiagnostic ->
         ExplicitFieldVisibilityMustBeLessPermissiveImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VAL_REASSIGNMENT_VIA_BACKING_FIELD_ERROR) { firDiagnostic ->
         ValReassignmentViaBackingFieldErrorImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a.fir.propertySymbol),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JAVA_CLASS_PROPERTY_REFERENCE.warningFactory) { firDiagnostic ->
         JavaClassPropertyReferenceWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NESTED_JS_EXPORT) { firDiagnostic ->
         NestedJsExportImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1144,32 +1144,32 @@ private fun KaDiagnosticConverterBuilder.addConversions21() {
     add(FirErrors.VAL_OR_VAR_ON_LOOP_PARAMETER) { firDiagnostic ->
         ValOrVarOnLoopParameterImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RESTRICTED_RETENTION_FOR_EXPRESSION_ANNOTATION_ERROR) { firDiagnostic ->
         RestrictedRetentionForExpressionAnnotationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INNER_CLASS_INSIDE_VALUE_CLASS) { firDiagnostic ->
         InnerClassInsideValueClassImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_YET_SUPPORTED_IN_INLINE_WARNING) { firDiagnostic ->
         NotYetSupportedInInlineWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_RECORD_NOT_LAST_VARARG_PARAMETER) { firDiagnostic ->
         JvmRecordNotLastVarargParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1179,7 +1179,7 @@ private fun KaDiagnosticConverterBuilder.addConversions22() {
     add(FirErrors.MISSING_DEPENDENCY_IN_INFERRED_TYPE_ANNOTATION.warningFactory) { firDiagnostic ->
         MissingDependencyInInferredTypeAnnotationWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1187,13 +1187,13 @@ private fun KaDiagnosticConverterBuilder.addConversions22() {
         RedundantModifierForTargetImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNEXPECTED_TRAILING_LAMBDA_ON_A_NEW_LINE) { firDiagnostic ->
         UnexpectedTrailingLambdaOnANewLineImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1203,13 +1203,13 @@ private fun KaDiagnosticConverterBuilder.addConversions22() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DYNAMIC_SUPERTYPE) { firDiagnostic ->
         DynamicSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1217,7 +1217,7 @@ private fun KaDiagnosticConverterBuilder.addConversions22() {
         VarOverriddenByValByDelegationImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1225,32 +1225,32 @@ private fun KaDiagnosticConverterBuilder.addConversions22() {
         ExtensionFunctionShadowedByMemberPropertyWithInvokeImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACCESSOR_FOR_DELEGATED_PROPERTY) { firDiagnostic ->
         AccessorForDelegatedPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONSTRUCTOR_OR_SUPERTYPE_ON_TYPEALIAS_WITH_TYPE_PROJECTION.warningFactory) { firDiagnostic ->
         ConstructorOrSupertypeOnTypealiasWithTypeProjectionWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USAGE_IS_NOT_INLINABLE) { firDiagnostic ->
         UsageIsNotInlinableImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.INAPPLICABLE_JVM_EXPOSE_BOXED_WITH_NAME) { firDiagnostic ->
         InapplicableJvmExposeBoxedWithNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1259,7 +1259,7 @@ private fun KaDiagnosticConverterBuilder.addConversions22() {
 private fun KaDiagnosticConverterBuilder.addConversions23() {
     add(FirErrors.VALUE_CLASS_CANNOT_BE_RECURSIVE_VIA_TYPE_PARAMETERS.warningFactory) { firDiagnostic ->
         ValueClassCannotBeRecursiveViaTypeParametersWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1268,20 +1268,20 @@ private fun KaDiagnosticConverterBuilder.addConversions23() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MULTIPLE_VARARG_PARAMETERS) { firDiagnostic ->
         MultipleVarargParametersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_ERROR) { firDiagnostic ->
         ImpossibleIsCheckErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1291,13 +1291,13 @@ private fun KaDiagnosticConverterBuilder.addConversions24() {
     add(FirErrors.VAL_OR_VAR_ON_CATCH_PARAMETER) { firDiagnostic ->
         ValOrVarOnCatchParameterImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_TARGET_PROPERTY_HAS_NO_BACKING_FIELD) { firDiagnostic ->
         InapplicableTargetPropertyHasNoBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1307,7 +1307,7 @@ private fun KaDiagnosticConverterBuilder.addConversions24() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.buildSymbol(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1316,26 +1316,26 @@ private fun KaDiagnosticConverterBuilder.addConversions24() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SENSELESS_COMPARISON) { firDiagnostic ->
         SenselessComparisonImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DECLARATION_OF_ENUM_ENTRY_ENTRIES.errorFactory) { firDiagnostic ->
         DeclarationOfEnumEntryEntriesErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_EXPOSE_OPEN_ABSTRACT) { firDiagnostic ->
         JvmExposeBoxedCannotExposeOpenAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1344,20 +1344,20 @@ private fun KaDiagnosticConverterBuilder.addConversions24() {
 private fun KaDiagnosticConverterBuilder.addConversions25() {
     add(FirErrors.AMBIGUOUS_CALL_WITH_IMPLICIT_CONTEXT_RECEIVER) { firDiagnostic ->
         AmbiguousCallWithImplicitContextReceiverImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NULLABLE_ON_DEFINITELY_NOT_NULLABLE) { firDiagnostic ->
         NullableOnDefinitelyNotNullableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXTENSION_SHADOWED_BY_MEMBER) { firDiagnostic ->
         ExtensionShadowedByMemberImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1366,7 +1366,7 @@ private fun KaDiagnosticConverterBuilder.addConversions25() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1376,7 +1376,7 @@ private fun KaDiagnosticConverterBuilder.addConversions25() {
                 whenMissingCase.toKaWhenMissingCase()
             },
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1385,26 +1385,26 @@ private fun KaDiagnosticConverterBuilder.addConversions25() {
 private fun KaDiagnosticConverterBuilder.addConversions27() {
     add(FirErrors.PLACEHOLDER_PROJECTION_IN_QUALIFIER) { firDiagnostic ->
         PlaceholderProjectionInQualifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.WRONG_MULTIPLE_INHERITANCE) { firDiagnostic ->
         WrongMultipleInheritanceImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPT_IN_MARKER_ON_OVERRIDE) { firDiagnostic ->
         OptInMarkerOnOverrideImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NULLABLE_RETURN_TYPE_OF_OPERATOR_OF) { firDiagnostic ->
         NullableReturnTypeOfOperatorOfImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1414,20 +1414,20 @@ private fun KaDiagnosticConverterBuilder.addConversions27() {
             firDiagnostic.b.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DYNAMIC_RECEIVER_NOT_ALLOWED) { firDiagnostic ->
         DynamicReceiverNotAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LOCAL_INTERFACE_NOT_ALLOWED) { firDiagnostic ->
         LocalInterfaceNotAllowedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1435,19 +1435,19 @@ private fun KaDiagnosticConverterBuilder.addConversions27() {
         IncompatibleEnumComparisonImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_RETURN_UNIT_TYPE) { firDiagnostic ->
         RedundantReturnUnitTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.REPEATABLE_ANNOTATION_HAS_NESTED_CLASS_NAMED_CONTAINER_ERROR) { firDiagnostic ->
         RepeatableAnnotationHasNestedClassNamedContainerErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1456,19 +1456,19 @@ private fun KaDiagnosticConverterBuilder.addConversions27() {
 private fun KaDiagnosticConverterBuilder.addConversions28() {
     add(FirErrors.KOTLIN_PACKAGE_USAGE) { firDiagnostic ->
         KotlinPackageUsageImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSUPPORTED_ARRAY_LITERAL_OUTSIDE_OF_ANNOTATION.warningFactory) { firDiagnostic ->
         UnsupportedArrayLiteralOutsideOfAnnotationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.POTENTIALLY_NON_REPORTED_ANNOTATION) { firDiagnostic ->
         PotentiallyNonReportedAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1479,19 +1479,19 @@ private fun KaDiagnosticConverterBuilder.addConversions28() {
             firDiagnostic.c.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MULTIPLE_VARARG_OVERLOADS_OF_OPERATOR_OF) { firDiagnostic ->
         MultipleVarargOverloadsOfOperatorOfImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DECLARATION_OF_ENUM_ENTRY_ENTRIES.warningFactory) { firDiagnostic ->
         DeclarationOfEnumEntryEntriesWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1500,7 +1500,7 @@ private fun KaDiagnosticConverterBuilder.addConversions28() {
 private fun KaDiagnosticConverterBuilder.addConversions29() {
     add(FirErrors.ASSIGNMENT_IN_EXPRESSION_CONTEXT) { firDiagnostic ->
         AssignmentInExpressionContextImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1510,7 +1510,7 @@ private fun KaDiagnosticConverterBuilder.addConversions29() {
             firDiagnostic.b,
             firDiagnostic.c,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.d),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1522,25 +1522,25 @@ private fun KaDiagnosticConverterBuilder.addConversions30() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.METHOD_OF_ANY_IMPLEMENTED_IN_INTERFACE) { firDiagnostic ->
         MethodOfAnyImplementedInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_STATIC_ON_NON_PUBLIC_MEMBER) { firDiagnostic ->
         JvmStaticOnNonPublicMemberImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.EXTERNAL_ENUM_ENTRY_WITH_BODY) { firDiagnostic ->
         ExternalEnumEntryWithBodyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1550,27 +1550,27 @@ private fun KaDiagnosticConverterBuilder.addConversions31() {
     add(FirErrors.NEW_INFERENCE_ERROR) { firDiagnostic ->
         NewInferenceErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.DATA_CLASS_COPY_JS_EXPORTABILITY_WILL_BE_CHANGED.warningFactory) { firDiagnostic ->
         DataClassCopyJsExportabilityWillBeChangedWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LOCAL_OBJECT_NOT_ALLOWED) { firDiagnostic ->
         LocalObjectNotAllowedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_EXTERNAL_ARGUMENT) { firDiagnostic ->
         JsExternalArgumentImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1579,38 +1579,38 @@ private fun KaDiagnosticConverterBuilder.addConversions31() {
 private fun KaDiagnosticConverterBuilder.addConversions32() {
     add(FirErrors.ERROR_FROM_JAVA_RESOLUTION) { firDiagnostic ->
         ErrorFromJavaResolutionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROJECTION_IN_IMMEDIATE_ARGUMENT_TO_SUPERTYPE) { firDiagnostic ->
         ProjectionInImmediateArgumentToSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.POTENTIALLY_NULLABLE_RETURN_TYPE_OF_OPERATOR_OF) { firDiagnostic ->
         PotentiallyNullableReturnTypeOfOperatorOfImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_SPREAD_OPERATOR_IN_NAMED_FORM_IN_ANNOTATION) { firDiagnostic ->
         RedundantSpreadOperatorInNamedFormInAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.AMBIGUOUS_CONTEXT_ARGUMENT) { firDiagnostic ->
         AmbiguousContextArgumentImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETERS_IN_OBJECT) { firDiagnostic ->
         TypeParametersInObjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1618,7 +1618,7 @@ private fun KaDiagnosticConverterBuilder.addConversions32() {
         InferredInvisibleReturnTypeWarningImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1626,13 +1626,13 @@ private fun KaDiagnosticConverterBuilder.addConversions32() {
         NonPublicCallFromPublicInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NESTED_EXTERNAL_DECLARATION) { firDiagnostic ->
         NestedExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1641,32 +1641,32 @@ private fun KaDiagnosticConverterBuilder.addConversions32() {
 private fun KaDiagnosticConverterBuilder.addConversions33() {
     add(FirErrors.DATA_CLASS_NOT_PROPERTY_PARAMETER) { firDiagnostic ->
         DataClassNotPropertyParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_WILL_BE_APPLIED_ALSO_TO_PROPERTY_OR_FIELD) { firDiagnostic ->
         AnnotationWillBeAppliedAlsoToPropertyOrFieldImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NAME_ON_PRIMARY_CONSTRUCTOR_PROHIBITED) { firDiagnostic ->
         JsNameOnPrimaryConstructorProhibitedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_EXPLICIT_VISIBILITY_IN_API_MODE) { firDiagnostic ->
         NoExplicitVisibilityInApiModeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LATEINIT_PROPERTY_WITHOUT_TYPE) { firDiagnostic ->
         LateinitPropertyWithoutTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1675,13 +1675,13 @@ private fun KaDiagnosticConverterBuilder.addConversions33() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IS_ENUM_ENTRY) { firDiagnostic ->
         IsEnumEntryImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1691,19 +1691,19 @@ private fun KaDiagnosticConverterBuilder.addConversions34() {
     add(FirErrors.RETURN_TYPE_MISMATCH_OF_OPERATOR_OF) { firDiagnostic ->
         ReturnTypeMismatchOfOperatorOfImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETERS_IN_ENUM) { firDiagnostic ->
         TypeParametersInEnumImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABBREVIATED_NOTHING_RETURN_TYPE) { firDiagnostic ->
         AbbreviatedNothingReturnTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1712,20 +1712,20 @@ private fun KaDiagnosticConverterBuilder.addConversions34() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_FOR_BUILT_IN_SUSPEND) { firDiagnostic ->
         ReturnForBuiltInSuspendImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_TYPE_EXTENDS_NON_EXTERNAL_TYPE) { firDiagnostic ->
         ExternalTypeExtendsNonExternalTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1735,7 +1735,7 @@ private fun KaDiagnosticConverterBuilder.addConversions35() {
     add(FirErrors.INCONSISTENT_RETURN_TYPES_IN_OF_OVERLOADS) { firDiagnostic ->
         InconsistentReturnTypesInOfOverloadsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1744,7 +1744,7 @@ private fun KaDiagnosticConverterBuilder.addConversions35() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1753,7 +1753,7 @@ private fun KaDiagnosticConverterBuilder.addConversions35() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1761,14 +1761,14 @@ private fun KaDiagnosticConverterBuilder.addConversions35() {
         ReturnTypeMismatchOnInheritanceImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSAFE_CALLABLE_REFERENCE) { firDiagnostic ->
         UnsafeCallableReferenceImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1776,7 +1776,7 @@ private fun KaDiagnosticConverterBuilder.addConversions35() {
         InlineFromHigherPlatformImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1786,7 +1786,7 @@ private fun KaDiagnosticConverterBuilder.addConversions36() {
     add(FirErrors.VAL_OR_VAR_ON_FUN_PARAMETER) { firDiagnostic ->
         ValOrVarOnFunParameterImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1798,19 +1798,19 @@ private fun KaDiagnosticConverterBuilder.addConversions36() {
             },
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_OR_FINAL_OR_ABSTRACT_WARNING) { firDiagnostic ->
         MustBeInitializedOrFinalOrAbstractWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNNECESSARY_LATEINIT) { firDiagnostic ->
         UnnecessaryLateinitImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1819,19 +1819,19 @@ private fun KaDiagnosticConverterBuilder.addConversions36() {
 private fun KaDiagnosticConverterBuilder.addConversions37() {
     add(FirErrors.ILLEGAL_CONST_EXPRESSION) { firDiagnostic ->
         IllegalConstExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MISSING_CONSTRUCTOR_KEYWORD) { firDiagnostic ->
         MissingConstructorKeywordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPERCLASS_NOT_ACCESSIBLE_FROM_INTERFACE) { firDiagnostic ->
         SuperclassNotAccessibleFromInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1840,43 +1840,43 @@ private fun KaDiagnosticConverterBuilder.addConversions37() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NATIVE_GETTER_RETURN_TYPE_SHOULD_BE_NULLABLE) { firDiagnostic ->
         NativeGetterReturnTypeShouldBeNullableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FUN_INTERFACE_ABSTRACT_METHOD_WITH_DEFAULT_VALUE) { firDiagnostic ->
         FunInterfaceAbstractMethodWithDefaultValueImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LATEINIT_INTRINSIC_CALL_IN_INLINE_FUNCTION) { firDiagnostic ->
         LateinitIntrinsicCallInInlineFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SENSELESS_NULL_IN_WHEN) { firDiagnostic ->
         SenselessNullInWhenImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ASSIGNED_VALUE_IS_NEVER_READ) { firDiagnostic ->
         AssignedValueIsNeverReadImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNUSED_LAMBDA_EXPRESSION) { firDiagnostic ->
         UnusedLambdaExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1885,14 +1885,14 @@ private fun KaDiagnosticConverterBuilder.addConversions37() {
 private fun KaDiagnosticConverterBuilder.addConversions38() {
     add(FirErrors.NOT_A_CLASS) { firDiagnostic ->
         NotAClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETER_AS_REIFIED_ARRAY_ERROR) { firDiagnostic ->
         TypeParameterAsReifiedArrayErrorImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1901,7 +1901,7 @@ private fun KaDiagnosticConverterBuilder.addConversions38() {
             firDiagnostic.a.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1911,13 +1911,13 @@ private fun KaDiagnosticConverterBuilder.addConversions38() {
             firDiagnostic.b.map { firModuleData ->
                 firModuleData
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_EXTENSION_RECEIVER_ANNOTATED) { firDiagnostic ->
         CompanionExtensionReceiverAnnotatedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1925,7 +1925,7 @@ private fun KaDiagnosticConverterBuilder.addConversions38() {
         JavaTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1935,39 +1935,39 @@ private fun KaDiagnosticConverterBuilder.addConversions39() {
     add(FirErrors.MISSING_DEPENDENCY_CLASS) { firDiagnostic ->
         MissingDependencyClassImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CYCLIC_CONSTRUCTOR_DELEGATION_CALL) { firDiagnostic ->
         CyclicConstructorDelegationCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONTEXT_PARAMETER_WITH_DEFAULT) { firDiagnostic ->
         ContextParameterWithDefaultImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_PRIVATE_DECLARATION) { firDiagnostic ->
         ExpectedPrivateDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_ELVIS) { firDiagnostic ->
         UselessElvisImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_RELYING_ON_NULL_DEPRECATION.warningFactory) { firDiagnostic ->
         ImpossibleIsCheckRelyingOnNullDeprecationWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1975,7 +1975,7 @@ private fun KaDiagnosticConverterBuilder.addConversions39() {
         ComponentFunctionMissingImpl(
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -1985,27 +1985,27 @@ private fun KaDiagnosticConverterBuilder.addConversions40() {
     add(FirErrors.NESTED_CLASS_NOT_ALLOWED_IN_LOCAL.errorFactory) { firDiagnostic ->
         NestedClassNotAllowedInLocalErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NATIVE_INDEXER_CAN_NOT_HAVE_DEFAULT_ARGUMENTS) { firDiagnostic ->
         NativeIndexerCanNotHaveDefaultArgumentsImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INEFFICIENT_EQUALS_OVERRIDING_IN_VALUE_CLASS) { firDiagnostic ->
         InefficientEqualsOverridingInValueClassImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.DELEGATION_BY_DYNAMIC) { firDiagnostic ->
         DelegationByDynamicImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2014,7 +2014,7 @@ private fun KaDiagnosticConverterBuilder.addConversions40() {
 private fun KaDiagnosticConverterBuilder.addConversions41() {
     add(FirErrors.SEALED_SUPERTYPE) { firDiagnostic ->
         SealedSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2022,33 +2022,33 @@ private fun KaDiagnosticConverterBuilder.addConversions41() {
         OptInUsageImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_VALUE_CLASS_WITH_NO_PRIMARY_CONSTRUCTOR_HAS_SECONDARY) { firDiagnostic ->
         ExpectValueClassWithNoPrimaryConstructorHasSecondaryImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_INFER_VISIBILITY_WARNING) { firDiagnostic ->
         CannotInferVisibilityWarningImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TAIL_RECURSION_IN_TRY_IS_NOT_SUPPORTED) { firDiagnostic ->
         TailRecursionInTryIsNotSupportedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LOCAL_VARIABLE_WITH_TYPE_PARAMETERS) { firDiagnostic ->
         LocalVariableWithTypeParametersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2057,20 +2057,20 @@ private fun KaDiagnosticConverterBuilder.addConversions41() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_VARARG) { firDiagnostic ->
         InvalidVersioningOnVarargImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.INAPPLICABLE_JVM_FIELD_WARNING) { firDiagnostic ->
         InapplicableJvmFieldWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2079,26 +2079,26 @@ private fun KaDiagnosticConverterBuilder.addConversions41() {
 private fun KaDiagnosticConverterBuilder.addConversions42() {
     add(FirErrors.ANNOTATION_ARGUMENT_KCLASS_LITERAL_OF_TYPE_PARAMETER_ERROR) { firDiagnostic ->
         AnnotationArgumentKclassLiteralOfTypeParameterErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPT_IN_ARGUMENT_IS_NOT_MARKER) { firDiagnostic ->
         OptInArgumentIsNotMarkerImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPERATOR_RENAMED_ON_IMPORT) { firDiagnostic ->
         OperatorRenamedOnImportImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_ON_VALUE_CLASS.errorFactory) { firDiagnostic ->
         SynchronizedOnValueClassErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2109,25 +2109,25 @@ private fun KaDiagnosticConverterBuilder.addConversions43() {
         NativeIndexerWrongParameterCountImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CANNOT_BE_RECURSIVE) { firDiagnostic ->
         ValueClassCannotBeRecursiveImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_LATEINIT_PROPERTY) { firDiagnostic ->
         ExpectedLateinitPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_EXTENSION_NULLABLE_RECEIVER) { firDiagnostic ->
         CompanionExtensionNullableReceiverImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2138,19 +2138,19 @@ private fun KaDiagnosticConverterBuilder.addConversions44() {
         VarTypeMismatchOnInheritanceImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNNAMED_VAR_PROPERTY) { firDiagnostic ->
         UnnamedVarPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MULTIPLE_LABELS_ARE_FORBIDDEN) { firDiagnostic ->
         MultipleLabelsAreForbiddenImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2159,13 +2159,13 @@ private fun KaDiagnosticConverterBuilder.addConversions44() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.EXTERNAL_DECLARATION_CANNOT_HAVE_BODY) { firDiagnostic ->
         ExternalDeclarationCannotHaveBodyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2174,19 +2174,19 @@ private fun KaDiagnosticConverterBuilder.addConversions44() {
 private fun KaDiagnosticConverterBuilder.addConversions45() {
     add(FirErrors.GETTER_VISIBILITY_DIFFERS_FROM_PROPERTY_VISIBILITY) { firDiagnostic ->
         GetterVisibilityDiffersFromPropertyVisibilityImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RECURSIVE_TYPEALIAS_EXPANSION) { firDiagnostic ->
         RecursiveTypealiasExpansionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_RECORDS_ILLEGAL_BYTECODE_TARGET) { firDiagnostic ->
         JvmRecordsIllegalBytecodeTargetImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2196,7 +2196,7 @@ private fun KaDiagnosticConverterBuilder.addConversions46() {
     add(FirErrors.NESTED_CLASS_NOT_ALLOWED) { firDiagnostic ->
         NestedClassNotAllowedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2204,25 +2204,25 @@ private fun KaDiagnosticConverterBuilder.addConversions46() {
         FunctionCallExpectedImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PRIMARY_CONSTRUCTOR_DELEGATION_CALL_EXPECTED) { firDiagnostic ->
         PrimaryConstructorDelegationCallExpectedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REIFIED_TYPE_PARAMETER_ON_ALIAS.warningFactory) { firDiagnostic ->
         ReifiedTypeParameterOnAliasWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_MODIFIER_FORM_FOR_BUILT_IN_SUSPEND) { firDiagnostic ->
         NonModifierFormForBuiltInSuspendImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2231,7 +2231,7 @@ private fun KaDiagnosticConverterBuilder.addConversions46() {
 private fun KaDiagnosticConverterBuilder.addConversions47() {
     add(FirErrors.REPEATED_ANNOTATION) { firDiagnostic ->
         RepeatedAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2240,13 +2240,13 @@ private fun KaDiagnosticConverterBuilder.addConversions47() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_BACKING_FIELD_IN_EXTENSION) { firDiagnostic ->
         ExplicitBackingFieldInExtensionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2254,13 +2254,13 @@ private fun KaDiagnosticConverterBuilder.addConversions47() {
         KSuspendFunctionTypeOfDangerouslyLargeArityImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_NONFINAL_CLASS) { firDiagnostic ->
         InvalidVersioningOnNonfinalClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2271,33 +2271,33 @@ private fun KaDiagnosticConverterBuilder.addConversions48() {
         ApiNotAvailableImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RESOLUTION_TO_CLASSIFIER) { firDiagnostic ->
         ResolutionToClassifierImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROJECTION_ON_NON_CLASS_TYPE_ARGUMENT) { firDiagnostic ->
         ProjectionOnNonClassTypeArgumentImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERRIDE_CANNOT_BE_STATIC) { firDiagnostic ->
         OverrideCannotBeStaticImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.EXPOSED_NOT_EXPORTED_SUPER_INTERFACE.warningFactory) { firDiagnostic ->
         ExposedNotExportedSuperInterfaceWarningImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2307,19 +2307,19 @@ private fun KaDiagnosticConverterBuilder.addConversions49() {
     add(FirErrors.INACCESSIBLE_OUTER_CLASS_RECEIVER) { firDiagnostic ->
         InaccessibleOuterClassReceiverImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FINAL_SUPERTYPE) { firDiagnostic ->
         FinalSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_OPEN) { firDiagnostic ->
         ValueClassOpenImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2329,19 +2329,19 @@ private fun KaDiagnosticConverterBuilder.addConversions49() {
             firDiagnostic.b.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DATA_OBJECT_CUSTOM_EQUALS_OR_HASH_CODE) { firDiagnostic ->
         DataObjectCustomEqualsOrHashCodeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_FINAL_PROPERTY_WITH_EXPLICIT_BACKING_FIELD) { firDiagnostic ->
         NonFinalPropertyWithExplicitBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2350,13 +2350,13 @@ private fun KaDiagnosticConverterBuilder.addConversions49() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.SPREAD_OPERATOR_IN_DYNAMIC_CALL) { firDiagnostic ->
         SpreadOperatorInDynamicCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2366,7 +2366,7 @@ private fun KaDiagnosticConverterBuilder.addConversions50() {
     add(FirErrors.OPERATOR_MODIFIER_REQUIRED) { firDiagnostic ->
         OperatorModifierRequiredImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2375,33 +2375,33 @@ private fun KaDiagnosticConverterBuilder.addConversions50() {
 private fun KaDiagnosticConverterBuilder.addConversions51() {
     add(FirErrors.NULLABLE_TYPE_OF_ANNOTATION_MEMBER) { firDiagnostic ->
         NullableTypeOfAnnotationMemberImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ASSIGNING_SINGLE_ELEMENT_TO_VARARG_IN_NAMED_FORM_FUNCTION.errorFactory) { firDiagnostic ->
         AssigningSingleElementToVarargInNamedFormFunctionErrorImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_RELYING_ON_NULL_WARNING) { firDiagnostic ->
         ImpossibleIsCheckRelyingOnNullWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_ON_ABSTRACT) { firDiagnostic ->
         SynchronizedOnAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_USELESS_ON_EXTERNAL_INTERFACE) { firDiagnostic ->
         JsNoRuntimeUselessOnExternalInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2412,13 +2412,13 @@ private fun KaDiagnosticConverterBuilder.addConversions52() {
         DeprecationImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CATCH_PARAMETER_WITH_DEFAULT_VALUE) { firDiagnostic ->
         CatchParameterWithDefaultValueImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2427,7 +2427,7 @@ private fun KaDiagnosticConverterBuilder.addConversions52() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2436,13 +2436,13 @@ private fun KaDiagnosticConverterBuilder.addConversions52() {
 private fun KaDiagnosticConverterBuilder.addConversions53() {
     add(FirErrors.VALUE_CLASS_NOT_TOP_LEVEL) { firDiagnostic ->
         ValueClassNotTopLevelImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_VARARG_ON_PARAMETER) { firDiagnostic ->
         UselessVarargOnParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2451,20 +2451,20 @@ private fun KaDiagnosticConverterBuilder.addConversions53() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_ELSE_IN_WHEN) { firDiagnostic ->
         RedundantElseInWhenImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.INAPPLICABLE_JVM_FIELD) { firDiagnostic ->
         InapplicableJvmFieldImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2473,13 +2473,13 @@ private fun KaDiagnosticConverterBuilder.addConversions53() {
 private fun KaDiagnosticConverterBuilder.addConversions54() {
     add(FirErrors.CLASS_IN_SUPERTYPE_FOR_ENUM) { firDiagnostic ->
         ClassInSupertypeForEnumImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPERTYPES_FOR_ANNOTATION_CLASS) { firDiagnostic ->
         SupertypesForAnnotationClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2488,20 +2488,20 @@ private fun KaDiagnosticConverterBuilder.addConversions54() {
             firDiagnostic.a,
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LATEINIT_INTRINSIC_CALL_ON_NON_LITERAL) { firDiagnostic ->
         LateinitIntrinsicCallOnNonLiteralImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_BE_IMPORTED) { firDiagnostic ->
         CannotBeImportedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2510,7 +2510,7 @@ private fun KaDiagnosticConverterBuilder.addConversions54() {
 private fun KaDiagnosticConverterBuilder.addConversions55() {
     add(FirErrors.SUPER_NOT_AVAILABLE) { firDiagnostic ->
         SuperNotAvailableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2520,7 +2520,7 @@ private fun KaDiagnosticConverterBuilder.addConversions55() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2530,20 +2530,20 @@ private fun KaDiagnosticConverterBuilder.addConversions55() {
             firDiagnostic.b.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.WRONG_CONDITION_SUGGEST_GUARD) { firDiagnostic ->
         WrongConditionSuggestGuardImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETER_ON_LHS_OF_DOT) { firDiagnostic ->
         TypeParameterOnLhsOfDotImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2551,7 +2551,7 @@ private fun KaDiagnosticConverterBuilder.addConversions55() {
         JavaClassOnCompanionImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2559,13 +2559,13 @@ private fun KaDiagnosticConverterBuilder.addConversions55() {
         RepeatableContainerHasNonDefaultParameterErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.INLINE_CLASS_IN_EXTERNAL_DECLARATION_WARNING) { firDiagnostic ->
         InlineClassInExternalDeclarationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2576,7 +2576,7 @@ private fun KaDiagnosticConverterBuilder.addConversions56() {
         IncompatibleTypesImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2587,26 +2587,26 @@ private fun KaDiagnosticConverterBuilder.addConversions56() {
             firDiagnostic.c.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_ACCESS_TO_ENTRY_PROPERTY_FROM_ENUM) { firDiagnostic ->
         DeprecatedAccessToEntryPropertyFromEnumImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERLOADS_INTERFACE) { firDiagnostic ->
         OverloadsInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED) { firDiagnostic ->
         RuntimeAnnotationOnLambdaIsNotRetainedImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2619,14 +2619,14 @@ private fun KaDiagnosticConverterBuilder.addConversions57() {
             firDiagnostic.b,
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INITIALIZATION_BEFORE_DECLARATION_WARNING) { firDiagnostic ->
         InitializationBeforeDeclarationWarningImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2635,7 +2635,7 @@ private fun KaDiagnosticConverterBuilder.addConversions57() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2644,25 +2644,25 @@ private fun KaDiagnosticConverterBuilder.addConversions57() {
 private fun KaDiagnosticConverterBuilder.addConversions58() {
     add(FirErrors.SUPERTYPE_NOT_INITIALIZED) { firDiagnostic ->
         SupertypeNotInitializedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CANNOT_BE_CLONEABLE) { firDiagnostic ->
         ValueClassCannotBeCloneableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_PARAMETER_WITHOUT_EXPLICIT_TYPE) { firDiagnostic ->
         ValueParameterWithoutExplicitTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPTIONAL_EXPECTATION_NOT_ON_EXPECTED) { firDiagnostic ->
         OptionalExpectationNotOnExpectedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2670,19 +2670,19 @@ private fun KaDiagnosticConverterBuilder.addConversions58() {
         ForbiddenIdentityEqualsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CAN_BE_VAL) { firDiagnostic ->
         CanBeValImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERLOADS_LOCAL) { firDiagnostic ->
         OverloadsLocalImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2691,13 +2691,13 @@ private fun KaDiagnosticConverterBuilder.addConversions58() {
 private fun KaDiagnosticConverterBuilder.addConversions59() {
     add(FirErrors.FLOAT_LITERAL_OUT_OF_RANGE) { firDiagnostic ->
         FloatLiteralOutOfRangeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NAME_PROHIBITED_FOR_OVERRIDE) { firDiagnostic ->
         JsNameProhibitedForOverrideImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2707,25 +2707,25 @@ private fun KaDiagnosticConverterBuilder.addConversions59() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.d),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NAME_FOR_AMBIGUOUS_PARAMETER) { firDiagnostic ->
         NameForAmbiguousParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_INFER_IT_PARAMETER_TYPE) { firDiagnostic ->
         CannotInferItParameterTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LOCAL_VARIABLE_WITH_TYPE_PARAMETERS_WARNING) { firDiagnostic ->
         LocalVariableWithTypeParametersWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2739,7 +2739,7 @@ private fun KaDiagnosticConverterBuilder.addConversions59() {
                                     firSymbolBuilder.buildSymbol(firBasedSymbol)
                                 }
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2748,14 +2748,14 @@ private fun KaDiagnosticConverterBuilder.addConversions59() {
 private fun KaDiagnosticConverterBuilder.addConversions60() {
     add(FirErrors.SEALED_INHERITOR_IN_DIFFERENT_PACKAGE) { firDiagnostic ->
         SealedInheritorInDifferentPackageImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EQUALITY_BOUND_ARGUMENT_EXPANDS_TO_NON_STAR_PROJECTED) { firDiagnostic ->
         EqualityBoundArgumentExpandsToNonStarProjectedImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2763,19 +2763,19 @@ private fun KaDiagnosticConverterBuilder.addConversions60() {
         DataClassOverrideConflictImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OVERRIDE_BY_INLINE) { firDiagnostic ->
         OverrideByInlineImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_EXPOSE_LOCALS) { firDiagnostic ->
         JvmExposeBoxedCannotExposeLocalsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2784,33 +2784,33 @@ private fun KaDiagnosticConverterBuilder.addConversions60() {
 private fun KaDiagnosticConverterBuilder.addConversions61() {
     add(FirErrors.DEPRECATED_SINCE_KOTLIN_WITH_DEPRECATED_LEVEL) { firDiagnostic ->
         DeprecatedSinceKotlinWithDeprecatedLevelImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INLINE_CLASS_CONSTRUCTOR_WRONG_PARAMETERS_SIZE) { firDiagnostic ->
         InlineClassConstructorWrongParametersSizeImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CALLABLE_REFERENCE_TO_CONTEXTUAL_DECLARATION) { firDiagnostic ->
         CallableReferenceToContextualDeclarationImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_FORBIDDEN_IS_CHECK) { firDiagnostic ->
         JsNoRuntimeForbiddenIsCheckImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT) { firDiagnostic ->
         JsNoRuntimeActualAnnotationsNotMatchExpectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2819,19 +2819,19 @@ private fun KaDiagnosticConverterBuilder.addConversions61() {
 private fun KaDiagnosticConverterBuilder.addConversions62() {
     add(FirErrors.TRIM_MARGIN_BLANK_PREFIX) { firDiagnostic ->
         TrimMarginBlankPrefixImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PLACEHOLDER_PROJECTION_IN_TYPEREF) { firDiagnostic ->
         PlaceholderProjectionInTyperefImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_USED_AS_ANNOTATION_ARGUMENT) { firDiagnostic ->
         AnnotationUsedAsAnnotationArgumentImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2841,32 +2841,32 @@ private fun KaDiagnosticConverterBuilder.addConversions62() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_NOT_FINAL) { firDiagnostic ->
         ValueClassNotFinalImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_PROPERTY_IN_PRIMARY_CONSTRUCTOR_PARAMETERS) { firDiagnostic ->
         AbstractPropertyInPrimaryConstructorParametersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMMA_IN_WHEN_CONDITION_WITHOUT_ARGUMENT) { firDiagnostic ->
         CommaInWhenConditionWithoutArgumentImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.ANNOTATION_TARGETS_ONLY_IN_JAVA) { firDiagnostic ->
         AnnotationTargetsOnlyInJavaImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2875,20 +2875,20 @@ private fun KaDiagnosticConverterBuilder.addConversions62() {
 private fun KaDiagnosticConverterBuilder.addConversions63() {
     add(FirErrors.DEPRECATED_SINCE_KOTLIN_WITH_UNORDERED_VERSIONS) { firDiagnostic ->
         DeprecatedSinceKotlinWithUnorderedVersionsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_OPERATOR_MODIFIER) { firDiagnostic ->
         InapplicableOperatorModifierImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_INFER_RECEIVER_PARAMETER_TYPE) { firDiagnostic ->
         CannotInferReceiverParameterTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2897,26 +2897,26 @@ private fun KaDiagnosticConverterBuilder.addConversions63() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_DEPRECATION.warningFactory) { firDiagnostic ->
         ImpossibleIsCheckDeprecationWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_PACKAGE_NAME_CANNOT_BE_EMPTY) { firDiagnostic ->
         JvmPackageNameCannotBeEmptyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_RECORD_NOT_VAL_PARAMETER) { firDiagnostic ->
         JvmRecordNotValParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2926,25 +2926,25 @@ private fun KaDiagnosticConverterBuilder.addConversions64() {
     add(FirErrors.EXTENDING_AN_ANNOTATION_CLASS.warningFactory) { firDiagnostic ->
         ExtendingAnAnnotationClassWarningImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_EXPLICIT_BACKING_FIELD) { firDiagnostic ->
         RedundantExplicitBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_RECORD_WITHOUT_PRIMARY_CONSTRUCTOR_PARAMETERS) { firDiagnostic ->
         JvmRecordWithoutPrimaryConstructorParametersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_ANONYMOUS_INITIALIZER) { firDiagnostic ->
         ExternalAnonymousInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2953,7 +2953,7 @@ private fun KaDiagnosticConverterBuilder.addConversions64() {
 private fun KaDiagnosticConverterBuilder.addConversions65() {
     add(FirErrors.UNSUPPORTED_SUSPEND_TEST) { firDiagnostic ->
         UnsupportedSuspendTestImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2961,7 +2961,7 @@ private fun KaDiagnosticConverterBuilder.addConversions65() {
         OptInUsageErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2970,20 +2970,20 @@ private fun KaDiagnosticConverterBuilder.addConversions65() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.WHEN_SUBJECT_CAN_BE_NULL_IN_JAVA) { firDiagnostic ->
         WhenSubjectCanBeNullInJavaImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.WRONG_BODY_OF_EXTERNAL_DECLARATION) { firDiagnostic ->
         WrongBodyOfExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -2992,7 +2992,7 @@ private fun KaDiagnosticConverterBuilder.addConversions65() {
 private fun KaDiagnosticConverterBuilder.addConversions66() {
     add(FirErrors.NOT_A_LOOP_LABEL) { firDiagnostic ->
         NotALoopLabelImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3002,37 +3002,37 @@ private fun KaDiagnosticConverterBuilder.addConversions66() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSUPPORTED_CONTEXTUAL_DECLARATION_CALL) { firDiagnostic ->
         UnsupportedContextualDeclarationCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PRIVATE_SETTER_FOR_ABSTRACT_PROPERTY) { firDiagnostic ->
         PrivateSetterForAbstractPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LATEINIT_NULLABLE_BACKING_FIELD) { firDiagnostic ->
         LateinitNullableBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.BACKING_FIELD_FOR_DELEGATED_PROPERTY) { firDiagnostic ->
         BackingFieldForDelegatedPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_BE_THE_SAME_AS_JVM_NAME) { firDiagnostic ->
         JvmExposeBoxedCannotBeTheSameAsJvmNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3041,7 +3041,7 @@ private fun KaDiagnosticConverterBuilder.addConversions66() {
 private fun KaDiagnosticConverterBuilder.addConversions67() {
     add(FirErrors.INT_LITERAL_WITH_LEADING_ZEROS) { firDiagnostic ->
         IntLiteralWithLeadingZerosImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3049,38 +3049,38 @@ private fun KaDiagnosticConverterBuilder.addConversions67() {
         ConditionTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COROUTINE_CONTEXT_AS_CONTEXT_PARAMETER_IS_RESERVED) { firDiagnostic ->
         CoroutineContextAsContextParameterIsReservedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DESTRUCTURING_SHORT_FORM_UNDERSCORE) { firDiagnostic ->
         DestructuringShortFormUnderscoreImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_VALUE_NOT_USED_COERCION) { firDiagnostic ->
         ReturnValueNotUsedCoercionImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_IN_FUNCTION_WITH_EXPRESSION_BODY) { firDiagnostic ->
         ReturnInFunctionWithExpressionBodyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_PACKAGE_NAME_MUST_BE_VALID_NAME) { firDiagnostic ->
         JvmPackageNameMustBeValidNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3090,32 +3090,32 @@ private fun KaDiagnosticConverterBuilder.addConversions68() {
     add(FirErrors.NESTED_CLASS_ACCESSED_VIA_INSTANCE_REFERENCE) { firDiagnostic ->
         NestedClassAccessedViaInstanceReferenceImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VARIABLE_WITH_NO_TYPE_NO_INITIALIZER) { firDiagnostic ->
         VariableWithNoTypeNoInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_SUSPEND_FUNCTION_CALL) { firDiagnostic ->
         IllegalSuspendFunctionCallImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.POSITIONED_VALUE_ARGUMENT_FOR_JAVA_ANNOTATION) { firDiagnostic ->
         PositionedValueArgumentForJavaAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.CALL_TO_DEFINED_EXTERNALLY_FROM_NON_EXTERNAL_DECLARATION) { firDiagnostic ->
         CallToDefinedExternallyFromNonExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3124,7 +3124,7 @@ private fun KaDiagnosticConverterBuilder.addConversions68() {
 private fun KaDiagnosticConverterBuilder.addConversions69() {
     add(FirErrors.ANNOTATION_ON_SUPERCLASS_ERROR) { firDiagnostic ->
         AnnotationOnSuperclassErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3132,7 +3132,7 @@ private fun KaDiagnosticConverterBuilder.addConversions69() {
         WrongModifierTargetImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3140,14 +3140,14 @@ private fun KaDiagnosticConverterBuilder.addConversions69() {
         ComponentFunctionOnNullableImpl(
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ERROR_IN_CONTRACT_DESCRIPTION) { firDiagnostic ->
         ErrorInContractDescriptionImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3157,14 +3157,14 @@ private fun KaDiagnosticConverterBuilder.addConversions70() {
     add(FirErrors.SUBCLASS_OPT_IN_ARGUMENT_IS_NOT_MARKER) { firDiagnostic ->
         SubclassOptInArgumentIsNotMarkerImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_TYPE_ARGUMENT_FOR_VARARG_PARAMETER_WARNING) { firDiagnostic ->
         IllegalTypeArgumentForVarargParameterWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3173,13 +3173,13 @@ private fun KaDiagnosticConverterBuilder.addConversions70() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONTEXT_PARAMETERS_WITH_BACKING_FIELD) { firDiagnostic ->
         ContextParametersWithBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3188,19 +3188,19 @@ private fun KaDiagnosticConverterBuilder.addConversions70() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DECLARATION_CANT_BE_INLINED) { firDiagnostic ->
         DeclarationCantBeInlinedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_ON_VALUE_CLASS.warningFactory) { firDiagnostic ->
         SynchronizedOnValueClassWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3208,7 +3208,7 @@ private fun KaDiagnosticConverterBuilder.addConversions70() {
         SyntheticPropertyWithoutJavaOriginImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3217,19 +3217,19 @@ private fun KaDiagnosticConverterBuilder.addConversions70() {
 private fun KaDiagnosticConverterBuilder.addConversions71() {
     add(FirErrors.ROOT_IDE_PACKAGE_DEPRECATED) { firDiagnostic ->
         RootIdePackageDeprecatedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SMARTCAST_TO_TYPE_VARIABLE) { firDiagnostic ->
         SmartcastToTypeVariableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_FILE_TARGET) { firDiagnostic ->
         InapplicableFileTargetImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3239,7 +3239,7 @@ private fun KaDiagnosticConverterBuilder.addConversions71() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3249,14 +3249,14 @@ private fun KaDiagnosticConverterBuilder.addConversions71() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPEALIAS_EXPANDS_TO_COMPILER_REQUIRED_ANNOTATION.warningFactory) { firDiagnostic ->
         TypealiasExpandsToCompilerRequiredAnnotationWarningImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3264,26 +3264,26 @@ private fun KaDiagnosticConverterBuilder.addConversions71() {
         RedundantRepeatableAnnotationImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_RECORD_EXTENDS_CLASS) { firDiagnostic ->
         JvmRecordExtendsClassImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SUBCLASS_CANT_CALL_COMPANION_PROTECTED_NON_STATIC) { firDiagnostic ->
         SubclassCantCallCompanionProtectedNonStaticImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_INTERFACE_AS_CLASS_LITERAL) { firDiagnostic ->
         ExternalInterfaceAsClassLiteralImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3292,13 +3292,13 @@ private fun KaDiagnosticConverterBuilder.addConversions71() {
 private fun KaDiagnosticConverterBuilder.addConversions72() {
     add(FirErrors.ILLEGAL_UNDERSCORE) { firDiagnostic ->
         IllegalUnderscoreImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INT_LITERAL_OUT_OF_RANGE) { firDiagnostic ->
         IntLiteralOutOfRangeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3306,7 +3306,7 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
         FunctionExpectedImpl(
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3315,14 +3315,14 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
             firDiagnostic.a.map { string ->
                 string
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPLICIT_PROPERTY_TYPE_MAKES_BEHAVIOR_ORDER_DEPENDANT) { firDiagnostic ->
         ImplicitPropertyTypeMakesBehaviorOrderDependantImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3330,7 +3330,7 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
         ReservedMemberFromInterfaceInsideValueClassImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3339,7 +3339,7 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3347,7 +3347,7 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
         PropertyTypeMismatchOnOverrideImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3355,7 +3355,7 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
         ManyImplMemberNotImplementedImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3363,7 +3363,7 @@ private fun KaDiagnosticConverterBuilder.addConversions72() {
         DeprecatedIdentityEqualsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3375,7 +3375,7 @@ private fun KaDiagnosticConverterBuilder.addConversions73() {
             firDiagnostic.a.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3383,7 +3383,7 @@ private fun KaDiagnosticConverterBuilder.addConversions73() {
         OverridingFinalMemberImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3391,32 +3391,32 @@ private fun KaDiagnosticConverterBuilder.addConversions73() {
         VirtualMemberHiddenImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FUN_INTERFACE_ABSTRACT_METHOD_WITH_TYPE_PARAMETERS) { firDiagnostic ->
         FunInterfaceAbstractMethodWithTypeParametersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONST_VAL_WITH_GETTER) { firDiagnostic ->
         ConstValWithGetterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_CANT_BE_USED_FOR_CONST_VAL) { firDiagnostic ->
         TypeCantBeUsedForConstValImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPLEMENTATION_BY_DELEGATION_IN_EXPECT_CLASS) { firDiagnostic ->
         ImplementationByDelegationInExpectClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3426,14 +3426,14 @@ private fun KaDiagnosticConverterBuilder.addConversions73() {
             firDiagnostic.b.map { firNamedFunctionSymbol ->
                 firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firNamedFunctionSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LEAKED_IN_PLACE_LAMBDA) { firDiagnostic ->
         LeakedInPlaceLambdaImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3441,13 +3441,13 @@ private fun KaDiagnosticConverterBuilder.addConversions73() {
         NonPublicInlineCallFromPublicInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_ANNOTATION_CLASS) { firDiagnostic ->
         InvalidVersioningOnAnnotationClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3457,19 +3457,19 @@ private fun KaDiagnosticConverterBuilder.addConversions74() {
     add(FirErrors.UNSUPPORTED_INHERITANCE_FROM_JAVA_MEMBER_REFERENCING_KOTLIN_FUNCTION) { firDiagnostic ->
         UnsupportedInheritanceFromJavaMemberReferencingKotlinFunctionImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VAL_WITH_SETTER) { firDiagnostic ->
         ValWithSetterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VARIABLE_NEVER_READ) { firDiagnostic ->
         VariableNeverReadImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3477,13 +3477,13 @@ private fun KaDiagnosticConverterBuilder.addConversions74() {
         PrivateClassMemberFromInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JAVA_MODULE_DOES_NOT_READ_UNNAMED_MODULE) { firDiagnostic ->
         JavaModuleDoesNotReadUnnamedModuleImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3496,7 +3496,7 @@ private fun KaDiagnosticConverterBuilder.addConversions75() {
             firDiagnostic.b.source!!.psi as KtExpression,
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3510,25 +3510,25 @@ private fun KaDiagnosticConverterBuilder.addConversions76() {
             firDiagnostic.c.map { kotlinTarget ->
                 kotlinTarget
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_VARARG_OVERLOAD_OF_OPERATOR_OF) { firDiagnostic ->
         NoVarargOverloadOfOperatorOfImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_DEFAULT_WITH_COMPATIBILITY_NOT_IN_NO_COMPATIBILITY_MODE) { firDiagnostic ->
         JvmDefaultWithCompatibilityNotInNoCompatibilityModeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_DELEGATED_CONSTRUCTOR_CALL) { firDiagnostic ->
         ExternalDelegatedConstructorCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3537,7 +3537,7 @@ private fun KaDiagnosticConverterBuilder.addConversions76() {
 private fun KaDiagnosticConverterBuilder.addConversions77() {
     add(FirErrors.DYNAMIC_UPPER_BOUND) { firDiagnostic ->
         DynamicUpperBoundImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3545,13 +3545,13 @@ private fun KaDiagnosticConverterBuilder.addConversions77() {
         ReturnTypeMismatchOnOverrideImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_STATIC_ON_CONST) { firDiagnostic ->
         JsStaticOnConstImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3562,38 +3562,38 @@ private fun KaDiagnosticConverterBuilder.addConversions78() {
         MissingDependencyClassInTypealiasImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_ARGUMENT_MUST_BE_ENUM_CONST) { firDiagnostic ->
         AnnotationArgumentMustBeEnumConstImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_IN_WHERE_CLAUSE_ERROR) { firDiagnostic ->
         AnnotationInWhereClauseErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_TAIL_CALLS_FOUND) { firDiagnostic ->
         NoTailCallsFoundImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_NULL_ASSERTION_ON_LAMBDA_EXPRESSION) { firDiagnostic ->
         NotNullAssertionOnLambdaExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPEALIAS_SHOULD_EXPAND_TO_CLASS) { firDiagnostic ->
         TypealiasShouldExpandToClassImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3601,7 +3601,7 @@ private fun KaDiagnosticConverterBuilder.addConversions78() {
         JavaModuleDoesNotExportPackageImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3614,14 +3614,14 @@ private fun KaDiagnosticConverterBuilder.addConversions79() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_PUBLIC_DATA_COPY_CALL_FROM_PUBLIC_INLINE.errorFactory) { firDiagnostic ->
         NonPublicDataCopyCallFromPublicInlineErrorImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3632,7 +3632,7 @@ private fun KaDiagnosticConverterBuilder.addConversions80() {
         OverrideDeprecationImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3641,7 +3641,7 @@ private fun KaDiagnosticConverterBuilder.addConversions80() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3651,19 +3651,19 @@ private fun KaDiagnosticConverterBuilder.addConversions80() {
             firDiagnostic.b.source!!.psi as KtExpression,
             firDiagnostic.c,
             firDiagnostic.d?.source?.psi as? KtExpression,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_BLOCK_NESTED) { firDiagnostic ->
         CompanionBlockNestedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_SYNTHETIC_ON_DELEGATE) { firDiagnostic ->
         JvmSyntheticOnDelegateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3672,13 +3672,13 @@ private fun KaDiagnosticConverterBuilder.addConversions80() {
 private fun KaDiagnosticConverterBuilder.addConversions81() {
     add(FirErrors.NOT_A_SUPERTYPE) { firDiagnostic ->
         NotASupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANONYMOUS_SUSPEND_FUNCTION) { firDiagnostic ->
         AnonymousSuspendFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3687,7 +3687,7 @@ private fun KaDiagnosticConverterBuilder.addConversions81() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3696,39 +3696,39 @@ private fun KaDiagnosticConverterBuilder.addConversions81() {
 private fun KaDiagnosticConverterBuilder.addConversions82() {
     add(FirErrors.SEALED_INHERITOR_IN_DIFFERENT_MODULE) { firDiagnostic ->
         SealedInheritorInDifferentModuleImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONSTRUCTOR_IN_OBJECT) { firDiagnostic ->
         ConstructorInObjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_SINCE_KOTLIN_WITHOUT_ARGUMENTS) { firDiagnostic ->
         DeprecatedSinceKotlinWithoutArgumentsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_DELEGATED_PROPERTY) { firDiagnostic ->
         AbstractDelegatedPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_TYPE_ARGUMENTS_IN_PROPERTY_ACCESS) { firDiagnostic ->
         ExplicitTypeArgumentsInPropertyAccessImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_COMPANION_OBJECT) { firDiagnostic ->
         NoCompanionObjectImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3737,13 +3737,13 @@ private fun KaDiagnosticConverterBuilder.addConversions82() {
 private fun KaDiagnosticConverterBuilder.addConversions83() {
     add(FirErrors.SELF_CALL_IN_NESTED_OBJECT_CONSTRUCTOR_ERROR) { firDiagnostic ->
         SelfCallInNestedObjectConstructorErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DATA_CLASS_INVISIBLE_COPY_USAGE.errorFactory) { firDiagnostic ->
         DataClassInvisibleCopyUsageErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3751,38 +3751,38 @@ private fun KaDiagnosticConverterBuilder.addConversions83() {
         DslMarkerAppliedToWrongTargetImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.JS_MODULE_PROHIBITED_ON_VAR) { firDiagnostic ->
         JsModuleProhibitedOnVarImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_PROPERTY_WITH_INITIALIZER) { firDiagnostic ->
         AbstractPropertyWithInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INITIALIZER_REQUIRED_FOR_DESTRUCTURING_DECLARATION) { firDiagnostic ->
         InitializerRequiredForDestructuringDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_RETURN_IN_FUNCTION_WITH_BLOCK_BODY) { firDiagnostic ->
         NoReturnInFunctionWithBlockBodyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPER_CALL_FROM_PUBLIC_INLINE) { firDiagnostic ->
         SuperCallFromPublicInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3791,26 +3791,26 @@ private fun KaDiagnosticConverterBuilder.addConversions83() {
 private fun KaDiagnosticConverterBuilder.addConversions84() {
     add(FirErrors.DELEGATION_IN_INTERFACE) { firDiagnostic ->
         DelegationInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DATA_CLASS_WITHOUT_PARAMETERS) { firDiagnostic ->
         DataClassWithoutParametersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSENCE_OF_PRIMARY_CONSTRUCTOR_FOR_VALUE_CLASS) { firDiagnostic ->
         AbsenceOfPrimaryConstructorForValueClassImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PRIVATE_PROPERTY_IN_INTERFACE) { firDiagnostic ->
         PrivatePropertyInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3820,14 +3820,14 @@ private fun KaDiagnosticConverterBuilder.addConversions85() {
     add(FirErrors.INTERFACE_AS_FUNCTION) { firDiagnostic ->
         InterfaceAsFunctionImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_ANNOTATION_TARGET) { firDiagnostic ->
         RedundantAnnotationTargetImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3836,26 +3836,26 @@ private fun KaDiagnosticConverterBuilder.addConversions85() {
             firDiagnostic.a,
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.BACKING_FIELD_IN_INTERFACE) { firDiagnostic ->
         BackingFieldInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_RETURN) { firDiagnostic ->
         RedundantReturnImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE) { firDiagnostic ->
         JavaModuleDoesNotDependOnModuleImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3867,7 +3867,7 @@ private fun KaDiagnosticConverterBuilder.addConversions86() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3876,7 +3876,7 @@ private fun KaDiagnosticConverterBuilder.addConversions86() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3886,7 +3886,7 @@ private fun KaDiagnosticConverterBuilder.addConversions86() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3895,7 +3895,7 @@ private fun KaDiagnosticConverterBuilder.addConversions86() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3904,13 +3904,13 @@ private fun KaDiagnosticConverterBuilder.addConversions86() {
             firDiagnostic.a.map { whenMissingCase ->
                 whenMissingCase.toKaWhenMissingCase()
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INLINE_CLASS_DEPRECATED) { firDiagnostic ->
         InlineClassDeprecatedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3919,7 +3919,7 @@ private fun KaDiagnosticConverterBuilder.addConversions86() {
 private fun KaDiagnosticConverterBuilder.addConversions87() {
     add(FirErrors.DELEGATED_PROPERTY_INSIDE_VALUE_CLASS) { firDiagnostic ->
         DelegatedPropertyInsideValueClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3928,26 +3928,26 @@ private fun KaDiagnosticConverterBuilder.addConversions87() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VAL_REASSIGNMENT) { firDiagnostic ->
         ValReassignmentImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_CALL_OF_CONVERSION_METHOD) { firDiagnostic ->
         RedundantCallOfConversionMethodImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.JSCODE_ARGUMENT_NON_CONST_EXPRESSION) { firDiagnostic ->
         JscodeArgumentNonConstExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3957,33 +3957,33 @@ private fun KaDiagnosticConverterBuilder.addConversions88() {
     add(FirErrors.ESCAPING_CAPTURED_VARIABLE) { firDiagnostic ->
         EscapingCapturedVariableImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PARENTHESIZED_PACKAGE_QUALIFIER.errorFactory) { firDiagnostic ->
         ParenthesizedPackageQualifierErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNRESOLVED_COLLECTION_LITERAL) { firDiagnostic ->
         UnresolvedCollectionLiteralImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_TARGET_PROPERTY_IMMUTABLE) { firDiagnostic ->
         InapplicableTargetPropertyImmutableImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED) { firDiagnostic ->
         MustBeInitializedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -3992,7 +3992,7 @@ private fun KaDiagnosticConverterBuilder.addConversions88() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4002,7 +4002,7 @@ private fun KaDiagnosticConverterBuilder.addConversions88() {
             firDiagnostic.b.source!!.psi as KtExpression,
             firDiagnostic.c,
             firDiagnostic.d?.source?.psi as? KtExpression,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4012,7 +4012,7 @@ private fun KaDiagnosticConverterBuilder.addConversions89() {
     add(FirErrors.VAL_OR_VAR_ON_SECONDARY_CONSTRUCTOR_PARAMETER) { firDiagnostic ->
         ValOrVarOnSecondaryConstructorParameterImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4022,33 +4022,33 @@ private fun KaDiagnosticConverterBuilder.addConversions89() {
             firDiagnostic.b.map { kotlinTarget ->
                 kotlinTarget
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_CANDIDATE) { firDiagnostic ->
         InapplicableCandidateImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_VARARG_SPREAD) { firDiagnostic ->
         NonVarargSpreadImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSUPPORTED_ARRAY_OF_NOTHING_IN_CLASS_LITERAL_LHS) { firDiagnostic ->
         UnsupportedArrayOfNothingInClassLiteralLhsImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_TYPE_ALIAS_WITH_USE_SITE_VARIANCE) { firDiagnostic ->
         ActualTypeAliasWithUseSiteVarianceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4057,21 +4057,21 @@ private fun KaDiagnosticConverterBuilder.addConversions89() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_COMPANION_BLOCK) { firDiagnostic ->
         IllegalCompanionBlockImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SUSPENSION_POINT_INSIDE_CRITICAL_SECTION) { firDiagnostic ->
         SuspensionPointInsideCriticalSectionImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4085,13 +4085,13 @@ private fun KaDiagnosticConverterBuilder.addConversions90() {
             firDiagnostic.c.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_INTERNAL_PUBLISHED_API) { firDiagnostic ->
         NonInternalPublishedApiImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4099,32 +4099,32 @@ private fun KaDiagnosticConverterBuilder.addConversions90() {
         DeprecatedModifierContainingDeclarationImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.BOUNDS_NOT_ALLOWED_IF_BOUNDED_BY_TYPE_PARAMETER) { firDiagnostic ->
         BoundsNotAllowedIfBoundedByTypeParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_NULLABLE) { firDiagnostic ->
         RedundantNullableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CLASS_LITERAL_LHS_NOT_A_CLASS_WARNING) { firDiagnostic ->
         ClassLiteralLhsNotAClassWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_FUNCTION_WITH_BODY) { firDiagnostic ->
         AbstractFunctionWithBodyImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4133,7 +4133,7 @@ private fun KaDiagnosticConverterBuilder.addConversions90() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4141,7 +4141,7 @@ private fun KaDiagnosticConverterBuilder.addConversions90() {
         InferredInvisibleWhenTypeWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4150,7 +4150,7 @@ private fun KaDiagnosticConverterBuilder.addConversions90() {
 private fun KaDiagnosticConverterBuilder.addConversions91() {
     add(FirErrors.SINGLETON_IN_SUPERTYPE) { firDiagnostic ->
         SingletonInSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4158,7 +4158,7 @@ private fun KaDiagnosticConverterBuilder.addConversions91() {
         SealedSupertypeInLocalClassImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4168,26 +4168,26 @@ private fun KaDiagnosticConverterBuilder.addConversions91() {
             firDiagnostic.b.map { kotlinTarget ->
                 kotlinTarget
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_EXPLICIT_VISIBILITY_IN_API_MODE_WARNING) { firDiagnostic ->
         NoExplicitVisibilityInApiModeWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_LOCAL_RETURN_NOT_ALLOWED) { firDiagnostic ->
         NonLocalReturnNotAllowedImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_INLINE_WITHOUT_VALUE_CLASS) { firDiagnostic ->
         JvmInlineWithoutValueClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4196,13 +4196,13 @@ private fun KaDiagnosticConverterBuilder.addConversions91() {
 private fun KaDiagnosticConverterBuilder.addConversions92() {
     add(FirErrors.VARIABLE_EXPECTED) { firDiagnostic ->
         VariableExpectedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PARENTHESIZED_PACKAGE_QUALIFIER.warningFactory) { firDiagnostic ->
         ParenthesizedPackageQualifierWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4210,46 +4210,46 @@ private fun KaDiagnosticConverterBuilder.addConversions92() {
         DeprecationErrorImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXTENDING_AN_ANNOTATION_CLASS.errorFactory) { firDiagnostic ->
         ExtendingAnAnnotationClassErrorImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.WRONG_EXTENSION_FUNCTION_TYPE) { firDiagnostic ->
         WrongExtensionFunctionTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_EMPTY_CONSTRUCTOR) { firDiagnostic ->
         ValueClassEmptyConstructorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FUNCTION_DECLARATION_WITH_NO_NAME) { firDiagnostic ->
         FunctionDeclarationWithNoNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNDERSCORE_IS_RESERVED) { firDiagnostic ->
         UnderscoreIsReservedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NON_EXPORTABLE_TYPE_IN_SYNTHETIC_COPY_WITHOUT_CONSISTENT_VISIBILITY) { firDiagnostic ->
         NonExportableTypeInSyntheticCopyWithoutConsistentVisibilityImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4258,25 +4258,25 @@ private fun KaDiagnosticConverterBuilder.addConversions92() {
 private fun KaDiagnosticConverterBuilder.addConversions93() {
     add(FirErrors.OPT_IN_CAN_ONLY_BE_USED_AS_ANNOTATION) { firDiagnostic ->
         OptInCanOnlyBeUsedAsAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DUPLICATE_BRANCH_CONDITION_IN_WHEN) { firDiagnostic ->
         DuplicateBranchConditionInWhenImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VARIABLE_INITIALIZER_IS_REDUNDANT) { firDiagnostic ->
         VariableInitializerIsRedundantImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.USELESS_JVM_EXPOSE_BOXED) { firDiagnostic ->
         UselessJvmExposeBoxedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4285,13 +4285,13 @@ private fun KaDiagnosticConverterBuilder.addConversions93() {
 private fun KaDiagnosticConverterBuilder.addConversions94() {
     add(FirErrors.NON_PRIVATE_CONSTRUCTOR_IN_ENUM) { firDiagnostic ->
         NonPrivateConstructorInEnumImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IGNORABILITY_ANNOTATIONS_WITH_CHECKER_DISABLED) { firDiagnostic ->
         IgnorabilityAnnotationsWithCheckerDisabledImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4301,32 +4301,32 @@ private fun KaDiagnosticConverterBuilder.addConversions94() {
             firDiagnostic.b.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_QUALIFIER_IN_LHS_OF_CALLABLE_REFERENCE_TO_STATIC.warningFactory) { firDiagnostic ->
         InvalidQualifierInLhsOfCallableReferenceToStaticWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INNER_CLASS_OF_GENERIC_THROWABLE_SUBCLASS) { firDiagnostic ->
         InnerClassOfGenericThrowableSubclassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_SET_METHOD) { firDiagnostic ->
         NoSetMethodImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_VISIBILITY_MODIFIER) { firDiagnostic ->
         RedundantVisibilityModifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4335,13 +4335,13 @@ private fun KaDiagnosticConverterBuilder.addConversions94() {
 private fun KaDiagnosticConverterBuilder.addConversions95() {
     add(FirErrors.SECONDARY_CONSTRUCTOR_WITH_BODY_INSIDE_VALUE_CLASS) { firDiagnostic ->
         SecondaryConstructorWithBodyInsideValueClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_EXPOSE_SYNTHETIC) { firDiagnostic ->
         JvmExposeBoxedCannotExposeSyntheticImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4353,13 +4353,13 @@ private fun KaDiagnosticConverterBuilder.addConversions96() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NULLABLE_TYPE_IN_CLASS_LITERAL_LHS) { firDiagnostic ->
         NullableTypeInClassLiteralLhsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4369,13 +4369,13 @@ private fun KaDiagnosticConverterBuilder.addConversions96() {
             firDiagnostic.b,
             firSymbolBuilder.buildSymbol(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CAN_BE_REPLACED_WITH_JVM_NAME) { firDiagnostic ->
         JvmExposeBoxedCanBeReplacedWithJvmNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4384,7 +4384,7 @@ private fun KaDiagnosticConverterBuilder.addConversions96() {
 private fun KaDiagnosticConverterBuilder.addConversions97() {
     add(FirErrors.INNER_ON_TOP_LEVEL_SCRIPT_CLASS.errorFactory) { firDiagnostic ->
         InnerOnTopLevelScriptClassErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4392,20 +4392,20 @@ private fun KaDiagnosticConverterBuilder.addConversions97() {
         EqualityBoundMismatchOnInheritanceImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONFLICTING_UPPER_BOUNDS) { firDiagnostic ->
         ConflictingUpperBoundsImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETERS_NOT_ALLOWED) { firDiagnostic ->
         TypeParametersNotAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4414,13 +4414,13 @@ private fun KaDiagnosticConverterBuilder.addConversions97() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MODIFIER_FORM_FOR_NON_BUILT_IN_SUSPEND_FUN_ERROR) { firDiagnostic ->
         ModifierFormForNonBuiltInSuspendFunErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4430,43 +4430,43 @@ private fun KaDiagnosticConverterBuilder.addConversions98() {
     add(FirErrors.UNRESOLVED_IMPORT) { firDiagnostic ->
         UnresolvedImportImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_TARGET_PROPERTY_HAS_NO_DELEGATE) { firDiagnostic ->
         InapplicableTargetPropertyHasNoDelegateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.GENERIC_QUALIFIER_ON_CONSTRUCTOR_CALL.warningFactory) { firDiagnostic ->
         GenericQualifierOnConstructorCallWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CALLABLE_REFERENCE_LHS_NOT_A_CLASS) { firDiagnostic ->
         CallableReferenceLhsNotAClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_FIELD_MUST_BE_INITIALIZED) { firDiagnostic ->
         ExplicitFieldMustBeInitializedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.WRONG_SETTER_RETURN_TYPE) { firDiagnostic ->
         WrongSetterReturnTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_ACCESS_TO_ENUM_ENTRY_COMPANION_PROPERTY) { firDiagnostic ->
         DeprecatedAccessToEnumEntryCompanionPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4475,46 +4475,46 @@ private fun KaDiagnosticConverterBuilder.addConversions98() {
 private fun KaDiagnosticConverterBuilder.addConversions99() {
     add(FirErrors.INCORRECT_CHARACTER_LITERAL) { firDiagnostic ->
         IncorrectCharacterLiteralImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPT_IN_MARKER_ON_WRONG_TARGET) { firDiagnostic ->
         OptInMarkerOnWrongTargetImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_EXPLICIT_RETURN_TYPE_IN_API_MODE_WARNING) { firDiagnostic ->
         NoExplicitReturnTypeInApiModeWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RESERVED_MEMBER_INSIDE_VALUE_CLASS) { firDiagnostic ->
         ReservedMemberInsideValueClassImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPANSIVE_INHERITANCE) { firDiagnostic ->
         ExpansiveInheritanceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_WARNING) { firDiagnostic ->
         ImpossibleIsCheckWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_NON_OPTIONAL) { firDiagnostic ->
         InvalidVersioningOnNonOptionalImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4522,7 +4522,7 @@ private fun KaDiagnosticConverterBuilder.addConversions99() {
         RepeatableContainerMustHaveValueArrayErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4534,32 +4534,32 @@ private fun KaDiagnosticConverterBuilder.addConversions100() {
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPERTYPE_INITIALIZED_IN_EXPECTED_CLASS) { firDiagnostic ->
         SupertypeInitializedInExpectedClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPRESSION_EXPECTED_PACKAGE_FOUND) { firDiagnostic ->
         ExpressionExpectedPackageFoundImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.INNER_JVM_RECORD) { firDiagnostic ->
         InnerJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.EXPOSED_NOT_EXPORTED_SUPER_INTERFACE.errorFactory) { firDiagnostic ->
         ExposedNotExportedSuperInterfaceErrorImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4571,25 +4571,25 @@ private fun KaDiagnosticConverterBuilder.addConversions101() {
             firDiagnostic.a.map { firRegularClassSymbol ->
                 firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firRegularClassSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPERTYPE_INITIALIZED_IN_INTERFACE) { firDiagnostic ->
         SupertypeInitializedInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_FUNCTION_SOURCE_WITH_DEFAULT_ARGUMENTS_NOT_FOUND) { firDiagnostic ->
         ExpectedFunctionSourceWithDefaultArgumentsNotFoundImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_REFINEMENT_ANNOTATION_MISSING) { firDiagnostic ->
         ExpectRefinementAnnotationMissingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4597,13 +4597,13 @@ private fun KaDiagnosticConverterBuilder.addConversions101() {
         IncompatibleEnumComparisonErrorImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.FIELD_IN_JVM_RECORD) { firDiagnostic ->
         FieldInJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4615,19 +4615,19 @@ private fun KaDiagnosticConverterBuilder.addConversions102() {
             firDiagnostic.a,
             firDiagnostic.b,
             firDiagnostic.c?.let { firSymbolBuilder.typeBuilder.buildKtType(it.type) },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NAME_ON_ACCESSOR_AND_PROPERTY) { firDiagnostic ->
         JsNameOnAccessorAndPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NESTED_JS_MODULE_PROHIBITED) { firDiagnostic ->
         NestedJsModuleProhibitedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4636,7 +4636,7 @@ private fun KaDiagnosticConverterBuilder.addConversions102() {
             firDiagnostic.a.map { functionTypeKind ->
                 functionTypeKind
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4646,39 +4646,39 @@ private fun KaDiagnosticConverterBuilder.addConversions102() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REIFIED_TYPE_PARAMETER_ON_ALIAS.errorFactory) { firDiagnostic ->
         ReifiedTypeParameterOnAliasErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCORRECT_RIGHT_COMPONENT_OF_INTERSECTION) { firDiagnostic ->
         IncorrectRightComponentOfIntersectionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNINITIALIZED_PARAMETER) { firDiagnostic ->
         UninitializedParameterImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_SUPPORTED_INLINE_PARAMETER_IN_INLINE_PARAMETER_DEFAULT_VALUE) { firDiagnostic ->
         NotSupportedInlineParameterInInlineParameterDefaultValueImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERLOADS_PRIVATE) { firDiagnostic ->
         OverloadsPrivateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4687,13 +4687,13 @@ private fun KaDiagnosticConverterBuilder.addConversions102() {
 private fun KaDiagnosticConverterBuilder.addConversions103() {
     add(FirErrors.MANY_CLASSES_IN_SUPERTYPE_LIST) { firDiagnostic ->
         ManyClassesInSupertypeListImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CYCLE_IN_ANNOTATION_PARAMETER_ERROR) { firDiagnostic ->
         CycleInAnnotationParameterErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4705,19 +4705,19 @@ private fun KaDiagnosticConverterBuilder.addConversions103() {
             },
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCORRECT_LEFT_COMPONENT_OF_INTERSECTION) { firDiagnostic ->
         IncorrectLeftComponentOfIntersectionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_ENUM_ENTRY_WITH_BODY) { firDiagnostic ->
         ExpectedEnumEntryWithBodyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4726,34 +4726,34 @@ private fun KaDiagnosticConverterBuilder.addConversions103() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNINITIALIZED_VARIABLE) { firDiagnostic ->
         UninitializedVariableImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_RELYING_ON_NULL_ERROR) { firDiagnostic ->
         ImpossibleIsCheckRelyingOnNullErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETER_IS_NOT_AN_EXPRESSION) { firDiagnostic ->
         TypeParameterIsNotAnExpressionImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_INLINE_PARAMETER_MODIFIER) { firDiagnostic ->
         IllegalInlineParameterModifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4762,32 +4762,32 @@ private fun KaDiagnosticConverterBuilder.addConversions103() {
 private fun KaDiagnosticConverterBuilder.addConversions104() {
     add(FirErrors.EXPRESSION_EXPECTED) { firDiagnostic ->
         ExpressionExpectedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_RECEIVER_ALLOWED) { firDiagnostic ->
         NoReceiverAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPEALIAS_EXPANDS_TO_ARRAY_OF_NOTHINGS) { firDiagnostic ->
         TypealiasExpandsToArrayOfNothingsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.INAPPLICABLE_JVM_NAME) { firDiagnostic ->
         InapplicableJvmNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_EXPOSE_SUSPEND) { firDiagnostic ->
         JvmExposeBoxedCannotExposeSuspendImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4798,33 +4798,33 @@ private fun KaDiagnosticConverterBuilder.addConversions105() {
         WrongNumberOfTypeArgumentsImpl(
             firDiagnostic.a,
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_TYPE_PARAMETER_SYNTAX) { firDiagnostic ->
         DeprecatedTypeParameterSyntaxImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPRESSION_OF_NULLABLE_TYPE_IN_CLASS_LITERAL_LHS) { firDiagnostic ->
         ExpressionOfNullableTypeInClassLiteralLhsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.UNEXHAUSTIVE_WHEN_BASED_ON_JAVA_ANNOTATIONS) { firDiagnostic ->
         UnexhaustiveWhenBasedOnJavaAnnotationsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.EXTERNAL_DECLARATION_CANNOT_BE_ABSTRACT) { firDiagnostic ->
         ExternalDeclarationCannotBeAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4834,20 +4834,20 @@ private fun KaDiagnosticConverterBuilder.addConversions106() {
     add(FirErrors.MISSING_DEPENDENCY_IN_INFERRED_TYPE_ANNOTATION.errorFactory) { firDiagnostic ->
         MissingDependencyInInferredTypeAnnotationErrorImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VOLATILE_ON_VALUE) { firDiagnostic ->
         VolatileOnValueImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CANNOT_EXTEND_CLASSES) { firDiagnostic ->
         ValueClassCannotExtendClassesImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4855,7 +4855,7 @@ private fun KaDiagnosticConverterBuilder.addConversions106() {
         ManyInterfacesMemberNotImplementedImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4863,25 +4863,25 @@ private fun KaDiagnosticConverterBuilder.addConversions106() {
         ProtectedConstructorCallFromPublicInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.STRICTFP_ON_CLASS) { firDiagnostic ->
         StrictfpOnClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SPREAD_ON_SIGNATURE_POLYMORPHIC_CALL_ERROR) { firDiagnostic ->
         SpreadOnSignaturePolymorphicCallErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_STATIC_ON_NON_PUBLIC_MEMBER) { firDiagnostic ->
         JsStaticOnNonPublicMemberImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4890,32 +4890,32 @@ private fun KaDiagnosticConverterBuilder.addConversions106() {
 private fun KaDiagnosticConverterBuilder.addConversions107() {
     add(FirErrors.ILLEGAL_SELECTOR) { firDiagnostic ->
         IllegalSelectorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NEWER_VERSION_IN_SINCE_KOTLIN) { firDiagnostic ->
         NewerVersionInSinceKotlinImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CANNOT_BE_RECURSIVE_VIA_TYPE_PARAMETERS.errorFactory) { firDiagnostic ->
         ValueClassCannotBeRecursiveViaTypeParametersErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONST_VAL_WITH_EBF) { firDiagnostic ->
         ConstValWithEbfImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_SERIALIZABLE_LAMBDA_ON_INLINED_FUNCTION_LITERALS.warningFactory) { firDiagnostic ->
         JvmSerializableLambdaOnInlinedFunctionLiteralsWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4923,7 +4923,7 @@ private fun KaDiagnosticConverterBuilder.addConversions107() {
         NonExportableTypeImpl(
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4932,7 +4932,7 @@ private fun KaDiagnosticConverterBuilder.addConversions107() {
 private fun KaDiagnosticConverterBuilder.addConversions108() {
     add(FirJvmErrors.INTERFACE_CANT_CALL_DEFAULT_METHOD_VIA_SUPER) { firDiagnostic ->
         InterfaceCantCallDefaultMethodViaSuperImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4941,52 +4941,52 @@ private fun KaDiagnosticConverterBuilder.addConversions108() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REPEATED_BOUND) { firDiagnostic ->
         RepeatedBoundImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_DELEGATED_PROPERTY) { firDiagnostic ->
         ExpectedDelegatedPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NULL_FOR_NONNULL_TYPE) { firDiagnostic ->
         NullForNonnullTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_NULL_ASSERTION_ON_CALLABLE_REFERENCE) { firDiagnostic ->
         NotNullAssertionOnCallableReferenceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_EXTENSION_RECEIVER_WITH_TYPE_ARGUMENTS) { firDiagnostic ->
         CompanionExtensionReceiverWithTypeArgumentsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_ON_INLINE) { firDiagnostic ->
         SynchronizedOnInlineImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JAVA_FIELD_SHADOWED_BY_KOTLIN_PROPERTY) { firDiagnostic ->
         JavaFieldShadowedByKotlinPropertyImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -4996,13 +4996,13 @@ private fun KaDiagnosticConverterBuilder.addConversions109() {
     add(FirErrors.UNSUPPORTED) { firDiagnostic ->
         UnsupportedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EMPTY_CHARACTER_LITERAL) { firDiagnostic ->
         EmptyCharacterLiteralImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5011,26 +5011,26 @@ private fun KaDiagnosticConverterBuilder.addConversions109() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SUBCLASS_CANT_CALL_COMPANION_PROTECTED_NON_STATIC_WARNING) { firDiagnostic ->
         SubclassCantCallCompanionProtectedNonStaticWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JAVA_SAM_INTERFACE_CONSTRUCTOR_REFERENCE) { firDiagnostic ->
         JavaSamInterfaceConstructorReferenceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirSyntaxErrors.SYNTAX) { firDiagnostic ->
         SyntaxImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5039,20 +5039,20 @@ private fun KaDiagnosticConverterBuilder.addConversions109() {
 private fun KaDiagnosticConverterBuilder.addConversions110() {
     add(FirErrors.ANNOTATIONS_ON_BLOCK_LEVEL_EXPRESSION_ON_THE_SAME_LINE) { firDiagnostic ->
         AnnotationsOnBlockLevelExpressionOnTheSameLineImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCONSISTENT_TYPE_PARAMETERS_IN_OF_OVERLOADS) { firDiagnostic ->
         InconsistentTypeParametersInOfOverloadsImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_ARGUMENTS_NOT_ALLOWED_IN_PACKAGE_QUALIFIER_WARNING) { firDiagnostic ->
         TypeArgumentsNotAllowedInPackageQualifierWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5061,7 +5061,7 @@ private fun KaDiagnosticConverterBuilder.addConversions110() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5070,25 +5070,25 @@ private fun KaDiagnosticConverterBuilder.addConversions110() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ELSE_MISPLACED_IN_WHEN) { firDiagnostic ->
         ElseMisplacedInWhenImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONSTRUCTOR_OR_SUPERTYPE_ON_TYPEALIAS_WITH_TYPE_PROJECTION.errorFactory) { firDiagnostic ->
         ConstructorOrSupertypeOnTypealiasWithTypeProjectionErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_REQUIRES_NAME) { firDiagnostic ->
         JvmExposeBoxedRequiresNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5099,50 +5099,50 @@ private fun KaDiagnosticConverterBuilder.addConversions111() {
         InferredInvisibleReifiedTypeArgumentWarningImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_FINAL_MEMBER_IN_OBJECT) { firDiagnostic ->
         NonFinalMemberInObjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONST_VAL_WITH_DELEGATE) { firDiagnostic ->
         ConstValWithDelegateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_ELVIS_LEFT_IS_NULL) { firDiagnostic ->
         UselessElvisLeftIsNullImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_CAST) { firDiagnostic ->
         UselessCastImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONFUSING_BRANCH_CONDITION_ERROR) { firDiagnostic ->
         ConfusingBranchConditionErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_IN_FUNCTION_WITH_EXPRESSION_BODY_AND_IMPLICIT_TYPE) { firDiagnostic ->
         ReturnInFunctionWithExpressionBodyAndImplicitTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE) { firDiagnostic ->
         NonExternalDeclarationInInappropriateFileImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5151,19 +5151,19 @@ private fun KaDiagnosticConverterBuilder.addConversions111() {
 private fun KaDiagnosticConverterBuilder.addConversions112() {
     add(FirErrors.ACTUAL_MISSING) { firDiagnostic ->
         ActualMissingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EMPTY_RANGE) { firDiagnostic ->
         EmptyRangeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MODIFIER_FORM_FOR_NON_BUILT_IN_SUSPEND) { firDiagnostic ->
         ModifierFormForNonBuiltInSuspendImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5172,7 +5172,7 @@ private fun KaDiagnosticConverterBuilder.addConversions112() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5181,14 +5181,14 @@ private fun KaDiagnosticConverterBuilder.addConversions112() {
 private fun KaDiagnosticConverterBuilder.addConversions113() {
     add(FirErrors.UNSIGNED_LITERAL_WITHOUT_DECLARATIONS_ON_CLASSPATH) { firDiagnostic ->
         UnsignedLiteralWithoutDeclarationsOnClasspathImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_ARGUMENTS_NOT_ALLOWED) { firDiagnostic ->
         TypeArgumentsNotAllowedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5198,20 +5198,20 @@ private fun KaDiagnosticConverterBuilder.addConversions114() {
     add(FirErrors.INAPPLICABLE_ALL_TARGET) { firDiagnostic ->
         InapplicableAllTargetImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_ARGUMENT_ON_TYPED_VALUE_CLASS_EQUALS) { firDiagnostic ->
         TypeArgumentOnTypedValueClassEqualsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NAMED_ARGUMENTS_NOT_ALLOWED) { firDiagnostic ->
         NamedArgumentsNotAllowedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5220,13 +5220,13 @@ private fun KaDiagnosticConverterBuilder.addConversions114() {
             firDiagnostic.a,
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PRIVATE_SETTER_FOR_OPEN_PROPERTY) { firDiagnostic ->
         PrivateSetterForOpenPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5235,13 +5235,13 @@ private fun KaDiagnosticConverterBuilder.addConversions114() {
 private fun KaDiagnosticConverterBuilder.addConversions115() {
     add(FirErrors.UNSUPPORTED_SEALED_FUN_INTERFACE) { firDiagnostic ->
         UnsupportedSealedFunInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NAME_PROHIBITED_FOR_EXTENSION_PROPERTY) { firDiagnostic ->
         JsNameProhibitedForExtensionPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5249,21 +5249,21 @@ private fun KaDiagnosticConverterBuilder.addConversions115() {
         ParameterNameChangedOnOverrideImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_RELYING_ON_NULL_DEPRECATION.errorFactory) { firDiagnostic ->
         ImpossibleIsCheckRelyingOnNullDeprecationErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_PUBLIC_DATA_COPY_CALL_FROM_PUBLIC_INLINE.warningFactory) { firDiagnostic ->
         NonPublicDataCopyCallFromPublicInlineWarningImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5274,20 +5274,20 @@ private fun KaDiagnosticConverterBuilder.addConversions116() {
         OptInOverrideErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ASSIGNING_SINGLE_ELEMENT_TO_VARARG_IN_NAMED_FORM_ANNOTATION.errorFactory) { firDiagnostic ->
         AssigningSingleElementToVarargInNamedFormAnnotationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REIFIED_TYPE_FORBIDDEN_SUBSTITUTION) { firDiagnostic ->
         ReifiedTypeForbiddenSubstitutionImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5296,27 +5296,27 @@ private fun KaDiagnosticConverterBuilder.addConversions116() {
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.buildSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_OR_BE_ABSTRACT_WARNING) { firDiagnostic ->
         MustBeInitializedOrBeAbstractWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.DANGEROUS_CHARACTERS) { firDiagnostic ->
         DangerousCharactersImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NON_CONSUMABLE_EXPORTED_IDENTIFIER) { firDiagnostic ->
         NonConsumableExportedIdentifierImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5327,44 +5327,44 @@ private fun KaDiagnosticConverterBuilder.addConversions117() {
         InapplicableOperatorModifierWarningImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SEALED_VALUE_CLASS_CONSTRUCTOR_PROPERTY_PARAMETER) { firDiagnostic ->
         SealedValueClassConstructorPropertyParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TOO_MANY_ARGUMENTS) { firDiagnostic ->
         TooManyArgumentsImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RECURSION_IN_IMPLICIT_TYPES) { firDiagnostic ->
         RecursionInImplicitTypesImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETERS_IN_ANONYMOUS_OBJECT) { firDiagnostic ->
         TypeParametersInAnonymousObjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_REFINEMENT_ANNOTATION_WRONG_TARGET) { firDiagnostic ->
         ExpectRefinementAnnotationWrongTargetImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_ACCESS_TO_ENTRIES_PROPERTY) { firDiagnostic ->
         DeprecatedAccessToEntriesPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5373,40 +5373,40 @@ private fun KaDiagnosticConverterBuilder.addConversions117() {
 private fun KaDiagnosticConverterBuilder.addConversions118() {
     add(FirErrors.CLASS_INHERITS_JAVA_SEALED_CLASS) { firDiagnostic ->
         ClassInheritsJavaSealedClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_QUALIFIER_IN_LHS_OF_CALLABLE_REFERENCE_TO_STATIC.errorFactory) { firDiagnostic ->
         InvalidQualifierInLhsOfCallableReferenceToStaticErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETER_IN_CATCH_CLAUSE) { firDiagnostic ->
         TypeParameterInCatchClauseImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_AND_ACTUAL_IN_THE_SAME_MODULE) { firDiagnostic ->
         ExpectAndActualInTheSameModuleImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_CHECK_FOR_ERASED) { firDiagnostic ->
         CannotCheckForErasedImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_FORBIDDEN_CLASS_REFERENCE) { firDiagnostic ->
         JsNoRuntimeForbiddenClassReferenceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5415,39 +5415,39 @@ private fun KaDiagnosticConverterBuilder.addConversions118() {
 private fun KaDiagnosticConverterBuilder.addConversions119() {
     add(FirErrors.ILLEGAL_ESCAPE) { firDiagnostic ->
         IllegalEscapeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPERTYPE_NOT_A_CLASS_OR_INTERFACE) { firDiagnostic ->
         SupertypeNotAClassOrInterfaceImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_CLASS_CONSTRUCTOR_CALL) { firDiagnostic ->
         AnnotationClassConstructorCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NAMED_PARAMETER_NOT_FOUND) { firDiagnostic ->
         NamedParameterNotFoundImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROPERTY_INITIALIZER_IN_INTERFACE) { firDiagnostic ->
         PropertyInitializerInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXTENSION_PROPERTY_WITH_BACKING_FIELD) { firDiagnostic ->
         ExtensionPropertyWithBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5456,7 +5456,7 @@ private fun KaDiagnosticConverterBuilder.addConversions119() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5465,7 +5465,7 @@ private fun KaDiagnosticConverterBuilder.addConversions119() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5474,14 +5474,14 @@ private fun KaDiagnosticConverterBuilder.addConversions119() {
 private fun KaDiagnosticConverterBuilder.addConversions120() {
     add(FirErrors.MISSING_STDLIB_CLASS) { firDiagnostic ->
         MissingStdlibClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INNER_CLASS_CONSTRUCTOR_NO_RECEIVER) { firDiagnostic ->
         InnerClassConstructorNoReceiverImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5490,13 +5490,13 @@ private fun KaDiagnosticConverterBuilder.addConversions120() {
             firDiagnostic.a.map { string ->
                 string
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VOLATILE_ON_DELEGATE) { firDiagnostic ->
         VolatileOnDelegateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5504,20 +5504,20 @@ private fun KaDiagnosticConverterBuilder.addConversions120() {
         OfOverloadsInBlockAndObjectImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_INFER_PARAMETER_TYPE) { firDiagnostic ->
         CannotInferParameterTypeImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DELEGATED_PROPERTY_IN_INTERFACE) { firDiagnostic ->
         DelegatedPropertyInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5526,7 +5526,7 @@ private fun KaDiagnosticConverterBuilder.addConversions120() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5534,7 +5534,7 @@ private fun KaDiagnosticConverterBuilder.addConversions120() {
         ContextParameterMustBeNoinlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5543,13 +5543,13 @@ private fun KaDiagnosticConverterBuilder.addConversions120() {
 private fun KaDiagnosticConverterBuilder.addConversions121() {
     add(FirErrors.DESERIALIZATION_ERROR) { firDiagnostic ->
         DeserializationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_IMPLICIT_DEFAULT_CONSTRUCTOR_ON_EXPECT_CLASS) { firDiagnostic ->
         NoImplicitDefaultConstructorOnExpectClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5557,32 +5557,32 @@ private fun KaDiagnosticConverterBuilder.addConversions121() {
         OptInToInheritanceErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REIFIED_TYPE_PARAMETER_NO_INLINE) { firDiagnostic ->
         ReifiedTypeParameterNoInlineImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSUPPORTED_CLASS_LITERALS_WITH_EMPTY_LHS) { firDiagnostic ->
         UnsupportedClassLiteralsWithEmptyLhsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNNAMED_PROPERTY_WITH_IMPLICIT_IGNORABLE_TYPE) { firDiagnostic ->
         UnnamedPropertyWithImplicitIgnorableTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.LOCAL_JVM_RECORD) { firDiagnostic ->
         LocalJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5592,20 +5592,20 @@ private fun KaDiagnosticConverterBuilder.addConversions122() {
     add(FirErrors.MISSING_DEPENDENCY_CLASS_IN_EXPRESSION_TYPE) { firDiagnostic ->
         MissingDependencyClassInExpressionTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPT_IN_WITHOUT_ARGUMENTS) { firDiagnostic ->
         OptInWithoutArgumentsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCONSISTENT_PARAMETER_TYPES_IN_OF_OVERLOADS) { firDiagnostic ->
         InconsistentParameterTypesInOfOverloadsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5614,20 +5614,20 @@ private fun KaDiagnosticConverterBuilder.addConversions122() {
             firDiagnostic.a.map { firTypeParameterSymbol ->
                 firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firTypeParameterSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_MEMBER_FUNCTION_NO_BODY) { firDiagnostic ->
         NonMemberFunctionNoBodyImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_CLASS_CONSTRUCTOR_PROPERTY_PARAMETER) { firDiagnostic ->
         ExpectedClassConstructorPropertyParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5636,14 +5636,14 @@ private fun KaDiagnosticConverterBuilder.addConversions122() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_IS_CHECK) { firDiagnostic ->
         UselessIsCheckImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5652,7 +5652,7 @@ private fun KaDiagnosticConverterBuilder.addConversions122() {
 private fun KaDiagnosticConverterBuilder.addConversions123() {
     add(FirErrors.VAR_PROPERTY_WITH_EXPLICIT_BACKING_FIELD) { firDiagnostic ->
         VarPropertyWithExplicitBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5661,13 +5661,13 @@ private fun KaDiagnosticConverterBuilder.addConversions123() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_RECEIVER_OR_CONTEXT_PARAMETER_POSITION) { firDiagnostic ->
         InvalidVersioningOnReceiverOrContextParameterPositionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5677,7 +5677,7 @@ private fun KaDiagnosticConverterBuilder.addConversions123() {
             firDiagnostic.b,
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5685,13 +5685,13 @@ private fun KaDiagnosticConverterBuilder.addConversions123() {
         RepeatableContainerTargetSetNotASubsetErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.EXTENSION_FUNCTION_IN_EXTERNAL_DECLARATION) { firDiagnostic ->
         ExtensionFunctionInExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5700,7 +5700,7 @@ private fun KaDiagnosticConverterBuilder.addConversions123() {
 private fun KaDiagnosticConverterBuilder.addConversions124() {
     add(FirErrors.CREATING_AN_INSTANCE_OF_ABSTRACT_CLASS) { firDiagnostic ->
         CreatingAnInstanceOfAbstractClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5709,25 +5709,25 @@ private fun KaDiagnosticConverterBuilder.addConversions124() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_WARNING) { firDiagnostic ->
         MustBeInitializedWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_BLOCK_MEMBER_EXTENSION) { firDiagnostic ->
         CompanionBlockMemberExtensionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_BE_THE_SAME) { firDiagnostic ->
         JvmExposeBoxedCannotBeTheSameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5735,13 +5735,13 @@ private fun KaDiagnosticConverterBuilder.addConversions124() {
         TypeMismatchWhenFlexibilityChangesImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_IN_ANNOTATION.warningFactory) { firDiagnostic ->
         SynchronizedInAnnotationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5750,7 +5750,7 @@ private fun KaDiagnosticConverterBuilder.addConversions124() {
 private fun KaDiagnosticConverterBuilder.addConversions125() {
     add(FirErrors.UNRESOLVED_LABEL) { firDiagnostic ->
         UnresolvedLabelImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5761,26 +5761,26 @@ private fun KaDiagnosticConverterBuilder.addConversions125() {
             firDiagnostic.c.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_SINCE_KOTLIN_WITHOUT_DEPRECATED) { firDiagnostic ->
         DeprecatedSinceKotlinWithoutDeprecatedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ARGUMENT_PASSED_TWICE) { firDiagnostic ->
         ArgumentPassedTwiceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_ARGUMENTS_NOT_ALLOWED_WARNING) { firDiagnostic ->
         TypeArgumentsNotAllowedWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5790,7 +5790,7 @@ private fun KaDiagnosticConverterBuilder.addConversions125() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5801,13 +5801,13 @@ private fun KaDiagnosticConverterBuilder.addConversions126() {
         MissingDependencySuperclassImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONSTRUCTOR_IN_INTERFACE) { firDiagnostic ->
         ConstructorInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5817,7 +5817,7 @@ private fun KaDiagnosticConverterBuilder.addConversions126() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5826,13 +5826,13 @@ private fun KaDiagnosticConverterBuilder.addConversions126() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANONYMOUS_FUNCTION_PARAMETER_WITH_DEFAULT_VALUE) { firDiagnostic ->
         AnonymousFunctionParameterWithDefaultValueImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5843,7 +5843,7 @@ private fun KaDiagnosticConverterBuilder.addConversions127() {
         InheritedIntersectionEqualityBoundImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5851,33 +5851,33 @@ private fun KaDiagnosticConverterBuilder.addConversions127() {
         OptInToInheritanceImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_LATEINIT_MODIFIER) { firDiagnostic ->
         InapplicableLateinitModifierImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_EXPLICIT_RETURN_TYPE_IN_API_MODE) { firDiagnostic ->
         NoExplicitReturnTypeInApiModeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPTIONAL_DECLARATION_USAGE_IN_NON_COMMON_SOURCE) { firDiagnostic ->
         OptionalDeclarationUsageInNonCommonSourceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSAFE_IMPLICIT_INVOKE_CALL) { firDiagnostic ->
         UnsafeImplicitInvokeCallImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5887,7 +5887,7 @@ private fun KaDiagnosticConverterBuilder.addConversions128() {
     add(FirErrors.NO_VALUE_FOR_PARAMETER) { firDiagnostic ->
         NoValueForParameterImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5895,7 +5895,7 @@ private fun KaDiagnosticConverterBuilder.addConversions128() {
         CompilerRequiredAnnotationAmbiguityImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5904,7 +5904,7 @@ private fun KaDiagnosticConverterBuilder.addConversions128() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5914,7 +5914,7 @@ private fun KaDiagnosticConverterBuilder.addConversions128() {
             firDiagnostic.b.source!!.psi as KtExpression,
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5922,14 +5922,14 @@ private fun KaDiagnosticConverterBuilder.addConversions128() {
         CannotOverrideInvisibleMemberImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNINITIALIZED_ENUM_COMPANION) { firDiagnostic ->
         UninitializedEnumCompanionImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5938,7 +5938,7 @@ private fun KaDiagnosticConverterBuilder.addConversions128() {
 private fun KaDiagnosticConverterBuilder.addConversions129() {
     add(FirErrors.NO_THIS) { firDiagnostic ->
         NoThisImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5946,7 +5946,7 @@ private fun KaDiagnosticConverterBuilder.addConversions129() {
         EqualityBoundMismatchByDelegationImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5956,33 +5956,33 @@ private fun KaDiagnosticConverterBuilder.addConversions129() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_SPREAD_OPERATOR_IN_NAMED_FORM_IN_FUNCTION) { firDiagnostic ->
         RedundantSpreadOperatorInNamedFormInFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETER_AS_REIFIED_DEPRECATION_WARNING) { firDiagnostic ->
         TypeParameterAsReifiedDeprecationWarningImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CAPTURED_MEMBER_VAL_INITIALIZATION) { firDiagnostic ->
         CapturedMemberValInitializationImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_CLASS_CONSTRUCTOR_PROPERTY_PARAMETER) { firDiagnostic ->
         ExternalClassConstructorPropertyParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -5991,33 +5991,33 @@ private fun KaDiagnosticConverterBuilder.addConversions129() {
 private fun KaDiagnosticConverterBuilder.addConversions130() {
     add(FirErrors.SUPERTYPE_IS_EXTENSION_OR_CONTEXT_FUNCTION_TYPE) { firDiagnostic ->
         SupertypeIsExtensionOrContextFunctionTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_SYMBOL_PROHIBITED_FOR_OVERRIDE) { firDiagnostic ->
         JsSymbolProhibitedForOverrideImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPT_IN_MARKER_WITH_WRONG_TARGET) { firDiagnostic ->
         OptInMarkerWithWrongTargetImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INFIX_MODIFIER_REQUIRED) { firDiagnostic ->
         InfixModifierRequiredImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCORRECT_TYPE_PARAMETER_OF_PROPERTY) { firDiagnostic ->
         IncorrectTypeParameterOfPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6025,13 +6025,13 @@ private fun KaDiagnosticConverterBuilder.addConversions130() {
         WrongGetterReturnTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NAME_BASED_DESTRUCTURING_UNDERSCORE_WITHOUT_RENAMING) { firDiagnostic ->
         NameBasedDestructuringUnderscoreWithoutRenamingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6039,7 +6039,7 @@ private fun KaDiagnosticConverterBuilder.addConversions130() {
         ForbiddenIdentityEqualsWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6048,26 +6048,26 @@ private fun KaDiagnosticConverterBuilder.addConversions130() {
 private fun KaDiagnosticConverterBuilder.addConversions131() {
     add(FirErrors.SUPER_IS_NOT_AN_EXPRESSION) { firDiagnostic ->
         SuperIsNotAnExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_ARGUMENTS_REDUNDANT_IN_SUPER_QUALIFIER) { firDiagnostic ->
         TypeArgumentsRedundantInSuperQualifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VAR_ANNOTATION_PARAMETER) { firDiagnostic ->
         VarAnnotationParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_TARGET_ON_PROPERTY_WARNING) { firDiagnostic ->
         InapplicableTargetOnPropertyWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6075,7 +6075,7 @@ private fun KaDiagnosticConverterBuilder.addConversions131() {
         IncompatibleModifiersImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6083,27 +6083,27 @@ private fun KaDiagnosticConverterBuilder.addConversions131() {
         BuilderInferenceStubReceiverImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_EXTENSION_RECEIVER_IS_TYPE_PARAMETER) { firDiagnostic ->
         CompanionExtensionReceiverIsTypeParameterImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.FUNCTION_DELEGATE_MEMBER_NAME_CLASH) { firDiagnostic ->
         FunctionDelegateMemberNameClashImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_BLOCK_ON_VALUE_CLASS_OR_PRIMITIVE.errorFactory) { firDiagnostic ->
         SynchronizedBlockOnValueClassOrPrimitiveErrorImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6112,19 +6112,19 @@ private fun KaDiagnosticConverterBuilder.addConversions131() {
 private fun KaDiagnosticConverterBuilder.addConversions132() {
     add(FirErrors.SEALED_CLASS_CONSTRUCTOR_CALL) { firDiagnostic ->
         SealedClassConstructorCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.KOTLIN_ACTUAL_ANNOTATION_HAS_NO_EFFECT_IN_KOTLIN) { firDiagnostic ->
         KotlinActualAnnotationHasNoEffectInKotlinImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.WRONG_JS_QUALIFIER) { firDiagnostic ->
         WrongJsQualifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6132,14 +6132,14 @@ private fun KaDiagnosticConverterBuilder.addConversions132() {
         DeprecatedModifierPairImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INCONSISTENT_VISIBILITY_IN_OF_OVERLOADS) { firDiagnostic ->
         InconsistentVisibilityInOfOverloadsImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6148,33 +6148,33 @@ private fun KaDiagnosticConverterBuilder.addConversions132() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_OR_BE_FINAL_WARNING) { firDiagnostic ->
         MustBeInitializedOrBeFinalWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PRIVATE_CONST_IN_INTERFACE) { firDiagnostic ->
         PrivateConstInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.DEPRECATED_JAVA_ANNOTATION) { firDiagnostic ->
         DeprecatedJavaAnnotationImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_BLOCK_ON_JAVA_VALUE_BASED_CLASS) { firDiagnostic ->
         SynchronizedBlockOnJavaValueBasedClassImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6187,13 +6187,13 @@ private fun KaDiagnosticConverterBuilder.addConversions133() {
             firDiagnostic.b.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UPPER_BOUND_IS_EXTENSION_OR_CONTEXT_FUNCTION_TYPE) { firDiagnostic ->
         UpperBoundIsExtensionOrContextFunctionTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6202,13 +6202,13 @@ private fun KaDiagnosticConverterBuilder.addConversions133() {
             firDiagnostic.a,
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_PROPERTY_WITHOUT_TYPE) { firDiagnostic ->
         AbstractPropertyWithoutTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6216,13 +6216,13 @@ private fun KaDiagnosticConverterBuilder.addConversions133() {
         ImplementationByDelegationWithDifferentGenericSignatureErrorImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.NOT_YET_SUPPORTED_LOCAL_INLINE_FUNCTION) { firDiagnostic ->
         NotYetSupportedLocalInlineFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6233,31 +6233,31 @@ private fun KaDiagnosticConverterBuilder.addConversions134() {
         WrongNumberOfTypeArgumentsInGetClassWarningImpl(
             firDiagnostic.a,
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SINGLE_ANONYMOUS_FUNCTION_WITH_NAME.warningFactory) { firDiagnostic ->
         SingleAnonymousFunctionWithNameWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_TYPEALIAS) { firDiagnostic ->
         ExpectedTypealiasImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNUSED_VARIABLE) { firDiagnostic ->
         UnusedVariableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_A_FUNCTION_LABEL) { firDiagnostic ->
         NotAFunctionLabelImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6266,13 +6266,13 @@ private fun KaDiagnosticConverterBuilder.addConversions134() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NAMED_COMPANION_IN_EXTERNAL_INTERFACE) { firDiagnostic ->
         NamedCompanionInExternalInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6281,20 +6281,20 @@ private fun KaDiagnosticConverterBuilder.addConversions134() {
 private fun KaDiagnosticConverterBuilder.addConversions135() {
     add(FirErrors.INVALID_TYPE_OF_ANNOTATION_MEMBER) { firDiagnostic ->
         InvalidTypeOfAnnotationMemberImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_TARGET_ON_PROPERTY) { firDiagnostic ->
         InapplicableTargetOnPropertyImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.RUNTIME_ANNOTATION_ON_EXTERNAL_DECLARATION) { firDiagnostic ->
         RuntimeAnnotationOnExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6302,20 +6302,20 @@ private fun KaDiagnosticConverterBuilder.addConversions135() {
         DelegatedMemberHidesSupertypeOverrideImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_CHARACTERS) { firDiagnostic ->
         InvalidCharactersImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOTHING_TO_INLINE) { firDiagnostic ->
         NothingToInlineImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6323,7 +6323,7 @@ private fun KaDiagnosticConverterBuilder.addConversions135() {
         NullableInlineParameterImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6331,13 +6331,13 @@ private fun KaDiagnosticConverterBuilder.addConversions135() {
         IncompatibleClassImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.NON_DATA_CLASS_JVM_RECORD) { firDiagnostic ->
         NonDataClassJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6346,7 +6346,7 @@ private fun KaDiagnosticConverterBuilder.addConversions135() {
 private fun KaDiagnosticConverterBuilder.addConversions136() {
     add(FirErrors.MISSING_VAL_ON_ANNOTATION_PARAMETER) { firDiagnostic ->
         MissingValOnAnnotationParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6356,7 +6356,7 @@ private fun KaDiagnosticConverterBuilder.addConversions136() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6365,25 +6365,25 @@ private fun KaDiagnosticConverterBuilder.addConversions136() {
 private fun KaDiagnosticConverterBuilder.addConversions137() {
     add(FirErrors.SUPERTYPE_INITIALIZED_WITHOUT_PRIMARY_CONSTRUCTOR) { firDiagnostic ->
         SupertypeInitializedWithoutPrimaryConstructorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_KOTLIN_VERSION_STRING_VALUE) { firDiagnostic ->
         IllegalKotlinVersionStringValueImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NAME_IS_NOT_ON_ALL_ACCESSORS) { firDiagnostic ->
         JsNameIsNotOnAllAccessorsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROPERTY_INITIALIZER_WITH_EXPLICIT_FIELD_DECLARATION) { firDiagnostic ->
         PropertyInitializerWithExplicitFieldDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6392,13 +6392,13 @@ private fun KaDiagnosticConverterBuilder.addConversions137() {
             firDiagnostic.a.map { functionTypeKind ->
                 functionTypeKind
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_STATIC_NOT_IN_OBJECT_OR_CLASS_COMPANION) { firDiagnostic ->
         JvmStaticNotInObjectOrClassCompanionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6407,39 +6407,39 @@ private fun KaDiagnosticConverterBuilder.addConversions137() {
 private fun KaDiagnosticConverterBuilder.addConversions138() {
     add(FirErrors.NAMED_CONTEXT_PARAMETER_IN_FUNCTION_TYPE) { firDiagnostic ->
         NamedContextParameterInFunctionTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_DECLARATION_WITH_BODY) { firDiagnostic ->
         ExpectedDeclarationWithBodyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MIXING_SUSPEND_AND_NON_SUSPEND_SUPERTYPES) { firDiagnostic ->
         MixingSuspendAndNonSuspendSupertypesImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.ILLEGAL_JAVA_LANG_RECORD_SUPERTYPE) { firDiagnostic ->
         IllegalJavaLangRecordSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.OVERRIDING_EXTERNAL_FUN_WITH_OPTIONAL_PARAMS_WITH_FAKE) { firDiagnostic ->
         OverridingExternalFunWithOptionalParamsWithFakeImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.CANNOT_CHECK_FOR_EXTERNAL_INTERFACE) { firDiagnostic ->
         CannotCheckForExternalInterfaceImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6448,32 +6448,32 @@ private fun KaDiagnosticConverterBuilder.addConversions138() {
 private fun KaDiagnosticConverterBuilder.addConversions139() {
     add(FirErrors.SPREAD_OF_NULLABLE) { firDiagnostic ->
         SpreadOfNullableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CALLABLE_REFERENCE_TO_ANNOTATION_CONSTRUCTOR) { firDiagnostic ->
         CallableReferenceToAnnotationConstructorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_INFER_VALUE_PARAMETER_TYPE) { firDiagnostic ->
         CannotInferValueParameterTypeImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_A_MULTIPLATFORM_COMPILATION) { firDiagnostic ->
         NotAMultiplatformCompilationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.WRONG_INITIALIZER_OF_EXTERNAL_DECLARATION) { firDiagnostic ->
         WrongInitializerOfExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6482,32 +6482,32 @@ private fun KaDiagnosticConverterBuilder.addConversions139() {
 private fun KaDiagnosticConverterBuilder.addConversions140() {
     add(FirErrors.DATA_CLASS_VARARG_PARAMETER) { firDiagnostic ->
         DataClassVarargParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUBCLASS_OPT_IN_INAPPLICABLE) { firDiagnostic ->
         SubclassOptInInapplicableImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VARIANCE_ON_TYPE_PARAMETER_NOT_ALLOWED) { firDiagnostic ->
         VarianceOnTypeParameterNotAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ADAPTED_CALLABLE_REFERENCE_AGAINST_REFLECTION_TYPE) { firDiagnostic ->
         AdaptedCallableReferenceAgainstReflectionTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DYNAMIC_NOT_ALLOWED) { firDiagnostic ->
         DynamicNotAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6516,13 +6516,13 @@ private fun KaDiagnosticConverterBuilder.addConversions140() {
 private fun KaDiagnosticConverterBuilder.addConversions141() {
     add(FirErrors.PROPERTY_WITH_NO_TYPE_NO_INITIALIZER) { firDiagnostic ->
         PropertyWithNoTypeNoInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_CALL_ON_NOT_NULL) { firDiagnostic ->
         UselessCallOnNotNullImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6531,13 +6531,13 @@ private fun KaDiagnosticConverterBuilder.addConversions141() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.PROPERTY_DELEGATION_BY_DYNAMIC) { firDiagnostic ->
         PropertyDelegationByDynamicImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6549,20 +6549,20 @@ private fun KaDiagnosticConverterBuilder.addConversions142() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_TYPE_ARGUMENTS_IN_PROPERTY_ACCESS_WARNING) { firDiagnostic ->
         ExplicitTypeArgumentsInPropertyAccessWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_TYPE_ALIAS_NOT_TO_CLASS) { firDiagnostic ->
         ActualTypeAliasNotToClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6571,14 +6571,14 @@ private fun KaDiagnosticConverterBuilder.addConversions142() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_DEFAULT_FUNCTIONAL_PARAMETER_FOR_INLINE) { firDiagnostic ->
         InvalidDefaultFunctionalParameterForInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6586,7 +6586,7 @@ private fun KaDiagnosticConverterBuilder.addConversions142() {
         BuilderInferenceMultiLambdaRestrictionImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6595,38 +6595,38 @@ private fun KaDiagnosticConverterBuilder.addConversions142() {
 private fun KaDiagnosticConverterBuilder.addConversions143() {
     add(FirErrors.REDUNDANT_INTERPOLATION_PREFIX) { firDiagnostic ->
         RedundantInterpolationPrefixImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONTEXT_PARAMETER_WITHOUT_NAME) { firDiagnostic ->
         ContextParameterWithoutNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_PARAMETER_AS_REIFIED) { firDiagnostic ->
         TypeParameterAsReifiedImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_BACKING_FIELD_IN_INTERFACE) { firDiagnostic ->
         ExplicitBackingFieldInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_TYPE_ALIAS_WITH_COMPLEX_SUBSTITUTION) { firDiagnostic ->
         ActualTypeAliasWithComplexSubstitutionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.WRONG_DEFAULT_VALUE_FOR_EXTERNAL_FUN_PARAMETER) { firDiagnostic ->
         WrongDefaultValueForExternalFunParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6638,19 +6638,19 @@ private fun KaDiagnosticConverterBuilder.addConversions144() {
             firDiagnostic.a.map { coneKotlinType ->
                 firSymbolBuilder.typeBuilder.buildKtType(coneKotlinType)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPT_IN_MARKER_CAN_ONLY_BE_USED_AS_ANNOTATION_OR_ARGUMENT_IN_OPT_IN) { firDiagnostic ->
         OptInMarkerCanOnlyBeUsedAsAnnotationOrArgumentInOptInImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_OR_FINAL_OR_ABSTRACT) { firDiagnostic ->
         MustBeInitializedOrFinalOrAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6658,20 +6658,20 @@ private fun KaDiagnosticConverterBuilder.addConversions144() {
         AssignmentOperatorShouldReturnUnitImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_SINGLE_EXPRESSION_STRING_TEMPLATE) { firDiagnostic ->
         RedundantSingleExpressionStringTemplateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RECURSION_IN_INLINE) { firDiagnostic ->
         RecursionInInlineImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6681,13 +6681,13 @@ private fun KaDiagnosticConverterBuilder.addConversions144() {
             firDiagnostic.b,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JAVA_CLASS_PROPERTY_REFERENCE.errorFactory) { firDiagnostic ->
         JavaClassPropertyReferenceErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6697,63 +6697,63 @@ private fun KaDiagnosticConverterBuilder.addConversions145() {
     add(FirErrors.UNSUPPORTED_FEATURE) { firDiagnostic ->
         UnsupportedFeatureImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_CLASS_AS_FUNCTION) { firDiagnostic ->
         ExpectClassAsFunctionImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NULLABLE_SUPERTYPE_THROUGH_TYPEALIAS.warningFactory) { firDiagnostic ->
         NullableSupertypeThroughTypealiasWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ASSIGNING_SINGLE_ELEMENT_TO_VARARG_IN_NAMED_FORM_FUNCTION.warningFactory) { firDiagnostic ->
         AssigningSingleElementToVarargInNamedFormFunctionWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INFERENCE_ERROR) { firDiagnostic ->
         InferenceErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPLICIT_NOTHING_PROPERTY_TYPE) { firDiagnostic ->
         ImplicitNothingPropertyTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FINITE_BOUNDS_VIOLATION) { firDiagnostic ->
         FiniteBoundsViolationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_PROPERTY_WITH_EXPLICIT_BACKING_FIELD) { firDiagnostic ->
         ExpectPropertyWithExplicitBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.HAS_NEXT_MISSING) { firDiagnostic ->
         HasNextMissingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INLINE_PROPERTY_WITH_BACKING_FIELD_DEPRECATION.errorFactory) { firDiagnostic ->
         InlinePropertyWithBackingFieldDeprecationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6762,31 +6762,31 @@ private fun KaDiagnosticConverterBuilder.addConversions145() {
 private fun KaDiagnosticConverterBuilder.addConversions146() {
     add(FirErrors.LOCAL_ANNOTATION_CLASS_ERROR) { firDiagnostic ->
         LocalAnnotationClassErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_PARAM_TARGET) { firDiagnostic ->
         InapplicableParamTargetImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MULTIPLE_CONTEXT_LISTS) { firDiagnostic ->
         MultipleContextListsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ITERATOR_ON_NULLABLE) { firDiagnostic ->
         IteratorOnNullableImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NAMED_COMPANION_IN_EXPORTED_INTERFACE) { firDiagnostic ->
         NamedCompanionInExportedInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6796,7 +6796,7 @@ private fun KaDiagnosticConverterBuilder.addConversions147() {
     add(FirErrors.CLASS_CANNOT_BE_EXTENDED_DIRECTLY) { firDiagnostic ->
         ClassCannotBeExtendedDirectlyImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6805,7 +6805,7 @@ private fun KaDiagnosticConverterBuilder.addConversions147() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6817,7 +6817,7 @@ private fun KaDiagnosticConverterBuilder.addConversions147() {
             },
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6826,20 +6826,20 @@ private fun KaDiagnosticConverterBuilder.addConversions147() {
 private fun KaDiagnosticConverterBuilder.addConversions148() {
     add(FirErrors.WRAPPED_LHS_IN_ASSIGNMENT.errorFactory) { firDiagnostic ->
         WrappedLhsInAssignmentErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SUPER_CALL_WITH_DEFAULT_PARAMETERS) { firDiagnostic ->
         SuperCallWithDefaultParametersImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SAFE_CALLABLE_REFERENCE_CALL) { firDiagnostic ->
         SafeCallableReferenceCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6848,7 +6848,7 @@ private fun KaDiagnosticConverterBuilder.addConversions148() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6856,7 +6856,7 @@ private fun KaDiagnosticConverterBuilder.addConversions148() {
         NonPublicCallFromPublicInlineDeprecationImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6866,13 +6866,13 @@ private fun KaDiagnosticConverterBuilder.addConversions148() {
             firDiagnostic.b,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_EXPOSE_REIFIED) { firDiagnostic ->
         JvmExposeBoxedCannotExposeReifiedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6881,13 +6881,13 @@ private fun KaDiagnosticConverterBuilder.addConversions148() {
 private fun KaDiagnosticConverterBuilder.addConversions149() {
     add(FirErrors.DELEGATION_SUPER_CALL_IN_ENUM_CONSTRUCTOR) { firDiagnostic ->
         DelegationSuperCallInEnumConstructorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.BOUND_ON_TYPE_ALIAS_PARAMETER_NOT_ALLOWED) { firDiagnostic ->
         BoundOnTypeAliasParameterNotAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6896,13 +6896,13 @@ private fun KaDiagnosticConverterBuilder.addConversions149() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_NOT_ALLOWED) { firDiagnostic ->
         ReturnNotAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6911,7 +6911,7 @@ private fun KaDiagnosticConverterBuilder.addConversions149() {
 private fun KaDiagnosticConverterBuilder.addConversions150() {
     add(FirErrors.INVALID_IF_AS_EXPRESSION) { firDiagnostic ->
         InvalidIfAsExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6920,7 +6920,7 @@ private fun KaDiagnosticConverterBuilder.addConversions150() {
 private fun KaDiagnosticConverterBuilder.addConversions151() {
     add(FirErrors.ABSTRACT_SUPER_CALL) { firDiagnostic ->
         AbstractSuperCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6929,13 +6929,13 @@ private fun KaDiagnosticConverterBuilder.addConversions151() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LOCAL_EXTENSION_PROPERTY) { firDiagnostic ->
         LocalExtensionPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6944,19 +6944,19 @@ private fun KaDiagnosticConverterBuilder.addConversions151() {
             firDiagnostic.a.map { firTypeParameterSymbol ->
                 firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firTypeParameterSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_PACKAGE_NAME_NOT_SUPPORTED_IN_FILES_WITH_CLASSES) { firDiagnostic ->
         JvmPackageNameNotSupportedInFilesWithClassesImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.MULTIPLE_JS_EXPORT_DEFAULT_IN_ONE_FILE) { firDiagnostic ->
         MultipleJsExportDefaultInOneFileImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6966,19 +6966,19 @@ private fun KaDiagnosticConverterBuilder.addConversions152() {
     add(FirErrors.OUTER_CLASS_ARGUMENTS_REQUIRED) { firDiagnostic ->
         OuterClassArgumentsRequiredImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUST_BE_INITIALIZED_OR_BE_FINAL) { firDiagnostic ->
         MustBeInitializedOrBeFinalImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.NESTED_CLASS_IN_EXTERNAL_INTERFACE) { firDiagnostic ->
         NestedClassInExternalInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -6987,14 +6987,14 @@ private fun KaDiagnosticConverterBuilder.addConversions152() {
 private fun KaDiagnosticConverterBuilder.addConversions153() {
     add(FirErrors.PROPERTY_FIELD_DECLARATION_MISSING_INITIALIZER) { firDiagnostic ->
         PropertyFieldDeclarationMissingInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.IDENTITY_SENSITIVE_OPERATIONS_WITH_VALUE_TYPE) { firDiagnostic ->
         IdentitySensitiveOperationsWithValueTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7004,25 +7004,25 @@ private fun KaDiagnosticConverterBuilder.addConversions154() {
     add(FirErrors.OTHER_ERROR_WITH_REASON) { firDiagnostic ->
         OtherErrorWithReasonImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.LABEL_NAME_CLASH) { firDiagnostic ->
         LabelNameClashImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_ON_ANNOTATION_ARGUMENT) { firDiagnostic ->
         AnnotationOnAnnotationArgumentImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.GENERIC_QUALIFIER_ON_CONSTRUCTOR_CALL.errorFactory) { firDiagnostic ->
         GenericQualifierOnConstructorCallErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7030,7 +7030,7 @@ private fun KaDiagnosticConverterBuilder.addConversions154() {
         OverridingFinalMemberByDelegationImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7040,7 +7040,7 @@ private fun KaDiagnosticConverterBuilder.addConversions155() {
     add(FirJsErrors.CALL_TO_JS_MODULE_WITHOUT_MODULE_SYSTEM) { firDiagnostic ->
         CallToJsModuleWithoutModuleSystemImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7049,20 +7049,20 @@ private fun KaDiagnosticConverterBuilder.addConversions155() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPEALIAS_EXPANDS_TO_COMPILER_REQUIRED_ANNOTATION.errorFactory) { firDiagnostic ->
         TypealiasExpandsToCompilerRequiredAnnotationErrorImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INLINE_PROPERTY_WITH_BACKING_FIELD) { firDiagnostic ->
         InlinePropertyWithBackingFieldImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7071,7 +7071,7 @@ private fun KaDiagnosticConverterBuilder.addConversions155() {
 private fun KaDiagnosticConverterBuilder.addConversions156() {
     add(FirErrors.DEPRECATED_SINCE_KOTLIN_OUTSIDE_KOTLIN_SUBPACKAGE) { firDiagnostic ->
         DeprecatedSinceKotlinOutsideKotlinSubpackageImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7080,7 +7080,7 @@ private fun KaDiagnosticConverterBuilder.addConversions156() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7088,7 +7088,7 @@ private fun KaDiagnosticConverterBuilder.addConversions156() {
         IncompatibleTypesWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7097,19 +7097,19 @@ private fun KaDiagnosticConverterBuilder.addConversions156() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CAN_BE_VAL_LATEINIT) { firDiagnostic ->
         CanBeValLateinitImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_FORBIDDEN_AS_CAST) { firDiagnostic ->
         JsNoRuntimeForbiddenAsCastImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7119,31 +7119,31 @@ private fun KaDiagnosticConverterBuilder.addConversions157() {
     add(FirErrors.ERROR_SUPPRESSION) { firDiagnostic ->
         ErrorSuppressionImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_WITH_USE_SITE_TARGET_ON_EXPRESSION.warningFactory) { firDiagnostic ->
         AnnotationWithUseSiteTargetOnExpressionWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INAPPLICABLE_INFIX_MODIFIER) { firDiagnostic ->
         InapplicableInfixModifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PROPERTY_WITH_BACKING_FIELD_INSIDE_VALUE_CLASS) { firDiagnostic ->
         PropertyWithBackingFieldInsideValueClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERLOADS_ABSTRACT) { firDiagnostic ->
         OverloadsAbstractImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7151,7 +7151,7 @@ private fun KaDiagnosticConverterBuilder.addConversions157() {
         JsExternalInheritorsOnlyImpl(
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7160,7 +7160,7 @@ private fun KaDiagnosticConverterBuilder.addConversions157() {
 private fun KaDiagnosticConverterBuilder.addConversions158() {
     add(FirErrors.ANNOTATION_PARAMETER_DEFAULT_VALUE_MUST_BE_CONSTANT) { firDiagnostic ->
         AnnotationParameterDefaultValueMustBeConstantImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7168,14 +7168,14 @@ private fun KaDiagnosticConverterBuilder.addConversions158() {
         DeprecatedModifierImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_NO_RUNTIME_INTERFACE_AS_REIFIED_TYPE_ARGUMENT) { firDiagnostic ->
         JsNoRuntimeInterfaceAsReifiedTypeArgumentImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7184,7 +7184,7 @@ private fun KaDiagnosticConverterBuilder.addConversions158() {
 private fun KaDiagnosticConverterBuilder.addConversions159() {
     add(FirJsErrors.JS_NAME_PROHIBITED_FOR_NAMED_NATIVE) { firDiagnostic ->
         JsNameProhibitedForNamedNativeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7194,7 +7194,7 @@ private fun KaDiagnosticConverterBuilder.addConversions159() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7204,14 +7204,14 @@ private fun KaDiagnosticConverterBuilder.addConversions159() {
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             (firDiagnostic.c as? KtPsiSourceElement)?.psi,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNNECESSARY_SAFE_CALL) { firDiagnostic ->
         UnnecessarySafeCallImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7221,7 +7221,7 @@ private fun KaDiagnosticConverterBuilder.addConversions160() {
     add(FirErrors.IMPLICIT_PROPERTY_TYPE_MAKES_BEHAVIOR_ORDER_DEPENDANT_ERROR) { firDiagnostic ->
         ImplicitPropertyTypeMakesBehaviorOrderDependantErrorImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7232,13 +7232,13 @@ private fun KaDiagnosticConverterBuilder.addConversions160() {
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONST_VAL_WITHOUT_INITIALIZER) { firDiagnostic ->
         ConstValWithoutInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7246,7 +7246,7 @@ private fun KaDiagnosticConverterBuilder.addConversions160() {
         ProtectedCallFromPublicInlineErrorImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7255,40 +7255,40 @@ private fun KaDiagnosticConverterBuilder.addConversions160() {
 private fun KaDiagnosticConverterBuilder.addConversions161() {
     add(FirErrors.BREAK_OR_CONTINUE_OUTSIDE_A_LOOP) { firDiagnostic ->
         BreakOrContinueOutsideALoopImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MUTABLE_PROPERTY_WITH_CAPTURED_TYPE) { firDiagnostic ->
         MutablePropertyWithCapturedTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_INLINE_MEMBER_VAL_INITIALIZATION) { firDiagnostic ->
         NonInlineMemberValInitializationImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_COMPANION_BLOCK_MEMBER) { firDiagnostic ->
         IllegalCompanionBlockMemberImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NON_EXPORTABLE_TYPE_IN_SYNTHETIC_COPY_FUNCTION_WITH_EXPOSED_COPY_VISIBILITY) { firDiagnostic ->
         NonExportableTypeInSyntheticCopyFunctionWithExposedCopyVisibilityImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_ACTUAL_EXTERNAL_INTERFACE_WHILE_EXPECT_WITHOUT_JS_NO_RUNTIME) { firDiagnostic ->
         JsActualExternalInterfaceWhileExpectWithoutJsNoRuntimeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7297,7 +7297,7 @@ private fun KaDiagnosticConverterBuilder.addConversions161() {
 private fun KaDiagnosticConverterBuilder.addConversions162() {
     add(FirErrors.PROJECTION_IN_TYPE_OF_ANNOTATION_MEMBER.errorFactory) { firDiagnostic ->
         ProjectionInTypeOfAnnotationMemberErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7306,14 +7306,14 @@ private fun KaDiagnosticConverterBuilder.addConversions162() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNINITIALIZED_ENUM_ENTRY) { firDiagnostic ->
         UninitializedEnumEntryImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7321,13 +7321,13 @@ private fun KaDiagnosticConverterBuilder.addConversions162() {
         ImplicitBoxingInIdentityEqualsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.IMPLEMENTING_FUNCTION_INTERFACE) { firDiagnostic ->
         ImplementingFunctionInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7337,13 +7337,13 @@ private fun KaDiagnosticConverterBuilder.addConversions163() {
     add(FirErrors.CONFLICTING_PROJECTION_IN_TYPEALIAS_EXPANSION) { firDiagnostic ->
         ConflictingProjectionInTypealiasExpansionImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABBREVIATED_NOTHING_PROPERTY_TYPE) { firDiagnostic ->
         AbbreviatedNothingPropertyTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7353,7 +7353,7 @@ private fun KaDiagnosticConverterBuilder.addConversions163() {
             firDiagnostic.b,
             firDiagnostic.c,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.d),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7364,19 +7364,19 @@ private fun KaDiagnosticConverterBuilder.addConversions163() {
             firDiagnostic.c.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_TAIL_RECURSIVE_CALL) { firDiagnostic ->
         NonTailRecursiveCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_PROPERTY_INITIALIZER) { firDiagnostic ->
         ExpectedPropertyInitializerImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7384,20 +7384,20 @@ private fun KaDiagnosticConverterBuilder.addConversions163() {
         UncheckedCastImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONFLICTING_IMPORT) { firDiagnostic ->
         ConflictingImportImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_STATIC_ON_EXTERNAL_IN_INTERFACE) { firDiagnostic ->
         JvmStaticOnExternalInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7406,7 +7406,7 @@ private fun KaDiagnosticConverterBuilder.addConversions163() {
 private fun KaDiagnosticConverterBuilder.addConversions164() {
     add(FirErrors.VARARG_OUTSIDE_PARENTHESES) { firDiagnostic ->
         VarargOutsideParenthesesImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7417,7 +7417,7 @@ private fun KaDiagnosticConverterBuilder.addConversions164() {
             firDiagnostic.c.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7425,13 +7425,13 @@ private fun KaDiagnosticConverterBuilder.addConversions164() {
         PropertyTypeMismatchByDelegationImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_PROPERTY_WITH_SETTER) { firDiagnostic ->
         AbstractPropertyWithSetterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7439,7 +7439,7 @@ private fun KaDiagnosticConverterBuilder.addConversions164() {
         TypealiasAsCallableQualifierInImportErrorImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7452,7 +7452,7 @@ private fun KaDiagnosticConverterBuilder.addConversions165() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7462,20 +7462,20 @@ private fun KaDiagnosticConverterBuilder.addConversions165() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CANNOT_INFER_VISIBILITY) { firDiagnostic ->
         CannotInferVisibilityImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNSAFE_CAST_RELYING_ON_NULL) { firDiagnostic ->
         UnsafeCastRelyingOnNullImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7484,7 +7484,7 @@ private fun KaDiagnosticConverterBuilder.addConversions165() {
 private fun KaDiagnosticConverterBuilder.addConversions166() {
     add(FirJsErrors.CALL_FROM_UMD_MUST_BE_JS_MODULE_AND_JS_NON_MODULE) { firDiagnostic ->
         CallFromUmdMustBeJsModuleAndJsNonModuleImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7492,31 +7492,31 @@ private fun KaDiagnosticConverterBuilder.addConversions166() {
         VarTypeMismatchOnOverrideImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FUN_INTERFACE_CANNOT_HAVE_ABSTRACT_PROPERTIES) { firDiagnostic ->
         FunInterfaceCannotHaveAbstractPropertiesImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMMA_IN_WHEN_CONDITION_WITH_WHEN_GUARD) { firDiagnostic ->
         CommaInWhenConditionWithWhenGuardImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DECLARATION_CANT_BE_INLINED_DEPRECATION.errorFactory) { firDiagnostic ->
         DeclarationCantBeInlinedDeprecationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.DELEGATION_BY_IN_JVM_RECORD) { firDiagnostic ->
         DelegationByInJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7525,19 +7525,19 @@ private fun KaDiagnosticConverterBuilder.addConversions166() {
 private fun KaDiagnosticConverterBuilder.addConversions167() {
     add(FirErrors.OPT_IN_MARKER_WITH_WRONG_RETENTION) { firDiagnostic ->
         OptInMarkerWithWrongRetentionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CANNOT_IMPLEMENT_INTERFACE_BY_DELEGATION) { firDiagnostic ->
         ValueClassCannotImplementInterfaceByDelegationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_EXTERNAL_DECLARATION) { firDiagnostic ->
         ExpectedExternalDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7549,7 +7549,7 @@ private fun KaDiagnosticConverterBuilder.addConversions167() {
             firDiagnostic.b.map { ktSourceElement ->
                 (ktSourceElement as KtPsiSourceElement).psi
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7557,26 +7557,26 @@ private fun KaDiagnosticConverterBuilder.addConversions167() {
         NotFunctionAsOperatorImpl(
             firDiagnostic.a,
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_IN_FUNCTION_WITH_EXPRESSION_BODY_WARNING) { firDiagnostic ->
         ReturnInFunctionWithExpressionBodyWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_SUSPEND_PROPERTY_ACCESS) { firDiagnostic ->
         IllegalSuspendPropertyAccessImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.THROWS_IN_ANNOTATION.errorFactory) { firDiagnostic ->
         ThrowsInAnnotationErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7586,7 +7586,7 @@ private fun KaDiagnosticConverterBuilder.addConversions168() {
     add(FirJsErrors.JS_BUILTIN_NAME_CLASH) { firDiagnostic ->
         JsBuiltinNameClashImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7594,26 +7594,26 @@ private fun KaDiagnosticConverterBuilder.addConversions168() {
         InconsistentSuspendInOfOverloadsImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DYNAMIC_RECEIVER_EXPECTED_BUT_WAS_NON_DYNAMIC) { firDiagnostic ->
         DynamicReceiverExpectedButWasNonDynamicImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INC_DEC_SHOULD_NOT_RETURN_UNIT) { firDiagnostic ->
         IncDecShouldNotReturnUnitImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.VALUE_CLASS_WITHOUT_JVM_INLINE_ANNOTATION) { firDiagnostic ->
         ValueClassWithoutJvmInlineAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7622,7 +7622,7 @@ private fun KaDiagnosticConverterBuilder.addConversions168() {
 private fun KaDiagnosticConverterBuilder.addConversions169() {
     add(FirErrors.ANNOTATION_WITH_USE_SITE_TARGET_ON_EXPRESSION.errorFactory) { firDiagnostic ->
         AnnotationWithUseSiteTargetOnExpressionErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7633,13 +7633,13 @@ private fun KaDiagnosticConverterBuilder.addConversions169() {
                                     string
                                 }
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MANY_COMPANION_OBJECTS) { firDiagnostic ->
         ManyCompanionObjectsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7651,13 +7651,13 @@ private fun KaDiagnosticConverterBuilder.addConversions170() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DATA_CLASS_COPY_VISIBILITY_WILL_BE_CHANGED.errorFactory) { firDiagnostic ->
         DataClassCopyVisibilityWillBeChangedErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7665,31 +7665,31 @@ private fun KaDiagnosticConverterBuilder.addConversions170() {
         NameInConstraintIsNotATypeParameterImpl(
             firDiagnostic.a,
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING) { firDiagnostic ->
         ExpectActualClassifiersAreInBetaWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CAST_NEVER_SUCCEEDS) { firDiagnostic ->
         CastNeverSucceedsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DECLARATION_CANT_BE_INLINED_DEPRECATION.warningFactory) { firDiagnostic ->
         DeclarationCantBeInlinedDeprecationWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.EXTERNAL_DECLARATION_CANNOT_BE_INLINED) { firDiagnostic ->
         ExternalDeclarationCannotBeInlinedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7698,7 +7698,7 @@ private fun KaDiagnosticConverterBuilder.addConversions170() {
 private fun KaDiagnosticConverterBuilder.addConversions171() {
     add(FirErrors.NULLABLE_SUPERTYPE_THROUGH_TYPEALIAS.errorFactory) { firDiagnostic ->
         NullableSupertypeThroughTypealiasErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7706,25 +7706,25 @@ private fun KaDiagnosticConverterBuilder.addConversions171() {
         NoTypeArgumentsOnRhsImpl(
             firDiagnostic.a,
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SETTER_VISIBILITY_INCONSISTENT_WITH_PROPERTY_VISIBILITY) { firDiagnostic ->
         SetterVisibilityInconsistentWithPropertyVisibilityImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_LABEL_WARNING) { firDiagnostic ->
         RedundantLabelWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_DELEGATION) { firDiagnostic ->
         ExternalDelegationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7733,13 +7733,13 @@ private fun KaDiagnosticConverterBuilder.addConversions171() {
 private fun KaDiagnosticConverterBuilder.addConversions172() {
     add(FirErrors.DIVISION_BY_ZERO) { firDiagnostic ->
         DivisionByZeroImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION) { firDiagnostic ->
         NonSourceAnnotationOnInlinedLambdaExpressionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7749,26 +7749,26 @@ private fun KaDiagnosticConverterBuilder.addConversions172() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PRIVATE_FUNCTION_WITH_NO_BODY) { firDiagnostic ->
         PrivateFunctionWithNoBodyImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.USELESS_ELVIS_RIGHT_IS_NULL) { firDiagnostic ->
         UselessElvisRightIsNullImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SAFE_CAST_RELYING_ON_NULL) { firDiagnostic ->
         SafeCastRelyingOnNullImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7777,7 +7777,7 @@ private fun KaDiagnosticConverterBuilder.addConversions172() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7786,33 +7786,33 @@ private fun KaDiagnosticConverterBuilder.addConversions172() {
 private fun KaDiagnosticConverterBuilder.addConversions173() {
     add(FirErrors.ANNOTATION_ARGUMENT_MUST_BE_CONST) { firDiagnostic ->
         AnnotationArgumentMustBeConstImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_OPEN_IN_INTERFACE) { firDiagnostic ->
         RedundantOpenInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NO_CONTEXT_ARGUMENT) { firDiagnostic ->
         NoContextArgumentImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.MISPLACED_TYPE_PARAMETER_CONSTRAINTS) { firDiagnostic ->
         MisplacedTypeParameterConstraintsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IMPOSSIBLE_IS_CHECK_DEPRECATION.errorFactory) { firDiagnostic ->
         ImpossibleIsCheckDeprecationErrorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7821,7 +7821,7 @@ private fun KaDiagnosticConverterBuilder.addConversions173() {
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7829,7 +7829,7 @@ private fun KaDiagnosticConverterBuilder.addConversions173() {
         ReceiverMutabilityMismatchBasedOnJavaAnnotationsImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7840,19 +7840,19 @@ private fun KaDiagnosticConverterBuilder.addConversions174() {
         MissingDependencySuperclassWarningImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DATA_CLASS_CONSISTENT_COPY_AND_EXPOSED_COPY_ARE_INCOMPATIBLE_ANNOTATIONS) { firDiagnostic ->
         DataClassConsistentCopyAndExposedCopyAreIncompatibleAnnotationsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DATA_CLASS_COPY_VISIBILITY_WILL_BE_CHANGED.warningFactory) { firDiagnostic ->
         DataClassCopyVisibilityWillBeChangedWarningImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7862,46 +7862,46 @@ private fun KaDiagnosticConverterBuilder.addConversions174() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PACKAGE_CONFLICTS_WITH_CLASSIFIER) { firDiagnostic ->
         PackageConflictsWithClassifierImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.SINGLE_ANONYMOUS_FUNCTION_WITH_NAME.errorFactory) { firDiagnostic ->
         SingleAnonymousFunctionWithNameErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INTEGER_LITERAL_CAST_INSTEAD_OF_TO_CALL) { firDiagnostic ->
         IntegerLiteralCastInsteadOfToCallImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNUSED_ANONYMOUS_PARAMETER) { firDiagnostic ->
         UnusedAnonymousParameterImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DEPRECATED_ACCESS_TO_ENTRIES_AS_QUALIFIER) { firDiagnostic ->
         DeprecatedAccessToEntriesAsQualifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_DEFAULT_WITHOUT_COMPATIBILITY_NOT_IN_ENABLE_MODE) { firDiagnostic ->
         JvmDefaultWithoutCompatibilityNotInEnableModeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7910,14 +7910,14 @@ private fun KaDiagnosticConverterBuilder.addConversions174() {
 private fun KaDiagnosticConverterBuilder.addConversions175() {
     add(FirErrors.SUPERTYPE_APPEARS_TWICE) { firDiagnostic ->
         SupertypeAppearsTwiceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.VALUE_CLASS_CONSTRUCTOR_NOT_FINAL_READ_ONLY_PARAMETER) { firDiagnostic ->
         ValueClassConstructorNotFinalReadOnlyParameterImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7926,13 +7926,13 @@ private fun KaDiagnosticConverterBuilder.addConversions175() {
             firDiagnostic.a,
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE) { firDiagnostic ->
         ActualTypeAliasToClassWithDeclarationSiteVarianceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7942,14 +7942,14 @@ private fun KaDiagnosticConverterBuilder.addConversions175() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONTRACT_NOT_ALLOWED) { firDiagnostic ->
         ContractNotAllowedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7960,7 +7960,7 @@ private fun KaDiagnosticConverterBuilder.addConversions176() {
         WrongModifierContainingDeclarationImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7968,13 +7968,13 @@ private fun KaDiagnosticConverterBuilder.addConversions176() {
         DeprecatedSmartcastOnDelegatedPropertyImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ABSTRACT_PROPERTY_WITH_GETTER) { firDiagnostic ->
         AbstractPropertyWithGetterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -7983,19 +7983,19 @@ private fun KaDiagnosticConverterBuilder.addConversions176() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECT_ACTUAL_OPT_IN_ANNOTATION) { firDiagnostic ->
         ExpectActualOptInAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.CONFLICT_VERSION_AND_JVM_OVERLOADS_ANNOTATION) { firDiagnostic ->
         ConflictVersionAndJvmOverloadsAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8008,21 +8008,21 @@ private fun KaDiagnosticConverterBuilder.addConversions177() {
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REPEATED_MODIFIER) { firDiagnostic ->
         RepeatedModifierImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RETURN_VALUE_NOT_USED) { firDiagnostic ->
         ReturnValueNotUsedImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8035,14 +8035,14 @@ private fun KaDiagnosticConverterBuilder.addConversions178() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
             firDiagnostic.d,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_INFERENCE_ONLY_INPUT_TYPES_ERROR) { firDiagnostic ->
         TypeInferenceOnlyInputTypesErrorImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8051,14 +8051,14 @@ private fun KaDiagnosticConverterBuilder.addConversions178() {
             firDiagnostic.a.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.UNSUPPORTED_REFLECTION_API) { firDiagnostic ->
         UnsupportedReflectionApiImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8066,7 +8066,7 @@ private fun KaDiagnosticConverterBuilder.addConversions178() {
         SuspendOverriddenByNonSuspendImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8074,13 +8074,13 @@ private fun KaDiagnosticConverterBuilder.addConversions178() {
         NonSuspendOverriddenBySuspendImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANONYMOUS_FUNCTION_WITH_NAME) { firDiagnostic ->
         AnonymousFunctionWithNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8089,7 +8089,7 @@ private fun KaDiagnosticConverterBuilder.addConversions178() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8098,20 +8098,20 @@ private fun KaDiagnosticConverterBuilder.addConversions178() {
 private fun KaDiagnosticConverterBuilder.addConversions179() {
     add(FirErrors.DEFINITELY_NON_NULLABLE_AS_REIFIED) { firDiagnostic ->
         DefinitelyNonNullableAsReifiedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CAPTURED_VAL_INITIALIZATION) { firDiagnostic ->
         CapturedValInitializationImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_CONDITION) { firDiagnostic ->
         ExpectedConditionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8121,33 +8121,33 @@ private fun KaDiagnosticConverterBuilder.addConversions180() {
     add(FirErrors.NESTED_CLASS_NOT_ALLOWED_IN_LOCAL.warningFactory) { firDiagnostic ->
         NestedClassNotAllowedInLocalWarningImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_PROJECTION) { firDiagnostic ->
         RedundantProjectionImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DELEGATE_USES_EXTENSION_PROPERTY_TYPE_PARAMETER_ERROR) { firDiagnostic ->
         DelegateUsesExtensionPropertyTypeParameterErrorImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNNAMED_DELEGATED_PROPERTY) { firDiagnostic ->
         UnnamedDelegatedPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.NON_DATA_VALUE_CLASS_JVM_RECORD) { firDiagnostic ->
         NonDataValueClassJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8156,7 +8156,7 @@ private fun KaDiagnosticConverterBuilder.addConversions180() {
 private fun KaDiagnosticConverterBuilder.addConversions181() {
     add(FirJsErrors.DATA_CLASS_COPY_JS_EXPORTABILITY_WILL_BE_CHANGED.errorFactory) { firDiagnostic ->
         DataClassCopyJsExportabilityWillBeChangedErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8168,25 +8168,25 @@ private fun KaDiagnosticConverterBuilder.addConversions182() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firDiagnostic.b,
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ANNOTATION_ARGUMENT_MUST_BE_KCLASS_LITERAL) { firDiagnostic ->
         AnnotationArgumentMustBeKclassLiteralImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TAILREC_ON_VIRTUAL_MEMBER_ERROR) { firDiagnostic ->
         TailrecOnVirtualMemberErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.COMPANION_OBJECT_IN_EXTERNAL_INTERFACE) { firDiagnostic ->
         CompanionObjectInExternalInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8199,32 +8199,32 @@ private fun KaDiagnosticConverterBuilder.addConversions183() {
             firDiagnostic.b.map { firBasedSymbol ->
                 firSymbolBuilder.buildSymbol(firBasedSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.OPTIONAL_DECLARATION_OUTSIDE_OF_ANNOTATION_ENTRY) { firDiagnostic ->
         OptionalDeclarationOutsideOfAnnotationEntryImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NOT_YET_SUPPORTED_IN_INLINE) { firDiagnostic ->
         NotYetSupportedInInlineImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_EXPOSE_BOXED_CANNOT_EXPOSE_PRIVATE) { firDiagnostic ->
         JvmExposeBoxedCannotExposePrivateImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NOT_EXPORTED_OR_EXTERNAL_ACTUAL_DECLARATION_WHILE_EXPECT_IS_EXPORTED) { firDiagnostic ->
         NotExportedOrExternalActualDeclarationWhileExpectIsExportedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8233,13 +8233,13 @@ private fun KaDiagnosticConverterBuilder.addConversions183() {
 private fun KaDiagnosticConverterBuilder.addConversions184() {
     add(FirErrors.UNRESOLVED_EQUALITY_BOUND_ARGUMENT) { firDiagnostic ->
         UnresolvedEqualityBoundArgumentImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ITERATOR_MISSING) { firDiagnostic ->
         IteratorMissingImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8247,7 +8247,7 @@ private fun KaDiagnosticConverterBuilder.addConversions184() {
         WrongTypeForJavaOverrideImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8257,13 +8257,13 @@ private fun KaDiagnosticConverterBuilder.addConversions185() {
     add(FirErrors.NOT_AN_ANNOTATION_CLASS) { firDiagnostic ->
         NotAnAnnotationClassImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NATIVE_SETTER_WRONG_RETURN_TYPE) { firDiagnostic ->
         NativeSetterWrongReturnTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8275,19 +8275,19 @@ private fun KaDiagnosticConverterBuilder.addConversions185() {
             firDiagnostic.d.map { firNamedFunctionSymbol ->
                 firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firNamedFunctionSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.WHEN_GUARD_WITHOUT_SUBJECT) { firDiagnostic ->
         WhenGuardWithoutSubjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.JVM_STATIC_NOT_IN_OBJECT_OR_COMPANION) { firDiagnostic ->
         JvmStaticNotInObjectOrCompanionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8297,38 +8297,38 @@ private fun KaDiagnosticConverterBuilder.addConversions186() {
     add(FirErrors.FINAL_UPPER_BOUND) { firDiagnostic ->
         FinalUpperBoundImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_FINAL_MEMBER_IN_FINAL_CLASS) { firDiagnostic ->
         NonFinalMemberInFinalClassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNNECESSARY_NOT_NULL_ASSERTION) { firDiagnostic ->
         UnnecessaryNotNullAssertionImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNDERSCORE_USAGE_WITHOUT_BACKTICKS) { firDiagnostic ->
         UnderscoreUsageWithoutBackticksImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.RESOLVED_TO_UNDERSCORE_NAMED_CATCH_PARAMETER) { firDiagnostic ->
         ResolvedToUnderscoreNamedCatchParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INVALID_VERSIONING_ON_VALUE_CLASS_PARAMETER) { firDiagnostic ->
         InvalidVersioningOnValueClassParameterImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8339,20 +8339,20 @@ private fun KaDiagnosticConverterBuilder.addConversions187() {
         ResultTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.EXTERNAL_DECLARATION_IN_INTERFACE) { firDiagnostic ->
         ExternalDeclarationInInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.MISSING_BUILT_IN_DECLARATION) { firDiagnostic ->
         MissingBuiltInDeclarationImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8361,7 +8361,7 @@ private fun KaDiagnosticConverterBuilder.addConversions187() {
 private fun KaDiagnosticConverterBuilder.addConversions188() {
     add(FirErrors.INTERFACE_WITH_SUPERCLASS) { firDiagnostic ->
         InterfaceWithSuperclassImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8369,7 +8369,7 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
         OptInOverrideImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8377,7 +8377,7 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
         RedundantModifierImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8385,19 +8385,19 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
         ValueClassHasInapplicableParameterTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.TYPE_ARGUMENTS_FOR_OUTER_CLASS_WHEN_NESTED_REFERENCED) { firDiagnostic ->
         TypeArgumentsForOuterClassWhenNestedReferencedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FUN_INTERFACE_WITH_SUSPEND_FUNCTION) { firDiagnostic ->
         FunInterfaceWithSuspendFunctionImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8405,7 +8405,7 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
         UnsafeCallImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b?.source?.psi as? KtExpression,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8415,7 +8415,7 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
             firDiagnostic.b.map { string ->
                 string
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8424,13 +8424,13 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERLOADS_WITHOUT_DEFAULT_ARGUMENTS) { firDiagnostic ->
         OverloadsWithoutDefaultArgumentsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8439,21 +8439,21 @@ private fun KaDiagnosticConverterBuilder.addConversions188() {
 private fun KaDiagnosticConverterBuilder.addConversions189() {
     add(FirErrors.ANNOTATION_CLASS_MEMBER) { firDiagnostic ->
         AnnotationClassMemberImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NATIVE_ANNOTATIONS_ALLOWED_ONLY_ON_MEMBER_OR_EXTENSION_FUN) { firDiagnostic ->
         NativeAnnotationsAllowedOnlyOnMemberOrExtensionFunImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.COMPANION_EXTENSION_RECEIVER_IS_OBJECT) { firDiagnostic ->
         CompanionExtensionReceiverIsObjectImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8462,7 +8462,7 @@ private fun KaDiagnosticConverterBuilder.addConversions189() {
 private fun KaDiagnosticConverterBuilder.addConversions190() {
     add(FirErrors.MIXING_NAMED_AND_POSITIONAL_ARGUMENTS) { firDiagnostic ->
         MixingNamedAndPositionalArgumentsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8478,21 +8478,21 @@ private fun KaDiagnosticConverterBuilder.addConversions190() {
                                                         }
                                 }
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.DSL_SCOPE_VIOLATION) { firDiagnostic ->
         DslScopeViolationImpl(
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.IR_WITH_UNSTABLE_ABI_COMPILED_CLASS) { firDiagnostic ->
         IrWithUnstableAbiCompiledClassImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8504,7 +8504,7 @@ private fun KaDiagnosticConverterBuilder.addConversions190() {
             firDiagnostic.b.map { string ->
                 string
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8515,7 +8515,7 @@ private fun KaDiagnosticConverterBuilder.addConversions191() {
         DataClassOverrideDefaultValuesImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8523,20 +8523,20 @@ private fun KaDiagnosticConverterBuilder.addConversions191() {
         VarOverriddenByValImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPLICIT_BACKING_FIELD_IN_ABSTRACT_PROPERTY) { firDiagnostic ->
         ExplicitBackingFieldInAbstractPropertyImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ILLEGAL_DECLARATION_IN_WHEN_SUBJECT) { firDiagnostic ->
         IllegalDeclarationInWhenSubjectImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8547,26 +8547,26 @@ private fun KaDiagnosticConverterBuilder.addConversions191() {
             firDiagnostic.c.map { firValueParameterSymbol ->
                 firSymbolBuilder.buildSymbol(firValueParameterSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_ON_SUSPEND_ERROR) { firDiagnostic ->
         SynchronizedOnSuspendErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.NON_SOURCE_REPEATED_ANNOTATION) { firDiagnostic ->
         NonSourceRepeatedAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.SYNCHRONIZED_BLOCK_ON_VALUE_CLASS_OR_PRIMITIVE.warningFactory) { firDiagnostic ->
         SynchronizedBlockOnValueClassOrPrimitiveWarningImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8575,7 +8575,7 @@ private fun KaDiagnosticConverterBuilder.addConversions191() {
 private fun KaDiagnosticConverterBuilder.addConversions192() {
     add(FirErrors.DATA_CLASS_CONSISTENT_COPY_WRONG_ANNOTATION_TARGET) { firDiagnostic ->
         DataClassConsistentCopyWrongAnnotationTargetImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8583,20 +8583,20 @@ private fun KaDiagnosticConverterBuilder.addConversions192() {
         ThrowableTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.KCLASS_WITH_NULLABLE_TYPE_PARAMETER_IN_SIGNATURE) { firDiagnostic ->
         KclassWithNullableTypeParameterInSignatureImpl(
             firSymbolBuilder.classifierBuilder.buildTypeParameterSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ONLY_ONE_CLASS_BOUND_ALLOWED) { firDiagnostic ->
         OnlyOneClassBoundAllowedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8605,7 +8605,7 @@ private fun KaDiagnosticConverterBuilder.addConversions192() {
             firDiagnostic.a,
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8616,7 +8616,7 @@ private fun KaDiagnosticConverterBuilder.addConversions192() {
             firDiagnostic.c.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8624,26 +8624,26 @@ private fun KaDiagnosticConverterBuilder.addConversions192() {
         AbstractFunctionInNonAbstractClassImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
             firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_ABSTRACT_FUNCTION_WITH_NO_BODY) { firDiagnostic ->
         NonAbstractFunctionWithNoBodyImpl(
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.EXPECTED_CLASS_CONSTRUCTOR_DELEGATION_CALL) { firDiagnostic ->
         ExpectedClassConstructorDelegationCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.INLINE_SUSPEND_FUNCTION_TYPE_UNSUPPORTED) { firDiagnostic ->
         InlineSuspendFunctionTypeUnsupportedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8653,7 +8653,7 @@ private fun KaDiagnosticConverterBuilder.addConversions193() {
     add(FirErrors.OPERATOR_CALL_ON_CONSTRUCTOR) { firDiagnostic ->
         OperatorCallOnConstructorImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8661,7 +8661,7 @@ private fun KaDiagnosticConverterBuilder.addConversions193() {
         ExpectedParameterTypeMismatchImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8670,33 +8670,33 @@ private fun KaDiagnosticConverterBuilder.addConversions193() {
             firSymbolBuilder.buildSymbol(firDiagnostic.a),
             firSymbolBuilder.buildSymbol(firDiagnostic.b),
             firDiagnostic.c,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_SETTER_PARAMETER_TYPE) { firDiagnostic ->
         RedundantSetterParameterTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.NON_FINAL_JVM_RECORD) { firDiagnostic ->
         NonFinalJvmRecordImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.WRONG_OPERATION_WITH_DYNAMIC) { firDiagnostic ->
         WrongOperationWithDynamicImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.EXTERNAL_INTERFACE_AS_REIFIED_TYPE_ARGUMENT) { firDiagnostic ->
         ExternalInterfaceAsReifiedTypeArgumentImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8707,26 +8707,26 @@ private fun KaDiagnosticConverterBuilder.addConversions194() {
         MissingDependencyClassInLambdaParameterImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_PRIVATE_OR_PROTECTED_CONSTRUCTOR_IN_SEALED) { firDiagnostic ->
         NonPrivateOrProtectedConstructorInSealedImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.NATIVE_INDEXER_KEY_SHOULD_BE_STRING_OR_NUMBER) { firDiagnostic ->
         NativeIndexerKeyShouldBeStringOrNumberImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.CONST_VAL_NOT_TOP_LEVEL_OR_OBJECT) { firDiagnostic ->
         ConstValNotTopLevelOrObjectImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8734,33 +8734,33 @@ private fun KaDiagnosticConverterBuilder.addConversions194() {
         DestructuringShortFormNameMismatchImpl(
             firDiagnostic.a,
             firDiagnostic.b,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_TYPE_ALIAS_TO_NULLABLE_TYPE) { firDiagnostic ->
         ActualTypeAliasToNullableTypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NUMERIC_CAST_NEVER_SUCCEEDS_BUT_CAN_BE_REPLACED_WITH_TO_CALL) { firDiagnostic ->
         NumericCastNeverSucceedsButCanBeReplacedWithToCallImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.OVERLOADS_ANNOTATION_CLASS_CONSTRUCTOR_ERROR) { firDiagnostic ->
         OverloadsAnnotationClassConstructorErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirWebCommonErrors.WRONG_EXTERNAL_DECLARATION) { firDiagnostic ->
         WrongExternalDeclarationImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8769,13 +8769,13 @@ private fun KaDiagnosticConverterBuilder.addConversions194() {
 private fun KaDiagnosticConverterBuilder.addConversions195() {
     add(FirErrors.INAPPLICABLE_ALL_TARGET_IN_MULTI_ANNOTATION) { firDiagnostic ->
         InapplicableAllTargetInMultiAnnotationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJsErrors.JS_SYMBOL_ON_TOP_LEVEL_DECLARATION) { firDiagnostic ->
         JsSymbolOnTopLevelDeclarationImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8783,7 +8783,7 @@ private fun KaDiagnosticConverterBuilder.addConversions195() {
         EqualityBoundNotSupertypeOfContainingClassImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8794,20 +8794,20 @@ private fun KaDiagnosticConverterBuilder.addConversions195() {
             firDiagnostic.c.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FORBIDDEN_VARARG_PARAMETER_TYPE) { firDiagnostic ->
         ForbiddenVarargParameterTypeImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.NON_LOCAL_SUSPENSION_POINT) { firDiagnostic ->
         NonLocalSuspensionPointImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8816,26 +8816,26 @@ private fun KaDiagnosticConverterBuilder.addConversions195() {
 private fun KaDiagnosticConverterBuilder.addConversions196() {
     add(FirErrors.NULLABLE_SUPERTYPE) { firDiagnostic ->
         NullableSupertypeImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.PLATFORM_CLASS_MAPPED_TO_KOTLIN) { firDiagnostic ->
         PlatformClassMappedToKotlinImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.FUN_INTERFACE_WRONG_COUNT_OF_ABSTRACT_MEMBERS) { firDiagnostic ->
         FunInterfaceWrongCountOfAbstractMembersImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.UNEXPECTED_SAFE_CALL) { firDiagnostic ->
         UnexpectedSafeCallImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8844,14 +8844,14 @@ private fun KaDiagnosticConverterBuilder.addConversions196() {
             firDiagnostic.a,
             firDiagnostic.b,
             firSymbolBuilder.callableBuilder.buildCallableSymbol(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.PROPERTY_HIDES_JAVA_FIELD) { firDiagnostic ->
         PropertyHidesJavaFieldImpl(
             firSymbolBuilder.variableBuilder.buildVariableSymbol(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8860,27 +8860,27 @@ private fun KaDiagnosticConverterBuilder.addConversions196() {
 private fun KaDiagnosticConverterBuilder.addConversions197() {
     add(FirErrors.DELEGATION_NOT_TO_INTERFACE) { firDiagnostic ->
         DelegationNotToInterfaceImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ATOMIC_REF_CALL_ARGUMENT_WITHOUT_CONSISTENT_IDENTITY) { firDiagnostic ->
         AtomicRefCallArgumentWithoutConsistentIdentityImpl(
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.ACTUAL_TYPEALIAS_TO_SPECIAL_ANNOTATION) { firDiagnostic ->
         ActualTypealiasToSpecialAnnotationImpl(
             firDiagnostic.a,
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirErrors.REDUNDANT_MODALITY_MODIFIER) { firDiagnostic ->
         RedundantModalityModifierImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8889,7 +8889,7 @@ private fun KaDiagnosticConverterBuilder.addConversions197() {
 private fun KaDiagnosticConverterBuilder.addConversions198() {
     add(FirErrors.ANNOTATION_IN_CONTRACT_ERROR) { firDiagnostic ->
         AnnotationInContractErrorImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8898,13 +8898,13 @@ private fun KaDiagnosticConverterBuilder.addConversions198() {
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.a),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.b),
             firSymbolBuilder.typeBuilder.buildKtType(firDiagnostic.c),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
     add(FirJvmErrors.ILLEGAL_JVM_NAME) { firDiagnostic ->
         IllegalJvmNameImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8913,7 +8913,7 @@ private fun KaDiagnosticConverterBuilder.addConversions198() {
 private fun KaDiagnosticConverterBuilder.addConversions199() {
     add(FirJsErrors.NAME_CONTAINS_ILLEGAL_CHARS) { firDiagnostic ->
         NameContainsIllegalCharsImpl(
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8923,7 +8923,7 @@ private fun KaDiagnosticConverterBuilder.addConversions199() {
             firDiagnostic.b.map { firCallableSymbol ->
                 firSymbolBuilder.callableBuilder.buildCallableSymbol(firCallableSymbol)
             },
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }
@@ -8931,7 +8931,7 @@ private fun KaDiagnosticConverterBuilder.addConversions199() {
         ImplementationByDelegationWithDifferentGenericSignatureWarningImpl(
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.a),
             firSymbolBuilder.functionBuilder.buildNamedFunctionSymbol(firDiagnostic.b),
-            firDiagnostic as KtPsiDiagnostic,
+            firDiagnostic as KtDiagnosticWithSource,
             token,
         )
     }

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.descriptors.RelationToType
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.descriptors.annotations.KotlinTarget
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.declarations.FirDeprecationInfo
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
@@ -105,249 +105,249 @@ import org.jetbrains.kotlin.types.Variance
 
 internal class UnsupportedImpl(
     override val unsupported: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.Unsupported
 
 internal class UnsupportedFeatureImpl(
     override val unsupportedFeature: Pair<LanguageFeature, LanguageVersionSettings>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedFeature
 
 internal class UnsupportedSuspendTestImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedSuspendTest
 
 internal class NewInferenceErrorImpl(
     override val error: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NewInferenceError
 
 internal class EscapingCapturedVariableImpl(
     override val variable: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.EscapingCapturedVariable
 
 internal class OtherErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OtherError
 
 internal class OtherErrorWithReasonImpl(
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OtherErrorWithReason
 
 internal class IllegalConstExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalConstExpression
 
 internal class IllegalUnderscoreImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalUnderscore
 
 internal class ExpressionExpectedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpressionExpected
 
 internal class AssignmentInExpressionContextImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.AssignmentInExpressionContext
 
 internal class BreakOrContinueOutsideALoopImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.BreakOrContinueOutsideALoop
 
 internal class NotALoopLabelImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NotALoopLabel
 
 internal class BreakOrContinueJumpsAcrossFunctionBoundaryImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpressionWithLabel>(firDiagnostic, token), KaFirDiagnostic.BreakOrContinueJumpsAcrossFunctionBoundary
 
 internal class VariableExpectedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.VariableExpected
 
 internal class DelegationInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DelegationInInterface
 
 internal class DelegationNotToInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DelegationNotToInterface
 
 internal class NestedClassNotAllowedImpl(
     override val declaration: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.NestedClassNotAllowed
 
 internal class NestedClassNotAllowedInLocalErrorImpl(
     override val declaration: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.NestedClassNotAllowedInLocalError
 
 internal class NestedClassNotAllowedInLocalWarningImpl(
     override val declaration: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.NestedClassNotAllowedInLocalWarning
 
 internal class IncorrectCharacterLiteralImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IncorrectCharacterLiteral
 
 internal class EmptyCharacterLiteralImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.EmptyCharacterLiteral
 
 internal class TooManyCharactersInCharacterLiteralImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TooManyCharactersInCharacterLiteral
 
 internal class IllegalEscapeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalEscape
 
 internal class IntLiteralOutOfRangeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IntLiteralOutOfRange
 
 internal class IntLiteralWithLeadingZerosImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IntLiteralWithLeadingZeros
 
 internal class FloatLiteralOutOfRangeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FloatLiteralOutOfRange
 
 internal class WrongLongSuffixImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongLongSuffix
 
 internal class UnsignedLiteralWithoutDeclarationsOnClasspathImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UnsignedLiteralWithoutDeclarationsOnClasspath
 
 internal class DivisionByZeroImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DivisionByZero
 
 internal class TrimMarginBlankPrefixImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.TrimMarginBlankPrefix
 
 internal class ValOrVarOnLoopParameterImpl(
     override val valOrVar: KtKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ValOrVarOnLoopParameter
 
 internal class ValOrVarOnFunParameterImpl(
     override val valOrVar: KtKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ValOrVarOnFunParameter
 
 internal class ValOrVarOnCatchParameterImpl(
     override val valOrVar: KtKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ValOrVarOnCatchParameter
 
 internal class ValOrVarOnSecondaryConstructorParameterImpl(
     override val valOrVar: KtKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ValOrVarOnSecondaryConstructorParameter
 
 internal class InnerOnTopLevelScriptClassErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InnerOnTopLevelScriptClassError
 
 internal class InnerOnTopLevelScriptClassWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InnerOnTopLevelScriptClassWarning
 
 internal class ErrorSuppressionImpl(
     override val diagnosticName: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ErrorSuppression
 
 internal class MissingConstructorKeywordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingConstructorKeyword
 
 internal class RedundantInterpolationPrefixImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RedundantInterpolationPrefix
 
 internal class WrappedLhsInAssignmentErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrappedLhsInAssignmentError
 
 internal class WrappedLhsInAssignmentWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrappedLhsInAssignmentWarning
 
 internal class ParenthesizedPackageQualifierErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ParenthesizedPackageQualifierError
 
 internal class ParenthesizedPackageQualifierWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ParenthesizedPackageQualifierWarning
 
 internal class KotlinPackageUsageImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.KotlinPackageUsage
 
 internal class UnsupportedArrayLiteralOutsideOfAnnotationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedArrayLiteralOutsideOfAnnotationError
 
 internal class UnsupportedArrayLiteralOutsideOfAnnotationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedArrayLiteralOutsideOfAnnotationWarning
 
@@ -355,7 +355,7 @@ internal class UnresolvedReferenceImpl(
     override val reference: String,
     override val operator: String?,
     override val receiverType: KaType?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnresolvedReference
 
@@ -363,19 +363,19 @@ internal class UnresolvedReferenceWrongReceiverImpl(
     override val candidate: KaSymbol,
     override val operator: String?,
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnresolvedReferenceWrongReceiver
 
 internal class InaccessibleOuterClassReceiverImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InaccessibleOuterClassReceiver
 
 internal class UnresolvedImportImpl(
     override val reference: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnresolvedImport
 
@@ -383,7 +383,7 @@ internal class InvisibleReferenceImpl(
     override val reference: KaSymbol,
     override val visible: Visibility,
     override val containingDeclaration: ClassId?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvisibleReference
 
@@ -391,7 +391,7 @@ internal class InvisibleReferenceWarningImpl(
     override val reference: KaSymbol,
     override val visible: Visibility,
     override val containingDeclaration: ClassId?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvisibleReferenceWarning
 
@@ -399,405 +399,405 @@ internal class InvisibleSetterImpl(
     override val property: KaVariableSymbol,
     override val visibility: Visibility,
     override val callableId: CallableId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvisibleSetter
 
 internal class UnresolvedLabelImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnresolvedLabel
 
 internal class AmbiguousLabelImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AmbiguousLabel
 
 internal class LabelNameClashImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LabelNameClash
 
 internal class DeserializationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeserializationError
 
 internal class ErrorFromJavaResolutionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ErrorFromJavaResolution
 
 internal class MissingStdlibClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingStdlibClass
 
 internal class NoThisImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoThis
 
 internal class ApiNotAvailableImpl(
     override val sinceKotlinVersion: ApiVersion,
     override val currentVersion: ApiVersion,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ApiNotAvailable
 
 internal class PlaceholderProjectionInQualifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PlaceholderProjectionInQualifier
 
 internal class PlaceholderProjectionInTyperefImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PlaceholderProjectionInTyperef
 
 internal class DuplicateParameterNameInFunctionTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DuplicateParameterNameInFunctionType
 
 internal class MissingDependencyClassImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyClass
 
 internal class MissingDependencyClassInExpressionTypeImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyClassInExpressionType
 
 internal class MissingDependencySuperclassImpl(
     override val missingTypeConstructorName: FqName,
     override val declarationTypeConstructorName: FqName,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencySuperclass
 
 internal class MissingDependencySuperclassWarningImpl(
     override val missingTypeConstructorName: FqName,
     override val declarationTypeConstructorName: FqName,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencySuperclassWarning
 
 internal class MissingDependencyClassInLambdaParameterImpl(
     override val type: KaType,
     override val parameterName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyClassInLambdaParameter
 
 internal class MissingDependencyClassInLambdaReceiverImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyClassInLambdaReceiver
 
 internal class MissingDependencyClassInTypealiasImpl(
     override val missingType: KaType,
     override val declarationType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyClassInTypealias
 
 internal class MissingDependencyInInferredTypeAnnotationErrorImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyInInferredTypeAnnotationError
 
 internal class MissingDependencyInInferredTypeAnnotationWarningImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingDependencyInInferredTypeAnnotationWarning
 
 internal class RootIdePackageDeprecatedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RootIdePackageDeprecated
 
 internal class SmartcastToTypeVariableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SmartcastToTypeVariable
 
 internal class CreatingAnInstanceOfAbstractClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CreatingAnInstanceOfAbstractClass
 
 internal class NoConstructorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoConstructor
 
 internal class NoImplicitDefaultConstructorOnExpectClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoImplicitDefaultConstructorOnExpectClass
 
 internal class FunctionCallExpectedImpl(
     override val functionName: String,
     override val hasValueParameters: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FunctionCallExpected
 
 internal class IllegalSelectorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalSelector
 
 internal class NoReceiverAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoReceiverAllowed
 
 internal class FunctionExpectedImpl(
     override val expression: String,
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FunctionExpected
 
 internal class InterfaceAsFunctionImpl(
     override val classSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InterfaceAsFunction
 
 internal class ExpectClassAsFunctionImpl(
     override val classSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpectClassAsFunction
 
 internal class InnerClassConstructorNoReceiverImpl(
     override val classSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InnerClassConstructorNoReceiver
 
 internal class PluginAmbiguousInterceptedSymbolImpl(
     override val names: List<String>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PluginAmbiguousInterceptedSymbol
 
 internal class ResolutionToClassifierImpl(
     override val classSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ResolutionToClassifier
 
 internal class AmbiguousAlteredAssignImpl(
     override val altererNames: List<String?>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AmbiguousAlteredAssign
 
 internal class SelfCallInNestedObjectConstructorErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SelfCallInNestedObjectConstructorError
 
 internal class AmbiguousCollectionLiteralImpl(
     override val candidatesWithOf: List<KaClassLikeSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtCollectionLiteralExpression>(firDiagnostic, token), KaFirDiagnostic.AmbiguousCollectionLiteral
 
 internal class UnresolvedCollectionLiteralImpl(
     override val incompatibleBound: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtCollectionLiteralExpression>(firDiagnostic, token), KaFirDiagnostic.UnresolvedCollectionLiteral
 
 internal class ImplicitPropertyTypeMakesBehaviorOrderDependantImpl(
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ImplicitPropertyTypeMakesBehaviorOrderDependant
 
 internal class ImplicitPropertyTypeMakesBehaviorOrderDependantErrorImpl(
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ImplicitPropertyTypeMakesBehaviorOrderDependantError
 
 internal class SuperIsNotAnExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SuperIsNotAnExpression
 
 internal class SuperNotAvailableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SuperNotAvailable
 
 internal class AbstractSuperCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AbstractSuperCall
 
 internal class InstanceAccessBeforeSuperCallImpl(
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InstanceAccessBeforeSuperCall
 
 internal class SuperCallWithDefaultParametersImpl(
     override val name: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SuperCallWithDefaultParameters
 
 internal class InterfaceCantCallDefaultMethodViaSuperImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InterfaceCantCallDefaultMethodViaSuper
 
 internal class JavaClassInheritsKtPrivateClassImpl(
     override val javaClassId: ClassId,
     override val privateKotlinType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JavaClassInheritsKtPrivateClass
 
 internal class NotASupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NotASupertype
 
 internal class TypeArgumentsRedundantInSuperQualifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypeArgumentsRedundantInSuperQualifier
 
 internal class SuperclassNotAccessibleFromInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SuperclassNotAccessibleFromInterface
 
 internal class SupertypeInitializedInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeInitializedInInterface
 
 internal class InterfaceWithSuperclassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InterfaceWithSuperclass
 
 internal class FinalSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.FinalSupertype
 
 internal class ClassCannotBeExtendedDirectlyImpl(
     override val classSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ClassCannotBeExtendedDirectly
 
 internal class SupertypeIsExtensionOrContextFunctionTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeIsExtensionOrContextFunctionType
 
 internal class SingletonInSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SingletonInSupertype
 
 internal class NullableSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NullableSupertype
 
 internal class NullableSupertypeThroughTypealiasErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NullableSupertypeThroughTypealiasError
 
 internal class NullableSupertypeThroughTypealiasWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NullableSupertypeThroughTypealiasWarning
 
 internal class ManyClassesInSupertypeListImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ManyClassesInSupertypeList
 
 internal class SupertypeAppearsTwiceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeAppearsTwice
 
 internal class ClassInSupertypeForEnumImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ClassInSupertypeForEnum
 
 internal class SealedSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SealedSupertype
 
 internal class SealedSupertypeInLocalClassImpl(
     override val declarationType: String,
     override val sealedClassKind: ClassKind,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SealedSupertypeInLocalClass
 
 internal class SealedInheritorInDifferentPackageImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SealedInheritorInDifferentPackage
 
 internal class SealedInheritorInDifferentModuleImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SealedInheritorInDifferentModule
 
 internal class ClassInheritsJavaSealedClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ClassInheritsJavaSealedClass
 
 internal class UnsupportedSealedFunInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedSealedFunInterface
 
 internal class SupertypeNotAClassOrInterfaceImpl(
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeNotAClassOrInterface
 
 internal class UnsupportedInheritanceFromJavaMemberReferencingKotlinFunctionImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedInheritanceFromJavaMemberReferencingKotlinFunction
 
 internal class CyclicInheritanceHierarchyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CyclicInheritanceHierarchy
 
 internal class ProjectionInImmediateArgumentToSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.ProjectionInImmediateArgumentToSupertype
 
@@ -805,7 +805,7 @@ internal class InconsistentTypeParameterValuesImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val type: KaClassLikeSymbol,
     override val bounds: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.InconsistentTypeParameterValues
 
@@ -813,296 +813,296 @@ internal class InconsistentTypeParameterBoundsImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val type: KaClassLikeSymbol,
     override val bounds: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InconsistentTypeParameterBounds
 
 internal class AmbiguousSuperImpl(
     override val candidates: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtSuperExpression>(firDiagnostic, token), KaFirDiagnostic.AmbiguousSuper
 
 internal class WrongMultipleInheritanceImpl(
     override val symbol: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongMultipleInheritance
 
 internal class ConstructorInObjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ConstructorInObject
 
 internal class ConstructorInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ConstructorInInterface
 
 internal class NonPrivateConstructorInEnumImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonPrivateConstructorInEnum
 
 internal class NonPrivateOrProtectedConstructorInSealedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonPrivateOrProtectedConstructorInSealed
 
 internal class CyclicConstructorDelegationCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CyclicConstructorDelegationCall
 
 internal class PrimaryConstructorDelegationCallExpectedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PrimaryConstructorDelegationCallExpected
 
 internal class ProtectedConstructorNotInSuperCallImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ProtectedConstructorNotInSuperCall
 
 internal class SupertypeNotInitializedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeNotInitialized
 
 internal class SupertypeInitializedWithoutPrimaryConstructorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeInitializedWithoutPrimaryConstructor
 
 internal class DelegationSuperCallInEnumConstructorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DelegationSuperCallInEnumConstructor
 
 internal class ExplicitDelegationCallRequiredImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExplicitDelegationCallRequired
 
 internal class SealedClassConstructorCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SealedClassConstructorCall
 
 internal class DataClassConsistentCopyAndExposedCopyAreIncompatibleAnnotationsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.DataClassConsistentCopyAndExposedCopyAreIncompatibleAnnotations
 
 internal class DataClassConsistentCopyWrongAnnotationTargetImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.DataClassConsistentCopyWrongAnnotationTarget
 
 internal class DataClassCopyVisibilityWillBeChangedErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPrimaryConstructor>(firDiagnostic, token), KaFirDiagnostic.DataClassCopyVisibilityWillBeChangedError
 
 internal class DataClassCopyVisibilityWillBeChangedWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPrimaryConstructor>(firDiagnostic, token), KaFirDiagnostic.DataClassCopyVisibilityWillBeChangedWarning
 
 internal class DataClassInvisibleCopyUsageErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNameReferenceExpression>(firDiagnostic, token), KaFirDiagnostic.DataClassInvisibleCopyUsageError
 
 internal class DataClassInvisibleCopyUsageWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNameReferenceExpression>(firDiagnostic, token), KaFirDiagnostic.DataClassInvisibleCopyUsageWarning
 
 internal class DataClassWithoutParametersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.DataClassWithoutParameters
 
 internal class DataClassVarargParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.DataClassVarargParameter
 
 internal class DataClassNotPropertyParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.DataClassNotPropertyParameter
 
 internal class DataClassCopyJsExportabilityWillBeChangedErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DataClassCopyJsExportabilityWillBeChangedError
 
 internal class DataClassCopyJsExportabilityWillBeChangedWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DataClassCopyJsExportabilityWillBeChangedWarning
 
 internal class AnnotationArgumentKclassLiteralOfTypeParameterErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AnnotationArgumentKclassLiteralOfTypeParameterError
 
 internal class AnnotationArgumentMustBeConstImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AnnotationArgumentMustBeConst
 
 internal class AnnotationArgumentMustBeEnumConstImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AnnotationArgumentMustBeEnumConst
 
 internal class AnnotationArgumentMustBeKclassLiteralImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AnnotationArgumentMustBeKclassLiteral
 
 internal class AnnotationClassMemberImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AnnotationClassMember
 
 internal class AnnotationParameterDefaultValueMustBeConstantImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AnnotationParameterDefaultValueMustBeConstant
 
 internal class InvalidTypeOfAnnotationMemberImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InvalidTypeOfAnnotationMember
 
 internal class ProjectionInTypeOfAnnotationMemberErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeReference>(firDiagnostic, token), KaFirDiagnostic.ProjectionInTypeOfAnnotationMemberError
 
 internal class ProjectionInTypeOfAnnotationMemberWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeReference>(firDiagnostic, token), KaFirDiagnostic.ProjectionInTypeOfAnnotationMemberWarning
 
 internal class LocalAnnotationClassErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.LocalAnnotationClassError
 
 internal class MissingValOnAnnotationParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.MissingValOnAnnotationParameter
 
 internal class NonConstValUsedInConstantExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NonConstValUsedInConstantExpression
 
 internal class CycleInAnnotationParameterErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.CycleInAnnotationParameterError
 
 internal class AnnotationClassConstructorCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.AnnotationClassConstructorCall
 
 internal class EnumClassConstructorCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.EnumClassConstructorCall
 
 internal class NotAnAnnotationClassImpl(
     override val annotationName: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NotAnAnnotationClass
 
 internal class NullableTypeOfAnnotationMemberImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NullableTypeOfAnnotationMember
 
 internal class VarAnnotationParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.VarAnnotationParameter
 
 internal class SupertypesForAnnotationClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClass>(firDiagnostic, token), KaFirDiagnostic.SupertypesForAnnotationClass
 
 internal class AnnotationUsedAsAnnotationArgumentImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationUsedAsAnnotationArgument
 
 internal class AnnotationOnAnnotationArgumentImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationOnAnnotationArgument
 
 internal class IllegalKotlinVersionStringValueImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.IllegalKotlinVersionStringValue
 
 internal class NewerVersionInSinceKotlinImpl(
     override val specifiedVersion: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NewerVersionInSinceKotlin
 
 internal class DeprecatedSinceKotlinWithUnorderedVersionsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedSinceKotlinWithUnorderedVersions
 
 internal class DeprecatedSinceKotlinWithoutArgumentsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedSinceKotlinWithoutArguments
 
 internal class DeprecatedSinceKotlinWithoutDeprecatedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedSinceKotlinWithoutDeprecated
 
 internal class DeprecatedSinceKotlinWithDeprecatedLevelImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedSinceKotlinWithDeprecatedLevel
 
 internal class DeprecatedSinceKotlinOutsideKotlinSubpackageImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedSinceKotlinOutsideKotlinSubpackage
 
 internal class KotlinActualAnnotationHasNoEffectInKotlinImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.KotlinActualAnnotationHasNoEffectInKotlin
 
 internal class DeprecationErrorImpl(
     override val reference: KaSymbol,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecationError
 
 internal class DeprecationImpl(
     override val reference: KaSymbol,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.Deprecation
 
@@ -1110,26 +1110,26 @@ internal class DeprecationErrorMigrationPeriodWarningImpl(
     override val reference: KaSymbol,
     override val message: String,
     override val migrationLanguageFeature: LanguageFeature,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecationErrorMigrationPeriodWarning
 
 internal class OverrideDeprecationImpl(
     override val overridenSymbol: KaSymbol,
     override val deprecationInfo: FirDeprecationInfo,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.OverrideDeprecation
 
 internal class ExtendingAnAnnotationClassErrorImpl(
     override val annotationSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExtendingAnAnnotationClassError
 
 internal class ExtendingAnAnnotationClassWarningImpl(
     override val annotationSymbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExtendingAnAnnotationClassWarning
 
@@ -1137,7 +1137,7 @@ internal class TypealiasExpansionDeprecationErrorImpl(
     override val alias: KaSymbol,
     override val reference: KaSymbol,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasExpansionDeprecationError
 
@@ -1145,7 +1145,7 @@ internal class TypealiasExpansionDeprecationImpl(
     override val alias: KaSymbol,
     override val reference: KaSymbol,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasExpansionDeprecation
 
@@ -1154,7 +1154,7 @@ internal class VersionRequirementDeprecationErrorImpl(
     override val version: Version,
     override val currentVersion: String,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.VersionRequirementDeprecationError
 
@@ -1163,37 +1163,37 @@ internal class VersionRequirementDeprecationImpl(
     override val version: Version,
     override val currentVersion: String,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.VersionRequirementDeprecation
 
 internal class RedundantAnnotationImpl(
     override val annotation: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RedundantAnnotation
 
 internal class AnnotationOnSuperclassErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationOnSuperclassError
 
 internal class RestrictedRetentionForExpressionAnnotationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RestrictedRetentionForExpressionAnnotationError
 
 internal class WrongAnnotationTargetImpl(
     override val actualTarget: String,
     override val allowedTargets: List<KotlinTarget>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.WrongAnnotationTarget
 
 internal class WrongAnnotationTargetWarningImpl(
     override val actualTarget: String,
     override val allowedTargets: List<KotlinTarget>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.WrongAnnotationTargetWarning
 
@@ -1201,271 +1201,271 @@ internal class WrongAnnotationTargetWithUseSiteTargetImpl(
     override val actualTarget: String,
     override val useSiteTarget: String,
     override val allowedTargets: List<KotlinTarget>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.WrongAnnotationTargetWithUseSiteTarget
 
 internal class AnnotationWithUseSiteTargetOnExpressionErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationWithUseSiteTargetOnExpressionError
 
 internal class AnnotationWithUseSiteTargetOnExpressionWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationWithUseSiteTargetOnExpressionWarning
 
 internal class InapplicableTargetOnPropertyImpl(
     override val useSiteDescription: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableTargetOnProperty
 
 internal class InapplicableTargetOnPropertyWarningImpl(
     override val useSiteDescription: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableTargetOnPropertyWarning
 
 internal class InapplicableTargetPropertyImmutableImpl(
     override val useSiteDescription: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableTargetPropertyImmutable
 
 internal class InapplicableTargetPropertyHasNoDelegateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableTargetPropertyHasNoDelegate
 
 internal class InapplicableTargetPropertyHasNoBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableTargetPropertyHasNoBackingField
 
 internal class InapplicableParamTargetImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableParamTarget
 
 internal class InapplicableFileTargetImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableFileTarget
 
 internal class InapplicableAllTargetImpl(
     override val inapplicableTargetDescription: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableAllTarget
 
 internal class InapplicableAllTargetInMultiAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableAllTargetInMultiAnnotation
 
 internal class RepeatedAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RepeatedAnnotation
 
 internal class RepeatedAnnotationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RepeatedAnnotationWarning
 
 internal class RedundantAnnotationTargetImpl(
     override val useSiteDescription: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RedundantAnnotationTarget
 
 internal class NotAClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NotAClass
 
 internal class WrongExtensionFunctionTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.WrongExtensionFunctionType
 
 internal class AnnotationInWhereClauseErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationInWhereClauseError
 
 internal class AnnotationInContractErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.AnnotationInContractError
 
 internal class AmbiguousAnnotationArgumentImpl(
     override val symbols: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AmbiguousAnnotationArgument
 
 internal class VolatileOnValueImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.VolatileOnValue
 
 internal class VolatileOnDelegateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.VolatileOnDelegate
 
 internal class NonInternalPublishedApiImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonInternalPublishedApi
 
 internal class NonSourceAnnotationOnInlinedLambdaExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.NonSourceAnnotationOnInlinedLambdaExpression
 
 internal class PotentiallyNonReportedAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.PotentiallyNonReportedAnnotation
 
 internal class AnnotationWillBeAppliedAlsoToPropertyOrFieldImpl(
     override val useSiteDescription: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationWillBeAppliedAlsoToPropertyOrField
 
 internal class AnnotationsOnBlockLevelExpressionOnTheSameLineImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AnnotationsOnBlockLevelExpressionOnTheSameLine
 
 internal class IgnorabilityAnnotationsWithCheckerDisabledImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.IgnorabilityAnnotationsWithCheckerDisabled
 
 internal class DslMarkerPropagatesToManyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.DslMarkerPropagatesToMany
 
 internal class DslMarkerAppliedToWrongTargetImpl(
     override val dslMarkerSymbol: KaClassLikeSymbol,
     override val actualTarget: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.DslMarkerAppliedToWrongTarget
 
 internal class JsModuleProhibitedOnNonNativeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsModuleProhibitedOnNonNative
 
 internal class CallFromUmdMustBeJsModuleAndJsNonModuleImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CallFromUmdMustBeJsModuleAndJsNonModule
 
 internal class CallToJsModuleWithoutModuleSystemImpl(
     override val callee: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CallToJsModuleWithoutModuleSystem
 
 internal class CallToJsNonModuleWithModuleSystemImpl(
     override val callee: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CallToJsNonModuleWithModuleSystem
 
 internal class RuntimeAnnotationOnExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RuntimeAnnotationOnExternalDeclaration
 
 internal class NativeAnnotationsAllowedOnlyOnMemberOrExtensionFunImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NativeAnnotationsAllowedOnlyOnMemberOrExtensionFun
 
 internal class NativeIndexerKeyShouldBeStringOrNumberImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NativeIndexerKeyShouldBeStringOrNumber
 
 internal class NativeIndexerWrongParameterCountImpl(
     override val parametersCount: Int,
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NativeIndexerWrongParameterCount
 
 internal class NativeIndexerCanNotHaveDefaultArgumentsImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NativeIndexerCanNotHaveDefaultArguments
 
 internal class NativeGetterReturnTypeShouldBeNullableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NativeGetterReturnTypeShouldBeNullable
 
 internal class NativeSetterWrongReturnTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NativeSetterWrongReturnType
 
 internal class JsNameIsNotOnAllAccessorsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameIsNotOnAllAccessors
 
 internal class JsNameProhibitedForNamedNativeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameProhibitedForNamedNative
 
 internal class JsNameProhibitedForOverrideImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameProhibitedForOverride
 
 internal class JsNameOnPrimaryConstructorProhibitedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameOnPrimaryConstructorProhibited
 
 internal class JsNameOnAccessorAndPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameOnAccessorAndProperty
 
 internal class JsNameProhibitedForExtensionPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameProhibitedForExtensionProperty
 
 internal class JsBuiltinNameClashImpl(
     override val name: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsBuiltinNameClash
 
 internal class NameContainsIllegalCharsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NameContainsIllegalChars
 
 internal class JsNameClashImpl(
     override val name: String,
     override val existing: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNameClash
 
@@ -1473,77 +1473,77 @@ internal class JsFakeNameClashImpl(
     override val name: String,
     override val override: KaSymbol,
     override val existing: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsFakeNameClash
 
 internal class JsSymbolOnTopLevelDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsSymbolOnTopLevelDeclaration
 
 internal class JsSymbolProhibitedForOverrideImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsSymbolProhibitedForOverride
 
 internal class WrongJsQualifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongJsQualifier
 
 internal class JsModuleProhibitedOnVarImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsModuleProhibitedOnVar
 
 internal class NestedJsModuleProhibitedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NestedJsModuleProhibited
 
 internal class UnresolvedEqualityBoundArgumentImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UnresolvedEqualityBoundArgument
 
 internal class AmbiguouslyResolvedEqualityBoundArgumentImpl(
     override val candidates: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AmbiguouslyResolvedEqualityBoundArgument
 
 internal class EqualityBoundArgumentExpandsToNonStarProjectedImpl(
     override val expandedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.EqualityBoundArgumentExpandsToNonStarProjected
 
 internal class EqualityBoundMismatchOnInheritanceImpl(
     override val overridingDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.EqualityBoundMismatchOnInheritance
 
 internal class EqualityBoundMismatchByDelegationImpl(
     override val delegateDeclaration: KaCallableSymbol,
     override val baseDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.EqualityBoundMismatchByDelegation
 
 internal class InheritedIntersectionEqualityBoundImpl(
     override val declaration: KaCallableSymbol,
     override val candidates: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.InheritedIntersectionEqualityBound
 
 internal class EqualityBoundNotSupertypeOfContainingClassImpl(
     override val equalityBoundType: KaType,
     override val receiverType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.EqualityBoundNotSupertypeOfContainingClass
 
@@ -1552,7 +1552,7 @@ internal class EqualityNotApplicableByEqualityBoundsImpl(
     override val rightType: KaType,
     override val leftIsEqualityBound: String,
     override val rightIsEqualityBound: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.EqualityNotApplicableByEqualityBounds
 
@@ -1561,109 +1561,109 @@ internal class EqualitySuspiciousByEqualityBoundsImpl(
     override val rightType: KaType,
     override val leftEqualityBound: KaType,
     override val rightEqualityBound: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.EqualitySuspiciousByEqualityBounds
 
 internal class OptInUsageImpl(
     override val optInMarkerClassId: ClassId,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInUsage
 
 internal class OptInUsageErrorImpl(
     override val optInMarkerClassId: ClassId,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInUsageError
 
 internal class OptInToInheritanceImpl(
     override val optInMarkerClassId: ClassId,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInToInheritance
 
 internal class OptInToInheritanceErrorImpl(
     override val optInMarkerClassId: ClassId,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInToInheritanceError
 
 internal class OptInOverrideImpl(
     override val optInMarkerClassId: ClassId,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInOverride
 
 internal class OptInOverrideErrorImpl(
     override val optInMarkerClassId: ClassId,
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInOverrideError
 
 internal class OptInCanOnlyBeUsedAsAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInCanOnlyBeUsedAsAnnotation
 
 internal class OptInMarkerCanOnlyBeUsedAsAnnotationOrArgumentInOptInImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptInMarkerCanOnlyBeUsedAsAnnotationOrArgumentInOptIn
 
 internal class OptInWithoutArgumentsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OptInWithoutArguments
 
 internal class OptInArgumentIsNotMarkerImpl(
     override val notMarkerClassId: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassLiteralExpression>(firDiagnostic, token), KaFirDiagnostic.OptInArgumentIsNotMarker
 
 internal class OptInMarkerWithWrongTargetImpl(
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OptInMarkerWithWrongTarget
 
 internal class OptInMarkerWithWrongRetentionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OptInMarkerWithWrongRetention
 
 internal class OptInMarkerOnWrongTargetImpl(
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OptInMarkerOnWrongTarget
 
 internal class OptInMarkerOnOverrideImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OptInMarkerOnOverride
 
 internal class OptInMarkerOnOverrideWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OptInMarkerOnOverrideWarning
 
 internal class SubclassOptInInapplicableImpl(
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SubclassOptInInapplicable
 
 internal class SubclassOptInArgumentIsNotMarkerImpl(
     override val notMarkerClassId: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassLiteralExpression>(firDiagnostic, token), KaFirDiagnostic.SubclassOptInArgumentIsNotMarker
 
@@ -1672,7 +1672,7 @@ internal class ExposedTypealiasExpandedTypeImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExposedTypealiasExpandedType
 
@@ -1681,7 +1681,7 @@ internal class ExposedFunctionReturnTypeImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExposedFunctionReturnType
 
@@ -1690,7 +1690,7 @@ internal class ExposedReceiverTypeImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedReceiverType
 
@@ -1699,7 +1699,7 @@ internal class ExposedPropertyTypeImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExposedPropertyType
 
@@ -1708,7 +1708,7 @@ internal class ExposedPropertyTypeInConstructorErrorImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExposedPropertyTypeInConstructorError
 
@@ -1717,7 +1717,7 @@ internal class ExposedParameterTypeImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ExposedParameterType
 
@@ -1726,7 +1726,7 @@ internal class ExposedSuperInterfaceImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedSuperInterface
 
@@ -1735,7 +1735,7 @@ internal class ExposedSuperClassImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedSuperClass
 
@@ -1744,7 +1744,7 @@ internal class ExposedTypeParameterBoundImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedTypeParameterBound
 
@@ -1753,387 +1753,387 @@ internal class ExposedTypeParameterBoundDeprecationWarningImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
     override val relationToType: RelationToType,
     override val restrictingVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedTypeParameterBoundDeprecationWarning
 
 internal class RepeatedModifierImpl(
     override val modifier: KtModifierKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RepeatedModifier
 
 internal class WrongModifierTargetImpl(
     override val modifier: KtModifierKeywordToken,
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongModifierTarget
 
 internal class WrongModifierContainingDeclarationImpl(
     override val modifier: KtModifierKeywordToken,
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongModifierContainingDeclaration
 
 internal class DeprecatedModifierImpl(
     override val deprecatedModifier: KtModifierKeywordToken,
     override val actualModifier: KtModifierKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedModifier
 
 internal class DeprecatedModifierForTargetImpl(
     override val deprecatedModifier: KtModifierKeywordToken,
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedModifierForTarget
 
 internal class DeprecatedModifierContainingDeclarationImpl(
     override val modifier: KtModifierKeywordToken,
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedModifierContainingDeclaration
 
 internal class IncompatibleModifiersImpl(
     override val modifier1: KtModifierKeywordToken,
     override val modifier2: KtModifierKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IncompatibleModifiers
 
 internal class DeprecatedModifierPairImpl(
     override val deprecatedModifier: KtModifierKeywordToken,
     override val conflictingModifier: KtModifierKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedModifierPair
 
 internal class RedundantModifierImpl(
     override val redundantModifier: KtModifierKeywordToken,
     override val conflictingModifier: KtModifierKeywordToken,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RedundantModifier
 
 internal class RedundantModifierForTargetImpl(
     override val redundantModifier: KtModifierKeywordToken,
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RedundantModifierForTarget
 
 internal class InfixModifierRequiredImpl(
     override val functionSymbol: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InfixModifierRequired
 
 internal class OperatorModifierRequiredImpl(
     override val functionSymbol: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OperatorModifierRequired
 
 internal class InapplicableInfixModifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InapplicableInfixModifier
 
 internal class InapplicableOperatorModifierImpl(
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InapplicableOperatorModifier
 
 internal class InapplicableOperatorModifierWarningImpl(
     override val message: String,
     override val deprecatingFeature: LanguageFeature,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InapplicableOperatorModifierWarning
 
 internal class InapplicableLateinitModifierImpl(
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.InapplicableLateinitModifier
 
 internal class PotentiallyNullableReturnTypeOfOperatorOfImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.PotentiallyNullableReturnTypeOfOperatorOf
 
 internal class NullableReturnTypeOfOperatorOfImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.NullableReturnTypeOfOperatorOf
 
 internal class ReturnTypeMismatchOfOperatorOfImpl(
     override val outerClass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.ReturnTypeMismatchOfOperatorOf
 
 internal class NoVarargOverloadOfOperatorOfImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.NoVarargOverloadOfOperatorOf
 
 internal class MultipleVarargOverloadsOfOperatorOfImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.MultipleVarargOverloadsOfOperatorOf
 
 internal class InconsistentReturnTypesInOfOverloadsImpl(
     override val mainOverloadType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.InconsistentReturnTypesInOfOverloads
 
 internal class InconsistentParameterTypesInOfOverloadsImpl(
     override val mainParameterType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InconsistentParameterTypesInOfOverloads
 
 internal class InconsistentVisibilityInOfOverloadsImpl(
     override val mainVisibility: Visibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.InconsistentVisibilityInOfOverloads
 
 internal class InconsistentSuspendInOfOverloadsImpl(
     override val overloadSuspendability: String,
     override val mainOverloadSuspendability: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.InconsistentSuspendInOfOverloads
 
 internal class OfOverloadsInBlockAndObjectImpl(
     override val overloadOrigin: String,
     override val mainOrigin: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.OfOverloadsInBlockAndObject
 
 internal class InconsistentTypeParametersInOfOverloadsImpl(
     override val mainOverload: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.InconsistentTypeParametersInOfOverloads
 
 internal class RedundantOpenInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.RedundantOpenInInterface
 
 internal class OperatorCallOnConstructorImpl(
     override val name: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OperatorCallOnConstructor
 
 internal class NoExplicitVisibilityInApiModeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NoExplicitVisibilityInApiMode
 
 internal class NoExplicitVisibilityInApiModeWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NoExplicitVisibilityInApiModeWarning
 
 internal class NoExplicitReturnTypeInApiModeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NoExplicitReturnTypeInApiMode
 
 internal class NoExplicitReturnTypeInApiModeWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NoExplicitReturnTypeInApiModeWarning
 
 internal class AnonymousSuspendFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.AnonymousSuspendFunction
 
 internal class ValueClassNotTopLevelImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ValueClassNotTopLevel
 
 internal class ValueClassNotFinalImpl(
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ValueClassNotFinal
 
 internal class ValueClassOpenImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ValueClassOpen
 
 internal class AbsenceOfPrimaryConstructorForValueClassImpl(
     override val modifier: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.AbsenceOfPrimaryConstructorForValueClass
 
 internal class ExpectValueClassWithNoPrimaryConstructorHasSecondaryImpl(
     override val modifier: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectValueClassWithNoPrimaryConstructorHasSecondary
 
 internal class InlineClassConstructorWrongParametersSizeImpl(
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InlineClassConstructorWrongParametersSize
 
 internal class ValueClassEmptyConstructorImpl(
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassEmptyConstructor
 
 internal class ValueClassConstructorNotFinalReadOnlyParameterImpl(
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ValueClassConstructorNotFinalReadOnlyParameter
 
 internal class AbstractValueClassConstructorPropertyParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.AbstractValueClassConstructorPropertyParameter
 
 internal class SealedValueClassConstructorPropertyParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.SealedValueClassConstructorPropertyParameter
 
 internal class PropertyWithBackingFieldInsideValueClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.PropertyWithBackingFieldInsideValueClass
 
 internal class DelegatedPropertyInsideValueClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DelegatedPropertyInsideValueClass
 
 internal class ValueClassHasInapplicableParameterTypeImpl(
     override val type: KaType,
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassHasInapplicableParameterType
 
 internal class ValueClassCannotImplementInterfaceByDelegationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotImplementInterfaceByDelegation
 
 internal class ValueClassCannotExtendClassesImpl(
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotExtendClasses
 
 internal class ValueClassCannotExtendIdentityClassesImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotExtendIdentityClasses
 
 internal class ValueClassCannotBeRecursiveImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotBeRecursive
 
 internal class ValueClassCannotBeRecursiveViaTypeParametersErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotBeRecursiveViaTypeParametersError
 
 internal class ValueClassCannotBeRecursiveViaTypeParametersWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotBeRecursiveViaTypeParametersWarning
 
 internal class SecondaryConstructorWithBodyInsideValueClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SecondaryConstructorWithBodyInsideValueClass
 
 internal class ReservedMemberInsideValueClassImpl(
     override val name: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.ReservedMemberInsideValueClass
 
 internal class ReservedMemberFromInterfaceInsideValueClassImpl(
     override val interfaceName: String,
     override val methodName: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClass>(firDiagnostic, token), KaFirDiagnostic.ReservedMemberFromInterfaceInsideValueClass
 
 internal class TypeArgumentOnTypedValueClassEqualsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypeArgumentOnTypedValueClassEquals
 
 internal class InnerClassInsideValueClassImpl(
     override val prefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.InnerClassInsideValueClass
 
 internal class ValueClassCannotBeCloneableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ValueClassCannotBeCloneable
 
 internal class NoneApplicableImpl(
     override val candidates: List<Pair<KaSymbol, List<String>>>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoneApplicable
 
 internal class InapplicableCandidateImpl(
     override val candidate: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InapplicableCandidate
 
 internal class HasNextFunctionNoneApplicableImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.HasNextFunctionNoneApplicable
 
 internal class NextNoneApplicableImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NextNoneApplicable
 
 internal class DelegateSpecialFunctionNoneApplicableImpl(
     override val expectedFunctionSignature: String,
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DelegateSpecialFunctionNoneApplicable
 
 internal class TypeInferenceOnlyInputTypesErrorImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeInferenceOnlyInputTypesError
 
@@ -2141,115 +2141,115 @@ internal class MemberProjectedOutImpl(
     override val receiver: KaType,
     override val projection: String,
     override val symbol: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MemberProjectedOut
 
 internal class NoValueForParameterImpl(
     override val violatedParameter: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NoValueForParameter
 
 internal class TooManyArgumentsImpl(
     override val function: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TooManyArguments
 
 internal class NamedParameterNotFoundImpl(
     override val name: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtValueArgument>(firDiagnostic, token), KaFirDiagnostic.NamedParameterNotFound
 
 internal class NameForAmbiguousParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtValueArgument>(firDiagnostic, token), KaFirDiagnostic.NameForAmbiguousParameter
 
 internal class ArgumentPassedTwiceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtValueArgument>(firDiagnostic, token), KaFirDiagnostic.ArgumentPassedTwice
 
 internal class NamedArgumentsNotAllowedImpl(
     override val forbiddenNamedArgumentsTarget: ForbiddenNamedArgumentsTarget,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtValueArgument>(firDiagnostic, token), KaFirDiagnostic.NamedArgumentsNotAllowed
 
 internal class MixingNamedAndPositionalArgumentsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MixingNamedAndPositionalArguments
 
 internal class VarargOutsideParenthesesImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.VarargOutsideParentheses
 
 internal class NonVarargSpreadImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<LeafPsiElement>(firDiagnostic, token), KaFirDiagnostic.NonVarargSpread
 
 internal class SpreadOfNullableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SpreadOfNullable
 
 internal class UnexpectedTrailingLambdaOnANewLineImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnexpectedTrailingLambdaOnANewLine
 
 internal class ManyLambdaExpressionArgumentsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtLambdaExpression>(firDiagnostic, token), KaFirDiagnostic.ManyLambdaExpressionArguments
 
 internal class AssigningSingleElementToVarargInNamedFormFunctionErrorImpl(
     override val expectedArrayType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AssigningSingleElementToVarargInNamedFormFunctionError
 
 internal class AssigningSingleElementToVarargInNamedFormFunctionWarningImpl(
     override val expectedArrayType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AssigningSingleElementToVarargInNamedFormFunctionWarning
 
 internal class AssigningSingleElementToVarargInNamedFormAnnotationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AssigningSingleElementToVarargInNamedFormAnnotationError
 
 internal class AssigningSingleElementToVarargInNamedFormAnnotationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AssigningSingleElementToVarargInNamedFormAnnotationWarning
 
 internal class RedundantSpreadOperatorInNamedFormInFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RedundantSpreadOperatorInNamedFormInFunction
 
 internal class RedundantSpreadOperatorInNamedFormInAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RedundantSpreadOperatorInNamedFormInAnnotation
 
 internal class IllegalTypeArgumentForVarargParameterWarningImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IllegalTypeArgumentForVarargParameterWarning
 
 internal class NestedClassAccessedViaInstanceReferenceImpl(
     override val symbol: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NestedClassAccessedViaInstanceReference
 
@@ -2257,7 +2257,7 @@ internal class TypeMismatchImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeMismatch
 
@@ -2265,7 +2265,7 @@ internal class ArgumentTypeMismatchImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ArgumentTypeMismatch
 
@@ -2274,14 +2274,14 @@ internal class ReturnTypeMismatchImpl(
     override val actualType: KaType,
     override val targetFunction: KaSymbol,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ReturnTypeMismatch
 
 internal class ExpectedParameterTypeMismatchImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpectedParameterTypeMismatch
 
@@ -2289,7 +2289,7 @@ internal class InitializerTypeMismatchImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.InitializerTypeMismatch
 
@@ -2297,7 +2297,7 @@ internal class FieldInitializerTypeMismatchImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.FieldInitializerTypeMismatch
 
@@ -2305,40 +2305,40 @@ internal class AssignmentTypeMismatchImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AssignmentTypeMismatch
 
 internal class ConditionTypeMismatchImpl(
     override val actualType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ConditionTypeMismatch
 
 internal class ThrowableTypeMismatchImpl(
     override val actualType: KaType,
     override val isMismatchDueToNullability: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ThrowableTypeMismatch
 
 internal class ResultTypeMismatchImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ResultTypeMismatch
 
 internal class CompareToTypeMismatchImpl(
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CompareToTypeMismatch
 
 internal class HasNextFunctionTypeMismatchImpl(
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.HasNextFunctionTypeMismatch
 
@@ -2346,7 +2346,7 @@ internal class ComponentFunctionReturnTypeMismatchImpl(
     override val componentFunctionName: Name,
     override val destructingType: KaType,
     override val expectedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ComponentFunctionReturnTypeMismatch
 
@@ -2354,37 +2354,37 @@ internal class DelegateSpecialFunctionReturnTypeMismatchImpl(
     override val delegateFunction: String,
     override val expectedType: KaType,
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DelegateSpecialFunctionReturnTypeMismatch
 
 internal class OverloadResolutionAmbiguityImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OverloadResolutionAmbiguity
 
 internal class AssignOperatorAmbiguityImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AssignOperatorAmbiguity
 
 internal class IteratorAmbiguityImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IteratorAmbiguity
 
 internal class HasNextFunctionAmbiguityImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.HasNextFunctionAmbiguity
 
 internal class NextAmbiguityImpl(
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NextAmbiguity
 
@@ -2392,113 +2392,113 @@ internal class ComponentFunctionAmbiguityImpl(
     override val functionWithAmbiguityName: Name,
     override val candidates: List<KaSymbol>,
     override val destructingType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ComponentFunctionAmbiguity
 
 internal class DelegateSpecialFunctionAmbiguityImpl(
     override val expectedFunctionSignature: String,
     override val candidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DelegateSpecialFunctionAmbiguity
 
 internal class CompilerRequiredAnnotationAmbiguityImpl(
     override val typeFromCompilerPhase: KaType,
     override val typeFromTypesPhase: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompilerRequiredAnnotationAmbiguity
 
 internal class AmbiguousFunctionTypeKindImpl(
     override val kinds: List<FunctionTypeKind>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AmbiguousFunctionTypeKind
 
 internal class ContextSensitiveResolutionAmbiguityImpl(
     override val resolvedCandidate: KaSymbol,
     override val contextSensitiveCandidates: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ContextSensitiveResolutionAmbiguity
 
 internal class NoContextArgumentImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NoContextArgument
 
 internal class AmbiguousContextArgumentImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.AmbiguousContextArgument
 
 internal class ContextualOverloadShadowedImpl(
     override val symbols: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ContextualOverloadShadowed
 
 internal class MultipleContextListsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleContextLists
 
 internal class ContextParameterWithoutNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtContextReceiver>(firDiagnostic, token), KaFirDiagnostic.ContextParameterWithoutName
 
 internal class ContextParametersWithBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ContextParametersWithBackingField
 
 internal class CallableReferenceToContextualDeclarationImpl(
     override val symbol: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CallableReferenceToContextualDeclaration
 
 internal class NamedContextParameterInFunctionTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NamedContextParameterInFunctionType
 
 internal class ContextParameterWithDefaultImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ContextParameterWithDefault
 
 internal class UnsupportedContextualDeclarationCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedContextualDeclarationCall
 
 internal class AmbiguousCallWithImplicitContextReceiverImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.AmbiguousCallWithImplicitContextReceiver
 
 internal class CoroutineContextAsContextParameterIsReservedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CoroutineContextAsContextParameterIsReserved
 
 internal class RecursionInImplicitTypesImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RecursionInImplicitTypes
 
 internal class InferenceErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InferenceError
 
 internal class ProjectionOnNonClassTypeArgumentImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ProjectionOnNonClassTypeArgument
 
@@ -2507,7 +2507,7 @@ internal class UpperBoundViolatedImpl(
     override val actualType: KaType,
     override val onTypeParameter: KaType,
     override val extraMessage: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolated
 
@@ -2516,7 +2516,7 @@ internal class UpperBoundViolatedDeprecationWarningImpl(
     override val actualType: KaType,
     override val onTypeParameter: KaType,
     override val extraMessage: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedDeprecationWarning
 
@@ -2525,7 +2525,7 @@ internal class UpperBoundViolatedInTypeOperatorOrParameterBoundsErrorImpl(
     override val actualType: KaType,
     override val onTypeParameter: KaType,
     override val extraMessage: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedInTypeOperatorOrParameterBoundsError
 
@@ -2534,7 +2534,7 @@ internal class UpperBoundViolatedInTypeOperatorOrParameterBoundsWarningImpl(
     override val actualType: KaType,
     override val onTypeParameter: KaType,
     override val extraMessage: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedInTypeOperatorOrParameterBoundsWarning
 
@@ -2542,7 +2542,7 @@ internal class UpperBoundViolatedInTypealiasExpansionImpl(
     override val expectedUpperBound: KaType,
     override val actualType: KaType,
     override val onTypeParameter: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedInTypealiasExpansion
 
@@ -2550,7 +2550,7 @@ internal class UpperBoundViolatedInTypealiasExpansionDeprecationWarningImpl(
     override val expectedUpperBound: KaType,
     override val actualType: KaType,
     override val onTypeParameter: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedInTypealiasExpansionDeprecationWarning
 
@@ -2558,36 +2558,36 @@ internal class UpperBoundViolatedInLhsOfClassLiteralWarningImpl(
     override val expectedUpperBound: KaType,
     override val actualType: KaType,
     override val onTypeParameter: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedInLhsOfClassLiteralWarning
 
 internal class TypeArgumentsNotAllowedImpl(
     override val place: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeArgumentsNotAllowed
 
 internal class TypeArgumentsNotAllowedWarningImpl(
     override val place: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeArgumentsNotAllowedWarning
 
 internal class TypeArgumentsNotAllowedInPackageQualifierWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeArgumentsNotAllowedInPackageQualifierWarning
 
 internal class TypeArgumentsForOuterClassWhenNestedReferencedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeArgumentsForOuterClassWhenNestedReferenced
 
 internal class WrongNumberOfTypeArgumentsImpl(
     override val expectedCount: Int,
     override val owner: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongNumberOfTypeArguments
 
@@ -2595,333 +2595,333 @@ internal class WrongNumberOfTypeArgumentsWarningImpl(
     override val expectedCount: Int,
     override val owner: KaSymbol,
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongNumberOfTypeArgumentsWarning
 
 internal class WrongNumberOfTypeArgumentsInLocalClassInLhsWarningImpl(
     override val expectedCount: Int,
     override val owner: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongNumberOfTypeArgumentsInLocalClassInLhsWarning
 
 internal class WrongNumberOfTypeArgumentsInGetClassWarningImpl(
     override val expectedCount: Int,
     override val owner: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongNumberOfTypeArgumentsInGetClassWarning
 
 internal class InvalidQualifierInLhsOfCallableReferenceToStaticErrorImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidQualifierInLhsOfCallableReferenceToStaticError
 
 internal class InvalidQualifierInLhsOfCallableReferenceToStaticWarningImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidQualifierInLhsOfCallableReferenceToStaticWarning
 
 internal class NoTypeArgumentsOnRhsImpl(
     override val expectedCount: Int,
     override val classifier: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoTypeArgumentsOnRhs
 
 internal class OuterClassArgumentsRequiredImpl(
     override val outer: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OuterClassArgumentsRequired
 
 internal class TypeParametersInObjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParametersInObject
 
 internal class TypeParametersInAnonymousObjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParametersInAnonymousObject
 
 internal class IllegalProjectionUsageImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalProjectionUsage
 
 internal class TypeParametersInEnumImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParametersInEnum
 
 internal class ConflictingProjectionImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeProjection>(firDiagnostic, token), KaFirDiagnostic.ConflictingProjection
 
 internal class ConflictingProjectionInTypealiasExpansionImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ConflictingProjectionInTypealiasExpansion
 
 internal class ConflictingProjectionInCallableReferenceWarningImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeProjection>(firDiagnostic, token), KaFirDiagnostic.ConflictingProjectionInCallableReferenceWarning
 
 internal class RedundantProjectionImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeProjection>(firDiagnostic, token), KaFirDiagnostic.RedundantProjection
 
 internal class VarianceOnTypeParameterNotAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.VarianceOnTypeParameterNotAllowed
 
 internal class CatchParameterWithDefaultValueImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CatchParameterWithDefaultValue
 
 internal class TypeParameterInCatchClauseImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParameterInCatchClause
 
 internal class GenericThrowableSubclassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.GenericThrowableSubclass
 
 internal class InnerClassOfGenericThrowableSubclassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.InnerClassOfGenericThrowableSubclass
 
 internal class KclassWithNullableTypeParameterInSignatureImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.KclassWithNullableTypeParameterInSignature
 
 internal class TypeParameterAsReifiedImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParameterAsReified
 
 internal class TypeParameterAsReifiedDeprecationWarningImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParameterAsReifiedDeprecationWarning
 
 internal class TypeParameterAsReifiedArrayErrorImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeParameterAsReifiedArrayError
 
 internal class ReifiedTypeForbiddenSubstitutionImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ReifiedTypeForbiddenSubstitution
 
 internal class DefinitelyNonNullableAsReifiedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DefinitelyNonNullableAsReified
 
 internal class TypeIntersectionAsReifiedErrorImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val types: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeIntersectionAsReifiedError
 
 internal class TypeIntersectionAsReifiedWarningImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val types: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeIntersectionAsReifiedWarning
 
 internal class TypeIntersectionAsReifiedDeprecationWarningImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val types: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeIntersectionAsReifiedDeprecationWarning
 
 internal class FinalUpperBoundImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.FinalUpperBound
 
 internal class UpperBoundIsExtensionOrContextFunctionTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundIsExtensionOrContextFunctionType
 
 internal class BoundsNotAllowedIfBoundedByTypeParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.BoundsNotAllowedIfBoundedByTypeParameter
 
 internal class OnlyOneClassBoundAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.OnlyOneClassBoundAllowed
 
 internal class RepeatedBoundImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RepeatedBound
 
 internal class ConflictingUpperBoundsImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ConflictingUpperBounds
 
 internal class NameInConstraintIsNotATypeParameterImpl(
     override val typeParameterName: Name,
     override val typeParametersOwner: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtSimpleNameExpression>(firDiagnostic, token), KaFirDiagnostic.NameInConstraintIsNotATypeParameter
 
 internal class BoundOnTypeAliasParameterNotAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.BoundOnTypeAliasParameterNotAllowed
 
 internal class ReifiedTypeParameterNoInlineImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.ReifiedTypeParameterNoInline
 
 internal class ReifiedTypeParameterOnAliasErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.ReifiedTypeParameterOnAliasError
 
 internal class ReifiedTypeParameterOnAliasWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.ReifiedTypeParameterOnAliasWarning
 
 internal class TypeParametersNotAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.TypeParametersNotAllowed
 
 internal class IncorrectTypeParameterOfPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.IncorrectTypeParameterOfProperty
 
 internal class ImplicitNothingReturnTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ImplicitNothingReturnType
 
 internal class ImplicitNothingPropertyTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ImplicitNothingPropertyType
 
 internal class AbbreviatedNothingReturnTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AbbreviatedNothingReturnType
 
 internal class AbbreviatedNothingPropertyTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AbbreviatedNothingPropertyType
 
 internal class CyclicGenericUpperBoundImpl(
     override val typeParameters: List<KaTypeParameterSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CyclicGenericUpperBound
 
 internal class FiniteBoundsViolationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FiniteBoundsViolation
 
 internal class FiniteBoundsViolationInJavaImpl(
     override val containingTypes: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FiniteBoundsViolationInJava
 
 internal class ExpansiveInheritanceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpansiveInheritance
 
 internal class ExpansiveInheritanceInJavaImpl(
     override val containingTypes: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpansiveInheritanceInJava
 
 internal class DeprecatedTypeParameterSyntaxImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.DeprecatedTypeParameterSyntax
 
 internal class MisplacedTypeParameterConstraintsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeParameter>(firDiagnostic, token), KaFirDiagnostic.MisplacedTypeParameterConstraints
 
 internal class DynamicSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DynamicSupertype
 
 internal class DynamicUpperBoundImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DynamicUpperBound
 
 internal class DynamicReceiverNotAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DynamicReceiverNotAllowed
 
 internal class DynamicReceiverExpectedButWasNonDynamicImpl(
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DynamicReceiverExpectedButWasNonDynamic
 
 internal class IncompatibleTypesImpl(
     override val typeA: KaType,
     override val typeB: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IncompatibleTypes
 
 internal class IncompatibleTypesWarningImpl(
     override val typeA: KaType,
     override val typeB: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IncompatibleTypesWarning
 
@@ -2930,7 +2930,7 @@ internal class TypeVarianceConflictErrorImpl(
     override val typeParameterVariance: Variance,
     override val variance: Variance,
     override val containingType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeVarianceConflictError
 
@@ -2939,7 +2939,7 @@ internal class TypeVarianceConflictInExpandedTypeImpl(
     override val typeParameterVariance: Variance,
     override val variance: Variance,
     override val containingType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeVarianceConflictInExpandedType
 
@@ -2948,7 +2948,7 @@ internal class SmartcastImpossibleImpl(
     override val subject: KtExpression,
     override val description: String,
     override val isCastToNotNull: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.SmartcastImpossible
 
@@ -2957,20 +2957,20 @@ internal class SmartcastImpossibleOnImplicitInvokeReceiverImpl(
     override val subject: KtExpression,
     override val description: String,
     override val isCastToNotNull: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.SmartcastImpossibleOnImplicitInvokeReceiver
 
 internal class DeprecatedSmartcastOnDelegatedPropertyImpl(
     override val desiredType: KaType,
     override val property: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DeprecatedSmartcastOnDelegatedProperty
 
 internal class PlatformClassMappedToKotlinImpl(
     override val kotlinClass: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PlatformClassMappedToKotlin
 
@@ -2979,7 +2979,7 @@ internal class InferredTypeVariableIntoEmptyIntersectionErrorImpl(
     override val incompatibleTypes: List<KaType>,
     override val description: String,
     override val causingTypes: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InferredTypeVariableIntoEmptyIntersectionError
 
@@ -2988,7 +2988,7 @@ internal class InferredTypeVariableIntoEmptyIntersectionWarningImpl(
     override val incompatibleTypes: List<KaType>,
     override val description: String,
     override val causingTypes: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InferredTypeVariableIntoEmptyIntersectionWarning
 
@@ -2997,34 +2997,34 @@ internal class InferredTypeVariableIntoPossibleEmptyIntersectionImpl(
     override val incompatibleTypes: List<KaType>,
     override val description: String,
     override val causingTypes: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InferredTypeVariableIntoPossibleEmptyIntersection
 
 internal class IncorrectLeftComponentOfIntersectionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IncorrectLeftComponentOfIntersection
 
 internal class IncorrectRightComponentOfIntersectionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IncorrectRightComponentOfIntersection
 
 internal class NullableOnDefinitelyNotNullableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NullableOnDefinitelyNotNullable
 
 internal class RedundantNullableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RedundantNullable
 
 internal class InferredInvisibleReifiedTypeArgumentWarningImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val typeArgumentType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InferredInvisibleReifiedTypeArgumentWarning
 
@@ -3032,24 +3032,24 @@ internal class InferredInvisibleVarargTypeArgumentWarningImpl(
     override val typeParameter: KaTypeParameterSymbol,
     override val typeArgumentType: KaType,
     override val valueParameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InferredInvisibleVarargTypeArgumentWarning
 
 internal class InferredInvisibleReturnTypeWarningImpl(
     override val calleeSymbol: KaSymbol,
     override val returnType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InferredInvisibleReturnTypeWarning
 
 internal class GenericQualifierOnConstructorCallErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.GenericQualifierOnConstructorCallError
 
 internal class GenericQualifierOnConstructorCallWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.GenericQualifierOnConstructorCallWarning
 
@@ -3057,111 +3057,111 @@ internal class AtomicRefWithoutConsistentIdentityImpl(
     override val atomicRef: ClassId,
     override val argumentType: KaType,
     override val suggestedType: ClassId?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AtomicRefWithoutConsistentIdentity
 
 internal class AtomicRefCallArgumentWithoutConsistentIdentityImpl(
     override val argumentType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AtomicRefCallArgumentWithoutConsistentIdentity
 
 internal class ExtensionInClassReferenceNotAllowedImpl(
     override val referencedDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExtensionInClassReferenceNotAllowed
 
 internal class CallableReferenceLhsNotAClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CallableReferenceLhsNotAClass
 
 internal class CallableReferenceToAnnotationConstructorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CallableReferenceToAnnotationConstructor
 
 internal class AdaptedCallableReferenceAgainstReflectionTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AdaptedCallableReferenceAgainstReflectionType
 
 internal class ClassLiteralLhsNotAClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ClassLiteralLhsNotAClass
 
 internal class ClassLiteralLhsNotAClassWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ClassLiteralLhsNotAClassWarning
 
 internal class NullableTypeInClassLiteralLhsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NullableTypeInClassLiteralLhs
 
 internal class ExpressionOfNullableTypeInClassLiteralLhsImpl(
     override val lhsType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpressionOfNullableTypeInClassLiteralLhs
 
 internal class ExpressionOfNullableTypeInClassLiteralLhsWarningImpl(
     override val lhsType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpressionOfNullableTypeInClassLiteralLhsWarning
 
 internal class UnsupportedClassLiteralsWithEmptyLhsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedClassLiteralsWithEmptyLhs
 
 internal class UnsupportedArrayOfNothingInClassLiteralLhsImpl(
     override val unsupported: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedArrayOfNothingInClassLiteralLhs
 
 internal class MutablePropertyWithCapturedTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MutablePropertyWithCapturedType
 
 internal class UnsupportedReflectionApiImpl(
     override val unsupportedReflectionAPI: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UnsupportedReflectionApi
 
 internal class NothingToOverrideImpl(
     override val declaration: KaCallableSymbol,
     override val candidates: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.NothingToOverride
 
 internal class CannotOverrideInvisibleMemberImpl(
     override val overridingMember: KaCallableSymbol,
     override val baseMember: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.CannotOverrideInvisibleMember
 
 internal class DataClassOverrideConflictImpl(
     override val overridingMember: KaCallableSymbol,
     override val baseMember: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.DataClassOverrideConflict
 
 internal class DataClassOverrideDefaultValuesImpl(
     override val overridingMember: KaCallableSymbol,
     override val baseType: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DataClassOverrideDefaultValues
 
@@ -3169,7 +3169,7 @@ internal class CannotWeakenAccessPrivilegeImpl(
     override val overridingVisibility: Visibility,
     override val overridden: KaCallableSymbol,
     override val containingClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.CannotWeakenAccessPrivilege
 
@@ -3177,7 +3177,7 @@ internal class CannotWeakenAccessPrivilegeWarningImpl(
     override val overridingVisibility: Visibility,
     override val overridden: KaCallableSymbol,
     override val containingClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.CannotWeakenAccessPrivilegeWarning
 
@@ -3185,7 +3185,7 @@ internal class CannotChangeAccessPrivilegeImpl(
     override val overridingVisibility: Visibility,
     override val overridden: KaCallableSymbol,
     override val containingClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.CannotChangeAccessPrivilege
 
@@ -3193,19 +3193,19 @@ internal class CannotChangeAccessPrivilegeWarningImpl(
     override val overridingVisibility: Visibility,
     override val overridden: KaCallableSymbol,
     override val containingClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.CannotChangeAccessPrivilegeWarning
 
 internal class CannotInferVisibilityImpl(
     override val callable: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.CannotInferVisibility
 
 internal class CannotInferVisibilityWarningImpl(
     override val callable: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.CannotInferVisibilityWarning
 
@@ -3213,7 +3213,7 @@ internal class MultipleDefaultsInheritedFromSupertypesImpl(
     override val name: Name,
     override val valueParameter: KaSymbol,
     override val baseFunctions: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleDefaultsInheritedFromSupertypes
 
@@ -3221,7 +3221,7 @@ internal class MultipleDefaultsInheritedFromSupertypesWhenNoExplicitOverrideImpl
     override val name: Name,
     override val valueParameter: KaSymbol,
     override val baseFunctions: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleDefaultsInheritedFromSupertypesWhenNoExplicitOverride
 
@@ -3229,7 +3229,7 @@ internal class MultipleDefaultsInheritedFromSupertypesDeprecationErrorImpl(
     override val name: Name,
     override val valueParameter: KaSymbol,
     override val baseFunctions: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleDefaultsInheritedFromSupertypesDeprecationError
 
@@ -3237,7 +3237,7 @@ internal class MultipleDefaultsInheritedFromSupertypesDeprecationWarningImpl(
     override val name: Name,
     override val valueParameter: KaSymbol,
     override val baseFunctions: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleDefaultsInheritedFromSupertypesDeprecationWarning
 
@@ -3245,7 +3245,7 @@ internal class MultipleDefaultsInheritedFromSupertypesWhenNoExplicitOverrideDepr
     override val name: Name,
     override val valueParameter: KaSymbol,
     override val baseFunctions: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleDefaultsInheritedFromSupertypesWhenNoExplicitOverrideDeprecationError
 
@@ -3253,173 +3253,173 @@ internal class MultipleDefaultsInheritedFromSupertypesWhenNoExplicitOverrideDepr
     override val name: Name,
     override val valueParameter: KaSymbol,
     override val baseFunctions: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleDefaultsInheritedFromSupertypesWhenNoExplicitOverrideDeprecationWarning
 
 internal class TypealiasExpandsToArrayOfNothingsImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasExpandsToArrayOfNothings
 
 internal class OverridingFinalMemberImpl(
     override val overriddenDeclaration: KaCallableSymbol,
     override val containingClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.OverridingFinalMember
 
 internal class ReturnTypeMismatchOnOverrideImpl(
     override val function: KaCallableSymbol,
     override val superFunction: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ReturnTypeMismatchOnOverride
 
 internal class PropertyTypeMismatchOnOverrideImpl(
     override val property: KaCallableSymbol,
     override val superProperty: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.PropertyTypeMismatchOnOverride
 
 internal class VarTypeMismatchOnOverrideImpl(
     override val variable: KaCallableSymbol,
     override val superVariable: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.VarTypeMismatchOnOverride
 
 internal class ReturnTypeMismatchOnInheritanceImpl(
     override val conflictingDeclaration1: KaCallableSymbol,
     override val conflictingDeclaration2: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.ReturnTypeMismatchOnInheritance
 
 internal class PropertyTypeMismatchOnInheritanceImpl(
     override val conflictingDeclaration1: KaCallableSymbol,
     override val conflictingDeclaration2: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.PropertyTypeMismatchOnInheritance
 
 internal class VarTypeMismatchOnInheritanceImpl(
     override val conflictingDeclaration1: KaCallableSymbol,
     override val conflictingDeclaration2: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.VarTypeMismatchOnInheritance
 
 internal class ReturnTypeMismatchByDelegationImpl(
     override val delegateDeclaration: KaCallableSymbol,
     override val baseDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.ReturnTypeMismatchByDelegation
 
 internal class PropertyTypeMismatchByDelegationImpl(
     override val delegateDeclaration: KaCallableSymbol,
     override val baseDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.PropertyTypeMismatchByDelegation
 
 internal class VarOverriddenByValByDelegationImpl(
     override val delegateDeclaration: KaCallableSymbol,
     override val baseDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.VarOverriddenByValByDelegation
 
 internal class ConflictingInheritedMembersImpl(
     override val owner: KaClassLikeSymbol,
     override val conflictingDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ConflictingInheritedMembers
 
 internal class AbstractMemberNotImplementedImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val missingDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.AbstractMemberNotImplemented
 
 internal class AbstractMemberIncorrectlyDelegatedErrorImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val missingDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.AbstractMemberIncorrectlyDelegatedError
 
 internal class AbstractMemberIncorrectlyDelegatedWarningImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val missingDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.AbstractMemberIncorrectlyDelegatedWarning
 
 internal class AbstractMemberNotImplementedByEnumEntryImpl(
     override val enumEntry: KaSymbol,
     override val missingDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtEnumEntry>(firDiagnostic, token), KaFirDiagnostic.AbstractMemberNotImplementedByEnumEntry
 
 internal class AbstractClassMemberNotImplementedImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val missingDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.AbstractClassMemberNotImplemented
 
 internal class InvisibleAbstractMemberFromSuperErrorImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val invisibleDeclarations: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.InvisibleAbstractMemberFromSuperError
 
 internal class AmbiguousAnonymousTypeInferredImpl(
     override val superTypes: List<KaType>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.AmbiguousAnonymousTypeInferred
 
 internal class ManyImplMemberNotImplementedImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val missingDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.ManyImplMemberNotImplemented
 
 internal class ManyInterfacesMemberNotImplementedImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val missingDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.ManyInterfacesMemberNotImplemented
 
 internal class OverridingFinalMemberByDelegationImpl(
     override val delegatedDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.OverridingFinalMemberByDelegation
 
 internal class DelegatedMemberHidesSupertypeOverrideImpl(
     override val delegatedDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.DelegatedMemberHidesSupertypeOverride
 
 internal class VarOverriddenByValImpl(
     override val overridingDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.VarOverriddenByVal
 
@@ -3427,7 +3427,7 @@ internal class VarImplementedByInheritedValErrorImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val overridingDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.VarImplementedByInheritedValError
 
@@ -3435,31 +3435,31 @@ internal class VarImplementedByInheritedValWarningImpl(
     override val classOrObject: KaClassLikeSymbol,
     override val overridingDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.VarImplementedByInheritedValWarning
 
 internal class NonFinalMemberInFinalClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.NonFinalMemberInFinalClass
 
 internal class NonFinalMemberInObjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.NonFinalMemberInObject
 
 internal class VirtualMemberHiddenImpl(
     override val declared: KaCallableSymbol,
     override val overriddenContainer: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.VirtualMemberHidden
 
 internal class ParameterNameChangedOnOverrideImpl(
     override val superType: KaClassLikeSymbol,
     override val conflictingParameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ParameterNameChangedOnOverride
 
@@ -3468,616 +3468,616 @@ internal class DifferentNamesForTheSameParameterInSupertypesImpl(
     override val conflictingParameter: KaSymbol,
     override val parameterNumber: Int,
     override val conflictingFunctions: List<KaFunctionSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.DifferentNamesForTheSameParameterInSupertypes
 
 internal class SuspendOverriddenByNonSuspendImpl(
     override val overridingDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtCallableDeclaration>(firDiagnostic, token), KaFirDiagnostic.SuspendOverriddenByNonSuspend
 
 internal class NonSuspendOverriddenBySuspendImpl(
     override val overridingDeclaration: KaCallableSymbol,
     override val overriddenDeclaration: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtCallableDeclaration>(firDiagnostic, token), KaFirDiagnostic.NonSuspendOverriddenBySuspend
 
 internal class OverridingIgnorableWithMustUseImpl(
     override val method: KaCallableSymbol,
     override val parentClass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.OverridingIgnorableWithMustUse
 
 internal class ManyCompanionObjectsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtObjectDeclaration>(firDiagnostic, token), KaFirDiagnostic.ManyCompanionObjects
 
 internal class ConflictingOverloadsImpl(
     override val conflictingOverloads: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ConflictingOverloads
 
 internal class RedeclarationImpl(
     override val conflictingDeclarations: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.Redeclaration
 
 internal class ClassifierRedeclarationImpl(
     override val conflictingDeclarations: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ClassifierRedeclaration
 
 internal class PackageConflictsWithClassifierImpl(
     override val conflictingClassId: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPackageDirective>(firDiagnostic, token), KaFirDiagnostic.PackageConflictsWithClassifier
 
 internal class ExpectAndActualInTheSameModuleImpl(
     override val declaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectAndActualInTheSameModule
 
 internal class MethodOfAnyImplementedInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MethodOfAnyImplementedInInterface
 
 internal class ExtensionShadowedByMemberImpl(
     override val member: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExtensionShadowedByMember
 
 internal class ExtensionFunctionShadowedByMemberPropertyWithInvokeImpl(
     override val member: KaCallableSymbol,
     override val invokeOperator: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExtensionFunctionShadowedByMemberPropertyWithInvoke
 
 internal class LocalObjectNotAllowedImpl(
     override val objectName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.LocalObjectNotAllowed
 
 internal class LocalInterfaceNotAllowedImpl(
     override val interfaceName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.LocalInterfaceNotAllowed
 
 internal class AbstractFunctionInNonAbstractClassImpl(
     override val function: KaCallableSymbol,
     override val containingClass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.AbstractFunctionInNonAbstractClass
 
 internal class AbstractFunctionWithBodyImpl(
     override val function: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.AbstractFunctionWithBody
 
 internal class NonAbstractFunctionWithNoBodyImpl(
     override val function: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.NonAbstractFunctionWithNoBody
 
 internal class PrivateFunctionWithNoBodyImpl(
     override val function: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.PrivateFunctionWithNoBody
 
 internal class NonMemberFunctionNoBodyImpl(
     override val function: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.NonMemberFunctionNoBody
 
 internal class FunctionDeclarationWithNoNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.FunctionDeclarationWithNoName
 
 internal class AnonymousFunctionWithNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.AnonymousFunctionWithName
 
 internal class SingleAnonymousFunctionWithNameErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.SingleAnonymousFunctionWithNameError
 
 internal class SingleAnonymousFunctionWithNameWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.SingleAnonymousFunctionWithNameWarning
 
 internal class AnonymousFunctionParameterWithDefaultValueImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.AnonymousFunctionParameterWithDefaultValue
 
 internal class UselessVarargOnParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.UselessVarargOnParameter
 
 internal class MultipleVarargParametersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.MultipleVarargParameters
 
 internal class ForbiddenVarargParameterTypeImpl(
     override val varargParameterType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ForbiddenVarargParameterType
 
 internal class ValueParameterWithoutExplicitTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ValueParameterWithoutExplicitType
 
 internal class CannotInferParameterTypeImpl(
     override val parameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CannotInferParameterType
 
 internal class CannotInferValueParameterTypeImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CannotInferValueParameterType
 
 internal class CannotInferItParameterTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CannotInferItParameterType
 
 internal class CannotInferReceiverParameterTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CannotInferReceiverParameterType
 
 internal class NoTailCallsFoundImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.NoTailCallsFound
 
 internal class TailrecOnVirtualMemberErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.TailrecOnVirtualMemberError
 
 internal class NonTailRecursiveCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonTailRecursiveCall
 
 internal class TailRecursionInTryIsNotSupportedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TailRecursionInTryIsNotSupported
 
 internal class DataObjectCustomEqualsOrHashCodeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.DataObjectCustomEqualsOrHashCode
 
 internal class DefaultValueNotAllowedInOverrideImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DefaultValueNotAllowedInOverride
 
 internal class FunInterfaceWrongCountOfAbstractMembersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClass>(firDiagnostic, token), KaFirDiagnostic.FunInterfaceWrongCountOfAbstractMembers
 
 internal class FunInterfaceCannotHaveAbstractPropertiesImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.FunInterfaceCannotHaveAbstractProperties
 
 internal class FunInterfaceAbstractMethodWithTypeParametersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.FunInterfaceAbstractMethodWithTypeParameters
 
 internal class FunInterfaceAbstractMethodWithDefaultValueImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.FunInterfaceAbstractMethodWithDefaultValue
 
 internal class FunInterfaceWithSuspendFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.FunInterfaceWithSuspendFunction
 
 internal class AbstractPropertyInNonAbstractClassImpl(
     override val property: KaCallableSymbol,
     override val containingClass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.AbstractPropertyInNonAbstractClass
 
 internal class PrivatePropertyInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.PrivatePropertyInInterface
 
 internal class AbstractPropertyWithInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AbstractPropertyWithInitializer
 
 internal class PropertyInitializerInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.PropertyInitializerInInterface
 
 internal class PropertyWithNoTypeNoInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.PropertyWithNoTypeNoInitializer
 
 internal class AbstractPropertyWithoutTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.AbstractPropertyWithoutType
 
 internal class LateinitPropertyWithoutTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.LateinitPropertyWithoutType
 
 internal class MustBeInitializedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitialized
 
 internal class MustBeInitializedWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedWarning
 
 internal class MustBeInitializedOrBeFinalImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedOrBeFinal
 
 internal class MustBeInitializedOrBeFinalWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedOrBeFinalWarning
 
 internal class MustBeInitializedOrBeAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedOrBeAbstract
 
 internal class MustBeInitializedOrBeAbstractWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedOrBeAbstractWarning
 
 internal class MustBeInitializedOrFinalOrAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedOrFinalOrAbstract
 
 internal class MustBeInitializedOrFinalOrAbstractWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.MustBeInitializedOrFinalOrAbstractWarning
 
 internal class ExplicitFieldMustBeInitializedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.ExplicitFieldMustBeInitialized
 
 internal class ExtensionPropertyMustHaveAccessorsOrBeAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.ExtensionPropertyMustHaveAccessorsOrBeAbstract
 
 internal class UnnecessaryLateinitImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.UnnecessaryLateinit
 
 internal class BackingFieldInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.BackingFieldInInterface
 
 internal class ExtensionPropertyWithBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExtensionPropertyWithBackingField
 
 internal class PropertyInitializerNoBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.PropertyInitializerNoBackingField
 
 internal class AbstractDelegatedPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AbstractDelegatedProperty
 
 internal class DelegatedPropertyInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DelegatedPropertyInInterface
 
 internal class AbstractPropertyWithGetterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPropertyAccessor>(firDiagnostic, token), KaFirDiagnostic.AbstractPropertyWithGetter
 
 internal class AbstractPropertyWithSetterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPropertyAccessor>(firDiagnostic, token), KaFirDiagnostic.AbstractPropertyWithSetter
 
 internal class PrivateSetterForAbstractPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.PrivateSetterForAbstractProperty
 
 internal class PrivateSetterForOpenPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.PrivateSetterForOpenProperty
 
 internal class ValWithSetterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPropertyAccessor>(firDiagnostic, token), KaFirDiagnostic.ValWithSetter
 
 internal class ConstValNotTopLevelOrObjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ConstValNotTopLevelOrObject
 
 internal class ConstValWithGetterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ConstValWithGetter
 
 internal class ConstValWithDelegateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ConstValWithDelegate
 
 internal class TypeCantBeUsedForConstValImpl(
     override val constValType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.TypeCantBeUsedForConstVal
 
 internal class ConstValWithoutInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.ConstValWithoutInitializer
 
 internal class ConstValWithEbfImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.ConstValWithEbf
 
 internal class ConstValWithNonConstInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ConstValWithNonConstInitializer
 
 internal class DelegateUsesExtensionPropertyTypeParameterErrorImpl(
     override val usedTypeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.DelegateUsesExtensionPropertyTypeParameterError
 
 internal class GetterVisibilityDiffersFromPropertyVisibilityImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.GetterVisibilityDiffersFromPropertyVisibility
 
 internal class SetterVisibilityInconsistentWithPropertyVisibilityImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.SetterVisibilityInconsistentWithPropertyVisibility
 
 internal class WrongGetterReturnTypeImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongGetterReturnType
 
 internal class WrongSetterReturnTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongSetterReturnType
 
 internal class WrongSetterParameterTypeImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongSetterParameterType
 
 internal class AccessorForDelegatedPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtPropertyAccessor>(firDiagnostic, token), KaFirDiagnostic.AccessorForDelegatedProperty
 
 internal class PropertyInitializerWithExplicitFieldDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.PropertyInitializerWithExplicitFieldDeclaration
 
 internal class PropertyFieldDeclarationMissingInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.PropertyFieldDeclarationMissingInitializer
 
 internal class LateinitNullableBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.LateinitNullableBackingField
 
 internal class BackingFieldForDelegatedPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.BackingFieldForDelegatedProperty
 
 internal class VarPropertyWithExplicitBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.VarPropertyWithExplicitBackingField
 
 internal class NonFinalPropertyWithExplicitBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.NonFinalPropertyWithExplicitBackingField
 
 internal class ExpectPropertyWithExplicitBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExpectPropertyWithExplicitBackingField
 
 internal class InconsistentBackingFieldTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.InconsistentBackingFieldType
 
 internal class ExplicitFieldVisibilityMustBeLessPermissiveImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.ExplicitFieldVisibilityMustBeLessPermissive
 
 internal class PropertyWithExplicitFieldAndAccessorsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PropertyWithExplicitFieldAndAccessors
 
 internal class ExplicitBackingFieldInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.ExplicitBackingFieldInInterface
 
 internal class ExplicitBackingFieldInAbstractPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.ExplicitBackingFieldInAbstractProperty
 
 internal class ExplicitBackingFieldInExtensionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.ExplicitBackingFieldInExtension
 
 internal class RedundantExplicitBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBackingField>(firDiagnostic, token), KaFirDiagnostic.RedundantExplicitBackingField
 
 internal class AbstractPropertyInPrimaryConstructorParametersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.AbstractPropertyInPrimaryConstructorParameters
 
 internal class LocalVariableWithTypeParametersWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.LocalVariableWithTypeParametersWarning
 
 internal class LocalVariableWithTypeParametersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtProperty>(firDiagnostic, token), KaFirDiagnostic.LocalVariableWithTypeParameters
 
 internal class ExplicitTypeArgumentsInPropertyAccessImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExplicitTypeArgumentsInPropertyAccess
 
 internal class ExplicitTypeArgumentsInPropertyAccessWarningImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExplicitTypeArgumentsInPropertyAccessWarning
 
 internal class SafeCallableReferenceCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.SafeCallableReferenceCall
 
 internal class LateinitIntrinsicCallOnNonLiteralImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LateinitIntrinsicCallOnNonLiteral
 
 internal class LateinitIntrinsicCallOnNonLateinitImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LateinitIntrinsicCallOnNonLateinit
 
 internal class LateinitIntrinsicCallInInlineFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LateinitIntrinsicCallInInlineFunction
 
 internal class LateinitIntrinsicCallOnNonAccessiblePropertyImpl(
     override val declaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LateinitIntrinsicCallOnNonAccessibleProperty
 
 internal class LocalExtensionPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LocalExtensionProperty
 
 internal class UnnamedVarPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnnamedVarProperty
 
 internal class UnnamedDelegatedPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnnamedDelegatedProperty
 
 internal class UnnamedPropertyWithImplicitIgnorableTypeImpl(
     override val ignorableType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnnamedPropertyWithImplicitIgnorableType
 
 internal class DestructuringShortFormNameMismatchImpl(
     override val destructuredName: Name,
     override val propertyName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DestructuringShortFormNameMismatch
 
@@ -4085,143 +4085,143 @@ internal class DestructuringShortFormOfNonDataClassImpl(
     override val rhsType: KaType,
     override val destructuredName: Name,
     override val target: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DestructuringShortFormOfNonDataClass
 
 internal class DestructuringShortFormUnderscoreImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DestructuringShortFormUnderscore
 
 internal class NameBasedDestructuringUnderscoreWithoutRenamingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NameBasedDestructuringUnderscoreWithoutRenaming
 
 internal class ExpectedDeclarationWithBodyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectedDeclarationWithBody
 
 internal class ExpectedClassConstructorDelegationCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtConstructorDelegationCall>(firDiagnostic, token), KaFirDiagnostic.ExpectedClassConstructorDelegationCall
 
 internal class ExpectedClassConstructorPropertyParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ExpectedClassConstructorPropertyParameter
 
 internal class ExpectedEnumConstructorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtConstructor<*>>(firDiagnostic, token), KaFirDiagnostic.ExpectedEnumConstructor
 
 internal class ExpectedEnumEntryWithBodyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtEnumEntry>(firDiagnostic, token), KaFirDiagnostic.ExpectedEnumEntryWithBody
 
 internal class ExpectedPropertyInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExpectedPropertyInitializer
 
 internal class ExpectedDelegatedPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExpectedDelegatedProperty
 
 internal class ExpectedLateinitPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.ExpectedLateinitProperty
 
 internal class SupertypeInitializedInExpectedClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SupertypeInitializedInExpectedClass
 
 internal class ExpectedPrivateDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.ExpectedPrivateDeclaration
 
 internal class ExpectedExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.ExpectedExternalDeclaration
 
 internal class ExpectedTailrecFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.ExpectedTailrecFunction
 
 internal class ImplementationByDelegationInExpectClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDelegatedSuperTypeEntry>(firDiagnostic, token), KaFirDiagnostic.ImplementationByDelegationInExpectClass
 
 internal class ActualTypeAliasNotToClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypeAliasNotToClass
 
 internal class ActualTypeAliasToClassWithDeclarationSiteVarianceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypeAliasToClassWithDeclarationSiteVariance
 
 internal class ActualTypeAliasWithUseSiteVarianceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypeAliasWithUseSiteVariance
 
 internal class ActualTypeAliasWithComplexSubstitutionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypeAliasWithComplexSubstitution
 
 internal class ActualTypeAliasToNullableTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypeAliasToNullableType
 
 internal class ActualTypeAliasToNothingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypeAliasToNothing
 
 internal class ActualFunctionWithDefaultArgumentsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtFunction>(firDiagnostic, token), KaFirDiagnostic.ActualFunctionWithDefaultArguments
 
 internal class DefaultArgumentsInExpectWithActualTypealiasImpl(
     override val expectClassSymbol: KaClassLikeSymbol,
     override val members: List<KaCallableSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.DefaultArgumentsInExpectWithActualTypealias
 
 internal class DefaultArgumentsInExpectActualizedByFakeOverrideImpl(
     override val expectClassSymbol: KaClassLikeSymbol,
     override val members: List<KaFunctionSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClass>(firDiagnostic, token), KaFirDiagnostic.DefaultArgumentsInExpectActualizedByFakeOverride
 
 internal class ExpectedFunctionSourceWithDefaultArgumentsNotFoundImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ExpectedFunctionSourceWithDefaultArgumentsNotFound
 
 internal class ActualWithoutExpectImpl(
     override val declaration: KaSymbol,
     override val compatibility: Map<ExpectActualMatchingCompatibility, List<KaSymbol>>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ActualWithoutExpect
 
@@ -4229,7 +4229,7 @@ internal class ExpectActualIncompatibleClassTypeParameterCountImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleClassTypeParameterCount
 
@@ -4237,7 +4237,7 @@ internal class ExpectActualIncompatibleReturnTypeImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleReturnType
 
@@ -4245,7 +4245,7 @@ internal class ExpectActualIncompatibleEqualityBoundsImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleEqualityBounds
 
@@ -4253,7 +4253,7 @@ internal class ExpectActualIncompatibleParameterNamesImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleParameterNames
 
@@ -4261,7 +4261,7 @@ internal class ExpectActualIncompatibleContextParameterNamesImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleContextParameterNames
 
@@ -4269,7 +4269,7 @@ internal class ExpectActualIncompatibleTypeParameterNamesImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleTypeParameterNames
 
@@ -4277,7 +4277,7 @@ internal class ExpectActualIncompatibleValueParameterVarargImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleValueParameterVararg
 
@@ -4285,7 +4285,7 @@ internal class ExpectActualIncompatibleValueParameterNoinlineImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleValueParameterNoinline
 
@@ -4293,7 +4293,7 @@ internal class ExpectActualIncompatibleValueParameterCrossinlineImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleValueParameterCrossinline
 
@@ -4301,7 +4301,7 @@ internal class ExpectActualIncompatibleFunctionModifiersDifferentImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleFunctionModifiersDifferent
 
@@ -4309,7 +4309,7 @@ internal class ExpectActualIncompatibleFunctionModifiersNotSubsetImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleFunctionModifiersNotSubset
 
@@ -4317,7 +4317,7 @@ internal class ExpectActualIncompatibleParametersWithDefaultValuesInExpectActual
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleParametersWithDefaultValuesInExpectActualizedByFakeOverride
 
@@ -4325,7 +4325,7 @@ internal class ExpectActualIncompatiblePropertyKindImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatiblePropertyKind
 
@@ -4333,7 +4333,7 @@ internal class ExpectActualIncompatiblePropertyLateinitModifierImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatiblePropertyLateinitModifier
 
@@ -4341,7 +4341,7 @@ internal class ExpectActualIncompatiblePropertyConstModifierImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatiblePropertyConstModifier
 
@@ -4349,7 +4349,7 @@ internal class ExpectActualIncompatiblePropertySetterVisibilityImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatiblePropertySetterVisibility
 
@@ -4357,7 +4357,7 @@ internal class ExpectActualIncompatibleClassKindImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleClassKind
 
@@ -4365,7 +4365,7 @@ internal class ExpectActualIncompatibleClassModifiersImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleClassModifiers
 
@@ -4373,7 +4373,7 @@ internal class ExpectActualIncompatibleFunInterfaceModifierImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleFunInterfaceModifier
 
@@ -4381,7 +4381,7 @@ internal class ExpectActualIncompatibleSupertypesImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleSupertypes
 
@@ -4389,7 +4389,7 @@ internal class ExpectActualIncompatibleNestedTypeAliasImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleNestedTypeAlias
 
@@ -4397,7 +4397,7 @@ internal class ExpectActualIncompatibleEnumEntriesImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleEnumEntries
 
@@ -4405,7 +4405,7 @@ internal class ExpectActualIncompatibleIllegalRequiresOptInImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleIllegalRequiresOptIn
 
@@ -4413,7 +4413,7 @@ internal class ExpectActualIncompatibleModalityImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleModality
 
@@ -4421,7 +4421,7 @@ internal class ExpectActualIncompatibleVisibilityImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleVisibility
 
@@ -4429,7 +4429,7 @@ internal class ExpectActualIncompatibleClassTypeParameterUpperBoundsImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleClassTypeParameterUpperBounds
 
@@ -4437,7 +4437,7 @@ internal class ExpectActualIncompatibleTypeParameterVarianceImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleTypeParameterVariance
 
@@ -4445,7 +4445,7 @@ internal class ExpectActualIncompatibleTypeParameterReifiedImpl(
     override val expectDeclaration: KaSymbol,
     override val actualDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleTypeParameterReified
 
@@ -4454,57 +4454,57 @@ internal class ExpectActualIncompatibleClassScopeImpl(
     override val expectMemberDeclaration: KaSymbol,
     override val actualMemberDeclaration: KaSymbol,
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualIncompatibleClassScope
 
 internal class ExpectRefinementAnnotationWrongTargetImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectRefinementAnnotationWrongTarget
 
 internal class AmbiguousExpectsImpl(
     override val declaration: KaSymbol,
     override val modules: List<FirModuleData>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.AmbiguousExpects
 
 internal class NoActualClassMemberForExpectedClassImpl(
     override val declaration: KaSymbol,
     override val members: List<Pair<KaSymbol, Map<Mismatch, List<KaSymbol>>>>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.NoActualClassMemberForExpectedClass
 
 internal class ActualMissingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ActualMissing
 
 internal class ExpectRefinementAnnotationMissingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectRefinementAnnotationMissing
 
 internal class ExpectActualClassifiersAreInBetaWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassLikeDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualClassifiersAreInBetaWarning
 
 internal class NotAMultiplatformCompilationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NotAMultiplatformCompilation
 
 internal class ExpectActualOptInAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExpectActualOptInAnnotation
 
 internal class ActualTypealiasToSpecialAnnotationImpl(
     override val typealiasedClassId: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeAlias>(firDiagnostic, token), KaFirDiagnostic.ActualTypealiasToSpecialAnnotation
 
@@ -4513,7 +4513,7 @@ internal class ActualAnnotationsNotMatchExpectImpl(
     override val actualSymbol: KaSymbol,
     override val actualAnnotationTargetSourceElement: PsiElement?,
     override val incompatibilityType: ExpectActualAnnotationsIncompatibilityType<FirAnnotation>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ActualAnnotationsNotMatchExpect
 
@@ -4522,76 +4522,76 @@ internal class ActualIgnorabilityNotMatchExpectImpl(
     override val expectIgnorability: ReturnValueStatus,
     override val actualDeclaration: KaSymbol,
     override val actualIgnorability: ReturnValueStatus,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.ActualIgnorabilityNotMatchExpect
 
 internal class OptionalDeclarationOutsideOfAnnotationEntryImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptionalDeclarationOutsideOfAnnotationEntry
 
 internal class OptionalDeclarationUsageInNonCommonSourceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptionalDeclarationUsageInNonCommonSource
 
 internal class OptionalExpectationNotOnExpectedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OptionalExpectationNotOnExpected
 
 internal class UninitializedVariableImpl(
     override val variable: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UninitializedVariable
 
 internal class UninitializedParameterImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtSimpleNameExpression>(firDiagnostic, token), KaFirDiagnostic.UninitializedParameter
 
 internal class UninitializedEnumEntryImpl(
     override val enumEntry: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UninitializedEnumEntry
 
 internal class UninitializedEnumCompanionImpl(
     override val enumClass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UninitializedEnumCompanion
 
 internal class ValReassignmentImpl(
     override val variable: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ValReassignment
 
 internal class ValReassignmentViaBackingFieldErrorImpl(
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ValReassignmentViaBackingFieldError
 
 internal class CapturedValInitializationImpl(
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CapturedValInitialization
 
 internal class CapturedMemberValInitializationImpl(
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CapturedMemberValInitialization
 
 internal class NonInlineMemberValInitializationImpl(
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NonInlineMemberValInitialization
 
@@ -4599,7 +4599,7 @@ internal class SetterProjectedOutImpl(
     override val receiverType: KaType,
     override val projection: String,
     override val property: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.SetterProjectedOut
 
@@ -4607,84 +4607,84 @@ internal class WrongInvocationKindImpl(
     override val declaration: KaSymbol,
     override val requiredRange: EventOccurrencesRange,
     override val actualRange: EventOccurrencesRange,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongInvocationKind
 
 internal class LeakedInPlaceLambdaImpl(
     override val lambda: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LeakedInPlaceLambda
 
 internal class VariableWithNoTypeNoInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtVariableDeclaration>(firDiagnostic, token), KaFirDiagnostic.VariableWithNoTypeNoInitializer
 
 internal class InitializationBeforeDeclarationImpl(
     override val property: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.InitializationBeforeDeclaration
 
 internal class InitializationBeforeDeclarationWarningImpl(
     override val property: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.InitializationBeforeDeclarationWarning
 
 internal class UnreachableCodeImpl(
     override val reachable: List<PsiElement>,
     override val unreachable: List<PsiElement>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UnreachableCode
 
 internal class SenselessComparisonImpl(
     override val compareResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.SenselessComparison
 
 internal class SenselessNullInWhenImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SenselessNullInWhen
 
 internal class TypecheckerHasRunIntoRecursiveProblemImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.TypecheckerHasRunIntoRecursiveProblem
 
 internal class ReturnValueNotUsedImpl(
     override val functionName: Name?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ReturnValueNotUsed
 
 internal class ReturnValueNotUsedCoercionImpl(
     override val functionName: Name?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ReturnValueNotUsedCoercion
 
 internal class NullForNonnullTypeImpl(
     override val expectedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NullForNonnullType
 
 internal class UnsafeCallImpl(
     override val receiverType: KaType,
     override val receiverExpression: KtExpression?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsafeCall
 
 internal class UnsafeImplicitInvokeCallImpl(
     override val receiverType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsafeImplicitInvokeCall
 
@@ -4693,7 +4693,7 @@ internal class UnsafeInfixCallImpl(
     override val receiverExpression: KtExpression,
     override val operator: String,
     override val argumentExpression: KtExpression?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UnsafeInfixCall
 
@@ -4702,325 +4702,325 @@ internal class UnsafeOperatorCallImpl(
     override val receiverExpression: KtExpression,
     override val operator: String,
     override val argumentExpression: KtExpression?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UnsafeOperatorCall
 
 internal class UnsafeCallableReferenceImpl(
     override val receiverType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnsafeCallableReference
 
 internal class IteratorOnNullableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.IteratorOnNullable
 
 internal class ComponentFunctionOnNullableImpl(
     override val componentFunctionName: Name,
     override val destructingType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ComponentFunctionOnNullable
 
 internal class UnexpectedSafeCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnexpectedSafeCall
 
 internal class UnnecessarySafeCallImpl(
     override val receiverType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnnecessarySafeCall
 
 internal class UnnecessaryNotNullAssertionImpl(
     override val receiverType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.UnnecessaryNotNullAssertion
 
 internal class NotNullAssertionOnLambdaExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NotNullAssertionOnLambdaExpression
 
 internal class NotNullAssertionOnCallableReferenceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NotNullAssertionOnCallableReference
 
 internal class UselessElvisImpl(
     override val receiverType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.UselessElvis
 
 internal class UselessElvisRightIsNullImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.UselessElvisRightIsNull
 
 internal class UselessElvisLeftIsNullImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.UselessElvisLeftIsNull
 
 internal class CannotCheckForErasedImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CannotCheckForErased
 
 internal class UnsafeCastRelyingOnNullImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.UnsafeCastRelyingOnNull
 
 internal class SafeCastRelyingOnNullImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.SafeCastRelyingOnNull
 
 internal class CastNeverSucceedsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.CastNeverSucceeds
 
 internal class UselessCastImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.UselessCast
 
 internal class UncheckedCastImpl(
     override val originalType: KaType,
     override val targetType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.UncheckedCast
 
 internal class NumericCastNeverSucceedsButCanBeReplacedWithToCallImpl(
     override val targetType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.NumericCastNeverSucceedsButCanBeReplacedWithToCall
 
 internal class IntegerLiteralCastInsteadOfToCallImpl(
     override val targetType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpressionWithTypeRHS>(firDiagnostic, token), KaFirDiagnostic.IntegerLiteralCastInsteadOfToCall
 
 internal class ImpossibleIsCheckErrorImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckError
 
 internal class ImpossibleIsCheckWarningImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckWarning
 
 internal class ImpossibleIsCheckDeprecationErrorImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckDeprecationError
 
 internal class ImpossibleIsCheckDeprecationWarningImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckDeprecationWarning
 
 internal class ImpossibleIsCheckRelyingOnNullErrorImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckRelyingOnNullError
 
 internal class ImpossibleIsCheckRelyingOnNullWarningImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckRelyingOnNullWarning
 
 internal class ImpossibleIsCheckRelyingOnNullDeprecationErrorImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckRelyingOnNullDeprecationError
 
 internal class ImpossibleIsCheckRelyingOnNullDeprecationWarningImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImpossibleIsCheckRelyingOnNullDeprecationWarning
 
 internal class UselessIsCheckImpl(
     override val compileTimeCheckResult: Boolean,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UselessIsCheck
 
 internal class IsEnumEntryImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IsEnumEntry
 
 internal class DynamicNotAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DynamicNotAllowed
 
 internal class EnumEntryAsTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.EnumEntryAsType
 
 internal class ExpectedConditionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtWhenCondition>(firDiagnostic, token), KaFirDiagnostic.ExpectedCondition
 
 internal class NoElseInWhenImpl(
     override val missingWhenCases: List<KaWhenMissingCase>,
     override val description: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtWhenExpression>(firDiagnostic, token), KaFirDiagnostic.NoElseInWhen
 
 internal class MissingBranchForNonAbstractSealedClassImpl(
     override val missingWhenCases: List<KaWhenMissingCase>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtWhenExpression>(firDiagnostic, token), KaFirDiagnostic.MissingBranchForNonAbstractSealedClass
 
 internal class InvalidIfAsExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtIfExpression>(firDiagnostic, token), KaFirDiagnostic.InvalidIfAsExpression
 
 internal class ElseMisplacedInWhenImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtWhenEntry>(firDiagnostic, token), KaFirDiagnostic.ElseMisplacedInWhen
 
 internal class RedundantElseInWhenImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtWhenEntry>(firDiagnostic, token), KaFirDiagnostic.RedundantElseInWhen
 
 internal class IllegalDeclarationInWhenSubjectImpl(
     override val illegalReason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IllegalDeclarationInWhenSubject
 
 internal class CommaInWhenConditionWithoutArgumentImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CommaInWhenConditionWithoutArgument
 
 internal class DuplicateBranchConditionInWhenImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DuplicateBranchConditionInWhen
 
 internal class ConfusingBranchConditionErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ConfusingBranchConditionError
 
 internal class WrongConditionSuggestGuardImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongConditionSuggestGuard
 
 internal class CommaInWhenConditionWithWhenGuardImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CommaInWhenConditionWithWhenGuard
 
 internal class WhenGuardWithoutSubjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WhenGuardWithoutSubject
 
 internal class InferredInvisibleWhenTypeWarningImpl(
     override val whenType: KaType,
     override val syntaxConstructionName: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InferredInvisibleWhenTypeWarning
 
 internal class TypeParameterIsNotAnExpressionImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtSimpleNameExpression>(firDiagnostic, token), KaFirDiagnostic.TypeParameterIsNotAnExpression
 
 internal class TypeParameterOnLhsOfDotImpl(
     override val typeParameter: KaTypeParameterSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtSimpleNameExpression>(firDiagnostic, token), KaFirDiagnostic.TypeParameterOnLhsOfDot
 
 internal class NoCompanionObjectImpl(
     override val klass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NoCompanionObject
 
 internal class ExpressionExpectedPackageFoundImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ExpressionExpectedPackageFound
 
 internal class ErrorInContractDescriptionImpl(
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ErrorInContractDescription
 
 internal class ContractNotAllowedImpl(
     override val reason: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ContractNotAllowed
 
 internal class NoGetMethodImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtArrayAccessExpression>(firDiagnostic, token), KaFirDiagnostic.NoGetMethod
 
 internal class NoSetMethodImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtArrayAccessExpression>(firDiagnostic, token), KaFirDiagnostic.NoSetMethod
 
 internal class IteratorMissingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.IteratorMissing
 
 internal class HasNextMissingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.HasNextMissing
 
 internal class NextMissingImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NextMissing
 
 internal class ComponentFunctionMissingImpl(
     override val missingFunctionName: Name,
     override val destructingType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ComponentFunctionMissing
 
@@ -5028,28 +5028,28 @@ internal class DelegateSpecialFunctionMissingImpl(
     override val expectedFunctionSignature: String,
     override val delegateType: KaType,
     override val description: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.DelegateSpecialFunctionMissing
 
 internal class UnderscoreIsReservedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnderscoreIsReserved
 
 internal class UnderscoreUsageWithoutBackticksImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnderscoreUsageWithoutBackticks
 
 internal class ResolvedToUnderscoreNamedCatchParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNameReferenceExpression>(firDiagnostic, token), KaFirDiagnostic.ResolvedToUnderscoreNamedCatchParameter
 
 internal class InvalidCharactersImpl(
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidCharacters
 
@@ -5057,7 +5057,7 @@ internal class EqualityNotApplicableImpl(
     override val operator: String,
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.EqualityNotApplicable
 
@@ -5065,79 +5065,79 @@ internal class EqualityNotApplicableWarningImpl(
     override val operator: String,
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtBinaryExpression>(firDiagnostic, token), KaFirDiagnostic.EqualityNotApplicableWarning
 
 internal class IncompatibleEnumComparisonErrorImpl(
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IncompatibleEnumComparisonError
 
 internal class IncompatibleEnumComparisonImpl(
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IncompatibleEnumComparison
 
 internal class ForbiddenIdentityEqualsImpl(
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ForbiddenIdentityEquals
 
 internal class ForbiddenIdentityEqualsWarningImpl(
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ForbiddenIdentityEqualsWarning
 
 internal class DeprecatedIdentityEqualsImpl(
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedIdentityEquals
 
 internal class ImplicitBoxingInIdentityEqualsImpl(
     override val leftType: KaType,
     override val rightType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ImplicitBoxingInIdentityEquals
 
 internal class IncDecShouldNotReturnUnitImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.IncDecShouldNotReturnUnit
 
 internal class AssignmentOperatorShouldReturnUnitImpl(
     override val functionSymbol: KaFunctionSymbol,
     override val operator: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.AssignmentOperatorShouldReturnUnit
 
 internal class InitializerRequiredForDestructuringDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDestructuringDeclaration>(firDiagnostic, token), KaFirDiagnostic.InitializerRequiredForDestructuringDeclaration
 
 internal class NotFunctionAsOperatorImpl(
     override val elementName: String,
     override val elementSymbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NotFunctionAsOperator
 
 internal class DslScopeViolationImpl(
     override val calleeSymbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DslScopeViolation
 
@@ -5145,363 +5145,363 @@ internal class ReceiverShadowedByContextParameterImpl(
     override val calleeSymbol: KaSymbol,
     override val isDispatchOfMemberExtension: Boolean,
     override val contextParameterSymbols: List<KaSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ReceiverShadowedByContextParameter
 
 internal class RecursiveTypealiasExpansionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RecursiveTypealiasExpansion
 
 internal class TypealiasShouldExpandToClassImpl(
     override val expandedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasShouldExpandToClass
 
 internal class ConstructorOrSupertypeOnTypealiasWithTypeProjectionErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ConstructorOrSupertypeOnTypealiasWithTypeProjectionError
 
 internal class ConstructorOrSupertypeOnTypealiasWithTypeProjectionWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ConstructorOrSupertypeOnTypealiasWithTypeProjectionWarning
 
 internal class TypealiasExpansionCapturesOuterTypeParametersImpl(
     override val outerTypeParameters: List<KaTypeParameterSymbol>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasExpansionCapturesOuterTypeParameters
 
 internal class TypealiasExpandsToCompilerRequiredAnnotationErrorImpl(
     override val annotation: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasExpandsToCompilerRequiredAnnotationError
 
 internal class TypealiasExpandsToCompilerRequiredAnnotationWarningImpl(
     override val annotation: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.TypealiasExpandsToCompilerRequiredAnnotationWarning
 
 internal class ExpectedTypealiasImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExpectedTypealias
 
 internal class RedundantVisibilityModifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.RedundantVisibilityModifier
 
 internal class RedundantModalityModifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtModifierListOwner>(firDiagnostic, token), KaFirDiagnostic.RedundantModalityModifier
 
 internal class RedundantReturnUnitTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RedundantReturnUnitType
 
 internal class RedundantSingleExpressionStringTemplateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RedundantSingleExpressionStringTemplate
 
 internal class CanBeValImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.CanBeVal
 
 internal class CanBeValLateinitImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.CanBeValLateinit
 
 internal class CanBeValDelayedInitializationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.CanBeValDelayedInitialization
 
 internal class RedundantCallOfConversionMethodImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RedundantCallOfConversionMethod
 
 internal class ArrayEqualityOperatorCanBeReplacedWithContentEqualsImpl(
     override val operator: String,
     override val replacementPrefix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.ArrayEqualityOperatorCanBeReplacedWithContentEquals
 
 internal class EmptyRangeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.EmptyRange
 
 internal class RedundantSetterParameterTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.RedundantSetterParameterType
 
 internal class UnusedVariableImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.UnusedVariable
 
 internal class AssignedValueIsNeverReadImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.AssignedValueIsNeverRead
 
 internal class VariableInitializerIsRedundantImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.VariableInitializerIsRedundant
 
 internal class VariableNeverReadImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.VariableNeverRead
 
 internal class UselessCallOnNotNullImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UselessCallOnNotNull
 
 internal class UnusedAnonymousParameterImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UnusedAnonymousParameter
 
 internal class UnusedExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnusedExpression
 
 internal class UnusedLambdaExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnusedLambdaExpression
 
 internal class ReturnNotAllowedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.ReturnNotAllowed
 
 internal class NotAFunctionLabelImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.NotAFunctionLabel
 
 internal class ReturnInFunctionWithExpressionBodyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.ReturnInFunctionWithExpressionBody
 
 internal class ReturnInFunctionWithExpressionBodyWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.ReturnInFunctionWithExpressionBodyWarning
 
 internal class ReturnInFunctionWithExpressionBodyAndImplicitTypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.ReturnInFunctionWithExpressionBodyAndImplicitType
 
 internal class NoReturnInFunctionWithBlockBodyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclarationWithBody>(firDiagnostic, token), KaFirDiagnostic.NoReturnInFunctionWithBlockBody
 
 internal class RedundantReturnImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.RedundantReturn
 
 internal class AnonymousInitializerInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnonymousInitializer>(firDiagnostic, token), KaFirDiagnostic.AnonymousInitializerInInterface
 
 internal class UsageIsNotInlinableImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UsageIsNotInlinable
 
 internal class NonLocalReturnNotAllowedImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonLocalReturnNotAllowed
 
 internal class NotYetSupportedInInlineImpl(
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NotYetSupportedInInline
 
 internal class NotYetSupportedInInlineWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NotYetSupportedInInlineWarning
 
 internal class NothingToInlineImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NothingToInline
 
 internal class NullableInlineParameterImpl(
     override val parameter: KaSymbol,
     override val function: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NullableInlineParameter
 
 internal class RecursionInInlineImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.RecursionInInline
 
 internal class NonPublicCallFromPublicInlineImpl(
     override val inlineDeclaration: KaSymbol,
     override val referencedDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonPublicCallFromPublicInline
 
 internal class NonPublicInlineCallFromPublicInlineImpl(
     override val inlineDeclaration: KaSymbol,
     override val referencedDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonPublicInlineCallFromPublicInline
 
 internal class NonPublicCallFromPublicInlineDeprecationImpl(
     override val inlineDeclaration: KaSymbol,
     override val referencedDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonPublicCallFromPublicInlineDeprecation
 
 internal class NonPublicDataCopyCallFromPublicInlineErrorImpl(
     override val inlineDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonPublicDataCopyCallFromPublicInlineError
 
 internal class NonPublicDataCopyCallFromPublicInlineWarningImpl(
     override val inlineDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonPublicDataCopyCallFromPublicInlineWarning
 
 internal class ProtectedConstructorCallFromPublicInlineImpl(
     override val inlineDeclaration: KaSymbol,
     override val referencedDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ProtectedConstructorCallFromPublicInline
 
 internal class ProtectedCallFromPublicInlineErrorImpl(
     override val inlineDeclaration: KaSymbol,
     override val referencedDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ProtectedCallFromPublicInlineError
 
 internal class PrivateClassMemberFromInlineImpl(
     override val inlineDeclaration: KaSymbol,
     override val referencedDeclaration: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.PrivateClassMemberFromInline
 
 internal class SuperCallFromPublicInlineImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SuperCallFromPublicInline
 
 internal class DeclarationCantBeInlinedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.DeclarationCantBeInlined
 
 internal class DeclarationCantBeInlinedDeprecationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.DeclarationCantBeInlinedDeprecationError
 
 internal class DeclarationCantBeInlinedDeprecationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.DeclarationCantBeInlinedDeprecationWarning
 
 internal class OverrideByInlineImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.OverrideByInline
 
 internal class InvalidDefaultFunctionalParameterForInlineImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InvalidDefaultFunctionalParameterForInline
 
 internal class NotSupportedInlineParameterInInlineParameterDefaultValueImpl(
     override val parameter: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NotSupportedInlineParameterInInlineParameterDefaultValue
 
 internal class ReifiedTypeParameterInOverrideImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ReifiedTypeParameterInOverride
 
 internal class InlinePropertyWithBackingFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.InlinePropertyWithBackingField
 
 internal class InlinePropertyWithBackingFieldDeprecationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.InlinePropertyWithBackingFieldDeprecationError
 
 internal class InlinePropertyWithBackingFieldDeprecationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.InlinePropertyWithBackingFieldDeprecationWarning
 
 internal class IllegalInlineParameterModifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IllegalInlineParameterModifier
 
 internal class InlineSuspendFunctionTypeUnsupportedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.InlineSuspendFunctionTypeUnsupported
 
 internal class InefficientEqualsOverridingInValueClassImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.InefficientEqualsOverridingInValueClass
 
 internal class InlineClassDeprecatedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InlineClassDeprecated
 
@@ -5509,7 +5509,7 @@ internal class LessVisibleTypeAccessInInlineErrorImpl(
     override val typeVisibility: EffectiveVisibility,
     override val type: KaType,
     override val inlineVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.LessVisibleTypeAccessInInlineError
 
@@ -5517,7 +5517,7 @@ internal class LessVisibleTypeAccessInInlineWarningImpl(
     override val typeVisibility: EffectiveVisibility,
     override val type: KaType,
     override val inlineVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.LessVisibleTypeAccessInInlineWarning
 
@@ -5526,7 +5526,7 @@ internal class LessVisibleTypeInInlineAccessedSignatureErrorImpl(
     override val typeVisibility: EffectiveVisibility,
     override val type: KaType,
     override val inlineVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.LessVisibleTypeInInlineAccessedSignatureError
 
@@ -5535,7 +5535,7 @@ internal class LessVisibleTypeInInlineAccessedSignatureWarningImpl(
     override val typeVisibility: EffectiveVisibility,
     override val type: KaType,
     override val inlineVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.LessVisibleTypeInInlineAccessedSignatureWarning
 
@@ -5543,7 +5543,7 @@ internal class CallableReferenceToLessVisibleDeclarationInInlineErrorImpl(
     override val symbol: KaSymbol,
     override val visibility: EffectiveVisibility,
     override val inlineVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CallableReferenceToLessVisibleDeclarationInInlineError
 
@@ -5551,256 +5551,256 @@ internal class CallableReferenceToLessVisibleDeclarationInInlineWarningImpl(
     override val symbol: KaSymbol,
     override val visibility: EffectiveVisibility,
     override val inlineVisibility: EffectiveVisibility,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CallableReferenceToLessVisibleDeclarationInInlineWarning
 
 internal class ContextParameterMustBeNoinlineImpl(
     override val parameter: KaSymbol,
     override val function: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ContextParameterMustBeNoinline
 
 internal class InlineFromHigherPlatformImpl(
     override val inlinedBytecodeVersion: String,
     override val currentModuleBytecodeVersion: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InlineFromHigherPlatform
 
 internal class CannotAllUnderImportFromSingletonImpl(
     override val objectName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.CannotAllUnderImportFromSingleton
 
 internal class PackageCannotBeImportedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.PackageCannotBeImported
 
 internal class CannotBeImportedImpl(
     override val name: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.CannotBeImported
 
 internal class ConflictingImportImpl(
     override val name: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.ConflictingImport
 
 internal class FunctionTypeOfTooLargeArityImpl(
     override val classId: ClassId,
     override val maxArity: Int,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.FunctionTypeOfTooLargeArity
 
 internal class KSuspendFunctionTypeOfDangerouslyLargeArityImpl(
     override val classId: ClassId,
     override val maxArity: Int,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.KSuspendFunctionTypeOfDangerouslyLargeArity
 
 internal class OperatorRenamedOnImportImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.OperatorRenamedOnImport
 
 internal class TypealiasAsCallableQualifierInImportErrorImpl(
     override val typealiasName: Name,
     override val originalClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.TypealiasAsCallableQualifierInImportError
 
 internal class TypealiasAsCallableQualifierInImportWarningImpl(
     override val typealiasName: Name,
     override val originalClassName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtImportDirective>(firDiagnostic, token), KaFirDiagnostic.TypealiasAsCallableQualifierInImportWarning
 
 internal class IllegalSuspendFunctionCallImpl(
     override val suspendCallable: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalSuspendFunctionCall
 
 internal class IllegalSuspendPropertyAccessImpl(
     override val suspendCallable: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalSuspendPropertyAccess
 
 internal class NonLocalSuspensionPointImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonLocalSuspensionPoint
 
 internal class IllegalRestrictedSuspendingFunctionCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalRestrictedSuspendingFunctionCall
 
 internal class NonModifierFormForBuiltInSuspendImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonModifierFormForBuiltInSuspend
 
 internal class ModifierFormForNonBuiltInSuspendImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ModifierFormForNonBuiltInSuspend
 
 internal class ModifierFormForNonBuiltInSuspendFunErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ModifierFormForNonBuiltInSuspendFunError
 
 internal class ReturnForBuiltInSuspendImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtReturnExpression>(firDiagnostic, token), KaFirDiagnostic.ReturnForBuiltInSuspend
 
 internal class MixingSuspendAndNonSuspendSupertypesImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MixingSuspendAndNonSuspendSupertypes
 
 internal class MixingFunctionalKindsInSupertypesImpl(
     override val kinds: List<FunctionTypeKind>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MixingFunctionalKindsInSupertypes
 
 internal class RedundantLabelWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtLabelReferenceExpression>(firDiagnostic, token), KaFirDiagnostic.RedundantLabelWarning
 
 internal class MultipleLabelsAreForbiddenImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtLabelReferenceExpression>(firDiagnostic, token), KaFirDiagnostic.MultipleLabelsAreForbidden
 
 internal class DeprecatedAccessToEnumEntryCompanionPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedAccessToEnumEntryCompanionProperty
 
 internal class DeprecatedAccessToEntryPropertyFromEnumImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedAccessToEntryPropertyFromEnum
 
 internal class DeprecatedAccessToEntriesPropertyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedAccessToEntriesProperty
 
 internal class DeprecatedAccessToEnumEntryPropertyAsReferenceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedAccessToEnumEntryPropertyAsReference
 
 internal class DeprecatedAccessToEntriesAsQualifierImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DeprecatedAccessToEntriesAsQualifier
 
 internal class DeclarationOfEnumEntryEntriesErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtEnumEntry>(firDiagnostic, token), KaFirDiagnostic.DeclarationOfEnumEntryEntriesError
 
 internal class DeclarationOfEnumEntryEntriesWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtEnumEntry>(firDiagnostic, token), KaFirDiagnostic.DeclarationOfEnumEntryEntriesWarning
 
 internal class IncompatibleClassImpl(
     override val presentableString: String,
     override val incompatibility: IncompatibleVersionErrorData<*>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IncompatibleClass
 
 internal class PreReleaseClassImpl(
     override val presentableString: String,
     override val poisoningFeatures: List<String>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PreReleaseClass
 
 internal class IrWithUnstableAbiCompiledClassImpl(
     override val presentableString: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IrWithUnstableAbiCompiledClass
 
 internal class BuilderInferenceStubReceiverImpl(
     override val typeParameterName: Name,
     override val containingDeclarationName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.BuilderInferenceStubReceiver
 
 internal class BuilderInferenceMultiLambdaRestrictionImpl(
     override val typeParameterName: Name,
     override val containingDeclarationName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.BuilderInferenceMultiLambdaRestriction
 
 internal class InvalidVersioningOnNonOptionalImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnNonOptional
 
 internal class InvalidVersioningOnNonfinalClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnNonfinalClass
 
 internal class InvalidVersioningOnLocalFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnLocalFunction
 
 internal class InvalidVersioningOnAnnotationClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnAnnotationClass
 
 internal class InvalidDefaultValueDependencyImpl(
     override val lowestVersion: MavenComparableVersion?,
     override val highestVersion: MavenComparableVersion?,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidDefaultValueDependency
 
 internal class InvalidNonOptionalParameterPositionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidNonOptionalParameterPosition
 
 internal class InvalidVersioningOnReceiverOrContextParameterPositionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnReceiverOrContextParameterPosition
 
 internal class InvalidVersioningOnVarargImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnVararg
 
 internal class InvalidVersioningOnValueClassParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InvalidVersioningOnValueClassParameter
 
@@ -5808,184 +5808,184 @@ internal class NonAscendingVersionAnnotationImpl(
     override val lowestVersion: MavenComparableVersion?,
     override val highestVersion: MavenComparableVersion?,
     override val sourceOfHighestVersion: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonAscendingVersionAnnotation
 
 internal class CompanionBlockMemberExtensionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionBlockMemberExtension
 
 internal class PrivateConstInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.PrivateConstInInterface
 
 internal class IllegalCompanionBlockImpl(
     override val parent: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalCompanionBlock
 
 internal class CompanionBlockNestedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionBlockNested
 
 internal class IllegalCompanionBlockMemberImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalCompanionBlockMember
 
 internal class CompanionExtensionReceiverWithTypeArgumentsImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionExtensionReceiverWithTypeArguments
 
 internal class CompanionExtensionReceiverIsObjectImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionExtensionReceiverIsObject
 
 internal class CompanionExtensionReceiverIsTypeParameterImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionExtensionReceiverIsTypeParameter
 
 internal class CompanionExtensionReceiverAnnotatedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionExtensionReceiverAnnotated
 
 internal class CompanionExtensionNullableReceiverImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CompanionExtensionNullableReceiver
 
 internal class OverrideCannotBeStaticImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.OverrideCannotBeStatic
 
 internal class JvmStaticNotInObjectOrClassCompanionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmStaticNotInObjectOrClassCompanion
 
 internal class JvmStaticNotInObjectOrCompanionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmStaticNotInObjectOrCompanion
 
 internal class JvmStaticOnNonPublicMemberImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmStaticOnNonPublicMember
 
 internal class JvmStaticOnConstOrJvmFieldImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmStaticOnConstOrJvmField
 
 internal class JvmStaticOnExternalInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmStaticOnExternalInInterface
 
 internal class InapplicableJvmNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InapplicableJvmName
 
 internal class IllegalJvmNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalJvmName
 
 internal class FunctionDelegateMemberNameClashImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FunctionDelegateMemberNameClash
 
 internal class ValueClassWithoutJvmInlineAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ValueClassWithoutJvmInlineAnnotation
 
 internal class JvmInlineWithoutValueClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmInlineWithoutValueClass
 
 internal class InapplicableJvmExposeBoxedWithNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InapplicableJvmExposeBoxedWithName
 
 internal class UselessJvmExposeBoxedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UselessJvmExposeBoxed
 
 internal class JvmExposeBoxedCannotExposeSuspendImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotExposeSuspend
 
 internal class JvmExposeBoxedRequiresNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedRequiresName
 
 internal class JvmExposeBoxedCannotBeTheSameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotBeTheSame
 
 internal class JvmExposeBoxedCannotBeTheSameAsJvmNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotBeTheSameAsJvmName
 
 internal class JvmExposeBoxedCannotExposeOpenAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotExposeOpenAbstract
 
 internal class JvmExposeBoxedCannotExposeSyntheticImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotExposeSynthetic
 
 internal class JvmExposeBoxedCannotExposeLocalsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotExposeLocals
 
 internal class JvmExposeBoxedCannotExposeReifiedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotExposeReified
 
 internal class JvmExposeBoxedCannotExposePrivateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCannotExposePrivate
 
 internal class JvmExposeBoxedCanBeReplacedWithJvmNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmExposeBoxedCanBeReplacedWithJvmName
 
 internal class WrongTypeForJavaOverrideImpl(
     override val override: KaCallableSymbol,
     override val base: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WrongTypeForJavaOverride
 
@@ -5993,44 +5993,44 @@ internal class AccidentalOverrideClashByJvmSignatureImpl(
     override val hidden: KaFunctionSymbol,
     override val overrideDescription: String,
     override val regular: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedFunction>(firDiagnostic, token), KaFirDiagnostic.AccidentalOverrideClashByJvmSignature
 
 internal class ImplementationByDelegationWithDifferentGenericSignatureErrorImpl(
     override val base: KaFunctionSymbol,
     override val override: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeReference>(firDiagnostic, token), KaFirDiagnostic.ImplementationByDelegationWithDifferentGenericSignatureError
 
 internal class ImplementationByDelegationWithDifferentGenericSignatureWarningImpl(
     override val base: KaFunctionSymbol,
     override val override: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtTypeReference>(firDiagnostic, token), KaFirDiagnostic.ImplementationByDelegationWithDifferentGenericSignatureWarning
 
 internal class NotYetSupportedLocalInlineFunctionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.NotYetSupportedLocalInlineFunction
 
 internal class PropertyHidesJavaFieldImpl(
     override val hidden: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtCallableDeclaration>(firDiagnostic, token), KaFirDiagnostic.PropertyHidesJavaField
 
 internal class ConflictVersionAndJvmOverloadsAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ConflictVersionAndJvmOverloadsAnnotation
 
 internal class JavaTypeMismatchImpl(
     override val expectedType: KaType,
     override val actualType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.JavaTypeMismatch
 
@@ -6038,14 +6038,14 @@ internal class ReceiverNullabilityMismatchBasedOnJavaAnnotationsImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
     override val messageSuffix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ReceiverNullabilityMismatchBasedOnJavaAnnotations
 
 internal class ReceiverMutabilityMismatchBasedOnJavaAnnotationsImpl(
     override val actualType: KaType,
     override val expectedType: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ReceiverMutabilityMismatchBasedOnJavaAnnotations
 
@@ -6053,7 +6053,7 @@ internal class TypeMismatchBasedOnJavaAnnotationsImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
     override val messageSuffix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeMismatchBasedOnJavaAnnotations
 
@@ -6061,48 +6061,48 @@ internal class NullabilityMismatchBasedOnExplicitTypeArgumentsForJavaImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
     override val messageSuffix: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NullabilityMismatchBasedOnExplicitTypeArgumentsForJava
 
 internal class TypeMismatchWhenFlexibilityChangesImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.TypeMismatchWhenFlexibilityChanges
 
 internal class JavaClassOnCompanionImpl(
     override val actualType: KaType,
     override val expectedType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaClassOnCompanion
 
 internal class JavaClassPropertyReferenceErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaClassPropertyReferenceError
 
 internal class JavaClassPropertyReferenceWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaClassPropertyReferenceWarning
 
 internal class UnexhaustiveWhenBasedOnJavaAnnotationsImpl(
     override val subjectType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnexhaustiveWhenBasedOnJavaAnnotations
 
 internal class WhenSubjectCanBeNullInJavaImpl(
     override val subjectType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.WhenSubjectCanBeNullInJava
 
 internal class UpperBoundCannotBeArrayImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundCannotBeArray
 
@@ -6110,7 +6110,7 @@ internal class UpperBoundViolatedBasedOnJavaAnnotationsImpl(
     override val expectedUpperBound: KaType,
     override val actualType: KaType,
     override val onTypeParameter: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedBasedOnJavaAnnotations
 
@@ -6118,298 +6118,298 @@ internal class UpperBoundViolatedInTypealiasExpansionBasedOnJavaAnnotationsImpl(
     override val expectedUpperBound: KaType,
     override val actualType: KaType,
     override val onTypeParameter: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UpperBoundViolatedInTypealiasExpansionBasedOnJavaAnnotations
 
 internal class StrictfpOnClassImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.StrictfpOnClass
 
 internal class SynchronizedOnAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedOnAbstract
 
 internal class SynchronizedInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedInInterface
 
 internal class SynchronizedInAnnotationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedInAnnotationError
 
 internal class SynchronizedInAnnotationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedInAnnotationWarning
 
 internal class SynchronizedOnInlineImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedOnInline
 
 internal class SynchronizedOnValueClassErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedOnValueClassError
 
 internal class SynchronizedOnValueClassWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedOnValueClassWarning
 
 internal class SynchronizedOnSuspendErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.SynchronizedOnSuspendError
 
 internal class OverloadsWithoutDefaultArgumentsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OverloadsWithoutDefaultArguments
 
 internal class OverloadsAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OverloadsAbstract
 
 internal class OverloadsInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OverloadsInterface
 
 internal class OverloadsLocalImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OverloadsLocal
 
 internal class OverloadsAnnotationClassConstructorErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OverloadsAnnotationClassConstructorError
 
 internal class OverloadsPrivateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.OverloadsPrivate
 
 internal class DeprecatedJavaAnnotationImpl(
     override val kotlinName: FqName,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.DeprecatedJavaAnnotation
 
 internal class JvmPackageNameCannotBeEmptyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.JvmPackageNameCannotBeEmpty
 
 internal class JvmPackageNameMustBeValidNameImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.JvmPackageNameMustBeValidName
 
 internal class JvmPackageNameNotSupportedInFilesWithClassesImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.JvmPackageNameNotSupportedInFilesWithClasses
 
 internal class PositionedValueArgumentForJavaAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.PositionedValueArgumentForJavaAnnotation
 
 internal class RedundantRepeatableAnnotationImpl(
     override val kotlinRepeatable: FqName,
     override val javaRepeatable: FqName,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RedundantRepeatableAnnotation
 
 internal class ThrowsInAnnotationErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.ThrowsInAnnotationError
 
 internal class ThrowsInAnnotationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.ThrowsInAnnotationWarning
 
 internal class JvmSerializableLambdaOnInlinedFunctionLiteralsErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.JvmSerializableLambdaOnInlinedFunctionLiteralsError
 
 internal class JvmSerializableLambdaOnInlinedFunctionLiteralsWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.JvmSerializableLambdaOnInlinedFunctionLiteralsWarning
 
 internal class IncompatibleAnnotationTargetsImpl(
     override val missingJavaTargets: List<String>,
     override val correspondingKotlinTargets: List<String>,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.IncompatibleAnnotationTargets
 
 internal class AnnotationTargetsOnlyInJavaImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationTargetsOnlyInJava
 
 internal class RuntimeAnnotationOnLambdaIsNotRetainedImpl(
     override val annotationClass: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RuntimeAnnotationOnLambdaIsNotRetained
 
 internal class LocalJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.LocalJvmRecord
 
 internal class NonFinalJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonFinalJvmRecord
 
 internal class EnumJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.EnumJvmRecord
 
 internal class JvmRecordWithoutPrimaryConstructorParametersImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmRecordWithoutPrimaryConstructorParameters
 
 internal class NonDataClassJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonDataClassJvmRecord
 
 internal class NonDataValueClassJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NonDataValueClassJvmRecord
 
 internal class JvmRecordNotValParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmRecordNotValParameter
 
 internal class JvmRecordNotLastVarargParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmRecordNotLastVarargParameter
 
 internal class InnerJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.InnerJvmRecord
 
 internal class FieldInJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.FieldInJvmRecord
 
 internal class DelegationByInJvmRecordImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.DelegationByInJvmRecord
 
 internal class JvmRecordExtendsClassImpl(
     override val superType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmRecordExtendsClass
 
 internal class IllegalJavaLangRecordSupertypeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.IllegalJavaLangRecordSupertype
 
 internal class JvmRecordsIllegalBytecodeTargetImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JvmRecordsIllegalBytecodeTarget
 
 internal class JavaModuleDoesNotDependOnModuleImpl(
     override val moduleName: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaModuleDoesNotDependOnModule
 
 internal class JavaModuleDoesNotReadUnnamedModuleImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaModuleDoesNotReadUnnamedModule
 
 internal class JavaModuleDoesNotExportPackageImpl(
     override val moduleName: String,
     override val packageName: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaModuleDoesNotExportPackage
 
 internal class JvmDefaultWithoutCompatibilityNotInEnableModeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JvmDefaultWithoutCompatibilityNotInEnableMode
 
 internal class JvmDefaultWithCompatibilityNotInNoCompatibilityModeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JvmDefaultWithCompatibilityNotInNoCompatibilityMode
 
 internal class ExternalDeclarationCannotBeAbstractImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExternalDeclarationCannotBeAbstract
 
 internal class ExternalDeclarationCannotHaveBodyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExternalDeclarationCannotHaveBody
 
 internal class ExternalDeclarationInInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExternalDeclarationInInterface
 
 internal class ExternalDeclarationCannotBeInlinedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.ExternalDeclarationCannotBeInlined
 
 internal class NonSourceRepeatedAnnotationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.NonSourceRepeatedAnnotation
 
 internal class RepeatedAnnotationWithContainerImpl(
     override val name: ClassId,
     override val explicitContainerName: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RepeatedAnnotationWithContainer
 
 internal class RepeatableContainerMustHaveValueArrayErrorImpl(
     override val container: ClassId,
     override val annotation: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RepeatableContainerMustHaveValueArrayError
 
 internal class RepeatableContainerHasNonDefaultParameterErrorImpl(
     override val container: ClassId,
     override val nonDefault: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RepeatableContainerHasNonDefaultParameterError
 
@@ -6418,443 +6418,443 @@ internal class RepeatableContainerHasShorterRetentionErrorImpl(
     override val retention: String,
     override val annotation: ClassId,
     override val annotationRetention: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RepeatableContainerHasShorterRetentionError
 
 internal class RepeatableContainerTargetSetNotASubsetErrorImpl(
     override val container: ClassId,
     override val annotation: ClassId,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RepeatableContainerTargetSetNotASubsetError
 
 internal class RepeatableAnnotationHasNestedClassNamedContainerErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RepeatableAnnotationHasNestedClassNamedContainerError
 
 internal class SuspensionPointInsideCriticalSectionImpl(
     override val function: KaCallableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SuspensionPointInsideCriticalSection
 
 internal class InapplicableJvmFieldImpl(
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableJvmField
 
 internal class InapplicableJvmFieldWarningImpl(
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.InapplicableJvmFieldWarning
 
 internal class IdentitySensitiveOperationsWithValueTypeImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.IdentitySensitiveOperationsWithValueType
 
 internal class SynchronizedBlockOnJavaValueBasedClassImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SynchronizedBlockOnJavaValueBasedClass
 
 internal class SynchronizedBlockOnValueClassOrPrimitiveErrorImpl(
     override val valueClassOrPrimitive: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SynchronizedBlockOnValueClassOrPrimitiveError
 
 internal class SynchronizedBlockOnValueClassOrPrimitiveWarningImpl(
     override val valueClassOrPrimitive: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SynchronizedBlockOnValueClassOrPrimitiveWarning
 
 internal class JvmSyntheticOnDelegateImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.JvmSyntheticOnDelegate
 
 internal class SubclassCantCallCompanionProtectedNonStaticImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SubclassCantCallCompanionProtectedNonStatic
 
 internal class SubclassCantCallCompanionProtectedNonStaticWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SubclassCantCallCompanionProtectedNonStaticWarning
 
 internal class ConcurrentHashMapContainsOperatorErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.ConcurrentHashMapContainsOperatorError
 
 internal class SpreadOnSignaturePolymorphicCallErrorImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SpreadOnSignaturePolymorphicCallError
 
 internal class JavaSamInterfaceConstructorReferenceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaSamInterfaceConstructorReference
 
 internal class NoReflectionInClassPathImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.NoReflectionInClassPath
 
 internal class SyntheticPropertyWithoutJavaOriginImpl(
     override val originalSymbol: KaFunctionSymbol,
     override val functionName: Name,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.SyntheticPropertyWithoutJavaOrigin
 
 internal class JavaFieldShadowedByKotlinPropertyImpl(
     override val kotlinProperty: KaVariableSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JavaFieldShadowedByKotlinProperty
 
 internal class MissingBuiltInDeclarationImpl(
     override val symbol: KaSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.MissingBuiltInDeclaration
 
 internal class DangerousCharactersImpl(
     override val characters: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.DangerousCharacters
 
 internal class ImplementingFunctionInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.ImplementingFunctionInterface
 
 internal class OverridingExternalFunWithOptionalParamsImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.OverridingExternalFunWithOptionalParams
 
 internal class OverridingExternalFunWithOptionalParamsWithFakeImpl(
     override val function: KaFunctionSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.OverridingExternalFunWithOptionalParamsWithFake
 
 internal class ExternalEnumEntryWithBodyImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExternalEnumEntryWithBody
 
 internal class EnumClassInExternalDeclarationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.EnumClassInExternalDeclarationWarning
 
 internal class InlineClassInExternalDeclarationWarningImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InlineClassInExternalDeclarationWarning
 
 internal class InlineClassInExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.InlineClassInExternalDeclaration
 
 internal class ExtensionFunctionInExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExtensionFunctionInExternalDeclaration
 
 internal class JsExternalInheritorsOnlyImpl(
     override val parent: KaClassLikeSymbol,
     override val kid: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.JsExternalInheritorsOnly
 
 internal class JsExternalArgumentImpl(
     override val argType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.JsExternalArgument
 
 internal class WrongExportedDeclarationImpl(
     override val kind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongExportedDeclaration
 
 internal class NonExportableTypeImpl(
     override val kind: String,
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonExportableType
 
 internal class NonExportableTypeInSyntheticCopyFunctionWithExposedCopyVisibilityImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonExportableTypeInSyntheticCopyFunctionWithExposedCopyVisibility
 
 internal class NonExportableTypeInSyntheticCopyWithoutConsistentVisibilityImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonExportableTypeInSyntheticCopyWithoutConsistentVisibility
 
 internal class NonConsumableExportedIdentifierImpl(
     override val name: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonConsumableExportedIdentifier
 
 internal class NamedCompanionInExportedInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NamedCompanionInExportedInterface
 
 internal class NotExportedOrExternalActualDeclarationWhileExpectIsExportedImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NotExportedOrExternalActualDeclarationWhileExpectIsExported
 
 internal class ExposedNotExportedSuperInterfaceErrorImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedNotExportedSuperInterfaceError
 
 internal class ExposedNotExportedSuperInterfaceWarningImpl(
     override val restrictingDeclaration: KaClassLikeSymbol,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExposedNotExportedSuperInterfaceWarning
 
 internal class NestedJsExportImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NestedJsExport
 
 internal class MultipleJsExportDefaultInOneFileImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.MultipleJsExportDefaultInOneFile
 
 internal class WrongJsExportTargetVisibilityImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongJsExportTargetVisibility
 
 internal class DelegationByDynamicImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.DelegationByDynamic
 
 internal class PropertyDelegationByDynamicImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.PropertyDelegationByDynamic
 
 internal class SpreadOperatorInDynamicCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.SpreadOperatorInDynamicCall
 
 internal class WrongOperationWithDynamicImpl(
     override val operation: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongOperationWithDynamic
 
 internal class JsStaticNotInObjectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JsStaticNotInObject
 
 internal class JsStaticOnNonPublicMemberImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JsStaticOnNonPublicMember
 
 internal class JsStaticOnConstImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.JsStaticOnConst
 
 internal class JsNoRuntimeWrongTargetImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeWrongTarget
 
 internal class JsNoRuntimeForbiddenIsCheckImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeForbiddenIsCheck
 
 internal class JsNoRuntimeForbiddenAsCastImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeForbiddenAsCast
 
 internal class JsNoRuntimeForbiddenClassReferenceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeForbiddenClassReference
 
 internal class JsNoRuntimeUselessOnExternalInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeUselessOnExternalInterface
 
 internal class JsNoRuntimeInterfaceAsReifiedTypeArgumentImpl(
     override val typeArgument: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeInterfaceAsReifiedTypeArgument
 
 internal class JsActualExternalInterfaceWhileExpectWithoutJsNoRuntimeImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.JsActualExternalInterfaceWhileExpectWithoutJsNoRuntime
 
 internal class JsNoRuntimeActualAnnotationsNotMatchExpectImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtNamedDeclaration>(firDiagnostic, token), KaFirDiagnostic.JsNoRuntimeActualAnnotationsNotMatchExpect
 
 internal class SyntaxImpl(
     override val message: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.Syntax
 
 internal class NestedExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NestedExternalDeclaration
 
 internal class WrongExternalDeclarationImpl(
     override val classKind: String,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.WrongExternalDeclaration
 
 internal class NestedClassInExternalInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NestedClassInExternalInterface
 
 internal class CompanionObjectInExternalInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.CompanionObjectInExternalInterface
 
 internal class InlineExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtDeclaration>(firDiagnostic, token), KaFirDiagnostic.InlineExternalDeclaration
 
 internal class NonAbstractMemberOfExternalInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtExpression>(firDiagnostic, token), KaFirDiagnostic.NonAbstractMemberOfExternalInterface
 
 internal class ExternalClassConstructorPropertyParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtParameter>(firDiagnostic, token), KaFirDiagnostic.ExternalClassConstructorPropertyParameter
 
 internal class ExternalAnonymousInitializerImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnonymousInitializer>(firDiagnostic, token), KaFirDiagnostic.ExternalAnonymousInitializer
 
 internal class ExternalDelegationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExternalDelegation
 
 internal class ExternalDelegatedConstructorCallImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExternalDelegatedConstructorCall
 
 internal class WrongBodyOfExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongBodyOfExternalDeclaration
 
 internal class WrongInitializerOfExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongInitializerOfExternalDeclaration
 
 internal class WrongDefaultValueForExternalFunParameterImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.WrongDefaultValueForExternalFunParameter
 
 internal class CannotCheckForExternalInterfaceImpl(
     override val targetType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.CannotCheckForExternalInterface
 
 internal class UncheckedCastToExternalInterfaceImpl(
     override val sourceType: KaType,
     override val targetType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.UncheckedCastToExternalInterface
 
 internal class ExternalInterfaceAsClassLiteralImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExternalInterfaceAsClassLiteral
 
 internal class ExternalInterfaceAsReifiedTypeArgumentImpl(
     override val typeArgument: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExternalInterfaceAsReifiedTypeArgument
 
 internal class NamedCompanionInExternalInterfaceImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NamedCompanionInExternalInterface
 
 internal class CallToDefinedExternallyFromNonExternalDeclarationImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.CallToDefinedExternallyFromNonExternalDeclaration
 
 internal class ExternalTypeExtendsNonExternalTypeImpl(
     override val superType: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.ExternalTypeExtendsNonExternalType
 
 internal class NonExternalDeclarationInInappropriateFileImpl(
     override val type: KaType,
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.NonExternalDeclarationInInappropriateFile
 
 internal class JscodeArgumentNonConstExpressionImpl(
-    firDiagnostic: KtPsiDiagnostic,
+    firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JscodeArgumentNonConstExpression
 

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirCompilerFacility.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirCompilerFacility.kt
@@ -1195,7 +1195,7 @@ internal class KaFirCompilerFacility(
             for (diagnostic in diagnostics) {
                 if (diagnostic.severity == Severity.ERROR) {
                     val ktDiagnostic = when (diagnostic) {
-                        is KtPsiDiagnostic -> diagnostic.asKaDiagnostic()
+                        is KtDiagnosticWithSource -> diagnostic.asKaDiagnostic()
                         else -> {
                             val message = diagnostic.renderMessage()
                             KaNonBoundToPsiErrorDiagnostic(diagnostic.factoryName, message, analysisSession.token)
@@ -1433,7 +1433,7 @@ private class KaFirDirectoryBasedCompiledCodeProvider(private val outputDirector
 
 private class SyntaxErrorReportingVisitor(
     private val useSiteSession: FirSession,
-    private val diagnosticConverter: (KtPsiDiagnostic) -> KaDiagnosticWithPsi<*>
+    private val diagnosticConverter: (KtDiagnosticWithSource) -> KaDiagnosticWithPsi<*>
 ) : KtTreeVisitorVoid() {
     private val collectedDiagnostics = mutableListOf<KaDiagnostic>()
 
@@ -1443,7 +1443,7 @@ private class SyntaxErrorReportingVisitor(
     override fun visitErrorElement(element: PsiErrorElement) {
         collectedDiagnostics += ConeSyntaxDiagnostic(element.errorDescription)
             .toFirDiagnostics(useSiteSession, KtRealPsiSourceElement(element), callOrAssignmentSource = null)
-            .map { diagnosticConverter(it as KtPsiDiagnostic) }
+            .map { diagnosticConverter(it as KtDiagnosticWithSource) }
 
         super.visitErrorElement(element)
     }

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirSessionComponent.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirSessionComponent.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.KaTypeProjection
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLDiagnostic
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLResolutionFacade
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.resolve.substitution.ConeSubstitutor
@@ -41,7 +41,7 @@ internal interface KaFirSessionComponent : KaSessionComponent {
 
     fun ConeKotlinType.asKaType(): KaType = asKaType(analysisSession)
 
-    fun KtPsiDiagnostic.asKaDiagnostic(): KaDiagnosticWithPsi<*> = asKaDiagnostic(analysisSession)
+    fun KtDiagnosticWithSource.asKaDiagnostic(): KaDiagnosticWithPsi<*> = asKaDiagnostic(analysisSession)
 
     fun LLDiagnostic.asKaDiagnostic(): KaDiagnosticWithPsi<*> = asKaDiagnostic(analysisSession)
 

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaAbstractFirDiagnostic.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaAbstractFirDiagnostic.kt
@@ -15,10 +15,10 @@ import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeOwner
 import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken
 import org.jetbrains.kotlin.analysis.api.lifetime.withValidityAssertion
 import org.jetbrains.kotlin.diagnostics.KtDiagnostic
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 
 internal abstract class KaAbstractFirDiagnostic<PSI : PsiElement>(
-    private val firDiagnostic: KtPsiDiagnostic,
+    private val firDiagnostic: KtDiagnosticWithSource,
     override val token: KaLifetimeToken,
 ) : KaDiagnosticWithPsi<PSI>, KaLifetimeOwner {
 

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaAbstractFirDiagnostic.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaAbstractFirDiagnostic.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.analysis.api.impl.base.util.toAnalysisApiSeverity
 import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeOwner
 import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken
 import org.jetbrains.kotlin.analysis.api.lifetime.withValidityAssertion
+import org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostics.fir.psi
 import org.jetbrains.kotlin.diagnostics.KtDiagnostic
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 
@@ -36,7 +37,7 @@ internal abstract class KaAbstractFirDiagnostic<PSI : PsiElement>(
 
     @Suppress("UNCHECKED_CAST")
     override val psi: PSI
-        get() = withValidityAssertion { firDiagnostic.psiElement as PSI }
+        get() = withValidityAssertion { firDiagnostic.psi as PSI }
 
     override val severity: KaSeverity
         get() = withValidityAssertion { firDiagnostic.severity.toAnalysisApiSeverity() }

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaCompilerPluginDiagnosticImpl.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaCompilerPluginDiagnosticImpl.kt
@@ -12,25 +12,25 @@ import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken
 import org.jetbrains.kotlin.diagnostics.*
 
 internal class KaCompilerPluginDiagnostic0Impl(
-    firDiagnostic: KtPsiSimpleDiagnostic,
+    firDiagnostic: KtSimpleDiagnostic,
     token: KaLifetimeToken
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaCompilerPluginDiagnostic0
 
 internal class KaCompilerPluginDiagnostic1Impl(
-    firDiagnostic: KtPsiDiagnosticWithParameters1<*>,
+    firDiagnostic: KtDiagnosticWithParameters1<*>,
     token: KaLifetimeToken,
     override val parameter1: Any?
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaCompilerPluginDiagnostic1
 
 internal class KaCompilerPluginDiagnostic2Impl(
-    firDiagnostic: KtPsiDiagnosticWithParameters2<*, *>,
+    firDiagnostic: KtDiagnosticWithParameters2<*, *>,
     token: KaLifetimeToken,
     override val parameter1: Any?,
     override val parameter2: Any?
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaCompilerPluginDiagnostic2
 
 internal class KaCompilerPluginDiagnostic3Impl(
-    firDiagnostic: KtPsiDiagnosticWithParameters3<*, *, *>,
+    firDiagnostic: KtDiagnosticWithParameters3<*, *, *>,
     token: KaLifetimeToken,
     override val parameter1: Any?,
     override val parameter2: Any?,
@@ -38,7 +38,7 @@ internal class KaCompilerPluginDiagnostic3Impl(
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaCompilerPluginDiagnostic3
 
 internal class KaCompilerPluginDiagnostic4Impl(
-    firDiagnostic: KtPsiDiagnosticWithParameters4<*, *, *, *>,
+    firDiagnostic: KtDiagnosticWithParameters4<*, *, *, *>,
     token: KaLifetimeToken,
     override val parameter1: Any?,
     override val parameter2: Any?,

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaDiagnosticConverter.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaDiagnosticConverter.kt
@@ -63,12 +63,12 @@ internal class KaDiagnosticConverter(private val conversions: Map<KtDiagnosticFa
     private fun buildCreatorForPluginDiagnostic(factory: AbstractKtDiagnosticFactory): KaFirDiagnosticCreator = when (factory) {
         is KtSourcelessDiagnosticFactory -> shouldNotBeCalled()
         is KtDiagnosticFactory0 -> KaFirDiagnostic0Creator {
-            KaCompilerPluginDiagnostic0Impl(it as KtPsiSimpleDiagnostic, token)
+            KaCompilerPluginDiagnostic0Impl(it, token)
         }
 
         is KtDiagnosticFactory1<*> -> KaFirDiagnostic1Creator<Any?> { // Type argument specified because of KT-55281
             KaCompilerPluginDiagnostic1Impl(
-                it as KtPsiDiagnosticWithParameters1<*>,
+                it,
                 token,
                 convertArgument(it.a, this)
             )
@@ -76,7 +76,7 @@ internal class KaDiagnosticConverter(private val conversions: Map<KtDiagnosticFa
 
         is KtDiagnosticFactory2<*, *> -> KaFirDiagnostic2Creator<Any?, Any?> {
             KaCompilerPluginDiagnostic2Impl(
-                it as KtPsiDiagnosticWithParameters2<*, *>,
+                it,
                 token,
                 convertArgument(it.a, this),
                 convertArgument(it.b, this)
@@ -85,7 +85,7 @@ internal class KaDiagnosticConverter(private val conversions: Map<KtDiagnosticFa
 
         is KtDiagnosticFactory3<*, *, *> -> KaFirDiagnostic3Creator<Any?, Any?, Any?> {
             KaCompilerPluginDiagnostic3Impl(
-                it as KtPsiDiagnosticWithParameters3<*, *, *>,
+                it,
                 token,
                 convertArgument(it.a, this),
                 convertArgument(it.b, this),
@@ -95,7 +95,7 @@ internal class KaDiagnosticConverter(private val conversions: Map<KtDiagnosticFa
 
         is KtDiagnosticFactory4<*, *, *, *> -> KaFirDiagnostic4Creator<Any?, Any?, Any?, Any?> {
             KaCompilerPluginDiagnostic4Impl(
-                it as KtPsiDiagnosticWithParameters4<*, *, *, *>,
+                it,
                 token,
                 convertArgument(it.a, this),
                 convertArgument(it.b, this),

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/psiUtils.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/psiUtils.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.diagnostics.KtDiagnostic
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.psi
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
@@ -215,9 +215,9 @@ internal val KaSymbolModality.isOpenFromInterface: Boolean
     get() = this == KaSymbolModality.OPEN && (callable.containingClassOrObject as? KtClass)?.isInterface() == true
 
 context(analysisSession: KaFirSession)
-internal fun KtPsiDiagnostic.asKaDiagnostic(): KaDiagnosticWithPsi<*> = asKaDiagnostic(analysisSession)
+internal fun KtDiagnosticWithSource.asKaDiagnostic(): KaDiagnosticWithPsi<*> = asKaDiagnostic(analysisSession)
 
-internal fun KtPsiDiagnostic.asKaDiagnostic(analysisSession: KaFirSession): KaDiagnosticWithPsi<*> {
+internal fun KtDiagnosticWithSource.asKaDiagnostic(analysisSession: KaFirSession): KaDiagnosticWithPsi<*> {
     @OptIn(KaUnstableDiagnosticApi::class)
     return KT_DIAGNOSTIC_CONVERTER.convert(analysisSession, this as KtDiagnostic)
 }

--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/utils/typeUtils.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/utils/typeUtils.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.analysis.api.fir.asKaDiagnostic
 import org.jetbrains.kotlin.analysis.api.fir.types.KaFirType
 import org.jetbrains.kotlin.analysis.api.impl.base.util.requireIsInstance
 import org.jetbrains.kotlin.analysis.api.types.*
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.typeParameterSymbols
 import org.jetbrains.kotlin.fir.analysis.diagnostics.toFirDiagnostics
@@ -292,7 +292,7 @@ internal fun ConeDiagnostic.asKaDiagnostic(
 ): KaDiagnosticWithPsi<*>? {
     with(analysisSession) {
         val firDiagnostic = toFirDiagnostics(firSession, source, callOrAssignmentSource = null).firstOrNull() ?: return null
-        check(firDiagnostic is KtPsiDiagnostic)
+        check(firDiagnostic is KtDiagnosticWithSource)
         return firDiagnostic.asKaDiagnostic()
     }
 }

--- a/analysis/analysis-api/testData/components/compilerFacility/compilation/inlineFuncCycle2.txt
+++ b/analysis/analysis-api/testData/components/compilerFacility/compilation/inlineFuncCycle2.txt
@@ -1,3 +1,3 @@
 (101,104) INLINE_CALL_CYCLE The 'c' invocation is part of an inline cycle.
-INLINE_CALL_CYCLE The 'a' invocation is part of an inline cycle.
-INLINE_CALL_CYCLE The 'b' invocation is part of an inline cycle.
+(105,108) INLINE_CALL_CYCLE The 'a' invocation is part of an inline cycle.
+(143,146) INLINE_CALL_CYCLE The 'b' invocation is part of an inline cycle.

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/api/LLDiagnostic.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/api/LLDiagnostic.kt
@@ -5,8 +5,11 @@
 
 package org.jetbrains.kotlin.analysis.low.level.api.fir.api
 
+import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
+import org.jetbrains.kotlin.utils.exceptions.requireWithAttachment
+import org.jetbrains.kotlin.utils.exceptions.withPsiEntry
 
 /**
  * A [diagnostic] reported by compiler checkers, together with its [suppression status][isSuppressed].
@@ -18,7 +21,7 @@ import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
  */
 @KaImplementationDetail
 class LLDiagnostic(
-    val diagnostic: KtPsiDiagnostic,
+    val diagnostic: KtDiagnosticWithSource,
 
     /**
      * Whether the diagnostic is suppressed at its use site, e.g., by a `@Suppress` annotation.
@@ -28,5 +31,25 @@ class LLDiagnostic(
      */
     val isSuppressed: Boolean,
 ) {
+    init {
+        diagnostic.checkPsiTypeConsistency()
+    }
+
     override fun toString(): String = if (isSuppressed) "$diagnostic (suppressed)" else diagnostic.toString()
+}
+
+private const val CHECK_PSI_CONSISTENCY_IN_DIAGNOSTICS = true
+
+private fun KtDiagnosticWithSource.checkPsiTypeConsistency() {
+    if (CHECK_PSI_CONSISTENCY_IN_DIAGNOSTICS) {
+        val element = this.element as? KtPsiSourceElement ?: return
+        val psiElement = element.psi
+        requireWithAttachment(
+            factory.psiType.isInstance(psiElement),
+            { "${psiElement::class} is not a subtype of ${factory.psiType} for factory $factory" }
+        ) {
+            withPsiEntry("psi", psiElement)
+            withPsiEntry("file", psiElement.containingFile)
+        }
+    }
 }

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/LLFirDiagnosticReporter.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/LLFirDiagnosticReporter.kt
@@ -41,7 +41,7 @@ internal class LLFirDiagnosticReporter : PendingDiagnosticReporter() {
         if (diagnostic.isAboutImplicitImport()) return
 
         val psiDiagnostic = when (diagnostic) {
-            is KtPsiDiagnostic -> diagnostic
+            is KtDiagnosticWithSource -> diagnostic
             else -> error("Unknown diagnostic type ${diagnostic::class.simpleName}")
         }
 
@@ -71,14 +71,14 @@ internal class LLFirDiagnosticReporter : PendingDiagnosticReporter() {
         }
     }
 
-    private class PendingDiagnostic(val diagnostic: KtPsiDiagnostic, var isSuppressed: Boolean)
+    private class PendingDiagnostic(val diagnostic: KtDiagnosticWithSource, var isSuppressed: Boolean)
 }
 
 /**
  * PSI ancestry is checked instead of text range containment, as walking the parent chain is cheaper than computing text ranges:
  * [PsiElement.getTextRange] has to traverse preceding siblings to compute the start offset.
  */
-private fun KtPsiDiagnostic.isInside(element: AbstractKtSourceElement): Boolean {
+private fun KtDiagnosticWithSource.isInside(element: AbstractKtSourceElement): Boolean {
     if (this.element == element) return true
 
     val elementPsi = (element as? KtPsiSourceElement)?.psi
@@ -89,6 +89,6 @@ private fun KtPsiDiagnostic.isInside(element: AbstractKtSourceElement): Boolean 
 
 @OptIn(SuspiciousFakeSourceCheck::class)
 private fun KtDiagnostic.isAboutImplicitImport(): Boolean {
-    if (this !is KtPsiDiagnostic) return false
+    if (this !is KtDiagnosticWithSource) return false
     return (element is KtFakePsiSourceElement && (element as KtFakePsiSourceElement).kind == KtFakeSourceElementKind.ImplicitImport)
 }

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/LLFirDiagnosticReporter.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/LLFirDiagnosticReporter.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostics
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.*
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLDiagnostic
+import org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostics.fir.psi
 import org.jetbrains.kotlin.analysis.low.level.api.fir.util.addValueFor
 import org.jetbrains.kotlin.diagnostics.*
 import org.jetbrains.kotlin.psi.psiUtil.isAncestor
@@ -46,7 +47,7 @@ internal class LLFirDiagnosticReporter : PendingDiagnosticReporter() {
         }
 
         val pendingDiagnostic = PendingDiagnostic(psiDiagnostic, isSuppressed = context.isDiagnosticSuppressed(diagnostic))
-        pendingDiagnostics.addValueFor(psiDiagnostic.psiElement, pendingDiagnostic)
+        pendingDiagnostics.addValueFor(psiDiagnostic.psi, pendingDiagnostic)
     }
 
     override fun checkAndCommitReportsOn(element: AbstractKtSourceElement, context: DiagnosticContext, commitEverything: Boolean) {
@@ -84,7 +85,7 @@ private fun KtDiagnosticWithSource.isInside(element: AbstractKtSourceElement): B
     val elementPsi = (element as? KtPsiSourceElement)?.psi
         ?: return this.element.startOffset >= element.startOffset && this.element.endOffset <= element.endOffset
 
-    return elementPsi.isAncestor(psiElement, strict = false)
+    return elementPsi.isAncestor(psi, strict = false)
 }
 
 @OptIn(SuspiciousFakeSourceCheck::class)

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/fir/LLDiagnosticUtils.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostics/fir/LLDiagnosticUtils.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostics.fir
+
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.KtPsiSourceElement
+import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
+
+@KaImplementationDetail
+val KtDiagnosticWithSource.psi: PsiElement
+    get() = (element as KtPsiSourceElement).psi

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/file/structure/FileStructure.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/file/structure/FileStructure.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.analysis.low.level.api.fir.LLFirModuleResolveCompone
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.DiagnosticCheckerFilter
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLDiagnostic
 import org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostics.LLFirDiagnosticVisitor
+import org.jetbrains.kotlin.analysis.low.level.api.fir.diagnostics.fir.psi
 import org.jetbrains.kotlin.analysis.low.level.api.fir.element.builder.getNonLocalContainingOrThisElement
 import org.jetbrains.kotlin.analysis.low.level.api.fir.element.builder.isAutonomousElement
 import org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.elementCanBeLazilyResolved
@@ -212,7 +213,7 @@ internal class FileStructure private constructor(
                 // A structure element may cover a wider piece of code than the requested element, and it may even own diagnostics reported
                 // outside its own declaration (e.g., a primary constructor element owns diagnostics of the super type call). So diagnostics
                 // reported outside the element have to be dropped.
-                if (isWholeFile || element.isAncestor(llDiagnostic.diagnostic.psiElement, strict = false)) {
+                if (isWholeFile || element.isAncestor(llDiagnostic.diagnostic.psi, strict = false)) {
                     yield(llDiagnostic)
                 }
             }

--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/compiler/based/LLDiagnosticParameterChecker.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/compiler/based/LLDiagnosticParameterChecker.kt
@@ -14,8 +14,6 @@ import org.jetbrains.kotlin.test.frontend.fir.handlers.FirAnalysisHandler
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.assertions
-import org.jetbrains.kotlin.utils.exceptions.errorWithAttachment
-import org.jetbrains.kotlin.utils.exceptions.withPsiEntry
 
 internal class LLDiagnosticParameterChecker(testServices: TestServices) : FirAnalysisHandler(testServices) {
     override fun processModule(module: TestModule, info: FirOutputArtifact) {
@@ -24,19 +22,19 @@ internal class LLDiagnosticParameterChecker(testServices: TestServices) : FirAna
             val diagnostics = facade.runCheckers().values.flatten()
 
             for (diagnostic in diagnostics) {
-                checkDiagnosticIsSuitableForFirIde(diagnostic as KtPsiDiagnostic)
+                checkDiagnosticIsSuitableForFirIde(diagnostic as KtDiagnosticWithSource)
             }
         }
     }
 
-    private fun checkDiagnosticIsSuitableForFirIde(diagnostic: KtPsiDiagnostic) {
+    private fun checkDiagnosticIsSuitableForFirIde(diagnostic: KtDiagnosticWithSource) {
         val parameters = diagnostic.allParameters()
         for (parameter in parameters) {
             checkDiagnosticParameter(diagnostic, parameter)
         }
     }
 
-    private fun checkDiagnosticParameter(diagnostic: KtPsiDiagnostic, parameter: Any?) {
+    private fun checkDiagnosticParameter(diagnostic: KtDiagnosticWithSource, parameter: Any?) {
         when (parameter) {
             is ConeKotlinType -> checkType(parameter, diagnostic as KtDiagnostic)
         }
@@ -52,15 +50,12 @@ internal class LLDiagnosticParameterChecker(testServices: TestServices) : FirAna
         }
     }
 
-    private fun KtPsiDiagnostic.allParameters(): List<Any?> = when (this) {
-        is KtPsiDiagnosticWithParameters1<*> -> listOf(a)
-        is KtPsiDiagnosticWithParameters2<*, *> -> listOf(a, b)
-        is KtPsiDiagnosticWithParameters3<*, *, *> -> listOf(a, b, c)
-        is KtPsiDiagnosticWithParameters4<*, *, *, *> -> listOf(a, b, c, d)
-        is KtPsiSimpleDiagnostic -> emptyList()
-        else -> errorWithAttachment("Unexpected diagnostic ${this::class}, $factoryName") {
-            withPsiEntry("onElement", psiElement)
-        }
+    private fun KtDiagnosticWithSource.allParameters(): List<Any?> = when (this) {
+        is KtDiagnosticWithParameters1<*> -> listOf(a)
+        is KtDiagnosticWithParameters2<*, *> -> listOf(a, b)
+        is KtDiagnosticWithParameters3<*, *, *> -> listOf(a, b, c)
+        is KtDiagnosticWithParameters4<*, *, *, *> -> listOf(a, b, c, d)
+        is KtSimpleDiagnostic -> emptyList()
     }
 
     override fun processAfterAllModules(someAssertionWasFailed: Boolean) {}

--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/firTestUtils.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/firTestUtils.kt
@@ -11,11 +11,9 @@ import org.jetbrains.kotlin.analysis.api.platform.projectStructure.KotlinProject
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibrarySourceModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
-import org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLDiagnostic
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.LLResolutionFacade
 import org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionConfigurator
 import org.jetbrains.kotlin.analysis.test.framework.services.environmentManager
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.render

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/fir/FirDiagnosticsCompilerResultsReporter.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/fir/FirDiagnosticsCompilerResultsReporter.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.cli.common.fir
 
 import org.jetbrains.kotlin.KtInMemoryTextSourceFile
 import org.jetbrains.kotlin.KtIoFileSourceFile
+import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.KtPsiSourceFile
 import org.jetbrains.kotlin.KtVirtualFileSourceFile
 import org.jetbrains.kotlin.cli.common.messages.*
@@ -83,7 +84,7 @@ object FirDiagnosticsCompilerResultsReporter {
                 val offsetsToPositions = positionFinder.value?.let { finder ->
                     val sortedOffsets = TreeSet<Int>().apply {
                         for (diagnostic in diagnosticList) {
-                            if (diagnostic is KtDiagnosticWithSource && diagnostic !is KtPsiDiagnostic) {
+                            if (diagnostic is KtDiagnosticWithSource && diagnostic.element !is KtPsiSourceElement) {
                                 val range = diagnostic.firstRange
                                 add(range.startOffset)
                                 add(range.endOffset)
@@ -96,9 +97,9 @@ object FirDiagnosticsCompilerResultsReporter {
                 for (diagnostic in diagnosticList.sortedWith(InFileDiagnosticsComparator)) {
                     val location = when (diagnostic) {
                         is KtDiagnosticWithoutSource -> diagnostic.location
-                        is KtDiagnosticWithSource -> when (diagnostic) {
-                            is KtPsiDiagnostic -> {
-                                val file = diagnostic.element.psi.containingFile
+                        is KtDiagnosticWithSource -> when (val element = diagnostic.element) {
+                            is KtPsiSourceElement -> {
+                                val file = element.psi.containingFile
                                 MessageUtil.psiFileToMessageLocation(
                                     file,
                                     file.name,

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/Context.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/Context.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.fir.builder
 
-import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirLabel
 import org.jetbrains.kotlin.fir.FirLoopTarget
@@ -13,7 +12,6 @@ import org.jetbrains.kotlin.fir.declarations.FirTypeParameterRef
 import org.jetbrains.kotlin.fir.declarations.builder.buildOuterClassTypeParameterRef
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirReplSnippetSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirScriptSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol

--- a/compiler/frontend.common-psi/src/org/jetbrains/kotlin/diagnostics/PositioningStrategy.kt
+++ b/compiler/frontend.common-psi/src/org/jetbrains/kotlin/diagnostics/PositioningStrategy.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
@@ -25,8 +26,10 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 annotation class DiagnosticLossRisk
 
 open class PositioningStrategy<in E : PsiElement> {
+
     open fun markDiagnostic(diagnostic: DiagnosticMarker): List<TextRange> {
         @Suppress("UNCHECKED_CAST")
+        @OptIn(K1Deprecation::class)
         return mark(diagnostic.psiElement as E)
     }
 

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
@@ -22,25 +22,3 @@ interface DiagnosticMarker {
     val severity: Severity
     val textRanges: List<TextRange>
 }
-
-interface DiagnosticWithParameters1Marker<A> : DiagnosticMarker {
-    val a: A
-}
-
-interface DiagnosticWithParameters2Marker<A, B> : DiagnosticMarker {
-    val a: A
-    val b: B
-}
-
-interface DiagnosticWithParameters3Marker<A, B, C> : DiagnosticMarker {
-    val a: A
-    val b: B
-    val c: C
-}
-
-interface DiagnosticWithParameters4Marker<A, B, C, D> : DiagnosticMarker {
-    val a: A
-    val b: B
-    val c: C
-    val d: D
-}

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
@@ -7,10 +7,17 @@ package org.jetbrains.kotlin.diagnostics
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.K1Deprecation
 
 interface DiagnosticMarker {
+
+    /**
+     * When working with [KtDiagnosticWithSource] consider using [KtDiagnosticWithSource.element] instead
+     */
+    @K1Deprecation
     val psiElement: PsiElement
         get() = error("psiElement should be called only on diagnostics with KtPsiSourceElement inside")
+
     val factoryName: String
     val severity: Severity
     val textRanges: List<TextRange>

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/DiagnosticMarker.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiElement
 
 interface DiagnosticMarker {
     val psiElement: PsiElement
-        get() = error("psiElement should be called only on KtPsiDiagnostic and equivalents")
+        get() = error("psiElement should be called only on diagnostics with KtPsiSourceElement inside")
     val factoryName: String
     val severity: Severity
     val textRanges: List<TextRange>

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
@@ -56,65 +56,29 @@ sealed class KtDiagnosticWithSource : KtDiagnostic(), DiagnosticMarker {
 
     final override val firstRange: TextRange
         get() = DiagnosticRangeUtils.firstRange(textRanges)
-}
 
-abstract class KtSimpleDiagnostic : KtDiagnosticWithSource() {
-    abstract override val factory: KtDiagnosticFactory0
-}
-
-abstract class KtDiagnosticWithParameters1<A> : KtDiagnosticWithSource(), DiagnosticWithParameters1Marker<A> {
-    abstract override val a: A
-    abstract override val factory: KtDiagnosticFactory1<A>
-}
-
-abstract class KtDiagnosticWithParameters2<A, B> : KtDiagnosticWithSource(), DiagnosticWithParameters2Marker<A, B> {
-    abstract override val a: A
-    abstract override val b: B
-    abstract override val factory: KtDiagnosticFactory2<A, B>
-}
-
-abstract class KtDiagnosticWithParameters3<A, B, C> : KtDiagnosticWithSource(), DiagnosticWithParameters3Marker<A, B, C> {
-    abstract override val a: A
-    abstract override val b: B
-    abstract override val c: C
-    abstract override val factory: KtDiagnosticFactory3<A, B, C>
-}
-
-abstract class KtDiagnosticWithParameters4<A, B, C, D> : KtDiagnosticWithSource(), DiagnosticWithParameters4Marker<A, B, C, D> {
-    abstract override val a: A
-    abstract override val b: B
-    abstract override val c: C
-    abstract override val d: D
-    abstract override val factory: KtDiagnosticFactory4<A, B, C, D>
-}
-
-// ------------------------------ regular (non-PSI) diagnostics ------------------------------
-
-interface KtRegularDiagnostic : DiagnosticMarker {
-    val element: AbstractKtSourceElement
-
-    override val psiElement: PsiElement
+    final override val psiElement: PsiElement
         get() = (element as KtPsiSourceElement).psi
 }
 
-data class KtRegularSimpleDiagnostic(
+data class KtSimpleDiagnostic(
     override val element: AbstractKtSourceElement,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory0,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtSimpleDiagnostic(), KtRegularDiagnostic
+) : KtDiagnosticWithSource()
 
-data class KtRegularDiagnosticWithParameters1<A>(
+data class KtDiagnosticWithParameters1<A>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory1<A>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters1<A>(), KtRegularDiagnostic
+) : KtDiagnosticWithSource(), DiagnosticWithParameters1Marker<A>
 
-data class KtRegularDiagnosticWithParameters2<A, B>(
+data class KtDiagnosticWithParameters2<A, B>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val b: B,
@@ -122,9 +86,9 @@ data class KtRegularDiagnosticWithParameters2<A, B>(
     override val factory: KtDiagnosticFactory2<A, B>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters2<A, B>(), KtRegularDiagnostic
+) : KtDiagnosticWithSource(), DiagnosticWithParameters2Marker<A, B>
 
-data class KtRegularDiagnosticWithParameters3<A, B, C>(
+data class KtDiagnosticWithParameters3<A, B, C>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val b: B,
@@ -133,9 +97,9 @@ data class KtRegularDiagnosticWithParameters3<A, B, C>(
     override val factory: KtDiagnosticFactory3<A, B, C>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters3<A, B, C>(), KtRegularDiagnostic
+) : KtDiagnosticWithSource(), DiagnosticWithParameters3Marker<A, B, C>
 
-data class KtRegularDiagnosticWithParameters4<A, B, C, D>(
+data class KtDiagnosticWithParameters4<A, B, C, D>(
     override val element: AbstractKtSourceElement,
     override val a: A,
     override val b: B,
@@ -145,4 +109,4 @@ data class KtRegularDiagnosticWithParameters4<A, B, C, D>(
     override val factory: KtDiagnosticFactory4<A, B, C, D>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters4<A, B, C, D>(), KtRegularDiagnostic
+) : KtDiagnosticWithSource(), DiagnosticWithParameters4Marker<A, B, C, D>

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
@@ -73,42 +73,42 @@ data class KtSimpleDiagnostic(
 
 data class KtDiagnosticWithParameters1<A>(
     override val element: AbstractKtSourceElement,
-    override val a: A,
+    val a: A,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory1<A>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithSource(), DiagnosticWithParameters1Marker<A>
+) : KtDiagnosticWithSource()
 
 data class KtDiagnosticWithParameters2<A, B>(
     override val element: AbstractKtSourceElement,
-    override val a: A,
-    override val b: B,
+    val a: A,
+    val b: B,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory2<A, B>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithSource(), DiagnosticWithParameters2Marker<A, B>
+) : KtDiagnosticWithSource()
 
 data class KtDiagnosticWithParameters3<A, B, C>(
     override val element: AbstractKtSourceElement,
-    override val a: A,
-    override val b: B,
-    override val c: C,
+    val a: A,
+    val b: B,
+    val c: C,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory3<A, B, C>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithSource(), DiagnosticWithParameters3Marker<A, B, C>
+) : KtDiagnosticWithSource()
 
 data class KtDiagnosticWithParameters4<A, B, C, D>(
     override val element: AbstractKtSourceElement,
-    override val a: A,
-    override val b: B,
-    override val c: C,
-    override val d: D,
+    val a: A,
+    val b: B,
+    val c: C,
+    val d: D,
     override val severity: Severity,
     override val factory: KtDiagnosticFactory4<A, B, C, D>,
     override val positioningStrategy: AbstractSourceElementPositioningStrategy,
     override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithSource(), DiagnosticWithParameters4Marker<A, B, C, D>
+) : KtDiagnosticWithSource()

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.diagnostics
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.AbstractKtSourceElement
+import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 
@@ -57,6 +58,7 @@ sealed class KtDiagnosticWithSource : KtDiagnostic(), DiagnosticMarker {
     final override val firstRange: TextRange
         get() = DiagnosticRangeUtils.firstRange(textRanges)
 
+    @K1Deprecation
     final override val psiElement: PsiElement
         get() = (element as KtPsiSourceElement).psi
 }

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnostic.kt
@@ -7,12 +7,9 @@ package org.jetbrains.kotlin.diagnostics
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.AbstractKtSourceElement
 import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
-import org.jetbrains.kotlin.utils.exceptions.requireWithAttachment
-import org.jetbrains.kotlin.utils.exceptions.withPsiEntry
 
 // ------------------------------ diagnostics ------------------------------
 
@@ -61,29 +58,29 @@ sealed class KtDiagnosticWithSource : KtDiagnostic(), DiagnosticMarker {
         get() = DiagnosticRangeUtils.firstRange(textRanges)
 }
 
-sealed class KtSimpleDiagnostic : KtDiagnosticWithSource() {
+abstract class KtSimpleDiagnostic : KtDiagnosticWithSource() {
     abstract override val factory: KtDiagnosticFactory0
 }
 
-sealed class KtDiagnosticWithParameters1<A> : KtDiagnosticWithSource(), DiagnosticWithParameters1Marker<A> {
+abstract class KtDiagnosticWithParameters1<A> : KtDiagnosticWithSource(), DiagnosticWithParameters1Marker<A> {
     abstract override val a: A
     abstract override val factory: KtDiagnosticFactory1<A>
 }
 
-sealed class KtDiagnosticWithParameters2<A, B> : KtDiagnosticWithSource(), DiagnosticWithParameters2Marker<A, B> {
+abstract class KtDiagnosticWithParameters2<A, B> : KtDiagnosticWithSource(), DiagnosticWithParameters2Marker<A, B> {
     abstract override val a: A
     abstract override val b: B
     abstract override val factory: KtDiagnosticFactory2<A, B>
 }
 
-sealed class KtDiagnosticWithParameters3<A, B, C> : KtDiagnosticWithSource(), DiagnosticWithParameters3Marker<A, B, C> {
+abstract class KtDiagnosticWithParameters3<A, B, C> : KtDiagnosticWithSource(), DiagnosticWithParameters3Marker<A, B, C> {
     abstract override val a: A
     abstract override val b: B
     abstract override val c: C
     abstract override val factory: KtDiagnosticFactory3<A, B, C>
 }
 
-sealed class KtDiagnosticWithParameters4<A, B, C, D> : KtDiagnosticWithSource(), DiagnosticWithParameters4Marker<A, B, C, D> {
+abstract class KtDiagnosticWithParameters4<A, B, C, D> : KtDiagnosticWithSource(), DiagnosticWithParameters4Marker<A, B, C, D> {
     abstract override val a: A
     abstract override val b: B
     abstract override val c: C
@@ -91,110 +88,13 @@ sealed class KtDiagnosticWithParameters4<A, B, C, D> : KtDiagnosticWithSource(),
     abstract override val factory: KtDiagnosticFactory4<A, B, C, D>
 }
 
-// ------------------------------ psi diagnostics ------------------------------
-
-interface KtPsiDiagnostic : DiagnosticMarker {
-    val factory: KtDiagnosticFactoryN
-    val element: KtPsiSourceElement
-    override val textRanges: List<TextRange>
-    override val severity: Severity
-
-    override val psiElement: PsiElement
-        get() = element.psi
-
-    val psiFile: PsiFile
-        get() = psiElement.containingFile
-}
-
-private const val CHECK_PSI_CONSISTENCY_IN_DIAGNOSTICS = true
-
-private fun KtPsiDiagnostic.checkPsiTypeConsistency() {
-    if (CHECK_PSI_CONSISTENCY_IN_DIAGNOSTICS) {
-        requireWithAttachment(
-            factory.psiType.isInstance(psiElement),
-            { "${psiElement::class} is not a subtype of ${factory.psiType} for factory $factory" }
-        ) {
-            withPsiEntry("psi", psiElement)
-            withPsiEntry("file", psiFile)
-        }
-    }
-}
-
-data class KtPsiSimpleDiagnostic(
-    override val element: KtPsiSourceElement,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory0,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtSimpleDiagnostic(), KtPsiDiagnostic {
-    init {
-        checkPsiTypeConsistency()
-    }
-}
-
-data class KtPsiDiagnosticWithParameters1<A>(
-    override val element: KtPsiSourceElement,
-    override val a: A,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory1<A>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters1<A>(), KtPsiDiagnostic {
-    init {
-        checkPsiTypeConsistency()
-    }
-}
-
-
-data class KtPsiDiagnosticWithParameters2<A, B>(
-    override val element: KtPsiSourceElement,
-    override val a: A,
-    override val b: B,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory2<A, B>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters2<A, B>(), KtPsiDiagnostic {
-    init {
-        checkPsiTypeConsistency()
-    }
-}
-
-data class KtPsiDiagnosticWithParameters3<A, B, C>(
-    override val element: KtPsiSourceElement,
-    override val a: A,
-    override val b: B,
-    override val c: C,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory3<A, B, C>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters3<A, B, C>(), KtPsiDiagnostic {
-    init {
-        checkPsiTypeConsistency()
-    }
-}
-
-data class KtPsiDiagnosticWithParameters4<A, B, C, D>(
-    override val element: KtPsiSourceElement,
-    override val a: A,
-    override val b: B,
-    override val c: C,
-    override val d: D,
-    override val severity: Severity,
-    override val factory: KtDiagnosticFactory4<A, B, C, D>,
-    override val positioningStrategy: AbstractSourceElementPositioningStrategy,
-    override val context: DiagnosticBaseContext,
-) : KtDiagnosticWithParameters4<A, B, C, D>(), KtPsiDiagnostic {
-    init {
-        checkPsiTypeConsistency()
-    }
-}
-
 // ------------------------------ regular (non-PSI) diagnostics ------------------------------
 
 interface KtRegularDiagnostic : DiagnosticMarker {
     val element: AbstractKtSourceElement
+
+    override val psiElement: PsiElement
+        get() = (element as KtPsiSourceElement).psi
 }
 
 data class KtRegularSimpleDiagnostic(

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
@@ -8,7 +8,6 @@
 package org.jetbrains.kotlin.diagnostics
 
 import org.jetbrains.kotlin.AbstractKtSourceElement
-import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.config.LanguageFeature
@@ -76,22 +75,13 @@ class KtDiagnosticFactory0(
         context: DiagnosticBaseContext,
     ): KtSimpleDiagnostic? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return when (element) {
-            is KtPsiSourceElement -> KtPsiSimpleDiagnostic(
-                element,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtRegularSimpleDiagnostic(
-                element,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-        }
+        return KtRegularSimpleDiagnostic(
+            element,
+            effectiveSeverity,
+            this,
+            positioningStrategy ?: defaultPositioningStrategy,
+            context,
+        )
     }
 }
 
@@ -110,24 +100,14 @@ class KtDiagnosticFactory1<A>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters1<A>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return when (element) {
-            is KtPsiSourceElement -> KtPsiDiagnosticWithParameters1(
-                element,
-                a,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtRegularDiagnosticWithParameters1(
-                element,
-                a,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-        }
+        return KtRegularDiagnosticWithParameters1(
+            element,
+            a,
+            effectiveSeverity,
+            this,
+            positioningStrategy ?: defaultPositioningStrategy,
+            context,
+        )
     }
 }
 
@@ -147,26 +127,15 @@ class KtDiagnosticFactory2<A, B>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters2<A, B>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return when (element) {
-            is KtPsiSourceElement -> KtPsiDiagnosticWithParameters2(
-                element,
-                a,
-                b,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtRegularDiagnosticWithParameters2(
-                element,
-                a,
-                b,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-        }
+        return KtRegularDiagnosticWithParameters2(
+            element,
+            a,
+            b,
+            effectiveSeverity,
+            this,
+            positioningStrategy ?: defaultPositioningStrategy,
+            context,
+        )
     }
 }
 
@@ -187,28 +156,16 @@ class KtDiagnosticFactory3<A, B, C>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters3<A, B, C>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return when (element) {
-            is KtPsiSourceElement -> KtPsiDiagnosticWithParameters3(
-                element,
-                a,
-                b,
-                c,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtRegularDiagnosticWithParameters3(
-                element,
-                a,
-                b,
-                c,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-        }
+        return KtRegularDiagnosticWithParameters3(
+            element,
+            a,
+            b,
+            c,
+            effectiveSeverity,
+            this,
+            positioningStrategy ?: defaultPositioningStrategy,
+            context,
+        )
     }
 }
 
@@ -230,30 +187,17 @@ class KtDiagnosticFactory4<A, B, C, D>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters4<A, B, C, D>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return when (element) {
-            is KtPsiSourceElement -> KtPsiDiagnosticWithParameters4(
-                element,
-                a,
-                b,
-                c,
-                d,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-            else -> KtRegularDiagnosticWithParameters4(
-                element,
-                a,
-                b,
-                c,
-                d,
-                effectiveSeverity,
-                this,
-                positioningStrategy ?: defaultPositioningStrategy,
-                context,
-            )
-        }
+        return KtRegularDiagnosticWithParameters4(
+            element,
+            a,
+            b,
+            c,
+            d,
+            effectiveSeverity,
+            this,
+            positioningStrategy ?: defaultPositioningStrategy,
+            context,
+        )
     }
 }
 

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
@@ -75,7 +75,7 @@ class KtDiagnosticFactory0(
         context: DiagnosticBaseContext,
     ): KtSimpleDiagnostic? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return KtRegularSimpleDiagnostic(
+        return KtSimpleDiagnostic(
             element,
             effectiveSeverity,
             this,
@@ -100,7 +100,7 @@ class KtDiagnosticFactory1<A>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters1<A>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return KtRegularDiagnosticWithParameters1(
+        return KtDiagnosticWithParameters1(
             element,
             a,
             effectiveSeverity,
@@ -127,7 +127,7 @@ class KtDiagnosticFactory2<A, B>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters2<A, B>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return KtRegularDiagnosticWithParameters2(
+        return KtDiagnosticWithParameters2(
             element,
             a,
             b,
@@ -156,7 +156,7 @@ class KtDiagnosticFactory3<A, B, C>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters3<A, B, C>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return KtRegularDiagnosticWithParameters3(
+        return KtDiagnosticWithParameters3(
             element,
             a,
             b,
@@ -187,7 +187,7 @@ class KtDiagnosticFactory4<A, B, C, D>(
         context: DiagnosticBaseContext,
     ): KtDiagnosticWithParameters4<A, B, C, D>? {
         val effectiveSeverity = getEffectiveSeverity(context.languageVersionSettings) ?: return null
-        return KtRegularDiagnosticWithParameters4(
+        return KtDiagnosticWithParameters4(
             element,
             a,
             b,

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/ClassicPositioningStrategies.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/ClassicPositioningStrategies.kt
@@ -37,8 +37,8 @@ object ClassicPositioningStrategies {
         get() {
             @Suppress("UNCHECKED_CAST")
             val map = when (factoryName) {
-                Errors.NO_ACTUAL_FOR_EXPECT.name -> (this as DiagnosticWithParameters3Marker<*, *, *>).c
-                Errors.ACTUAL_WITHOUT_EXPECT.name -> (this as DiagnosticWithParameters2Marker<*, *>).b
+                Errors.NO_ACTUAL_FOR_EXPECT.name -> (this as DiagnosticWithParameters3<*, *, *, *>).c
+                Errors.ACTUAL_WITHOUT_EXPECT.name -> (this as DiagnosticWithParameters2<*, *, *>).b
                 else -> null
             } as? Map<K1ExpectActualCompatibility.Incompatible<MemberDescriptor>, Collection<MemberDescriptor>> ?: return null
             return map.keys.firstOrNull()
@@ -124,7 +124,7 @@ object ClassicPositioningStrategies {
     val UNREACHABLE_CODE: PositioningStrategy<PsiElement> = object : PositioningStrategy<PsiElement>() {
         override fun markDiagnostic(diagnostic: DiagnosticMarker): List<TextRange> {
             @Suppress("UNCHECKED_CAST")
-            val unreachableCode = diagnostic as DiagnosticWithParameters2Marker<Set<KtElement>, Set<KtElement>>
+            val unreachableCode = diagnostic as DiagnosticWithParameters2<*, Set<KtElement>, Set<KtElement>>
             return UnreachableCode.getUnreachableTextRanges(diagnostic.psiElement as KtElement, unreachableCode.a, unreachableCode.b)
         }
     }

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/ClassicPositioningStrategies.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/ClassicPositioningStrategies.kt
@@ -125,7 +125,7 @@ object ClassicPositioningStrategies {
         override fun markDiagnostic(diagnostic: DiagnosticMarker): List<TextRange> {
             @Suppress("UNCHECKED_CAST")
             val unreachableCode = diagnostic as DiagnosticWithParameters2Marker<Set<KtElement>, Set<KtElement>>
-            return UnreachableCode.getUnreachableTextRanges(unreachableCode.psiElement as KtElement, unreachableCode.a, unreachableCode.b)
+            return UnreachableCode.getUnreachableTextRanges(diagnostic.psiElement as KtElement, unreachableCode.a, unreachableCode.b)
         }
     }
 

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters1.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters1.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class DiagnosticWithParameters1<E extends PsiElement, A> extends AbstractDiagnostic<E> implements DiagnosticWithParameters1Marker<A> {
+public class DiagnosticWithParameters1<E extends PsiElement, A> extends AbstractDiagnostic<E> {
     private final A a;
 
     public DiagnosticWithParameters1(
@@ -42,7 +42,6 @@ public class DiagnosticWithParameters1<E extends PsiElement, A> extends Abstract
     }
 
     @NotNull
-    @Override
     public A getA() {
         return a;
     }

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters2.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters2.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class DiagnosticWithParameters2<E extends PsiElement, A, B> extends AbstractDiagnostic<E> implements DiagnosticWithParameters2Marker<A, B>{
+public class DiagnosticWithParameters2<E extends PsiElement, A, B> extends AbstractDiagnostic<E> {
     private final A a;
     private final B b;
 
@@ -45,13 +45,11 @@ public class DiagnosticWithParameters2<E extends PsiElement, A, B> extends Abstr
     }
 
     @NotNull
-    @Override
     public A getA() {
         return a;
     }
 
     @NotNull
-    @Override
     public B getB() {
         return b;
     }

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters3.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters3.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class DiagnosticWithParameters3<E extends PsiElement, A, B, C> extends AbstractDiagnostic<E> implements DiagnosticWithParameters3Marker<A, B, C> {
+public class DiagnosticWithParameters3<E extends PsiElement, A, B, C> extends AbstractDiagnostic<E> {
     private final A a;
     private final B b;
     private final C c;
@@ -48,19 +48,16 @@ public class DiagnosticWithParameters3<E extends PsiElement, A, B, C> extends Ab
     }
 
     @NotNull
-    @Override
     public B getB() {
         return b;
     }
 
     @NotNull
-    @Override
     public A getA() {
         return a;
     }
 
     @NotNull
-    @Override
     public C getC() {
         return c;
     }

--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters4.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/DiagnosticWithParameters4.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class DiagnosticWithParameters4<E extends PsiElement, A, B, C, D> extends AbstractDiagnostic<E> implements DiagnosticWithParameters4Marker<A, B, C, D> {
+public class DiagnosticWithParameters4<E extends PsiElement, A, B, C, D> extends AbstractDiagnostic<E> {
     private final A a;
     private final B b;
     private final C c;
@@ -51,25 +51,21 @@ public class DiagnosticWithParameters4<E extends PsiElement, A, B, C, D> extends
     }
 
     @NotNull
-    @Override
     public A getA() {
         return a;
     }
 
     @NotNull
-    @Override
     public B getB() {
         return b;
     }
 
     @NotNull
-    @Override
     public C getC() {
         return c;
     }
 
     @NotNull
-    @Override
     public D getD() {
         return d;
     }

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
@@ -497,22 +497,13 @@ private class DebugDiagnosticConsumer(
             return
         }
 
-        val diagnostic = when (sourceElement) {
-            is KtPsiSourceElement -> KtPsiSimpleDiagnostic(
-                sourceElement,
-                factory.severity,
-                factory,
-                factory.defaultPositioningStrategy,
-                DiagnosticContext.Default,
-            )
-            is KtLightSourceElement -> KtRegularSimpleDiagnostic(
-                sourceElement,
-                factory.severity,
-                factory,
-                factory.defaultPositioningStrategy,
-                DiagnosticContext.Default,
-            )
-        }
+        val diagnostic = KtRegularSimpleDiagnostic(
+            sourceElement,
+            factory.severity,
+            factory,
+            factory.defaultPositioningStrategy,
+            DiagnosticContext.Default,
+        )
 
         result.add(diagnostic)
     }
@@ -533,24 +524,14 @@ private class DebugDiagnosticConsumer(
             return
         }
 
-        val diagnostic = when (positionedElement) {
-            is KtPsiSourceElement -> KtPsiDiagnosticWithParameters1(
-                positionedElement,
-                argumentFactory(),
-                factory.severity,
-                factory,
-                factory.defaultPositioningStrategy,
-                DiagnosticContext.Default,
-            )
-            is KtLightSourceElement -> KtRegularDiagnosticWithParameters1(
-                positionedElement,
-                argumentFactory(),
-                factory.severity,
-                factory,
-                factory.defaultPositioningStrategy,
-                DiagnosticContext.Default,
-            )
-        }
+        val diagnostic = KtRegularDiagnosticWithParameters1(
+            positionedElement,
+            argumentFactory(),
+            factory.severity,
+            factory,
+            factory.defaultPositioningStrategy,
+            DiagnosticContext.Default,
+        )
 
         result.add(diagnostic)
     }

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
@@ -58,7 +58,6 @@ import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.resolve.AnalyzingUtils
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.backend.handlers.assertFileDoesntExist
-import org.jetbrains.kotlin.test.testInfraError
 import org.jetbrains.kotlin.test.directives.*
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.METADATA_ONLY_COMPILATION
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.SEPARATE_KMP_COMPILATION
@@ -72,6 +71,7 @@ import org.jetbrains.kotlin.test.frontend.fir.FirOutputPartForDependsOnModule
 import org.jetbrains.kotlin.test.model.TestFile
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.*
+import org.jetbrains.kotlin.test.testInfraError
 import org.jetbrains.kotlin.test.utils.AbstractTwoAttributesMetaInfoProcessor
 import org.jetbrains.kotlin.test.utils.MultiModuleInfoDumper
 import org.jetbrains.kotlin.util.OperatorNameConventions
@@ -497,7 +497,7 @@ private class DebugDiagnosticConsumer(
             return
         }
 
-        val diagnostic = KtRegularSimpleDiagnostic(
+        val diagnostic = KtSimpleDiagnostic(
             sourceElement,
             factory.severity,
             factory,
@@ -524,7 +524,7 @@ private class DebugDiagnosticConsumer(
             return
         }
 
-        val diagnostic = KtRegularDiagnosticWithParameters1(
+        val diagnostic = KtDiagnosticWithParameters1(
             positionedElement,
             argumentFactory(),
             factory.severity,

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/facade/K2CompilerFacade.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/facade/K2CompilerFacade.kt
@@ -68,7 +68,7 @@ class FirAnalysisResult(
 ) : AnalysisResult {
     override val diagnostics: Map<String, List<AnalysisResult.Diagnostic>>
         get() = reporter.diagnostics.filterIsInstance<KtDiagnosticWithSource>().filter { it.element is KtPsiSourceElement }.groupBy(
-            keySelector = { it.psiElement.containingFile.name },
+            keySelector = { (it.element as KtPsiSourceElement).psi.containingFile.name },
             valueTransform = { AnalysisResult.Diagnostic(it.factoryName, it.textRanges) }
         )
 }

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/facade/K2CompilerFacade.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/facade/K2CompilerFacade.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.StandardFileSystems
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.search.ProjectScope
+import org.jetbrains.kotlin.KtPsiSourceElement
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory
 import org.jetbrains.kotlin.cli.common.fir.FirDiagnosticsCompilerResultsReporter
@@ -35,7 +36,7 @@ import org.jetbrains.kotlin.compiler.plugin.getCompilerExtensions
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.languageVersionSettings
-import org.jetbrains.kotlin.diagnostics.KtPsiDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithSource
 import org.jetbrains.kotlin.diagnostics.impl.BaseDiagnosticsCollector
 import org.jetbrains.kotlin.diagnostics.impl.DiagnosticsCollectorImpl
 import org.jetbrains.kotlin.fir.DependencyListForCliModule
@@ -66,7 +67,7 @@ class FirAnalysisResult(
     val reporter: BaseDiagnosticsCollector,
 ) : AnalysisResult {
     override val diagnostics: Map<String, List<AnalysisResult.Diagnostic>>
-        get() = reporter.diagnostics.filterIsInstance<KtPsiDiagnostic>().groupBy(
+        get() = reporter.diagnostics.filterIsInstance<KtDiagnosticWithSource>().filter { it.element is KtPsiSourceElement }.groupBy(
             keySelector = { it.psiElement.containingFile.name },
             valueTransform = { AnalysisResult.Diagnostic(it.factoryName, it.textRanges) }
         )


### PR DESCRIPTION
This commit allows us to use the same KtRegularDiagnostic classes with different kinds of source elements (KtPsiSourceElement or KtLightSourceElement), thus finishing the process of abstracting diagnostics from the source element types.
