### PR TITLE
[Gradle] Remove LanguageSettings.enabledLanguageFeatures API

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
+++ b/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
@@ -1330,9 +1330,7 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/KotlinTestRun
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/plugin/LanguageSettingsBuilder : org/jetbrains/kotlin/project/model/LanguageSettings {
-	public abstract fun enableLanguageFeature (Ljava/lang/String;)V
 	public abstract fun getApiVersion ()Ljava/lang/String;
-	public abstract fun getEnabledLanguageFeatures ()Ljava/util/Set;
 	public abstract fun getLanguageVersion ()Ljava/lang/String;
 	public abstract fun getProgressiveMode ()Z
 	public abstract fun optIn (Ljava/lang/String;)V
@@ -1602,7 +1600,6 @@ public abstract interface class org/jetbrains/kotlin/gradle/tasks/abi/KotlinLega
 
 public abstract interface class org/jetbrains/kotlin/project/model/LanguageSettings {
 	public abstract fun getApiVersion ()Ljava/lang/String;
-	public abstract fun getEnabledLanguageFeatures ()Ljava/util/Set;
 	public abstract fun getLanguageVersion ()Ljava/lang/String;
 	public abstract fun getOptInAnnotationsInUse ()Ljava/util/Set;
 	public abstract fun getProgressiveMode ()Z

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/LanguageSettings.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/LanguageSettings.kt
@@ -49,15 +49,6 @@ interface LanguageSettings {
     val progressiveMode: Boolean
 
     /**
-     * @suppress
-     */
-    @Deprecated(
-        "Configures internal Kotlin compiler argument and should not be used in the projects",
-        level = DeprecationLevel.ERROR
-    )
-    val enabledLanguageFeatures: Set<String>
-
-    /**
      * Enable API usages that require opt-in with an opt-in requirement marker with the given fully qualified name.
      *
      * Default value: emptyList<String>()

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/LanguageSettingsBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/LanguageSettingsBuilder.kt
@@ -23,24 +23,6 @@ interface LanguageSettingsBuilder : LanguageSettings {
     override var progressiveMode: Boolean
 
     /**
-     * @suppress
-     */
-    @Deprecated(
-        "Configures internal Kotlin compiler argument and should not be used in the projects",
-        level = DeprecationLevel.ERROR
-    )
-    fun enableLanguageFeature(name: String)
-
-    /**
-     * @suppress
-     */
-    @Deprecated(
-        "Configures internal Kotlin compiler argument and should not be used in the projects",
-        level = DeprecationLevel.ERROR
-    )
-    override val enabledLanguageFeatures: Set<String>
-
-    /**
      * Adds an additional opt-in requirement marker with the given fully qualified name.
      *
      * See also [org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions.optIn].

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-multi-modules/top-mpp/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-multi-modules/top-mpp/build.gradle
@@ -178,6 +178,3 @@ kotlin {
         }
     }
 }
-kotlin.sourceSets.all {
-    it.languageSettings.enableLanguageFeature("InlineClasses")
-}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/sources/ConsistencyChecker.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/sources/ConsistencyChecker.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.gradle.plugin.sources
 
 import org.gradle.api.InvalidUserDataException
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.project.model.LanguageSettings
 
@@ -39,24 +38,6 @@ internal class FragmentConsistencyChecks<T>(
         consistencyConditionHint = languageVersionCheckHint
     )
 
-    private val unstableFeaturesHint = "The dependent $unitName must enable all unstable language features that its dependency has."
-
-    private val unstableFeaturesCheck = ConsistencyCheck<T, Set<LanguageFeature>?>(
-        name = "unstable language feature set",
-        getValue = { unit ->
-            unit.languageSettings().getValueIfExists {
-                @Suppress("DEPRECATION_ERROR")
-                enabledLanguageFeatures
-                    .mapNotNull { parseLanguageFeature(it) }
-                    .filterTo(mutableSetOf()) { it.forcesPreReleaseBinaries }
-            }
-        },
-        leftExtendsRightConsistently = { left, right ->
-            if (left == null || right == null) true else left.containsAll(right)
-        },
-        consistencyConditionHint = unstableFeaturesHint
-    )
-
     private val optInAnnotationsInUseHint = "The dependent $unitName must use all opt-in annotations that its dependency uses."
 
     private val optInAnnotationsCheck = ConsistencyCheck<T, Set<String>?>(
@@ -68,7 +49,7 @@ internal class FragmentConsistencyChecks<T>(
         consistencyConditionHint = optInAnnotationsInUseHint
     )
 
-    val allChecks = listOf(languageVersionCheck, unstableFeaturesCheck, optInAnnotationsCheck)
+    val allChecks = listOf(languageVersionCheck, optInAnnotationsCheck)
 
     private fun <T> LanguageSettings.getValueIfExists(
         getValue: LanguageSettings.() -> T?
@@ -81,8 +62,6 @@ internal class FragmentConsistencyChecks<T>(
         }
     }
 }
-
-internal fun parseLanguageFeature(featureName: String) = LanguageFeature.fromString(featureName)
 
 internal class FragmentConsistencyChecker<T>(
     private val unitsName: String,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/sources/DefaultLanguageSettingsBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/sources/DefaultLanguageSettingsBuilder.kt
@@ -68,37 +68,6 @@ internal open class DefaultLanguageSettingsBuilder @Inject constructor(
             }
         }
 
-    private val enabledLanguageFeaturesField = mutableSetOf<String>()
-
-    @Deprecated(
-        "Configures internal Kotlin compiler argument and should not be used in the projects",
-        level = DeprecationLevel.ERROR
-    )
-    override val enabledLanguageFeatures: Set<String>
-        get() = if (compilationCompilerOptions.isCompleted) {
-            compilationCompilerOptions.getOrThrow()
-                .freeCompilerArgs
-                .get()
-                .filter { it.startsWith("-XXLanguage:+") }
-                .map { it.substringAfter("-XXLanguage:+") }
-                .toSet()
-        } else {
-            enabledLanguageFeaturesField.toSet()
-        }
-
-    @Deprecated(
-        "Configures internal Kotlin compiler argument and should not be used in the projects",
-        level = DeprecationLevel.ERROR
-    )
-    override fun enableLanguageFeature(name: String) {
-        enabledLanguageFeaturesField.add(name)
-        project.launch {
-            compilationCompilerOptions.await()
-                .freeCompilerArgs
-                .add("-XXLanguage:+$name")
-        }
-    }
-
     private val optInAnnotationsInUseField = mutableSetOf<String>()
 
     override val optInAnnotationsInUse: Set<String>

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/CompilerOptionsProjectTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/CompilerOptionsProjectTest.kt
@@ -108,8 +108,6 @@ class CompilerOptionsProjectTest {
                 apiVersion = settingsVersion.versionString
                 progressiveMode = false
                 optIn("another.CustomOptInAnnotation")
-                @Suppress("DEPRECATION_ERROR")
-                enableLanguageFeature("UnitConversionsOnArbitraryExpressions")
             }
         }
         project.evaluate()
@@ -120,7 +118,6 @@ class CompilerOptionsProjectTest {
             "-api-version ${settingsVersion.versionString}",
             "-Xdebug",
             "-opt-in my.custom.OptInAnnotation,another.CustomOptInAnnotation",
-            "-XXLanguage:+UnitConversionsOnArbitraryExpressions",
         )
         assertTrue(
             expected.all { it in arguments },

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/LanguageSettingsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/LanguageSettingsTests.kt
@@ -164,25 +164,6 @@ class LanguageSettingsTests {
     }
 
     @Test
-    fun `language settings MonotonousCheck - unstable features`() {
-        val project = kmpProject {
-            with(multiplatformExtension) {
-                sourceSets.commonMain {
-                    @Suppress("DEPRECATION_ERROR")
-                    languageSettings.enableLanguageFeature("InlineClasses")
-                }
-            }
-        }
-
-        val configException = assertThrows<ProjectConfigurationException> { project.evaluate() }
-        val dataException = configException.allCauses.filterIsInstance<InvalidUserDataException>().single()
-        assertContains(
-            expected = "The dependent source set must enable all unstable language features that its dependency has.",
-            actual = dataException.message.toString(),
-        )
-    }
-
-    @Test
     fun `language settings MonotonousCheck - opt-in`() {
         val project = kmpProject {
             with(multiplatformExtension) {
@@ -212,8 +193,6 @@ class LanguageSettingsTests {
                     languageSettings {
                         apiVersion = "1.4"
                         languageVersion = "1.3"
-                        @Suppress("DEPRECATION_ERROR")
-                        enableLanguageFeature("SoundSmartcastForEnumEntries")
                         progressiveMode = true
                     }
                 }


### PR DESCRIPTION
This reverts commit 3a578d6e27adfa75e29dcbc652fc72bacf20056b.

^KT-88839 Verification Pending

---

@CherepanovAleksei & I confirmed that this change does not in fact break the IDE sync, as stated in KTIJ-40066, the IDE simply logs an error message when it fails to invoke a missing method via reflection. Aleksei will work on a change in IDEA to silence the log when the method can't be invoked.