### PR TITLE
Codeowners: make Kotlin JVM own parts of reflection sources

### DIFF
--- a/.space/CODEOWNERS
+++ b/.space/CODEOWNERS
@@ -203,7 +203,7 @@
 /compiler/testData/klib/ "Kotlin Common Backend"
 /compiler/testData/loadJava/ "Kotlin Frontend"
 /compiler/testData/loadJavaPackageAnnotations/ "Kotlin Frontend"
-/compiler/testData/reflection/ vsevolod.tolstopyatov@jetbrains.com leonid.startsev@jetbrains.com filipp.zhinkin@jetbrains.com ilya.gorbunov@jetbrains.com alexander.udalov@jetbrains.com
+/compiler/testData/reflection/ "Kotlin JVM" vsevolod.tolstopyatov@jetbrains.com leonid.startsev@jetbrains.com filipp.zhinkin@jetbrains.com ilya.gorbunov@jetbrains.com
 /compiler/testData/serialization/builtinsSerializer/ "Kotlin Frontend"
 /compiler/testData/serialization/klib/ "Kotlin Common Backend"
 /compiler/testData/writeFlags/ "Kotlin JVM"
@@ -265,8 +265,9 @@
 /core/deserialization.common.jvm/ "Kotlin Frontend"
 /core/metadata/ "Kotlin Frontend"
 /core/metadata.jvm/ "Kotlin JVM"
-/core/reflection.common.jvm/ vsevolod.tolstopyatov@jetbrains.com leonid.startsev@jetbrains.com filipp.zhinkin@jetbrains.com ilya.gorbunov@jetbrains.com alexander.udalov@jetbrains.com
+/core/reflection.common.jvm/ "Kotlin JVM" vsevolod.tolstopyatov@jetbrains.com leonid.startsev@jetbrains.com filipp.zhinkin@jetbrains.com ilya.gorbunov@jetbrains.com
 /core/reflection.jvm/ vsevolod.tolstopyatov@jetbrains.com leonid.startsev@jetbrains.com filipp.zhinkin@jetbrains.com ilya.gorbunov@jetbrains.com alexander.udalov@jetbrains.com
+/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ "Kotlin JVM" vsevolod.tolstopyatov@jetbrains.com leonid.startsev@jetbrains.com filipp.zhinkin@jetbrains.com ilya.gorbunov@jetbrains.com
 /core/script.runtime/ "Kotlin Frontend"
 /core/util.runtime/ "Kotlin Frontend"
 


### PR DESCRIPTION
`core/reflection.common.jvm` is a part of kotlin-reflect implementation and is not supposed to contain any public API that would require review from the libraries team. Same about the `kotlin.reflect.jvm.internal` package in `core/reflection.jvm`.