### PR TITLE
[Tests][Native] Migrate main part of Klib backward compatibility tests to grouping testinfra

### DIFF
--- a/.idea/inspectionProfiles/idea_default.xml
+++ b/.idea/inspectionProfiles/idea_default.xml
@@ -48,8 +48,7 @@
     <inspection_tool class="ContinueOrBreakFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CovariantCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CovariantEquals" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CustomRegExpInspection" enabled="true" level="WARNING" enabled_by_default="true">
-    </inspection_tool>
+    <inspection_tool class="CustomRegExpInspection" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DataFlowIssue" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="runtime.classes" level="WARNING" enabled="false">
         <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
@@ -420,6 +419,13 @@
     <inspection_tool class="MultipleTypedDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NestedSynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="NewGroovyClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
+      <extension name="JUnitTestClassNamingConvention" enabled="true">
+        <option name="m_regex" value="[A-Z][A-Za-z0-9]*Test" />
+        <option name="m_minLength" value="8" />
+        <option name="m_maxLength" value="64" />
+      </extension>
+    </inspection_tool>
     <inspection_tool class="NoExplicitFinalizeCalls" enabled="true" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="NonExceptionNameEndsWithException" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonStaticFinalLogger" enabled="true" level="WARNING" enabled_by_default="true">
@@ -573,7 +579,6 @@
     <inspection_tool class="WhileLoopSpinsOnField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreNonEmtpyLoops" value="false" />
     </inspection_tool>
-    <inspection_tool class="fa590a8d-4fac-48d3-b2bb-81756ba56c6e" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="DEPRECATED_ATTRIBUTES" />
     <inspection_tool class="e11eeaf1-b3a1-41ab-8f7f-1348991e97fa" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="DEPRECATED_ATTRIBUTES" />
   </profile>
 </component>

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/services/SourceFileProvider.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/services/SourceFileProvider.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.test.TestInfrastructureInternals
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.model.TestFile
 import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.testInfraError
 import org.jetbrains.kotlin.test.util.KtTestUtil
 import java.io.File
 
@@ -107,7 +108,8 @@ class SourceFileProviderImpl(
 
     override fun getOrCreateRealFileForSourceFile(testFile: TestFile): File {
         return realFileMap.getOrPut(testFile) {
-            val module = testServices.moduleStructure.modules.single { testFile in it.files }
+            val module = testServices.moduleStructure.modules.singleOrNull { testFile in it.files }
+                ?: testInfraError("No module found for source file: $testFile")
             val directory = when {
                 testFile.isKtFile -> getKotlinSourceDirectoryForModule(module)
                 testFile.isJavaFile -> getJavaSourceDirectoryForModule(module)

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/services/impl/TestModuleStructureImpl.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/services/impl/TestModuleStructureImpl.kt
@@ -22,7 +22,7 @@ class TestModuleStructureImpl(
     override val modules: List<TestModule>,
     override val originalTestDataFiles: List<File>
 ) : TestModuleStructure() {
-    override val allDirectives: RegisteredDirectives = ComposedRegisteredDirectives(modules.map { it.directives })
+    override val allDirectives: RegisteredDirectives = ComposedRegisteredDirectives(modules.map { it.directives }.distinct())
 
     override fun toString(): String {
         return buildString {

--- a/compiler/testData/klib/klib-compatibility/helpers/ReflectionPackageName.kt
+++ b/compiler/testData/klib/klib-compatibility/helpers/ReflectionPackageName.kt
@@ -1,0 +1,7 @@
+package kotlin.internal
+
+// This annotation is not part of stdlib before v2.5
+// It's needed by grouping testinfra v2.5+ for backward compatibility testing against Kotlin versions less then v2.5.
+@Target(AnnotationTarget.FILE)
+@Retention(AnnotationRetention.BINARY)
+internal annotation class ReflectionPackageName(val name: String)

--- a/compiler/tests-common-new/build.gradle.kts
+++ b/compiler/tests-common-new/build.gradle.kts
@@ -67,6 +67,7 @@ tasks.processTestFixturesResources.configure {
         include("/diagnostics/helpers/**")
         include("/codegen/helpers/**")
         include("/ir/interpreter/helpers/**")
+        include("/klib/klib-compatibility/helpers/**")
     }
     into("stdlib") {
         from(project(":kotlin-stdlib").isolated.projectDirectory.dir("src/kotlin")) {

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/CustomKlibCompilerFirstStageTestSuppressor.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/CustomKlibCompilerFirstStageTestSuppressor.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
 import org.jetbrains.kotlin.test.directives.model.StringDirective
 import org.jetbrains.kotlin.test.klib.CustomKlibCompilerTestDirectives.IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_FIRST_STAGE
 import org.jetbrains.kotlin.test.klib.CustomKlibCompilerTestDirectives.IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE
+import org.jetbrains.kotlin.test.model.ArtifactKinds
 import org.jetbrains.kotlin.test.model.BinaryArtifactHandler
 import org.jetbrains.kotlin.test.model.TestFailureSuppressor
 import org.jetbrains.kotlin.test.services.TestServices
@@ -53,6 +54,11 @@ class CustomKlibCompilerFirstStageTestSuppressor(
                     is NoFirCompilationErrorsHandler -> processFirstStageException(wrappedException)
                     is BinaryArtifactHandler -> processNonFirstStageException(wrappedException, IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE)
                     else -> listOf(wrappedException)
+                }
+            } else if (wrappedException is WrappedException.FromGroupingHandler) {
+                when (wrappedException.handler.artifactKind) {
+                    is ArtifactKinds.KLib -> processFirstStageException(wrappedException)
+                    else -> processNonFirstStageException(wrappedException, IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE)
                 }
             } else {
                 listOf(wrappedException)

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/ReflectionPackageNameAdditionalSourceProvider.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/ReflectionPackageNameAdditionalSourceProvider.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.test.klib
+
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
+import org.jetbrains.kotlin.test.model.TestFile
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.AdditionalSourceProvider
+import org.jetbrains.kotlin.test.services.TestModuleStructure
+import org.jetbrains.kotlin.test.services.TestServices
+
+class ReflectionPackageNameAdditionalSourceProvider(testServices: TestServices) : AdditionalSourceProvider(testServices) {
+    override fun produceAdditionalFiles(
+        globalDirectives: RegisteredDirectives,
+        module: TestModule,
+        testModuleStructure: TestModuleStructure
+    ): List<TestFile> {
+        val classLoader = this::class.java.classLoader
+        return listOf(classLoader.getResource("klib/klib-compatibility/helpers/ReflectionPackageName.kt")!!.toTestFile())
+    }
+}

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/ReflectionPackageNameHelperModuleTransformer.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/ReflectionPackageNameHelperModuleTransformer.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.test.klib
+
+import org.jetbrains.kotlin.test.TestInfrastructureInternals
+import org.jetbrains.kotlin.test.model.DependencyDescription
+import org.jetbrains.kotlin.test.model.DependencyKind
+import org.jetbrains.kotlin.test.model.DependencyRelation
+import org.jetbrains.kotlin.test.model.TestFile
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.DefaultsProvider
+import org.jetbrains.kotlin.test.services.ModuleStructureTransformer
+import org.jetbrains.kotlin.test.services.TestModuleStructure
+import org.jetbrains.kotlin.test.services.impl.TestModuleStructureImpl
+import org.jetbrains.kotlin.test.testInfraError
+
+/**
+ * Extracts helper files added by `ReflectionPackageNameAdditionalSourceProvider` from each test
+ * module and places them into a single dedicated module named [HELPERS_MODULE_NAME].
+ *
+ * The original test modules then get a regular `DependencyKind.Binary` dependency on the new
+ * helpers module instead of carrying the helper sources themselves.
+ *
+ * This allows `BatchingPackageInserter` to annotate grouped backward compatibility tests
+ * with the annotation `kotlin.internal.ReflectionPackageName` without it present in stdlib older than v2.5.
+ * This annotation is used in backends from v2.5 to keep its original package name for the reflection.
+ * The current stdlib contains this annotation as well, so it is necessary not to link the helper module into the executable,
+ * to prevent `IllegalStateException: IrClassSymbolImpl is already bound. Signature: helpers/...` at link time.
+ */
+@OptIn(TestInfrastructureInternals::class)
+object ReflectionPackageNameHelperModuleTransformer : ModuleStructureTransformer() {
+    const val HELPERS_MODULE_NAME: String = "reflectionPackageNameHelper"
+
+    override fun transformModuleStructure(
+        moduleStructure: TestModuleStructure,
+        defaultsProvider: DefaultsProvider
+    ): TestModuleStructure {
+        val originalModules = moduleStructure.modules
+        if (originalModules.isEmpty()) return moduleStructure
+
+        // We only act when at least one module has actual helpers files attached.
+        val hasHelperFile = originalModules.any { module ->
+            module.files.any { isReflectionPackageNameHelperFile(it) }
+        }
+        if (!hasHelperFile) return moduleStructure
+
+        // 1. Collect all helper files from all modules (deduplicated by relative path).
+        val helperFilesByPath = linkedMapOf<String, TestFile>()
+        originalModules.forEach { module ->
+            module.files.forEach { file ->
+                if (isReflectionPackageNameHelperFile(file)) {
+                    helperFilesByPath.putIfAbsent(file.relativePath, file)
+                }
+            }
+        }
+
+        // 2. Build the new helpers module.
+        //    - Uses the same language version settings as the first original module.
+        //    - Has no dependencies of its own.
+        val firstModule = originalModules.first()
+        val helpersModule = TestModule(
+            name = HELPERS_MODULE_NAME,
+            files = helperFilesByPath.values.toList(),
+            allDependencies = emptyList(),
+            directives = firstModule.directives,
+            languageVersionSettings = firstModule.languageVersionSettings,
+        )
+
+        val helpersDependency = DependencyDescription(
+            dependencyModule = helpersModule,
+            kind = DependencyKind.Binary,
+            relation = DependencyRelation.RegularDependency,
+        )
+
+        // 3. Strip helper files from each original module and add the dependency.
+        //    Rewrite dependencies recursively so every edge points to the final rewritten module
+        //    instance, rather than to an intermediate copy with stale dependencies.
+        val originalModulesByName = originalModules.associateBy { it.name }
+        val rewrittenModulesByName = mutableMapOf(HELPERS_MODULE_NAME to helpersModule)
+
+        fun rewriteModule(module: TestModule): TestModule {
+            rewrittenModulesByName[module.name]?.let { return it }
+
+            val rewrittenDependencies = module.allDependencies.map { dependency ->
+                val dependencyModule = when (val dependencyModuleName = dependency.dependencyModule.name) {
+                    HELPERS_MODULE_NAME -> helpersModule
+                    else -> originalModulesByName[dependencyModuleName]?.let(::rewriteModule)
+                        ?: testInfraError("Module $dependencyModuleName not found while rewriting dependencies of ${module.name}")
+                }
+                dependency.copy(dependencyModule = dependencyModule)
+            }
+            val newDependencies = if (rewrittenDependencies.any { it.dependencyModule.name == HELPERS_MODULE_NAME }) {
+                rewrittenDependencies
+            } else {
+                rewrittenDependencies + helpersDependency
+            }
+
+            return module.copy(
+                files = module.files.filterNot { isReflectionPackageNameHelperFile(it) },
+                allDependencies = newDependencies,
+            ).also { rewrittenModulesByName[module.name] = it }
+        }
+
+        val rewrittenModules = originalModules.map(::rewriteModule)
+
+        return TestModuleStructureImpl(
+            modules = listOf(helpersModule) + rewrittenModules,
+            originalTestDataFiles = moduleStructure.originalTestDataFiles,
+        )
+    }
+
+    /**
+     * Returns true if the given file is the synthetic ReflectionPackageName helper file produced
+     * by `ReflectionPackageNameAdditionalSourceProvider`.
+     */
+    private fun isReflectionPackageNameHelperFile(file: TestFile): Boolean {
+        if (!file.isAdditional) return false
+        // Cheap content check: helper files start with `package kotlin.internal`.
+        val content = file.originalContent
+        // Either it begins with `package kotlin.internal` (first line), or contains it as a
+        // non-commented line at the top.
+        val lineSequence = content.lineSequence()
+        val firstNonEmptyLine = lineSequence.firstOrNull { it.isNotBlank() } ?: return false
+        return firstNonEmptyLine.trim() == "package kotlin.internal" &&
+                lineSequence.any { it.contains("annotation class ReflectionPackageName") }
+    }
+}

--- a/native/native.tests/klib-compatibility/build.gradle.kts
+++ b/native/native.tests/klib-compatibility/build.gradle.kts
@@ -94,6 +94,7 @@ fun Project.customCompilerTest(
         taskName,
         allowParallelExecution = true,
         requirePlatformLibs = false,
+        enableGroupingTestEngine = true,
     ) {
         val testTargetName = providers.gradleProperty("kotlin.internal.native.test.target")
             .orElse(providers.gradleProperty("kn.target"))

--- a/native/native.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/konan/test/klib/AbstractCustomNativeCompilerFirstStageTest.kt
+++ b/native/native.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/konan/test/klib/AbstractCustomNativeCompilerFirstStageTest.kt
@@ -5,93 +5,112 @@
 
 package org.jetbrains.kotlin.konan.test.klib
 
-import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeCoreTest
+import org.jetbrains.kotlin.config.LanguageVersion
+import org.jetbrains.kotlin.konan.test.blackbox.AbstractTwoStageNativeCoreTest
+import org.jetbrains.kotlin.konan.test.blackbox.NativeGroupingTestIsolator
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives
-import org.jetbrains.kotlin.konan.test.handlers.NativeBoxRunner
+import org.jetbrains.kotlin.konan.test.configuration.commonConfigurationForNativeCodegenTest
+import org.jetbrains.kotlin.konan.test.handlers.NativeBoxRunnerGroupingStage
 import org.jetbrains.kotlin.konan.test.services.CInteropTestSkipper
 import org.jetbrains.kotlin.konan.test.services.DisabledNativeTestSkipper
 import org.jetbrains.kotlin.konan.test.services.FileCheckTestTotalSkipper
 import org.jetbrains.kotlin.konan.test.services.sourceProviders.NativeLauncherAdditionalSourceProvider
-import org.jetbrains.kotlin.platform.konan.NativePlatforms
-import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
-import org.jetbrains.kotlin.test.builders.nativeArtifactsHandlersStep
-import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
+import org.jetbrains.kotlin.konan.test.suppressors.NativeTestsSuppressor
+import org.jetbrains.kotlin.test.builders.TwoStageTestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.DIAGNOSTICS
+import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.OPT_IN
+import org.jetbrains.kotlin.test.frontend.fir.FirMetaInfoDiffSuppressor
 import org.jetbrains.kotlin.test.frontend.objcinterop.ObjCInteropFacade
 import org.jetbrains.kotlin.test.klib.CustomKlibCompilerFirstStageTestSuppressor
 import org.jetbrains.kotlin.test.klib.CustomKlibCompilerTestSuppressor
+import org.jetbrains.kotlin.test.klib.ReflectionPackageNameAdditionalSourceProvider
+import org.jetbrains.kotlin.test.klib.ReflectionPackageNameHelperModuleTransformer
 import org.jetbrains.kotlin.test.klib.setupCustomLanguageVersionForKlibCompatibilityTest
-import org.jetbrains.kotlin.test.model.DependencyKind
-import org.jetbrains.kotlin.test.model.FrontendKinds
+import org.jetbrains.kotlin.test.model.ArtifactKinds
+import org.jetbrains.kotlin.test.services.CompilationStage
 import org.jetbrains.kotlin.test.services.TargetBackendTestSkipper
 import org.jetbrains.kotlin.test.services.configuration.CommonEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.NativeFirstStageEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.NativeSecondStageEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.UnsupportedFeaturesTestConfigurator
-import org.jetbrains.kotlin.test.services.sourceProviders.AdditionalDiagnosticsSourceFilesProvider
-import org.jetbrains.kotlin.test.services.sourceProviders.CoroutineHelpersSourceFilesProvider
 import org.jetbrains.kotlin.utils.bind
 import org.junit.jupiter.api.Tag
 
 @Tag("custom-first-stage")
-open class AbstractCustomNativeCompilerFirstStageTest : AbstractNativeCoreTest() {
-    override fun configure(builder: TestConfigurationBuilder): Unit = with(builder) {
+open class AbstractCustomNativeCompilerFirstStageTest : AbstractTwoStageNativeCoreTest() {
+    override fun configure(builder: TwoStageTestConfigurationBuilder): Unit = with(builder) {
         super.configure(builder)
-        useMetaTestConfigurators(
-            ::UnsupportedFeaturesTestConfigurator,
-            ::TargetBackendTestSkipper,
-            ::DisabledNativeTestSkipper,
-            ::CInteropTestSkipper,
-            ::FileCheckTestTotalSkipper,
-        )
-        globalDefaults {
-            frontend = FrontendKinds.FIR
-            targetPlatform = NativePlatforms.unspecifiedNativePlatform
-            dependencyKind = DependencyKind.Binary
+        commonConfiguration {
+            defaultDirectives {
+                setupCustomLanguageVersionForKlibCompatibilityTest(customNativeCompilerSettings.defaultLanguageVersion)
+                OPT_IN with listOf(
+                    "kotlin.native.internal.InternalForKotlinNative",
+                    "kotlin.experimental.ExperimentalNativeApi"
+                )
+            }
+            commonConfigurationForNativeCodegenTest()
+            useMetaTestConfigurators(
+                ::UnsupportedFeaturesTestConfigurator,
+                ::TargetBackendTestSkipper,
+                ::DisabledNativeTestSkipper,
+                ::CInteropTestSkipper,
+                ::FileCheckTestTotalSkipper,
+            )
+            useFailureSuppressors(
+                ::NativeTestsSuppressor,
+            )
         }
-        defaultDirectives {
-            // We need to set the custom LV to let `UnsupportedFeaturesTestConfigurator` skip tests with
-            // the language features that are not supported in the given custom LV.
-            setupCustomLanguageVersionForKlibCompatibilityTest(customNativeCompilerSettings.defaultLanguageVersion)
 
-            // K/N does not have minimized stdlib for tests, so need to use the full stdlib
-            +WITH_STDLIB
+        nonGroupingStage {
+            useDirectives(TestDirectives)
+            useConfigurators(
+                ::CommonEnvironmentConfigurator,
+                ::NativeFirstStageEnvironmentConfigurator.bind(customNativeCompilerSettings.nativeHome),
+            )
+            useGroupingTestIsolators(::NativeGroupingTestIsolator)
+            useFailureSuppressors(
+                // Suppress all tests that have not been successfully compiled by the first stage.
+                // And the limited number of tests where KLIBs generated by a specific compiler version
+                // are known to have some problems that cause crash on the second stage.
+                ::CustomKlibCompilerFirstStageTestSuppressor.bind(customNativeCompilerSettings.defaultLanguageVersion),
+
+                // Suppress all tests that failed on the second stage if they are anyway marked as "IGNORE_BACKEND*".
+                ::CustomKlibCompilerTestSuppressor,
+                ::CustomFirstStageCInteropTestSuppressor,
+            )
+            useAdditionalSourceProviders(
+                ::NativeLauncherAdditionalSourceProvider,
+            )
+            if (customNativeCompilerSettings.defaultLanguageVersion < LanguageVersion.KOTLIN_2_5) {
+                // in 2.5.0, annotation `kotlin.internal.ReflectionPackageName` was introduced (renamed from `kotlin.native.internal.ReflectionPackageName`)
+                // so it's present in stdlib 2.5, but not in stdlib 2.4.20 and earlier
+                useAdditionalSourceProviders(::ReflectionPackageNameAdditionalSourceProvider)
+                @OptIn(org.jetbrains.kotlin.test.TestInfrastructureInternals::class)
+                useModuleStructureTransformers(ReflectionPackageNameHelperModuleTransformer)
+            }
+            forTestsNotMatching(
+                "compiler/testData/codegen/box/diagnostics/functions/tailRecursion/*" or
+                        "compiler/testData/diagnostics/*"
+            ) {
+                defaultDirectives {
+                    DIAGNOSTICS with "-warnings"
+                }
+            }
+
+            // CInterop-related tests are not that different from regular tests. That's how they work:
+            // Modules containing .def files are compiled with ObjCInteropFacade to klib artifact using the old CInterop tool.
+            // The rest of the 1st stage pipeline will be skipped naturally, since further facades don't accept klibs as input artifacts.
+            facadeStep(::ObjCInteropFacade.bind(/*isForwardTest*/false, customNativeCompilerSettings.compiler.getIsolatedClassLoader()))
+            facadeStep(::CustomNativeCompilerFirstStageFacade)
         }
 
-        useConfigurators(
-            ::CommonEnvironmentConfigurator,
-            ::NativeFirstStageEnvironmentConfigurator.bind(customNativeCompilerSettings.nativeHome),
-            ::NativeSecondStageEnvironmentConfigurator,
-        )
-        useAdditionalSourceProviders(
-            ::NativeLauncherAdditionalSourceProvider,
-            ::CoroutineHelpersSourceFilesProvider,
-            ::AdditionalDiagnosticsSourceFilesProvider,
-        )
+        groupingStage {
+            useConfigurators(::NativeSecondStageEnvironmentConfigurator)
 
-        // CInterop-related tests are not that different from regular tests. That's how they work:
-        // Modules containing .def files are compiled with ObjCInteropFacade to klib artifact using the old CInterop tool.
-        // The rest of the 1st stage pipeline will be skipped naturally, since further facades don't accept klibs as input artifacts.
-        facadeStep(::ObjCInteropFacade.bind(/*isForwardTest*/false, customNativeCompilerSettings.compiler.getIsolatedClassLoader()))
-
-        facadeStep(::CustomNativeCompilerFirstStageFacade)
-
-        useFailureSuppressors(
-            // Suppress all tests that have not been successfully compiled by the first stage.
-            // And the limited number of tests where KLIBs generated by a specific compiler version
-            // are known to have some problems that cause crash on the second stage.
-            ::CustomKlibCompilerFirstStageTestSuppressor.bind(customNativeCompilerSettings.defaultLanguageVersion),
-
-            // Suppress all tests that failed on the second stage if they are anyway marked as "IGNORE_BACKEND*".
-            ::CustomKlibCompilerTestSuppressor,
-            ::CustomFirstStageCInteropTestSuppressor,
-        )
-        useDirectives(TestDirectives)
-        facadeStep(NativeCompilerSecondStageFacade::NonGrouping.bind(
-                currentCustomNativeCompilerSettings,
-                /*isCompatibilityTesting*/ true,
-            ))
-        nativeArtifactsHandlersStep {
-            useHandlers(::NativeBoxRunner)
+            facadeStep(NativeCompilerSecondStageFacade::Grouping.bind(currentCustomNativeCompilerSettings, true))
+            handlersStep(ArtifactKinds.Native, CompilationStage.SECOND) {
+                useHandlers(::NativeBoxRunnerGroupingStage)
+            }
         }
     }
 }

--- a/native/native.tests/klib-compatibility/tests/org/jetbrains/kotlin/konan/test/klib/CustomNativeCompilerFirstStageSanity.kt
+++ b/native/native.tests/klib-compatibility/tests/org/jetbrains/kotlin/konan/test/klib/CustomNativeCompilerFirstStageSanity.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.kotlin.konan.test.klib
 
+import com.intellij.testFramework.TestDataFile
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseDummyTestCaseGroupProvider
+import org.jetbrains.kotlin.test.NonGroupingStageOutput
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -67,5 +69,43 @@ class CustomNativeCompilerFirstStageSanity : AbstractCustomNativeCompilerFirstSt
     fun checkRecompilePassed() {
         // `// RECOMPILE` test directive is unknown to Native testinfra, so it must not affect test runs
         runTest(testDataRoot + "recompile.kt")
+    }
+
+    /**
+     * Drives both compilation stages synchronously for a single test, mirroring what
+     * [CompilerTestGroupingTestEngine] does for a single-sized batch.
+     *
+     * Generated box/boxInline tests are executed by the grouping test engine via `initTestRunnerAndCreateModuleStructure`;
+     * this helper is used by the sanity tests that need to assert synchronously on the outcome of a single test.
+     */
+    private fun runTest(@TestDataFile filePath: String) {
+        initTestRunnerAndCreateModuleStructure(filePath)
+        try {
+            nonGroupingRunner.runTestPreprocessing()
+            nonGroupingRunner.runSteps()
+
+            // Report first-stage failures first (and throw on a real, non-suppressed failure). If the first stage
+            // failed or was muted/ignored, the grouping (second) stage must be skipped, exactly like the grouping
+            // test engine excludes such tests from the batch. Otherwise both stages would contribute failures and
+            // they'd be aggregated into a `MultipleFailuresError` instead of the single expected exception.
+            val hadIgnoredFailuresOnFirstStage = nonGroupingRunner.failuresInterceptor.reportFailures(checkForUnmuting = false)
+            if (hadIgnoredFailuresOnFirstStage) return
+
+            val nonGroupingStageOutput = NonGroupingStageOutput(
+                testServices = nonGroupingRunner.testServices,
+                catchingExecutor = { wrapper, block ->
+                    nonGroupingRunner.failuresInterceptor.withAssertionCatching(wrapper, block)
+                },
+            )
+            groupingStageRunner.run(listOf(nonGroupingStageOutput))
+
+            // Exceptions from grouped facades were reported to the grouping runner's failures interceptor,
+            // but failure suppressors must be run from the non-grouping runner, as they need access to the
+            // real module structure of the specific test to extract directives from there.
+            nonGroupingRunner.failuresInterceptor += groupingStageRunner.failuresInterceptor
+            nonGroupingRunner.failuresInterceptor.reportFailures(checkForUnmuting = true)
+        } finally {
+            nonGroupingRunner.finalizeAndDispose()
+        }
     }
 }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
@@ -104,7 +104,7 @@ abstract class AbstractNativeCodegenBoxCoreTest : AbstractTwoStageNativeCoreTest
         groupingStage {
             useConfigurators(::NativeSecondStageEnvironmentConfigurator)
 
-            facadeStep(NativeCompilerSecondStageFacade::Grouping.bind(currentCustomNativeCompilerSettings))
+            facadeStep(NativeCompilerSecondStageFacade::Grouping.bind(currentCustomNativeCompilerSettings, false))
             handlersStep(ArtifactKinds.Native, CompilationStage.SECOND) {
                 useHandlers(::NativeBoxRunnerGroupingStage, ::FileCheckHandler)
             }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeCompilerSecondStageFacade.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeCompilerSecondStageFacade.kt
@@ -99,7 +99,8 @@ class NativeCompilerSecondStageFacade private constructor(
 
     class Grouping(
         val testServices: TestServices,
-        private val customNativeCompilerSettings: CustomNativeCompilerSettings
+        private val customNativeCompilerSettings: CustomNativeCompilerSettings,
+        private val isCompatibilityTesting: Boolean,
     ) : AbstractGroupingStageTestFacade<GroupingStageInputArtifact, BinaryArtifacts.Native>() {
         override fun transform(inputArtifact: GroupingStageInputArtifact): BinaryArtifacts.Native {
             val servicesOfSomeModule = inputArtifact.nonGroupingStageOutputs.first().testServices
@@ -147,7 +148,7 @@ class NativeCompilerSecondStageFacade private constructor(
                 enableAssertions = AssertionsMode.ALWAYS_DISABLE !in someModule.directives[ASSERTIONS_MODE],
                 withPlatformLibs = someModule.directives.contains(WITH_PLATFORM_LIBS),
                 freeArgs = freeArgs + irCheckersArguments(someModule) + "-Xklib-duplicated-unique-name-strategy=allow-all-with-warning",
-                verifyIrMode = VerifyIrMode.ERROR,
+                verifyIrMode = if (isCompatibilityTesting) VerifyIrMode.NONE else VerifyIrMode.ERROR,
             )
 
             if (exitCode == ExitCode.OK) {

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeGroupingTestIsolator.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeGroupingTestIsolator.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.singleOrZeroValue
 import org.jetbrains.kotlin.test.model.GroupingTestIsolator
+import org.jetbrains.kotlin.test.model.TestFile
+import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestModuleStructure
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
@@ -46,7 +48,7 @@ class NativeGroupingTestIsolator(testServices: TestServices) : GroupingTestIsola
         val testRunSettings = testServices.testRunSettings
         val shouldBeIsolated = testRunSettings.testKind(moduleStructure.modules.firstOrNull()?.directives) != TestKind.REGULAR
                 || isolationDirectives.any { it in registeredDirectives }
-                || moduleStructure.sourceContains(packageKotlinInternalRegex)
+                || moduleStructure.modules.any { module -> testDataContainsKotlinInternalFQNames(module) }
                 || moduleStructure.modules.any { module -> module.files.any { it.name.endsWith(".def") } }
                 || testRunSettings.isIgnoredTarget(registeredDirectives) // considers IGNORE_BACKEND* and IGNORE_NATIVE directives
                 || testRunSettings.isDisabledNative(registeredDirectives) // considers DISABLE_NATIVE directive
@@ -81,6 +83,17 @@ class NativeGroupingTestIsolator(testServices: TestServices) : GroupingTestIsola
 
 
     private val packageKotlinInternalRegex = Regex("package\\s${StandardNames.KOTLIN_INTERNAL_FQ_NAME}")
+
+    private fun testDataContainsKotlinInternalFQNames(module: TestModule): Boolean = module.files.any { file ->
+        !isSyntheticReflectionPackageNameHelper(file) &&
+                file.originalContent.contains(packageKotlinInternalRegex)
+    }
+
+    private fun isSyntheticReflectionPackageNameHelper(file: TestFile): Boolean =
+        file.isAdditional &&
+                file.name == "ReflectionPackageName.kt" &&
+                file.originalContent.contains("package ${StandardNames.KOTLIN_INTERNAL_FQ_NAME}") &&
+                file.originalContent.contains("annotation class ReflectionPackageName")
 
     private data class FreeCompilerArgsToken(val freeArgs: Set<String>) : BatchToken()
 }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/handlers/NativeBoxRunner.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/handlers/NativeBoxRunner.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.util.TestOutputFilter
 import org.jetbrains.kotlin.konan.test.blackbox.support.util.computePackageName
 import org.jetbrains.kotlin.konan.test.blackbox.testRunSettings
 import org.jetbrains.kotlin.native.executors.Executor
-import org.jetbrains.kotlin.test.TestInfrastructureException
 import org.jetbrains.kotlin.test.WrappedException
 import org.jetbrains.kotlin.test.checkTestInfrastructure
 import org.jetbrains.kotlin.test.backend.handlers.NativeBinaryArtifactHandler
@@ -226,7 +225,7 @@ class PrettyResultsHandler(
         //   in grouped mode: `<long_test_name>.__launcher__Kt.runTest`
         @Suppress("RegExpRepeatedSpace")
         val failedRegexWithoutTCLogger = """\[  FAILED  ] (.*)__launcher__Kt.runTest""".toRegex()
-        val failedRegexWithTCLogger = """-\s+(.*)__launcher__Kt.runTest""".toRegex()
+        val failedRegexWithTCLogger = """-\s+(.*)__launcher(.*)__Kt.runTest""".toRegex()
     }
 
     override fun handle() {


### PR DESCRIPTION
^[KT-88966 Fixed](https://youtrack.jetbrains.com/issue/KT-88970) [Tests][Native] Support MPP in backward compatibility tests