### PR TITLE
Build patched IntelliJ fat-JARs on Gradle import

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.gradle.crypto.checksum.Checksum
 import org.gradle.plugins.ide.idea.model.IdeaModel
+import org.jetbrains.gradle.ext.ProjectSettings
+import org.jetbrains.gradle.ext.TaskTriggersConfig
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootEnvSpec
 import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnPlugin
@@ -713,6 +715,22 @@ configure<IdeaModel> {
                 "intellij",
             )
         )
+    }
+
+    project {
+        // Patched IntelliJ classes are consumed as fat-JAR artifacts of the ':dependencies:intellij-*' projects,
+        // so on a clean checkout the IDE cannot resolve IntelliJ PSI references until those JARs are built.
+        // Build them (together with sources for navigation) right after every Gradle import.
+        (this as ExtensionAware).configure<ProjectSettings> {
+            (this as ExtensionAware).configure<TaskTriggersConfig> {
+                afterSync(
+                    ":dependencies:intellij-java-psi-api:jar",
+                    ":dependencies:intellij-java-psi-api:sourcesJar",
+                    ":dependencies:intellij-core-implementation:jar",
+                    ":dependencies:intellij-core-implementation:sourcesJar",
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Patched IntelliJ classes are now consumed as fat-JAR artifacts of the ':dependencies:intellij-java-psi-api' and
':dependencies:intellij-core-implementation' projects instead of plain Maven artifacts. On a clean checkout, those JARs do not exist yet, so after importing the project, the IDE cannot resolve IntelliJ PSI references until the JARs are built.

The commit registers 'afterSync' task triggers for tasks of both projects, so IntelliJ builds them right after every Gradle import.