### PR TITLE
[FIR] Fix DEPRECATED_JAVA_ANNOTATION false positive with arguments

### DIFF
--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/expression/FirJavaAnnotationsChecker.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/expression/FirJavaAnnotationsChecker.kt
@@ -43,9 +43,16 @@ object FirJavaAnnotationsChecker : FirAnnotationChecker(MppCheckerKind.Common) {
         val classSymbol = annotationType.classLikeLookupTagIfAny?.toClassSymbol() ?: return
         if (classSymbol.origin !is FirDeclarationOrigin.Java) return
 
-        val lookupTag = classSymbol.toLookupTag()
-        javaToKotlinNameMap[lookupTag.classId]?.let { betterName ->
-            reporter.reportOn(expression.source, FirJvmErrors.DEPRECATED_JAVA_ANNOTATION, betterName.asSingleFqName())
+        val classId = classSymbol.toLookupTag().classId
+        // Java's 'since' and 'forRemoval' cannot be represented by 'kotlin.Deprecated'.
+        // In particular, dropping 'forRemoval = true' changes the javac lint category
+        // for Java callers from '[removal]' to '[deprecation]'.
+        val hasJavaSpecificArguments = classId == JvmStandardClassIds.Annotations.Java.Deprecated &&
+                expression.argumentMapping.mapping.isNotEmpty()
+        if (!hasJavaSpecificArguments) {
+            javaToKotlinNameMap[classId]?.let { betterName ->
+                reporter.reportOn(expression.source, FirJvmErrors.DEPRECATED_JAVA_ANNOTATION, betterName.asSingleFqName())
+            }
         }
 
         if (expression is FirAnnotationCall) {

--- a/compiler/testData/diagnostics/tests/annotations/DeprecatedWithArguments.kt
+++ b/compiler/testData/diagnostics/tests/annotations/DeprecatedWithArguments.kt
@@ -1,0 +1,28 @@
+// RUN_PIPELINE_TILL: BACKEND
+// JDK_KIND: FULL_JDK_11
+// ISSUE: KT-33232
+
+// Java's 'since' and 'forRemoval' have no counterpart in 'kotlin.Deprecated', so
+// migrating would drop them. The replacement is not suggested once either one is
+// passed, explicitly written default values included.
+
+@java.lang.Deprecated(forRemoval = true)
+fun withForRemoval() {}
+
+@java.lang.Deprecated(since = "1.0")
+fun withSince() {}
+
+@java.lang.Deprecated(since = "1.0", forRemoval = true)
+fun withSinceAndForRemoval() {}
+
+@java.lang.Deprecated(forRemoval = false)
+fun withExplicitDefaultForRemoval() {}
+
+@java.lang.Deprecated(since = "")
+fun withExplicitEmptySince() {}
+
+// Without arguments both annotations make javac report the same '[deprecation]'
+// warning, so the replacement is still suggested.
+<!DEPRECATED_JAVA_ANNOTATION!>@java.lang.Deprecated<!> fun withoutArguments() {}
+
+/* GENERATED_FIR_TAGS: functionDeclaration, stringLiteral */


### PR DESCRIPTION
Fixes [KT-33232](https://youtrack.jetbrains.com/issue/KT-33232).

### Problem

`DEPRECATED_JAVA_ANNOTATION` tells the user to replace `@java.lang.Deprecated` with `@kotlin.Deprecated`, unconditionally. But `java.lang.Deprecated` declares `since` and `forRemoval`, and `kotlin.Deprecated` has no counterpart for either.

For `forRemoval = true` the difference is observable. Given these two Kotlin declarations:

```kotlin
@java.lang.Deprecated(forRemoval = true)
fun viaJava() {}

@kotlin.Deprecated("use something else")
fun viaKotlin() {}
```

a Java caller compiled with `-Xlint:all` gets:

```
Use.java:3: warning: [removal] viaJava() in LibKt has been deprecated and marked for removal
Use.java:4: warning: [deprecation] viaKotlin() in LibKt has been deprecated
```

Following the compiler's advice changes the lint category for downstream Java callers from `[removal]` to `[deprecation]`. And in that case the advice cannot be followed literally at all — `@kotlin.Deprecated("x", forRemoval = true)` fails with `error: no parameter with name 'forRemoval' found`.

### Fix

`FirJavaAnnotationsChecker` no longer reports the diagnostic for `java.lang.Deprecated` when any argument is explicitly passed. `java.lang.Deprecated` declares only `since` and `forRemoval`, so any explicit argument means the source is using a Java-specific annotation member that `kotlin.Deprecated` cannot represent.

The argument-less form keeps warning: neither `since` nor `forRemoval` is being used, and both forms produce the same `[deprecation]` lint category for Java callers. `Target`, `Retention` and `Documented` are untouched, since their Kotlin counterparts do accept the corresponding arguments.

Explicitly written default values (`forRemoval = false`, `since = ""`) are also exempted, and covered by tests. This is deliberate and matches the issue, whose reproducer is exactly `@Deprecated(forRemoval = false)`.

The change is limited to the K2 checker. K1's `JavaAnnotationCallChecker` is left unchanged.

### Tests

New `compiler/testData/diagnostics/tests/annotations/DeprecatedWithArguments.kt` covers `since`, `forRemoval`, both together, both explicit defaults, and the argument-less form that must keep warning. It needs `// JDK_KIND: FULL_JDK_11`, because the mock JDK's `java.lang.Deprecated` declares no members at all.

Reverting the checker change makes the new test fail. Ran green locally, 972 tests across both runners:

- `PhasedJvmDiagnostic{LightTree,Psi}TestGenerated$Tests$Annotations`
- `PhasedJvmDiagnostic{LightTree,Psi}TestGenerated$TestsWithStdLib$Annotations`
- `PhasedJvmDiagnostic{LightTree,Psi}TestGenerated$Tests$TestsWithJava17$JvmRecord`