### PR TITLE
[K/N][Tests] Increase execution timeout for LitmusKt tests

### DIFF
--- a/native/native.tests/litmus-tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateLitmusTests.kt
+++ b/native/native.tests/litmus-tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateLitmusTests.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.generators.tests
 import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUnit5
 import org.jetbrains.kotlin.generators.model.annotation
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeBlackBoxTest
+import org.jetbrains.kotlin.konan.test.blackbox.support.ClassLevelProperty
+import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedProperty
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
 import org.junit.jupiter.api.Tag
 
@@ -22,6 +24,7 @@ fun main(args: Array<String>) {
                 suiteTestClassName = "FirLitmusKtTestsGenerated",
                 annotations = listOf(
                     litmusktNative(),
+                    litmusktExecutionTimeout(),
                     provider<UseExtTestCaseGroupProvider>(),
                     forceHostTarget(),
                 )
@@ -33,3 +36,14 @@ fun main(args: Array<String>) {
 }
 
 private fun litmusktNative() = annotation(Tag::class.java, "litmuskt-native")
+
+/**
+ * One test executable runs all test functions of a single test data file, and each of them spawns 8 worker
+ * threads spinning on a barrier. On slow or oversubscribed CI agents this does not fit into the default
+ * execution timeout. See KT-87923.
+ */
+private fun litmusktExecutionTimeout() = annotation(
+    EnforcedProperty::class.java,
+    "property" to ClassLevelProperty.EXECUTION_TIMEOUT,
+    "propertyValue" to "20m"
+)


### PR DESCRIPTION
One LitmusKt test executable runs all test functions of a single test data file, and each of them spawns 8 worker threads spinning on a barrier. On slow or oversubscribed CI agents, mingw_x64 in particular, that does not fit into the default 10-minute execution timeout, so the suite sporadically fails with "Timeout exceeded during test execution".

Enforce a 20-minute timeout on the generated suite from its generator, the way the native stress tests already do it. A class-level EnforcedProperty takes precedence over the system property in ClassLevelProperty.readValue, so -Pkn.executionTimeout stops affecting this suite, exactly as it already does not affect the stress, stdlib and gc-fuzzing suites. Should overriding the duration from the command line ever be needed, that precedence is the thing to fix.

^KT-87923