### PR TITLE
LibraryPathFilter: Fix symlinks

### DIFF
--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.serialization.SerializerExtensionProtocol
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
 import org.jetbrains.kotlin.serialization.deserialization.getName
 import org.jetbrains.kotlin.utils.mapToSetOrEmpty
+import java.io.IOException
 import java.nio.file.Path
 
 class PackagePartsCacheData(
@@ -88,8 +89,24 @@ abstract class LibraryPathFilter {
                 if (isAbsolute) normalizedPath else path.toAbsolutePath().normalize()
             }
 
+            val realPath: Path? by lazy {
+                try {
+                    path.toRealPath()
+                } catch (_: IOException) {
+                    null
+                } catch (_: SecurityException) {
+                    null
+                }
+            }
+
             fun startsWith(wrappedPath: WrappedPath): Boolean =
                 path.startsWith(wrappedPath.normalizedPath)
+
+            fun realPathStartsWith(wrappedPath: WrappedPath): Boolean {
+                val realPath = realPath ?: return false
+                val otherRealPath = wrappedPath.realPath ?: return false
+                return realPath.startsWith(otherRealPath)
+            }
         }
 
         // TODO: Migrate to wrappedLibs only use by K2ScriptingCompilerEnviroment
@@ -107,7 +124,7 @@ abstract class LibraryPathFilter {
                     !it.isAbsolute && wrappedPath.isAbsolute -> wrappedPath.absoluteNormalizedPath.startsWith(it.absoluteNormalizedPath)
                     else -> wrappedPath.startsWith(it)
                 }
-            }
+            } || wrappedLibs.any(wrappedPath::realPathStartsWith)
         }
     }
 }

--- a/compiler/tests/org/jetbrains/kotlin/klib/KlibLibraryPathFilterTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/klib/KlibLibraryPathFilterTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.klib
+
+import org.jetbrains.kotlin.fir.deserialization.LibraryPathFilter
+import org.jetbrains.kotlin.library.KotlinLibraryVersioning
+import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.writer.KlibWriter
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.pathString
+
+class KlibLibraryPathFilterTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun testCanonicalFilterAcceptsLibraryLoadedThroughSymlink() {
+        val klib = createKlib(tempDir.resolve("library"))
+        val library = loadKlib(createSymlink(tempDir.resolve("library-link"), klib))
+        assertNotEquals(library.path, library.canonicalPath)
+
+        val filter = LibraryPathFilter.LibraryList(setOf(library.canonicalPath))
+        assertTrue(filter.accepts(library.path))
+    }
+
+    @Test
+    fun testCanonicalDirectoryFilterAcceptsLibraryLoadedThroughSymlinkedDirectory() {
+        val realDirectory = tempDir.resolve("real").createDirectories()
+        createKlib(realDirectory.resolve("library"))
+        val linkedDirectory = createSymlink(tempDir.resolve("linked"), realDirectory)
+        val library = loadKlib(linkedDirectory.resolve("library"))
+
+        val filter = LibraryPathFilter.LibraryList(setOf(realDirectory))
+        assertTrue(filter.accepts(library.path))
+    }
+
+    @Test
+    fun testCanonicalFilterRejectsDifferentLibraryLoadedThroughSymlink() {
+        val firstKlib = createKlib(tempDir.resolve("first"))
+        val secondKlib = createKlib(tempDir.resolve("second"))
+        val firstLibrary = loadKlib(createSymlink(tempDir.resolve("first-link"), firstKlib))
+
+        val filter = LibraryPathFilter.LibraryList(setOf(secondKlib.toRealPath()))
+        assertFalse(filter.accepts(firstLibrary.path))
+    }
+
+    @Test
+    fun testLexicalFiltering() {
+        val libraryDirectory = tempDir.resolve("libraries")
+        val filter = LibraryPathFilter.LibraryList(setOf(libraryDirectory))
+
+        assertAll(
+            { assertTrue(filter.accepts(libraryDirectory)) },
+            { assertTrue(filter.accepts(libraryDirectory.resolve("library.klib"))) },
+            { assertFalse(filter.accepts(tempDir)) },
+            { assertFalse(filter.accepts(tempDir.resolve("other-libraries"))) },
+            { assertFalse(filter.accepts(null)) },
+        )
+    }
+
+    @Test
+    fun testNonExistingPathsDoNotMatchThroughRealPathFallback() {
+        val filter = LibraryPathFilter.LibraryList(setOf(tempDir.resolve("missing-library")))
+        assertFalse(filter.accepts(tempDir.resolve("other-missing-library")))
+    }
+
+    private fun createKlib(path: Path): Path {
+        KlibWriter {
+            manifest {
+                moduleName(path.fileName.pathString)
+                versions(KotlinLibraryVersioning(null, null, null))
+                platformAndTargets(BuiltInsPlatform.COMMON)
+            }
+        }.writeTo(path.pathString)
+        return path
+    }
+
+    private fun createSymlink(link: Path, target: Path): Path {
+        assumeTrue(runCatching { Files.createSymbolicLink(link, target) }.isSuccess)
+        return link
+    }
+
+    private fun loadKlib(path: Path) = KlibLoader { libraryPaths(path) }.load().let { result ->
+        assertFalse(result.hasProblems)
+        assertEquals(1, result.librariesStdlibFirst.size)
+        result.librariesStdlibFirst.single()
+    }
+}


### PR DESCRIPTION
A previous commit: [23142f0f95803f6e435739760a96785b471d6ef4](https://github.com/JetBrains/kotlin/commit/23142f0f95803f6e435739760a96785b471d6ef4) started to use the canonicalPath of files, whereas the filter only uses the absolutePath. This mismatch causes the filter to behave erratically. 

Alternative Solution: 
Have the commit's change to using 'canonicalPath' reverted to 'absolutePath' as the commit's description does not mention this behavior explicitly 

Attention: 
From discovering KT-85647, I suspect that this may be performance critical and the calculation of 'realPath' may only be done carefully.

