### PR TITLE
[Gradle] Use correct build options in MppIdeDependencyResolutionIT

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MppIdeDependencyResolutionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MppIdeDependencyResolutionIT.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLI
 import org.jetbrains.kotlin.gradle.plugin.ide.IdeDependencyResolver
 import org.jetbrains.kotlin.gradle.plugin.ide.IdeMultiplatformImport
 import org.jetbrains.kotlin.gradle.plugin.ide.IdeMultiplatformImportImpl
+import org.jetbrains.kotlin.gradle.plugin.ide.IdeMultiplatformImportLogger
 import org.jetbrains.kotlin.gradle.plugin.ide.kotlinIdeMultiplatformImport
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.testbase.TestVersions.AgpCompatibilityMatrix
@@ -752,8 +753,11 @@ class MppIdeDependencyResolutionIT : KGPBaseTest() {
         assertThrows<Exception> { project.resolveIdeDependencies(strictMode = true) {} }
 
         val events =
-            project.catchBuildFailures<org.jetbrains.kotlin.gradle.plugin.ide.IdeMultiplatformImportLogger.Events>().buildAndReturn(
-                ":resolveIdeDependencies", "-P${KOTLIN_KMP_STRICT_RESOLVE_IDE_DEPENDENCIES}=true"
+            project.catchBuildFailures<IdeMultiplatformImportLogger.Events>().buildAndReturn(
+                ":resolveIdeDependencies", "-P${KOTLIN_KMP_STRICT_RESOLVE_IDE_DEPENDENCIES}=true",
+                // Important: use the same build options configuration for this invocation of :resolveIdeDependencies
+                // as the one used by resolveIdeDependencies().
+                deriveBuildOptions = { buildOptions.disableConfigurationCache_KT70416() }
             ).unwrap().single()
         assertEquals<List<Class<*>>>(
             listOf(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/resolveIdeDependencies.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/resolveIdeDependencies.kt
@@ -24,7 +24,7 @@ import kotlin.test.fail
 
 
 // TODO: KT-70416 :resolveIdeDependencies doesn't support Configuration Cache & Project Isolation
-private fun BuildOptions.disableConfigurationCache_KT70416() = copy(
+internal fun BuildOptions.disableConfigurationCache_KT70416() = copy(
     configurationCache = BuildOptions.ConfigurationCacheValue.DISABLED,
     isolatedProjects = BuildOptions.IsolatedProjectsMode.DISABLED,
 )


### PR DESCRIPTION
This change fixes a stability issue with the
`IDE resolution strict mode` test: the test makes two calls to the resolveIdeDependencies() helper, which modifies buildOptions internally to turn off configuration cache (CC) and isolated projects (IP), unsupported by the :resolveIdeDependencies task (see KT-70416). However, the third call to :resolveIdeDependencies inside the test is made without the helper, hence CC and IP don't get disabled, running into the incompatibility issues. The change ensures this third call is made with the same build options configuration as the previous ones.

^KT-88890 Fixed