### PR TITLE
[Build] Unescape dollar from logging line

### DIFF
--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
@@ -491,7 +491,7 @@ fun Project.configureMigratedRootSettings() {
             configurations.all {
                 // Remove kotlin-compiler from dependencies during Idea import. KTI-1598
                 if (dependencies.removeIf { (it as? ProjectDependency)?.path == ":kotlin-compiler" }) {
-                    logger.warn("Removed :kotlin-compiler project dependency from \$this")
+                    logger.warn("Removed :kotlin-compiler project dependency from $this")
                 }
             }
         }


### PR DESCRIPTION
Currently this log line logs `Removed :kotlin-compiler project dependency from $this`, because the log uses `\$this` instead of `$this`.