### PR TITLE
[CRI] Enable compiler reference index generation by default outside CI

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerReferenceIndexIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerReferenceIndexIT.kt
@@ -28,14 +28,32 @@ import kotlin.io.path.readBytes
 import kotlin.io.path.relativeTo
 import kotlin.test.*
 
-@OptIn(ExperimentalBuildToolsApi::class)
+@OptIn(ExperimentalBuildToolsApi::class, EnvironmentalVariablesOverride::class)
 @DisplayName("Gradle / Compiler Reference Index")
 @AffectedByBuildToolsApi
 class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
 
+    // Env variables for CI detection are the same as in [org.jetbrains.kotlin.gradle.fus.internal.isCiBuild]
+    private val ciEnvironmentVariables = setOf(
+        "CI",
+        "JENKINS_URL",
+        "HUDSON_URL",
+        "TEAMCITY_VERSION",
+        "CIRCLE_BUILD_URL",
+        "bamboo_resultsUrl",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "TRAVIS_JOB_ID",
+        "BITRISE_BUILD_URL",
+        "GO_SERVER_URL",
+        "TF_BUILD",
+        "BUILDKITE",
+    )
+
+    private val localEnvironment = EnvironmentalVariables { it - ciEnvironmentVariables }
+
     override val defaultBuildOptions: BuildOptions = super.defaultBuildOptions.copy(
         runViaBuildToolsApi = true,
-        generateCompilerRefIndex = true,
     )
 
     private val defaultInProcessBuildOptions: BuildOptions = defaultBuildOptions.copy(
@@ -58,6 +76,7 @@ class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
                 "daemon" -> defaultDaemonBuildOptions
                 else -> return
             },
+            environmentVariables = localEnvironment,
         ) {
             kotlinSourcesDir().source("main.kt") {
                 //language=kotlin
@@ -86,6 +105,7 @@ class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
             "kotlinProject",
             gradleVersion,
             buildOptions = defaultInProcessBuildOptions,
+            environmentVariables = localEnvironment,
         ) {
             val source1Filename = "file1.kt"
             val source2Filename = "file2.kt"
@@ -177,16 +197,50 @@ class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
     }
 
     @GradleTest
+    @DisplayName("CI disables implicit CRI generation, but explicit CRI enables it")
+    fun testCiEnvironmentDisablesImplicitCriGeneration(gradleVersion: GradleVersion) {
+        project(
+            "kotlinProject",
+            gradleVersion,
+            environmentVariables = EnvironmentalVariables { it - ciEnvironmentVariables + ("CI" to "true") },
+        ) {
+            val lookups = projectPath / "build/kotlin/compileKotlin/cacheable" / DATA_PATH / LOOKUPS_FILENAME
+
+            build("assemble") {
+                assertNoDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
+            }
+            assertFileNotExists(lookups)
+
+            build(
+                "assemble",
+                buildOptions = buildOptions.copy(generateCompilerRefIndex = true),
+            )
+            assertFileExists(lookups)
+        }
+    }
+
+    @GradleTest
+    @DisplayName("TeamCity system property disables implicit CRI generation")
+    fun testTeamCitySystemPropertyCriDefault(gradleVersion: GradleVersion) {
+        project("kotlinProject", gradleVersion, environmentVariables = localEnvironment) {
+            val lookups = projectPath / "build/kotlin/compileKotlin/cacheable" / DATA_PATH / LOOKUPS_FILENAME
+
+            build("assemble", "-DTEAMCITY_VERSION=1.0.0")
+            assertFileNotExists(lookups)
+        }
+    }
+
+    @GradleTest
     @DisplayName("CRI generation can't be enabled without BTA. KT-83161")
     fun testCriWithoutBta(gradleVersion: GradleVersion) {
         project(
             "kotlinProject",
             gradleVersion,
         ) {
-            build("assemble", buildOptions = buildOptions.copy(runViaBuildToolsApi = false)) {
+            build("assemble", buildOptions = buildOptions.copy(runViaBuildToolsApi = false, generateCompilerRefIndex = true)) {
                 assertHasDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
             }
-            build("assemble", buildOptions = buildOptions.copy(runViaBuildToolsApi = true)) {
+            build("assemble", buildOptions = buildOptions.copy(runViaBuildToolsApi = true, generateCompilerRefIndex = true)) {
                 assertNoDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
             }
         }
@@ -214,7 +268,7 @@ class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
     @DisplayName("Enabling CRI does not fail Kotlin/Native compile tasks. KT-86118")
     fun testEnablingCriDoesNotFailNativeCompile(gradleVersion: GradleVersion) {
         nativeProject("native-simple-project", gradleVersion) {
-            build("assemble") {
+            build("assemble", buildOptions = buildOptions.copy(generateCompilerRefIndex = true)) {
                 assertNoDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
@@ -301,11 +301,7 @@ private fun TestProject.buildWithAction(
         )
         val gradleRunnerForBuild = gradleRunner
             .also { if (forwardBuildOutput) it.forwardOutput() }
-            .withEnvironment(
-                if (environmentVariables.environmentalVariables.isNotEmpty()) {
-                    System.getenv() + environmentVariables.environmentalVariables
-                } else null
-            )
+            .withEnvironment(environmentVariables.resolve())
             .withDebug(runWithDebug && !connectSubprocessVMToDebugger)
             .withArguments(allBuildArguments)
 
@@ -564,15 +560,48 @@ open class GradleProject(
 }
 
 /**
- * You need at least Gradle "7.0" for supporting environment variables with Gradle runner
+ * You need at least Gradle "7.0" for supporting environment variables with Gradle runner.
+ *
+ * [environmentProvider] receives the environment of the current process and returns the complete environment
+ * for the build, e.g. `EnvironmentalVariables { it - "CI" }`. The default `null` inherits the environment
+ * of the current process unchanged. To add or override variables on top of the current environment,
+ * use the secondary constructors taking a map or pairs.
  */
 class EnvironmentalVariables @EnvironmentalVariablesOverride constructor(
-    val environmentalVariables: Map<String, String> = emptyMap(),
+    private val environmentProvider: ((systemEnvironment: Map<String, String>) -> Map<String, String>)? = null,
 ) {
-    val overridingEnvironmentVariablesInstantiationBacktrace: Throwable? = if (environmentalVariables.isNotEmpty()) Throwable() else null
+    val overridingEnvironmentVariablesInstantiationBacktrace: Throwable? =
+        if (environmentProvider != null) Throwable() else null
+
+    /**
+     * Adds [environmentalVariables] on top of the environment of the current process.
+     */
+    @EnvironmentalVariablesOverride
+    constructor(environmentalVariables: Map<String, String>) : this(
+        // An empty map must not count as an override: it would force a forked daemon and disable `withDebug`
+        if (environmentalVariables.isEmpty()) null else ({ systemEnvironment -> systemEnvironment + environmentalVariables })
+    )
 
     @EnvironmentalVariablesOverride
-    constructor(vararg environmentVariables: Pair<String, String>) : this(mapOf(*environmentVariables))
+    constructor(vararg environmentalVariables: Pair<String, String>) : this(mapOf(*environmentalVariables))
+
+    /**
+     * The complete environment for the build, or `null` to inherit the environment of the current process.
+     */
+    fun resolve(): Map<String, String>? = environmentProvider?.invoke(System.getenv())
+
+    /**
+     * Variables that are added or changed compared to the environment of the current process,
+     * i.e. what has to be passed to a child process that inherits the current environment.
+     * Variables removed by [environmentProvider] cannot be expressed this way and are not included.
+     */
+    val environmentalVariables: Map<String, String>
+        get() {
+            val systemEnvironment = System.getenv()
+            return environmentProvider?.invoke(systemEnvironment)
+                ?.filter { (key, value) -> systemEnvironment[key] != value }
+                .orEmpty()
+        }
 }
 
 @RequiresOptIn("Environmental variables override may lead to interference of parallel builds")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
@@ -13,6 +13,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.compilerRunner.KotlinCompilerArgumentsLogLevel
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
+import org.jetbrains.kotlin.gradle.fus.internal.isCiBuild
 import org.jetbrains.kotlin.gradle.internal.properties.PropertiesBuildService
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessageOutputStreamHandler.Companion.IGNORE_TCSM_OVERFLOW
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_CLASSLOADER_CACHE_TIMEOUT
@@ -485,8 +486,14 @@ internal class PropertiesProvider private constructor(private val project: Proje
     val runKotlinMetadataCompilerViaBuildToolsApi: Provider<Boolean>
         get() = booleanProvider(KOTLIN_METADATA_RUN_COMPILER_VIA_BUILD_TOOLS_API).orElse(true)
 
+    @Suppress("DEPRECATION")
+    // Uses [runKotlinCompilerViaBuildToolsApi] as the default value provider to avoid warnings when BTA is explicitly disabled
     val generateCompilerRefIndex: Provider<Boolean>
-        get() = booleanProvider(KOTLIN_GENERATE_COMPILER_REF_INDEX).orElse(false)
+        get() = booleanProvider(KOTLIN_GENERATE_COMPILER_REF_INDEX).orElse(
+            runKotlinCompilerViaBuildToolsApi.zip(project.providers.provider { isCiBuild() }) { runsViaBta, isCi ->
+                runsViaBta && !isCi
+            }
+        )
 
     val allowLegacyMppDependencies: Boolean
         get() = booleanProperty(KOTLIN_MPP_ALLOW_LEGACY_DEPENDENCIES) ?: false


### PR DESCRIPTION
[KT-81782](https://youtrack.jetbrains.com/issue/KT-81782) Enable CRI by default