### PR TITLE
[Tests][Wasm] Fix Stepping tests by using old way of adding additional sources

### DIFF
--- a/compiler/testData/debug/stepping/kt82044.kt
+++ b/compiler/testData/debug/stepping/kt82044.kt
@@ -1,7 +1,7 @@
 // DONT_TARGET_EXACT_BACKEND: JS_IR
 // ^^^ Test hangs while executing the debugger.
-// WASM_IGNORE_FOR: mode=single-module
-// ^^^ KT-88234
+
+
 
 // MODULE: a
 // FILE: a.kt

--- a/compiler/testData/debug/stepping/multiModule.kt
+++ b/compiler/testData/debug/stepping/multiModule.kt
@@ -1,7 +1,7 @@
-// WASM_IGNORE_FOR: mode=single-module
-// ^^^ KT-88234
 // MODULE: lib
 // FILE: a.kt
+
+
 
 fun a() = "a"
 

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/WasmAdditionalSourceProvider.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/WasmAdditionalSourceProvider.kt
@@ -56,8 +56,11 @@ class WasmAdditionalSourceProvider(testServices: TestServices) : AdditionalSourc
         testModuleStructure: TestModuleStructure
     ): List<TestFile> {
         if (WasmEnvironmentConfigurationDirectives.NO_COMMON_FILES in module.directives) return emptyList()
-        // Add the files only to modules with no dependencies to avoid duplicates in case of multiple `// MODULE` test directives.
-        if (module.allDependencies.isNotEmpty()) {
+        if (module.allDependencies.isNotEmpty() &&
+            // This optimization (don't add additional files to modules with dependencies) should not be done
+            // for tests which golden data depends on sourcemaps, for ex, stepping tests.
+            WasmEnvironmentConfigurationDirectives.GENERATE_SOURCE_MAP !in module.directives
+        ) {
             return emptyList()
         }
         return getAdditionalGlobalFiles() + getAdditionalLocalFiles(module.files.first().originalFile.parent)


### PR DESCRIPTION
in [86129643bdd7](https://github.com/jetbrains/kotlin/commit/86129643bdd7), logic of WasmAdditionalSourceProvider was optimized, which broke two tests in FirWasmJsSteppingSingleModuleTestGenerated: kt82044.kt and multiModule.kt

It turned out, stepping tests depend on exact way of adding additional sources.
this PR disables this optimization in the presence of GENERATE_SOURCE_MAP test directive

^[KT-88234 Fixed](https://youtrack.jetbrains.com/issue/KT-88234) K/Wasm: Grouping test runner causes different output in test data of multi-module stepping tests
