### PR TITLE
[Gradle] Delete deprecated Kotlin Native tasks API

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -5919,7 +5919,6 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/AbstractKotlinCompileToo
 
 public abstract class org/jetbrains/kotlin/gradle/tasks/AbstractKotlinNativeCompile : org/jetbrains/kotlin/gradle/tasks/AbstractKotlinCompileTool, org/jetbrains/kotlin/gradle/internal/tasks/ProducesKlib {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/provider/ProviderFactory;)V
-	public abstract fun getAdditionalCompilerOptions ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getBaseName ()Ljava/lang/String;
 	public fun getCompilerPluginClasspath ()Lorg/gradle/api/file/FileCollection;
 	public final fun getCompilerPluginCommandLine ()Ljava/util/List;
@@ -5930,13 +5929,11 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/AbstractKotlinNativeComp
 	public final fun getKotlinNativeVersion ()Ljava/lang/String;
 	public abstract fun getKotlinOptions ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinCommonToolOptions;
 	public final fun getKotlinPluginData ()Lorg/gradle/api/provider/Provider;
-	public final fun getLanguageSettings ()Lorg/jetbrains/kotlin/project/model/LanguageSettings;
 	public fun getLibraries ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getOptimized ()Z
 	public fun getOutputFile ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getOutputKind ()Lorg/jetbrains/kotlin/konan/target/CompilerOutputKind;
 	public fun getProduceUnpackagedKlib ()Lorg/gradle/api/provider/Property;
-	public final fun getProgressiveMode ()Z
 	public final fun getTarget ()Ljava/lang/String;
 	public fun setCompilerPluginClasspath (Lorg/gradle/api/file/FileCollection;)V
 	public final fun setKotlinPluginData (Lorg/gradle/api/provider/Provider;)V
@@ -5946,7 +5943,6 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/CInteropProcess : org/gr
 	public final fun getAllHeadersDirs ()Ljava/util/Set;
 	public final fun getBaseKlibName ()Ljava/lang/String;
 	public final fun getCompilerOpts ()Ljava/util/List;
-	public final fun getDefFile ()Ljava/io/File;
 	public abstract fun getDefinitionFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getDestinationDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getExtraOpts ()Ljava/util/List;
@@ -5956,15 +5952,12 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/CInteropProcess : org/gr
 	public fun getKlibDirectory ()Lorg/gradle/api/provider/Provider;
 	public fun getKlibFile ()Lorg/gradle/api/provider/Provider;
 	public fun getKlibOutput ()Lorg/gradle/api/provider/Provider;
-	public final fun getKonanDataDir ()Lorg/gradle/api/provider/Provider;
-	public final fun getKonanHome ()Lorg/gradle/api/provider/Provider;
 	public final fun getKonanTarget ()Lorg/jetbrains/kotlin/konan/target/KonanTarget;
 	public final fun getLibraries ()Lorg/gradle/api/file/FileCollection;
 	public final fun getLibraryVersion ()Ljava/lang/String;
 	public final fun getLinkerOpts ()Ljava/util/List;
 	public final fun getMetrics ()Lorg/gradle/api/provider/Property;
 	public final fun getModuleName ()Ljava/lang/String;
-	public final fun getOutputFile ()Ljava/io/File;
 	public final fun getOutputFileName ()Ljava/lang/String;
 	public final fun getOutputFileProvider ()Lorg/gradle/api/provider/Provider;
 	public final fun getPackageName ()Ljava/lang/String;
@@ -6188,24 +6181,16 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/KotlinNativeCompile : or
 	public fun compilerOptions (Lorg/gradle/api/Action;)V
 	public synthetic fun createCompilerArguments (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilerArgumentsProducer$CreateCompilerArgumentsContext;)Lorg/jetbrains/kotlin/cli/common/arguments/CommonToolArguments;
 	public fun createCompilerArguments (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilerArgumentsProducer$CreateCompilerArgumentsContext;)Lorg/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments;
-	public fun getAdditionalCompilerOptions ()Lorg/gradle/api/provider/Provider;
-	public final fun getApiVersion ()Ljava/lang/String;
 	public fun getBaseName ()Ljava/lang/String;
 	public final fun getCommonSources ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public synthetic fun getCompilerOptions ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerOptions;
 	public fun getCompilerOptions ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinNativeCompilerOptions;
 	public fun getDebuggable ()Z
-	public final fun getEnabledLanguageFeatures ()Ljava/util/Set;
 	public final fun getExportKdoc ()Lorg/gradle/api/provider/Property;
 	public fun getKlibOutput ()Lorg/gradle/api/provider/Provider;
-	public final fun getKonanDataDir ()Lorg/gradle/api/provider/Provider;
-	public final fun getKonanHome ()Lorg/gradle/api/provider/Provider;
 	public fun getKotlinOptions ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinCommonOptions;
 	public synthetic fun getKotlinOptions ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinCommonToolOptions;
-	public final fun getLanguageVersion ()Ljava/lang/String;
-	public final fun getModuleName ()Ljava/lang/String;
 	public fun getMultiplatformStructure ()Lorg/jetbrains/kotlin/gradle/tasks/K2MultiplatformStructure;
-	public final fun getOptInAnnotationsInUse ()Ljava/util/Set;
 	public fun getOptimized ()Z
 	public fun getOutputKind ()Lorg/jetbrains/kotlin/konan/target/CompilerOutputKind;
 	public final fun getShortModuleName ()Ljava/lang/String;
@@ -6221,7 +6206,6 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/KotlinNativeLink : org/j
 	public final fun compile ()V
 	public synthetic fun createCompilerArguments (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilerArgumentsProducer$CreateCompilerArgumentsContext;)Lorg/jetbrains/kotlin/cli/common/arguments/CommonToolArguments;
 	public fun createCompilerArguments (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilerArgumentsProducer$CreateCompilerArgumentsContext;)Lorg/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments;
-	public final fun getAdditionalCompilerOptions ()Lorg/gradle/api/provider/Provider;
 	public final fun getApiFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getBaseName ()Ljava/lang/String;
 	public final fun getBinary ()Lorg/jetbrains/kotlin/gradle/plugin/mpp/NativeBinary;
@@ -6235,11 +6219,8 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/KotlinNativeLink : org/j
 	public final fun getExportKdoc ()Lorg/gradle/api/provider/Provider;
 	public final fun getExportLibraries ()Lorg/gradle/api/file/FileCollection;
 	protected final fun getFriendModule ()Lorg/gradle/api/file/FileCollection;
-	public final fun getKonanDataDir ()Lorg/gradle/api/provider/Provider;
-	public final fun getKonanHome ()Lorg/gradle/api/provider/Provider;
 	public final fun getKotlinOptions ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinCommonToolOptions;
 	public final fun getKotlinPluginData ()Lorg/gradle/api/provider/Provider;
-	public final fun getLanguageSettings ()Lorg/jetbrains/kotlin/project/model/LanguageSettings;
 	public fun getLibraries ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getLinkerOpts ()Ljava/util/List;
 	public final fun getOptimized ()Z

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeLink.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeLink.kt
@@ -48,7 +48,6 @@ import org.jetbrains.kotlin.internal.compilerRunner.native.KotlinNativeCompilerR
 import org.jetbrains.kotlin.internal.compilerRunner.native.KotlinNativeToolRunner
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.target.HostManager
-import org.jetbrains.kotlin.project.model.LanguageSettings
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import org.jetbrains.kotlin.tooling.core.toKotlinVersion
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
@@ -146,14 +145,6 @@ constructor(
         binary.buildType.name.lowercase(Locale.ROOT).replaceFirstChar { it.titlecase(Locale.ROOT) }
     }
 
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        message = "Use toolOptions to configure the task",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val languageSettings: LanguageSettings = compilation.defaultSourceSet.languageSettings
-
     @get:Internal
     internal val disableCache: Provider<Boolean> = objects.propertyWithConvention(
         simpleKotlinNativeVersion
@@ -191,15 +182,6 @@ constructor(
         object NonCacheableTarget : CacheSettingsInput
         data class Configured(val kind: NativeCacheKind) : CacheSettingsInput
     }
-
-    @Suppress("unused", "UNCHECKED_CAST")
-    @Deprecated(
-        message = "Use toolOptions.freeCompilerArgs",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("toolOptions.freeCompilerArgs.get()")
-    )
-    @get:Internal
-    val additionalCompilerOptions: Provider<Collection<String>> = toolOptions.freeCompilerArgs as Provider<Collection<String>>
 
     @Suppress("DEPRECATION_ERROR")
     @Deprecated(KOTLIN_OPTIONS_AS_TOOLS_DEPRECATION_MESSAGE)
@@ -468,20 +450,6 @@ constructor(
             // and added convention for backwards compatibility.
             NoopKotlinNativeProvider(project)
         )
-
-    @Deprecated(
-        message = "This property will be removed in future releases. Don't use it in your code.",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val konanDataDir: Provider<String?> = kotlinNativeProvider.flatMap { it.konanDataDir }
-
-    @Deprecated(
-        message = "This property will be removed in future releases. Don't use it in your code.",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val konanHome: Provider<String> = kotlinNativeProvider.flatMap { it.bundleDirectory }
 
     @get:Internal
     internal abstract val kotlinCompilerArgumentsLogLevel: Property<KotlinCompilerArgumentsLogLevel>

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
@@ -62,7 +62,6 @@ import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind.*
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.DefFile
-import org.jetbrains.kotlin.project.model.LanguageSettings
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 import java.io.File
 import java.nio.file.Files
@@ -194,30 +193,6 @@ abstract class AbstractKotlinNativeCompile<
     )
     @get:Internal
     abstract val kotlinOptions: T
-
-    @Deprecated(
-        message = "Use implementations compilerOptions to get/set freeCompilerArgs",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Input
-    abstract val additionalCompilerOptions: Provider<Collection<String>>
-
-    @Deprecated(
-        message = "Use implementations compilerOptions",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val languageSettings: LanguageSettings
-        get() = compilation.languageSettings
-
-    @Suppress("DeprecatedCallableAddReplaceWith")
-    @get:Deprecated(
-        message = "Replaced with 'compilerOptions.progressiveMode'",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val progressiveMode: Boolean
-        get() = compilation.compilerOptions.options.progressiveMode.get()
     // endregion.
 
     @get:Input
@@ -308,14 +283,6 @@ internal constructor(
         else "${project.name}_${compilation.compilationName}"
     }
 
-    @Deprecated(
-        message = "Please use 'compilerOptions.moduleName' to configure",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("compilerOptions.moduleName.get()")
-    )
-    @get:Internal
-    val moduleName: String get() = compilerOptions.moduleName.get()
-
     @get:Input
     val shortModuleName: String by providerFactory.provider { baseName }
 
@@ -341,62 +308,12 @@ internal constructor(
             NoopKotlinNativeProvider(project)
         )
 
-    @Deprecated(
-        message = "This property will be removed in future releases. Don't use it in your code.",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val konanDataDir: Provider<String?> = kotlinNativeProvider.flatMap { it.konanDataDir }
-
-    @Deprecated(
-        message = "This property will be removed in future releases. Don't use it in your code.",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val konanHome: Provider<String> = kotlinNativeProvider.flatMap { it.bundleDirectory }
-
     @get:Nested
     override val multiplatformStructure: K2MultiplatformStructure = objectFactory.newInstance()
 
     private val commonSourcesTree: FileTree
         get() = commonSources.asFileTree
 
-    // endregion.
-
-    // region Language settings imported from a SourceSet.
-    @Deprecated(
-        message = "Replaced with kotlinOptions.languageVersion",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("kotlinOptions.languageVersion")
-    )
-    val languageVersion: String?
-        @Optional @Input get() = compilerOptions.languageVersion.orNull?.version
-
-    @Deprecated(
-        message = "Replaced with kotlinOptions.apiVersion",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("kotlinOptions.apiVersion")
-    )
-    val apiVersion: String?
-        @Optional @Input get() = compilerOptions.apiVersion.orNull?.version
-
-    @Deprecated(
-        message = "Language features is internal Kotlin compiler flags and should not be used directly",
-        level = DeprecationLevel.ERROR,
-    )
-    val enabledLanguageFeatures: Set<String>
-        @Internal get() = compilerOptions
-            .freeCompilerArgs.get()
-            .filter { it.startsWith("-XXLanguage:+") }
-            .toSet()
-
-    @Deprecated(
-        message = "Replaced with compilerOptions.optIn",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("compilerOptions.optIn")
-    )
-    val optInAnnotationsInUse: Set<String>
-        @Internal get() = compilerOptions.optIn.get().toSet()
     // endregion.
 
     // region Kotlin options
@@ -415,16 +332,6 @@ internal constructor(
         override val options: KotlinCommonCompilerOptions
             get() = compilerOptions
     }
-
-    @Suppress("UNCHECKED_CAST")
-    @Deprecated(
-        message = "Replaced with compilerOptions.freeCompilerArgs",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("compilerOptions.freeCompilerArgs.get()")
-    )
-    @get:Input
-    override val additionalCompilerOptions: Provider<Collection<String>>
-        get() = compilerOptions.freeCompilerArgs as Provider<Collection<String>>
 
     @get:Internal
     internal val kotlinCompilerArgumentsLogLevel: Property<KotlinCompilerArgumentsLogLevel> = objectFactory
@@ -846,15 +753,6 @@ abstract class CInteropProcess @Inject internal constructor(params: Params) :
     @get:Internal
     internal var isGeneratedCinterop: Boolean = false
 
-    @Deprecated(
-        "Eager outputFile was replaced with lazy outputFileProvider",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("outputFileProvider")
-    )
-    @get:Internal
-    val outputFile: File
-        get() = outputFileProvider.get()
-
     @get:Nested
     internal val kotlinNativeProvider: Property<KotlinNativeProvider> =
         project.objects.propertyWithConvention<KotlinNativeProvider>(
@@ -863,20 +761,6 @@ abstract class CInteropProcess @Inject internal constructor(params: Params) :
             // and added convention for backwards compatibility.
             NoopKotlinNativeProvider(project)
         )
-
-    @Deprecated(
-        message = "This property will be removed in future releases. Don't use it in your code.",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val konanDataDir: Provider<String?> = kotlinNativeProvider.flatMap { it.konanDataDir }
-
-    @Deprecated(
-        message = "This property will be removed in future releases. Don't use it in your code.",
-        level = DeprecationLevel.ERROR,
-    )
-    @get:Internal
-    val konanHome: Provider<String> = kotlinNativeProvider.flatMap { it.bundleDirectory }
 
     private val actualNativeHomeDirectory = project.nativeProperties.actualNativeHomeDirectory
     private val runnerJvmArgs = project.nativeProperties.jvmArgs
@@ -911,15 +795,6 @@ abstract class CInteropProcess @Inject internal constructor(params: Params) :
     @get:NormalizeLineEndings
     @get:Optional
     abstract val definitionFile: RegularFileProperty
-
-    @get:Internal
-    @Deprecated(
-        "This eager parameter is deprecated.",
-        level = DeprecationLevel.ERROR,
-        replaceWith = ReplaceWith("definitionFile")
-    )
-    val defFile: File get() = definitionFile.asFile.get()
-
 
     @get:Optional
     @get:Input


### PR DESCRIPTION
These API have been deprecated as ERROR since Kotlin 2.4.0-Beta2, this change deletes them from the codebase.

^KT-88813 Verification Pending