### PR TITLE
[KGP] Fix MPP metadata target not invoke onPublicationCreated

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/publishing/Publishing.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/publishing/Publishing.kt
@@ -16,6 +16,7 @@ import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.plugins.signing.Sign
+import org.jetbrains.kotlin.gradle.dsl.metadataTarget
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
@@ -102,6 +103,8 @@ private fun createRootPublication(project: Project, publishing: PublishingExtens
         (this as MavenPublicationInternal).publishWithOriginalFileName()
 
         addKotlinToolingMetadataArtifactIfNeeded(project)
+
+        project.multiplatformExtension.metadataTarget.onPublicationCreated(this)
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT85034MppMetadataTargetInvokePublicationCreated.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT85034MppMetadataTargetInvokePublicationCreated.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.regressionTests
+
+import org.jetbrains.kotlin.gradle.dsl.metadataTarget
+import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.util.buildProject
+import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertEquals
+import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertTrue
+import kotlin.test.Test
+
+class KT85034MppMetadataTargetInvokePublicationCreated {
+    @Test
+    fun `KT-85034 - metadata target mavenPublication action is invoked for root publication`() {
+        val project = buildProjectWithMPP(
+            preApplyCode = {
+                plugins.apply("maven-publish")
+            }
+        )
+        val kotlin = project.multiplatformExtension
+        val configuredPublications = mutableListOf<String>()
+
+        kotlin.metadataTarget.mavenPublication {
+            configuredPublications += name
+        }
+        kotlin.jvm()
+
+        project.evaluate()
+
+        assertEquals(
+            listOf("kotlinMultiplatform"),
+            configuredPublications,
+        ) {
+            "kotlin metadata target mavenPublication action should be invoked only once for root publication"
+        }
+    }
+}

--- a/plugins/power-assert/power-assert-runtime/build.gradle.kts
+++ b/plugins/power-assert/power-assert-runtime/build.gradle.kts
@@ -127,19 +127,3 @@ tasks.withType<Test>().configureEach {
 }
 
 configureDefaultPublishing()
-
-// TODO(KT-85034): mavenPublication doesn't work for metadata
-publishing {
-    publications.configureEach {
-        if (this is MavenPublication && name == "kotlinMultiplatform") {
-            // Maven Central requires a Javadoc classified artifact for every non-'pom` publication.
-            artifact(emptyJavadocJar)
-            project.configureSbomForTarget(kotlin.targets["metadata"], this)
-            configureKotlinPomAttributes(
-                project = project,
-                explicitDescription = provider { project.description },
-                explicitName = provider { project.description },
-            )
-        }
-    }
-}


### PR DESCRIPTION
Fix Metadata Target not invoke onPublicationCreated when publishing

^KT-85034 Fixed