### PR TITLE
[Native] Keep the stable order of [K]Function declarations, v2

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.serialization.*
+import org.jetbrains.kotlin.backend.konan.util.sortDeclarationsInFunctionInterfaceFile
 import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.cli.common.diagnosticsCollector
 import org.jetbrains.kotlin.config.languageVersionSettings
@@ -19,8 +20,6 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.*
 import org.jetbrains.kotlin.ir.IrBasedFunctionFactory.Companion.isFunctionInterfaceFile
 import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrDeclaration
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
 import org.jetbrains.kotlin.ir.objcinterop.IrObjCOverridabilityCondition
@@ -236,24 +235,6 @@ private fun generateImplForCStructsAndEnums(linker: KonanIrLinker, builtIns: IrB
 }
 
 private fun IrModuleDependencies.sortFilesAndDeclarationsToKeepPipelineDeterministic() {
-    data class SortingKey(val prefix: String, val index: Int?) : Comparable<SortingKey> {
-        override fun compareTo(other: SortingKey): Int {
-            val prefixDiff = prefix.compareTo(other.prefix)
-            return if (prefixDiff != 0) prefixDiff else when (index) {
-                other.index -> 0
-                null -> -1
-                else -> 1
-            }
-        }
-    }
-
-    fun IrDeclaration.toSortingKey(): SortingKey {
-        val name = (this as IrDeclarationWithName).name.asString()
-        val prefix = name.trimEnd { it.isDigit() }
-        val index = name.substringAfter(prefix).toIntOrNull()
-        return SortingKey(prefix, index)
-    }
-
     allDependencies.forEach { module ->
         module.files.sortBy { file -> file.fileEntry.name }
 
@@ -262,9 +243,7 @@ private fun IrModuleDependencies.sortFilesAndDeclarationsToKeepPipelineDetermini
         // the deserialization queue).
         if (module.kotlinLibrary?.isNativeStdlib == true) {
             module.files.forEach { file ->
-                if (file.isFunctionInterfaceFile) {
-                    file.declarations.sortBy { it.toSortingKey() }
-                }
+                if (file.isFunctionInterfaceFile) sortDeclarationsInFunctionInterfaceFile(file)
             }
         }
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/FunctionalInterfaceClassSorting.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/FunctionalInterfaceClassSorting.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.util
+
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
+import org.jetbrains.kotlin.ir.declarations.IrFile
+
+/**
+ * This utility is used to sort synthetic `*Function` classes in a special function interface file inside the standard library.
+ * The classes might be generated and added to the file on demand and in the different order (based on the order or the deserialization queue).
+ * So, we need to sort them explicitly after the IR linkage stage to keep the stable order.
+ */
+internal fun sortDeclarationsInFunctionInterfaceFile(file: IrFile) {
+    val sortedDeclarations: List<FunctionalInterfaceClassSortingKey> = file.declarations
+            .map { FunctionalInterfaceClassSortingKey(it as IrDeclarationWithName) }
+            .sorted()
+    file.declarations.clear()
+    sortedDeclarations.mapTo(file.declarations) { it.declaration }
+}
+
+private class FunctionalInterfaceClassSortingKey(val declaration: IrDeclarationWithName) : Comparable<FunctionalInterfaceClassSortingKey> {
+    val prefix: String
+    val index: Int
+
+    init {
+        val name = declaration.name.asString()
+        prefix = name.trimEnd { it.isDigit() }
+        index = name.substringAfter(prefix).toIntOrNull() ?: -1
+    }
+
+    override fun compareTo(other: FunctionalInterfaceClassSortingKey): Int {
+        val prefixDiff = prefix.compareTo(other.prefix)
+        return if (prefixDiff != 0) prefixDiff else index.compareTo(other.index)
+    }
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/test/org/jetbrains/kotlin/backend/konan/util/FunctionalInterfaceClassSortingTest.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/test/org/jetbrains/kotlin/backend/konan/util/FunctionalInterfaceClassSortingTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.util
+
+import org.jetbrains.kotlin.ir.builders.declarations.buildClass
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
+import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
+import org.jetbrains.kotlin.ir.symbols.impl.IrFileSymbolImpl
+import org.jetbrains.kotlin.ir.util.IrErrorModuleFragment
+import org.jetbrains.kotlin.ir.util.NaiveSourceBasedFileEntryImpl
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlin.with
+
+class FunctionalInterfaceClassSortingTest {
+    @Test
+    fun testSorting() {
+        val file = newFile()
+
+        file.newClass("Function9")
+        file.newClass("Function8")
+        file.newClass("Function7")
+        file.newClass("Function6")
+        file.newClass("Function10")
+        file.newClass("Function5")
+        file.newClass("Function0")
+        file.newClass("Function4")
+        file.newClass("Function1")
+        file.newClass("Function3")
+        file.newClass("Function2")
+        file.newClass("KFunction5")
+        file.newClass("KFunction4")
+        file.newClass("KFunction3")
+        file.newClass("KFunction2")
+        file.newClass("KFunction1")
+        file.newClass("KFunction0")
+        file.newClass("KFunction")
+        file.newClass("Foo")
+
+        sortDeclarationsInFunctionInterfaceFile(file)
+
+        assertEquals(
+                /* expected = */
+                listOf(
+                        "Foo",
+
+                        "Function0",
+                        "Function1",
+                        "Function2",
+                        "Function3",
+                        "Function4",
+                        "Function5",
+                        "Function6",
+                        "Function7",
+                        "Function8",
+                        "Function9",
+                        "Function10",
+
+                        "KFunction",
+                        "KFunction0",
+                        "KFunction1",
+                        "KFunction2",
+                        "KFunction3",
+                        "KFunction4",
+                        "KFunction5",
+                ),
+                /* actual = */ file.declarations.map { (it as IrDeclarationWithName).name.asString() }
+        )
+    }
+
+    private companion object {
+        fun newFile(): IrFile = IrFileImpl(
+                fileEntry = NaiveSourceBasedFileEntryImpl(name = "test.kt"),
+                symbol = IrFileSymbolImpl(null),
+                packageFqName = FqName.ROOT,
+                module = IrErrorModuleFragment, // we don't care here, let it be just an error fragment
+        )
+
+        fun IrFile.newClass(name: String): IrClass = with(IrFactoryImpl) {
+            buildClass {
+                this.name = Name.identifier(name)
+            }.also { this@newClass.declarations += it }
+        }
+    }
+}


### PR DESCRIPTION
Previous PR: https://github.com/JetBrains/kotlin/pull/7756

Fix the incorrect behavior in sorting of [K]Function declarations introduced in 5a670d34bde8fd4619b585f8406bf8abd5ae5286.

Add a corresponding test.

^KT-61096