### PR TITLE
[Native] Fix AtomicFU tests to always load platform libs from distro

### DIFF
--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/SettingsContainers.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/SettingsContainers.kt
@@ -98,4 +98,5 @@ val Settings.configurables: Configurables
  * True, when all tests are required to have platform libraries available.
  */
 val Settings.withPlatformLibs: Boolean
-    get() = get<XCTestRunner>().isEnabled // XCTest depends on platform libraries, so platform libraries must be available.
+    // XCTest depends on platform libraries, so platform libraries must be available.
+    get() = get<XCTestRunner>().isEnabled || get<PlatformLibs>() == PlatformLibs.DEFAULT

--- a/plugins/atomicfu/atomicfu-compiler/test/org/jetbrains/kotlin/generators/tests/GenerateAtomicfuTests.kt
+++ b/plugins/atomicfu/atomicfu-compiler/test/org/jetbrains/kotlin/generators/tests/GenerateAtomicfuTests.kt
@@ -8,7 +8,9 @@ package org.jetbrains.kotlin.generators.tests
 import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUnit5
 import org.jetbrains.kotlin.generators.model.annotation
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeCodegenBoxTest
+import org.jetbrains.kotlin.konan.test.blackbox.support.ClassLevelProperty
 import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget
+import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedProperty
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
 import org.jetbrains.kotlinx.atomicfu.incremental.AbstractIncrementalJVMWithAtomicfuRunnerTest
 import org.jetbrains.kotlinx.atomicfu.runners.*
@@ -80,4 +82,10 @@ fun main(args: Array<String>) {
 private fun atomicfuNative() = arrayOf(
     annotation(Tag::class.java, "atomicfu-native"),
     annotation(EnforcedHostTarget::class.java), // TODO(KT-65977): Make atomicfu tests run on all targets.
+
+    annotation(
+        EnforcedProperty::class.java,
+        "property" to ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS,
+        "propertyValue" to "true"
+    ),
 )

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -9,6 +9,8 @@ import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.jupiter.api.Tag;
 import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget;
+import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedProperty;
+import org.jetbrains.kotlin.konan.test.blackbox.support.ClassLevelProperty;
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider;
 import org.jetbrains.kotlin.test.TestMetadata;
 import org.junit.jupiter.api.Nested;
@@ -23,6 +25,7 @@ import java.util.regex.Pattern;
 @TestDataPath("$PROJECT_ROOT")
 @Tag("atomicfu-native")
 @EnforcedHostTarget
+@EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
 @UseExtTestCaseGroupProvider
 public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   private void run(String fileName) {
@@ -39,6 +42,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Atomic_extensions {
     private void run(String fileName) {
@@ -128,6 +132,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Atomics_basic {
     private void run(String fileName) {
@@ -247,6 +252,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Companion_blocks {
     private void run(String fileName) {
@@ -300,6 +306,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Context_parameters {
     private void run(String fileName) {
@@ -323,6 +330,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Delegated {
     private void run(String fileName) {
@@ -352,6 +360,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Locks {
     private void run(String fileName) {
@@ -381,6 +390,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Top_level {
     private void run(String fileName) {
@@ -416,6 +426,7 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   @UseExtTestCaseGroupProvider
   public class Trace {
     private void run(String fileName) {

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeDiagnosticTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeDiagnosticTestGenerated.java
@@ -9,6 +9,8 @@ import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.jupiter.api.Tag;
 import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget;
+import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedProperty;
+import org.jetbrains.kotlin.konan.test.blackbox.support.ClassLevelProperty;
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider;
 import org.jetbrains.kotlin.test.TestMetadata;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,7 @@ import java.util.regex.Pattern;
 @TestDataPath("$PROJECT_ROOT")
 @Tag("atomicfu-native")
 @EnforcedHostTarget
+@EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
 @UseExtTestCaseGroupProvider
 public class AtomicfuNativeDiagnosticTestGenerated extends AbstractAtomicfuNativeDiagnosticTest {
   private void run(String fileName) {

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 @UseExtTestCaseGroupProvider
 @Tag("atomicfu-native")
 @EnforcedHostTarget
+@EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
 public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAtomicfuNativeKlibSyntheticAccessorTest {
   private void run(String fileName) {
     runTest("plugins/atomicfu/atomicfu-compiler/testData/box/" + fileName);
@@ -46,6 +47,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Atomic_extensions {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/" + fileName);
@@ -137,6 +139,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Atomics_basic {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/" + fileName);
@@ -258,6 +261,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Companion_blocks {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
@@ -313,6 +317,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Context_parameters {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters/" + fileName);
@@ -338,6 +343,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Delegated {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/delegated/" + fileName);
@@ -369,6 +375,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Locks {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/locks/" + fileName);
@@ -400,6 +407,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Top_level {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/top-level/" + fileName);
@@ -437,6 +445,7 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   @UseExtTestCaseGroupProvider
   @Tag("atomicfu-native")
   @EnforcedHostTarget
+  @EnforcedProperty(property = ClassLevelProperty.DEPEND_ON_PLATFORM_LIBS, propertyValue = "true")
   public class Trace {
     private void run(String fileName) {
       runTest("plugins/atomicfu/atomicfu-compiler/testData/box/trace/" + fileName);


### PR DESCRIPTION
This is a preparatory commit before switching the second stage of the Kotlin/Natice compiler from the KLIB resolver to KlibLoader.

We need to explicitly specify that the tests for AtomicFU require platform libraries from the Kotlin/Native distribution (specifically, posix library). Because loading of platform libraries happens automatically by the KLIB resolver, but it won't happen so after switching to KlibLoader.

^KT-61096