### PR TITLE
[Tests] KQA-3278: PL cases for more specific equals

### DIFF
--- a/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib1/l1.kt
+++ b/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib1/l1.kt
@@ -13,3 +13,15 @@ interface Base {
 class C(override val x: String) : Base {
     override fun equals(@EqualityBound(C::class) other: Any?): Boolean = x == other.x
 }
+
+interface NewBase {
+    val x: String
+}
+
+open class WithNewBase(override val x: String) : Base
+
+open class AliasTarget(val x: String)
+open class ChangedAliasTarget(val x: String)
+
+typealias RemovedAlias = AliasTarget
+typealias ChangedAlias = AliasTarget

--- a/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib1/l1.kt.1
+++ b/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib1/l1.kt.1
@@ -13,3 +13,15 @@ interface Base {
 class C(override val x: String) : Base {
     override fun equals(@EqualityBound(Base::class) other: Any?): Boolean = x == other.x
 }
+
+interface NewBase {
+    val x: String
+}
+
+open class WithNewBase(override val x: String) : NewBase
+
+open class AliasTarget(val x: String)
+open class ChangedAliasTarget(val x: String)
+
+//typealias RemovedAlias = AliasTarget
+typealias ChangedAlias = ChangedAliasTarget

--- a/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib2/l2.kt
@@ -2,3 +2,20 @@ fun removedEqualityBound() = A("1") == A("1")
 fun addedEqualityBound() = B("2") == B("2")
 fun differentClasses() = B("3") == A("3") || A("3") == B("3")
 fun changedEqualityBound() = C("4") == C("4")
+
+class D(override val x: String) : WithNewBase(x) {
+    override fun equals(@EqualityBound(Base::class) other: Any?): Boolean = x == other.x
+}
+
+fun changedHierarchyEquals() = D("5") == D("5")
+
+open class WithRemovedAlias(x: String) : AliasTarget(x) {
+    override fun equals(@EqualityBound(RemovedAlias::class) other: Any?): Boolean = x == other.x
+}
+
+open class WithChangedAlias(x: String) : AliasTarget(x) {
+    override fun equals(@EqualityBound(ChangedAlias::class) other: Any?): Boolean = x == other.x
+}
+
+fun removedAliasEquals() = WithRemovedAlias("6") == WithRemovedAlias("6")
+fun changedAliasEquals() = WithChangedAlias("7") == WithChangedAlias("7")

--- a/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib2/module.info
+++ b/compiler/testData/klib/partial-linkage/moreSpecificEquals/lib2/module.info
@@ -1,2 +1,3 @@
 STEP 0:
     dependencies: stdlib, lib1
+    arguments: -XXLanguage:+StrictEquals

--- a/compiler/testData/klib/partial-linkage/moreSpecificEquals/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/moreSpecificEquals/main/m.kt
@@ -5,4 +5,9 @@ fun box() = abiTest {
     expectSuccess(true) { addedEqualityBound() }
     expectSuccess(false) { differentClasses() }
     expectSuccess(true) { changedEqualityBound() }
+
+    expectSuccess(false) { changedHierarchyEquals() }
+
+    expectSuccess(true) { removedAliasEquals() }
+    expectSuccess(true) { changedAliasEquals() }
 }


### PR DESCRIPTION
Cover removed and changed types of equality bounds, typealiases in
 equality bounds, and changed class hierarchy.

^KQA-3278