### PR TITLE
Reflection: fix AssertionError in enhancePossiblyFlexible

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/java/membersOfSelfRecursiveRawType.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/java/membersOfSelfRecursiveRawType.kt
@@ -10,12 +10,18 @@ public class JBase<T extends JBase, F extends T> {
 // FILE: JChild.java
 public class JChild extends JBase {}
 
+// FILE: KtSubclass.kt
+open class KtSubclass : JChild()
+
+// FILE: JChildChild.java
+public class JChildChild extends KtSubclass {
+    public JBase method() { return null; }
+}
+
 // FILE: box.kt
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
-
-class KtSubclass : JChild()
 
 fun check(expected: String, reference: KCallable<*>, klass: KClass<*>) {
     assertEquals(expected, reference.toString())
@@ -33,6 +39,9 @@ fun box(): String {
 
     check("var KtSubclass.field: JBase<(raw) JBase<*, *>!, (raw) JBase<*, *>!>", KtSubclass::field, KtSubclass::class)
     check("fun KtSubclass.method(): JBase<(raw) JBase<*, *>!, (raw) JBase<*, *>!>", KtSubclass::method, KtSubclass::class)
+
+    check("var JChildChild.field: JBase<(raw) JBase<*, *>!, (raw) JBase<*, *>!>", JChildChild::field, JChildChild::class)
+    check("fun JChildChild.method(): JBase<(raw) JBase<*, *>!, (raw) JBase<*, *>!>", JChildChild::method, JChildChild::class)
 
     return "OK"
 }

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectTypeEnhancement.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectTypeEnhancement.kt
@@ -110,7 +110,9 @@ private fun AbstractKType.enhancePossiblyFlexible(
             lowerBound.enhanceInflexible(qualifiers, index, TypeComponentPosition.FLEXIBLE_LOWER, isRawType, isSuperTypesEnhancement)
         val upperResult =
             upperBound.enhanceInflexible(qualifiers, index, TypeComponentPosition.FLEXIBLE_UPPER, isRawType, isSuperTypesEnhancement)
-        assert(lowerResult.subtreeSize == upperResult.subtreeSize) {
+        // We don't try to create raw types exactly in the same way as in the compiler, see createRawJavaType in ConvertFromJava.kt.
+        // So, for raw types we sometimes produce trees of different sizes, but it's OK, since the underlying algorithm handles it fine.
+        assert(isRawType || lowerResult.subtreeSize == upperResult.subtreeSize) {
             "Different tree sizes of bounds: " +
                     "lower = ($lowerBound, ${lowerResult.subtreeSize}), " +
                     "upper = ($upperBound, ${upperResult.subtreeSize})"


### PR DESCRIPTION
The correct fix would probably be to change `createRawJavaType` to behave exactly like in the compiler, but it's out of scope of the current rewrite of kotlin-reflect.

 #KT-87948 Fixed