### PR TITLE
[Build] Remove unused configuration helper functions from stdlib build script

### DIFF
--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -41,20 +41,6 @@ description = "Kotlin Standard Library"
 
 configureJvmToolchain(JdkMajorVersion.JDK_1_8)
 
-fun resolvingConfiguration(name: String, configure: Action<Configuration> = Action {}) =
-    configurations.create(name) {
-        isCanBeResolved = true
-        isCanBeConsumed = false
-        configure(this)
-    }
-
-fun outgoingConfiguration(name: String, configure: Action<Configuration> = Action {}) =
-    configurations.create(name) {
-        isCanBeResolved = false
-        isCanBeConsumed = true
-        configure(this)
-    }
-
 fun KotlinCommonCompilerOptions.mainCompilationOptions() {
     // Use this to override language and API versions for stdlib compared to the version used to build the whole Kotlin
     // languageVersion = KotlinVersion.KOTLIN_...


### PR DESCRIPTION
The two util functions, `resolvingConfiguration()` and `outgoingConfiguration()`, are not used and can be simply deleted.

The usages were removed in d4b245615a52faa427a931cbe82863b0b6cc881a