### PR TITLE
[Gradle] Bump K/N to 2.5.0-dev-5907

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -74,7 +74,7 @@ kotlin.internal.suppress.buildToolsApiVersionConsistencyChecks=true
 
 kotlin.native.enabled=false
 kotlin.native.ignoreDisabledTargets=true
-kotlin.native.version.default=2.5.0-dev-498
+kotlin.native.version.default=2.5.0-dev-5907
 
 # A version of Xcode required to build the Kotlin/Native compiler.
 xcodeMajorVersion=26


### PR DESCRIPTION
This includes fix from https://github.com/JetBrains/kotlin/pull/7718