### PR TITLE
[build] create npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,43 @@
+name: Publish to npm
+on:
+  repository_dispatch:
+    types: [npm_publish]
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.jetbrains.team/p/kt/containers-public/kotlin-build-env:v48
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.client_payload.branch }}
+      - name: Download and Unpack ZIP
+        shell: bash
+        run: |
+          # 1. Read URL from payload
+          ZIP_URL="${{ github.event.client_payload.zip_url }}"
+          
+          if [ -z "$ZIP_URL" ]; then
+            echo "Error: zip_url parameter is missing from client_payload"
+            exit 1
+          fi
+          # 2. Define directory paths
+          DEST_DIR="${GITHUB_WORKSPACE}/dist"
+          mkdir -p "$DEST_DIR"
+          echo "Downloading from: $ZIP_URL"
+          echo "Extracting to: $DEST_DIR"
+          # 3. Download using curl (-L follows redirects)
+          curl -L -o archive.zip "$ZIP_URL"
+          # 4. Extract directly into /dist/
+          unzip -q archive.zip -d "$DEST_DIR"
+      - name: Publish to npm
+        run: >
+          ./gradlew -p js/npm -PdryRun=true
+          -Pkotlin.deploy.tag=${{ github.event.client_payload.deploy_tag }}
+          -Pkotlin.deploy.version=${{ github.event.client_payload.deploy_version }}
+          publishAll
+

--- a/.space/CODEOWNERS
+++ b/.space/CODEOWNERS
@@ -74,6 +74,7 @@
 /.idea/kotlinTestDataPluginTestDataPaths.xml dmitriy.novozhilov@jetbrains.com kirill.rakhman@jetbrains.com sergej.jaskiewicz@jetbrains.com
 
 /.space/ "Kotlin Build Infrastructure"
+/.github/ "Kotlin Build Infrastructure"
 
 # AI
 /.ai/ "Kotlin" "Kotlin Analysis API" "Kotlin Build Infrastructure"

--- a/js/npm/build.gradle.kts
+++ b/js/npm/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 description = "Node utils"
 
 node {
+    version.set("24.19.0")
+    npmVersion.set("11.17.0")
     download.set(true)
     distBaseUrl.set(null as String?)
 }
@@ -21,8 +23,7 @@ fun getProperty(name: String, default: String = "") = findProperty(name)?.toStri
 
 val deployVersion = getProperty("kotlin.deploy.version", "0.0.0")
 val deployTag = getProperty("kotlin.deploy.tag", "dev")
-val authToken = getProperty("kotlin.npmjs.auth.token")
-val dryRun = getProperty("dryRun", "false") // Pack instead of publish
+val dryRun = getProperty("dryRun", "false") // Only stage publish
 
 fun Project.createCopyTemplateTask(templateName: String): TaskProvider<Copy> {
     return tasks.register<Copy>("copy-$templateName-template") {
@@ -46,7 +47,6 @@ val makeBinExecutable = tasks.register<Exec>("chmod-kotlinc-bin") {
     commandLine = listOf("chmod", "-R", "ugo+rx", "$deployDir/kotlin-compiler/bin")
 }
 
-val npmWhoami = createWhoamiNpmTask()
 
 fun Project.createPublishToNpmTask(templateName: String): TaskProvider<NpmTask> {
     return tasks.register<NpmTask>("publish-$templateName-to-npm") {
@@ -54,20 +54,10 @@ fun Project.createPublishToNpmTask(templateName: String): TaskProvider<NpmTask> 
         val deployDir = File("$deployDir/$templateName")
         workingDir.set(deployDir)
 
-        val deployArgs = listOf("publish", "--//registry.npmjs.org/:_authToken=$authToken", "--tag=$deployTag")
-        if (dryRun == "true") {
-            println("$deployDir \$ npm arguments: $deployArgs");
-            args.set(listOf("pack"))
-            dependsOn(npmWhoami)
-        } else {
-            args.set(deployArgs)
-        }
-    }
-}
+        val deployArgs = if (dryRun == "true") listOf("stage", "publish", "--tag=$deployTag") else listOf("publish", "--tag=$deployTag")
 
-fun Project.createWhoamiNpmTask(): TaskProvider<NpmTask> {
-    return tasks.register<NpmTask>("npm-whoami") {
-        args.set(listOf("whoami", "--//registry.npmjs.org/:_authToken=$authToken"))
+        println("$deployDir \$ npm arguments: $deployArgs");
+        args.set(deployArgs)
     }
 }
 

--- a/repo/domains.dump.txt
+++ b/repo/domains.dump.txt
@@ -260,6 +260,7 @@ Unknown:
  - .claude
  - .editorconfig
  - .gitattributes
+ - .github
  - .gitignore
  - .junie
  - AGENTS.md


### PR DESCRIPTION
After npm 2fabypass tokens deprecation (see url below) we cannot publish from internal CI anymore
Creating a workflow that should be REST triggered
- checkout repo
- download compiler dist from public URL
- perform the publishing

Npm token will be provided via OIDC (see url below)

https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/ https://docs.npmjs.com/trusted-publishers

KTI-3548