### PR TITLE
KT-88769: Fix supertype scope comparison for default parameter values in expect/actual matching

### DIFF
--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/mpp/AbstractExpectActualChecker.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/mpp/AbstractExpectActualChecker.kt
@@ -475,7 +475,18 @@ object AbstractExpectActualChecker {
 
             // If default params came from common supertypes of actual class and expect class then it's a valid code.
             // Here we filter out such default params.
-            if ((actualOverriddenDeclarations - expectOverriddenDeclarations).flatMap { it.valueParameters }.any { it.hasDefaultValue }) {
+            // In the HMPP compilation scheme there could be two different real classes for the same supertype (one from platform
+            // dependencies, one from common), so to filter out declarations which are present in both expect and actual
+            // supertype scopes, we need to compare members by their dispatch receiver.
+            val actualOverriddenDeclarationsNotFromExpect = actualOverriddenDeclarations.filter { actualOverridden ->
+                // We want to preserve the original declaration, but only if it's explictly declared in the actual class
+                if (actualOverridden == actualDeclaration && !actualDeclaration.isFakeOverride(actualContainingClass)) return@filter true
+                val actualOverriddenContainingClassConstructor = actualOverridden.dispatchReceiverType?.typeConstructor() ?: return@filter true
+                expectOverriddenDeclarations.none { expectOverridden ->
+                    expectOverridden.dispatchReceiverType?.typeConstructor() == actualOverriddenContainingClassConstructor
+                }
+            }
+            if (actualOverriddenDeclarationsNotFromExpect.flatMap { it.valueParameters }.any { it.hasDefaultValue }) {
                 add(ExpectActualIncompatibility.ActualFunctionWithOptionalParameters)
             }
         }

--- a/compiler/testData/codegen/box/multiplatform/k2/complexInheritanceWithDelegation.kt
+++ b/compiler/testData/codegen/box/multiplatform/k2/complexInheritanceWithDelegation.kt
@@ -1,6 +1,5 @@
 // LANGUAGE: +MultiPlatformProjects
 // ISSUE: KT-88769
-// IGNORE_HMPP: ANY
 
 // MODULE: lib-common
 interface A {
@@ -22,7 +21,7 @@ expect class C : B {
 }
 
 // MODULE: app-platform(lib-platform)()(app-common)
-actual class <!EXPECT_ACTUAL_INCOMPATIBLE_CLASS_SCOPE{PLATFORM}!>C<!> : B, A by AImpl {}
+actual class C : B, A by AImpl {}
 
 fun box(): String {
     return C().foo(1)

--- a/compiler/testData/codegen/box/multiplatform/k2/complexInheritanceWithDelegation.kt
+++ b/compiler/testData/codegen/box/multiplatform/k2/complexInheritanceWithDelegation.kt
@@ -1,0 +1,29 @@
+// LANGUAGE: +MultiPlatformProjects
+// ISSUE: KT-88769
+// IGNORE_HMPP: ANY
+
+// MODULE: lib-common
+interface A {
+    fun foo(x: Int, y: String = "OK"): String
+}
+
+interface B : A
+
+object AImpl : A {
+    override fun foo(x: Int, y: String): String = y
+}
+
+// MODULE: lib-platform()()(lib-common)
+
+
+// MODULE: app-common(lib-common)
+expect class C : B {
+    override fun foo(x: Int, y: String): String
+}
+
+// MODULE: app-platform(lib-platform)()(app-common)
+actual class <!EXPECT_ACTUAL_INCOMPATIBLE_CLASS_SCOPE{PLATFORM}!>C<!> : B, A by AImpl {}
+
+fun box(): String {
+    return C().foo(1)
+}


### PR DESCRIPTION
User projects run: https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_UserProjectsAggregateK2/1042279671