### PR TITLE
[Tests][PL] Treat internal linkage changes as incompatible for functions, properties and classes

### DIFF
--- a/compiler/testData/klib/partial-linkage/changeClassVisibility/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/changeClassVisibility/main/m.kt
@@ -71,6 +71,15 @@ fun box() = abiTest {
     success("PublicTopLevelClassInheritor") { PublicTopLevelClassInheritor() }
     success("PublicToInternalTopLevelClassInheritor") { PublicToInternalTopLevelClassInheritor() }
     expectFailure(linkage("Constructor 'PublicToPrivateTopLevelClassInheritor.<init>' can not be called: Class 'PublicToPrivateTopLevelClassInheritor' uses unlinked class symbol '/PublicToPrivateTopLevelClass'")) { PublicToPrivateTopLevelClassInheritor() }
+
+    // Friend module access:
+    success("PublicToInternalTopLevelClass") { PublicToInternalTopLevelClass().toString() }
+    success("PublicTopLevelClass.PublicToInternalNestedClass") { PublicTopLevelClass.PublicToInternalNestedClass().toString() }
+    success("PublicTopLevelClass.PublicToInternalInnerClass") { PublicTopLevelClass().PublicToInternalInnerClass().toString() }
+    success("PublicToInternalTopLevelClass.PublicToInternalNestedClass") { PublicToInternalTopLevelClass.PublicToInternalNestedClass().toString() }
+    success("PublicToInternalTopLevelClass.PublicToProtectedNestedClass") { PublicToInternalTopLevelClass.PublicToProtectedNestedClass().toString() }
+    success("PublicToInternalTopLevelClass.PublicToInternalInnerClass") { PublicToInternalTopLevelClass().PublicToInternalInnerClass().toString() }
+    success("PublicToInternalTopLevelClass.PublicToProtectedInnerClass") { PublicToInternalTopLevelClass().PublicToProtectedInnerClass().toString() }
 }
 
 // Shortcuts:

--- a/compiler/testData/klib/partial-linkage/changeClassVisibility/main/module.info
+++ b/compiler/testData/klib/partial-linkage/changeClassVisibility/main/module.info
@@ -1,2 +1,3 @@
 STEP 0:
     dependencies: stdlib, lib1, lib2
+    friends: lib1

--- a/compiler/testData/klib/partial-linkage/changeFunctionVisibility/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/changeFunctionVisibility/lib2/l2.kt
@@ -49,3 +49,5 @@ class ContainerImpl : Container() {
     fun newOpenInternalPAFunctionAccess() = newOpenInternalPAFunction()
     fun newPrivateFunctionAccess() = newPrivateFunction()
 }
+
+internal fun friendInternalTopLevelFunction() = "friendInternalTopLevelFunction"

--- a/compiler/testData/klib/partial-linkage/changeFunctionVisibility/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/changeFunctionVisibility/main/m.kt
@@ -48,6 +48,8 @@ fun box() = abiTest {
 
     success("publicTopLevelFunWithPrivateDefaultArgument.v2(privateTopLevelFun.v2)") { publicTopLevelFunWithPrivateDefaultArgument() }
     success("publicNestedFunWithPrivateDefaultArgument.v2(privateNestedFun.v2)") { TopLevel.publicNestedFunWithPrivateDefaultArgument() }
+
+    success("friendInternalTopLevelFunction") { friendInternalTopLevelFunction() }
 }
 
 // Shortcuts:

--- a/compiler/testData/klib/partial-linkage/changeFunctionVisibility/main/module.info
+++ b/compiler/testData/klib/partial-linkage/changeFunctionVisibility/main/module.info
@@ -1,2 +1,3 @@
 STEP 0:
     dependencies: stdlib, lib1, lib2
+    friends: lib2


### PR DESCRIPTION
^[KT-60415](https://youtrack.jetbrains.com/issue/KT-60415) K1/K2: exposing internal entities in evolving klib