### PR TITLE
[AI] Clarify test-first bug-fix commit guidelines

### DIFF
--- a/.ai/commit-guidelines.md
+++ b/.ai/commit-guidelines.md
@@ -15,7 +15,7 @@ IMPORTANT formatting rules:
   new line when the next word would cross 72. Do not wrap early.
 - Use imperative mood.
 - Commit messages must explain not just WHAT but also WHY and HOW.
-- Commit tests together with corresponding code changes.
+- Before fixing a bug, make sure existing tests reproduce the problem. If they do not, add and commit the reproducer first. Keep the implementation fix and any resulting expected-output or test-data updates in the following commit, so its diff clearly demonstrates exactly what was fixed. If the reproducer cannot form a usable standalone commit — for example, because running it aborts with an exception or enters an infinite loop — commit the test together with the fix instead.
 - Non-functional changes (refactorings, reformats) should be in separate commits.
 
 #### Example


### PR DESCRIPTION
Replace the blanket requirement to commit tests with their corresponding code changes. Require a reproducer commit before a bug fix when the existing suite does not already capture the problem, so the fixing commit's test-data diff clearly shows the corrected behavior.

Allow tests to accompany the fix when a standalone reproducer is not usable, such as when it aborts with an exception or enters an infinite loop.