### PR TITLE
Reflection: don't unwrap primitives loaded from a wrapper's name

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/types/primitiveTypeClassifier.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/types/primitiveTypeClassifier.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertEquals
 class A(
     val primitive: Boolean,
     val wrapper: Boolean?,
+    val wrapperJavaLang: java.lang.Boolean,
 )
 
 fun primitive(): Byte = 0.toByte()
@@ -38,7 +39,7 @@ fun box(): String {
     )
 
     assertEquals(
-        listOfNotNull(Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType),
+        listOfNotNull(Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType, Boolean::class.javaObjectType),
         A::class.constructors.single().parameters.map { it.type.javaClass() },
     )
 

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ConvertFromMetadata.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ConvertFromMetadata.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.NameUtils
+import org.jetbrains.kotlin.resolve.jvm.JvmPrimitiveType
 import org.jetbrains.kotlin.types.model.TypeConstructorMarker
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
@@ -48,7 +49,16 @@ internal fun ClassName.toNonLocalSimpleName(): String {
 }
 
 internal fun ClassLoader.loadKClass(name: ClassName, forceWrapperClass: Boolean = false): KClass<*>? =
-    loadClass(name.toClassId())?.let { if (forceWrapperClass) it else it.primitiveByWrapper ?: it }?.kotlin
+    loadClass(name.toClassId())
+        ?.let {
+            // For Kotlin code that uses Java wrappers (like Integer), don't return the primitive
+            if (forceWrapperClass || JvmPrimitiveType.isWrapperClassInternalName(name)) {
+                it
+            } else {
+                it.primitiveByWrapper ?: it
+            }
+        }
+        ?.kotlin
 
 /**
  * Provides the access to the type parameters of a Kotlin declaration, and allows to obtain a type parameter given its id.


### PR DESCRIPTION
If the Kotlin source code used a wrapper type, it should be returned as such.

^KT-88884 Fixed