### PR TITLE
[Tests] Add `TestPropertiesTest` to ensure test properties are synced

### DIFF
--- a/compiler/jklib.tests/build.gradle.kts
+++ b/compiler/jklib.tests/build.gradle.kts
@@ -1,3 +1,5 @@
+import TestCompilePaths.KOTLIN_JKLIB_STDLIB_PATH
+
 plugins {
     id("common-configuration")
     id("com.autonomousapps.dependency-analysis")
@@ -42,7 +44,7 @@ projectTests {
         defineJDKEnvVariables = listOf(JdkMajorVersion.JDK_1_8, JdkMajorVersion.JDK_11_0, JdkMajorVersion.JDK_17_0)
     ) {
         val klibProvider = objects.newInstance<SystemPropertyClasspathProvider>().apply {
-            property.set("kotlin.stdlib.jklib.for.test")
+            property.set(KOTLIN_JKLIB_STDLIB_PATH)
             classpath.from(stdlibJvmIr.elements.map { it.filter { it.asFile.name.endsWith(".klib") } })
         }
         jvmArgumentProviders.add(klibProvider)

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
@@ -22,9 +22,21 @@ object TestCompilePaths {
     const val KOTLIN_WASM_STDLIB_KLIB_PATH: String = "kotlin.wasm-js.stdlib.path"
     const val KOTLIN_JS_REDUCED_STDLIB_PATH: String = "kotlin.js.reduced.stdlib.path"
     const val KOTLIN_JS_KOTLIN_TEST_KLIB_PATH: String = "kotlin.js.kotlin.test.klib.path"
+
+    const val KOTLIN_WASM_JS_STDLIB_KLIB_PATH: String = "kotlin.wasm-js.stdlib.path"
+    const val KOTLIN_WASM_WASI_STDLIB_KLIB_PATH: String = "kotlin.wasm-wasi.stdlib.path"
+    const val KOTLIN_WASM_JS_KOTLIN_TEST_KLIB_PATH: String = "kotlin.wasm-js.kotlin.test.path"
+    const val KOTLIN_WASM_WASI_KOTLIN_TEST_KLIB_PATH: String = "kotlin.wasm-wasi.kotlin.test.path"
+
+    const val PLUGIN_SANDBOX_ANNOTATIONS_JAR_PATH: String = "firPluginAnnotations.jvm.path"
+    const val PLUGIN_SANDBOX_ANNOTATIONS_JS_KLIB_PATH: String = "firPluginAnnotations.js.path"
+    const val PLUGIN_SANDBOX_ANNOTATIONS_WASM_KLIB_PATH: String = "firPluginAnnotations.wasm.path"
+    const val PLUGIN_SANDBOX_JAR_PATH: String = "firPlugin.jar.path"
+
     const val KOTLIN_SCRIPTING_PLUGIN_CLASSPATH = "kotlin.scriptingPlugin.classpath"
     const val KOTLIN_TEST_SCRIPT_DEFINITION_CLASSPATH = "kotlin.script.test.script.definition.classpath"
     const val KOTLIN_SCRIPTING_TESTS_RUNTIME_CLASSPATH = "kotlin.scripting.tests.runtime.classpath"
+
     const val KOTLIN_DIST_PATH = "kotlin.dist.path"
     const val KOTLIN_NATIVE_IMAGE_DIST_PATH = "kotlin.native-image.dist.path"
     const val KOTLIN_NATIVE_IMAGE_RESOURCES_PATH = "kotlin.native-image.resources.path"
@@ -39,10 +51,7 @@ object TestCompilePaths {
     const val KOTLIN_THIRDPARTY_JAVA9_ANNOTATIONS_PATH = "third-party/java9-annotations"
     const val KOTLIN_THIRDPARTY_JSR305_PATH = "third-party/jsr305"
     const val KOTLIN_TESTDATA_ROOTS = "kotlin.testData.roots"
-    const val PLUGIN_SANDBOX_ANNOTATIONS_JAR_PATH: String = "firPluginAnnotations.jvm.path"
-    const val PLUGIN_SANDBOX_ANNOTATIONS_JS_KLIB_PATH: String = "firPluginAnnotations.js.path"
-    const val PLUGIN_SANDBOX_ANNOTATIONS_WASM_KLIB_PATH: String = "firPluginAnnotations.wasm.path"
-    const val PLUGIN_SANDBOX_JAR_PATH: String = "firPlugin.jar.path"
+
     const val LOMBOK_COMPILER_PLUGIN_JAR_PATH: String = "lombok.compiler.plugin.jar.path"
     const val ALLOPEN_COMPILER_PLUGIN_JAR_PATH: String = "allopen.compiler.plugin.jar.path"
     const val NOARG_COMPILER_PLUGIN_JAR_PATH: String = "noarg.compiler.plugin.jar.path"

--- a/plugins/parcelize/parcelize-compiler/build.gradle.kts
+++ b/plugins/parcelize/parcelize-compiler/build.gradle.kts
@@ -1,3 +1,4 @@
+import TestCompilePaths.PARCELIZE_COMPILER_PLUGIN_CLASSPATH
 import org.jetbrains.kotlin.build.androidsdkprovisioner.ProvisioningType
 import java.util.zip.ZipFile
 
@@ -130,7 +131,7 @@ projectTests {
             provideToThisTaskAsSystemProperty(ProvisioningType.PLATFORM_JAR)
         }
 
-        addClasspathProperty(parcelizeRuntimeForTests, "parcelizeRuntime.classpath")
+        addClasspathProperty(parcelizeRuntimeForTests, PARCELIZE_COMPILER_PLUGIN_CLASSPATH)
         addClasspathProperty(robolectricClasspath, "robolectric.classpath")
         addClasspathProperty(layoutLib, "layoutLib.path")
         addClasspathProperty(layoutLibApi, "layoutLibApi.path")

--- a/plugins/parcelize/parcelize-compiler/testFixtures/org/jetbrains/kotlin/parcelize/test/services/ParcelizeEnvironmentConfigurator.kt
+++ b/plugins/parcelize/parcelize-compiler/testFixtures/org/jetbrains/kotlin/parcelize/test/services/ParcelizeEnvironmentConfigurator.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.parcelize.test.services
 
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
+import org.jetbrains.kotlin.codegen.forTestCompile.TestCompilePaths.PARCELIZE_COMPILER_PLUGIN_CLASSPATH
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.parcelize.ParcelizeComponentRegistrar
@@ -29,7 +30,7 @@ private fun getLibraryJar(classToDetect: String): File? = try {
 class ParcelizeEnvironmentConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
     override fun configureCompilerConfiguration(configuration: CompilerConfiguration, module: TestModule) {
         if (ENABLE_PARCELIZE !in module.directives) return
-        val runtimeLibraries = System.getProperty("parcelizeRuntime.classpath")
+        val runtimeLibraries = System.getProperty(PARCELIZE_COMPILER_PLUGIN_CLASSPATH)
             .split(File.pathSeparator)
             .map { File(it) }
         val androidApiJar = KtTestUtil.findAndroidApiJar()

--- a/plugins/parcelize/parcelize-compiler/testFixtures/org/jetbrains/kotlin/parcelize/test/services/ParcelizeRuntimeClasspathProvider.kt
+++ b/plugins/parcelize/parcelize-compiler/testFixtures/org/jetbrains/kotlin/parcelize/test/services/ParcelizeRuntimeClasspathProvider.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.parcelize.test.services
 
 import org.hamcrest.BaseDescription
+import org.jetbrains.kotlin.codegen.forTestCompile.TestCompilePaths.PARCELIZE_COMPILER_PLUGIN_CLASSPATH
 import org.jetbrains.kotlin.parcelize.test.services.ParcelizeDirectives.ENABLE_PARCELIZE
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.RuntimeClasspathProvider
@@ -116,8 +117,8 @@ class ParcelizeRuntimeClasspathProvider(testServices: TestServices) : RuntimeCla
             .map { File(it) }
             .sortedBy { it.nameWithoutExtension }
 
-        val parcelizeRuntimeJars = System.getProperty("parcelizeRuntime.classpath")?.split(File.pathSeparator)?.map(::File)
-            ?: error("Unable to get a valid classpath from 'parcelizeRuntime.classpath' property")
+        val parcelizeRuntimeJars = System.getProperty(PARCELIZE_COMPILER_PLUGIN_CLASSPATH)?.split(File.pathSeparator)?.map(::File)
+            ?: error("Unable to get a valid classpath from '$PARCELIZE_COMPILER_PLUGIN_CLASSPATH' property")
 
         val tempDir = testServices.temporaryDirectoryManager.getOrCreateTempDirectory("additionalClassFiles")
         tempDir

--- a/repo/codebase-tests/tests/org/jetbrains/kotlin/code/TestPropertiesTest.kt
+++ b/repo/codebase-tests/tests/org/jetbrains/kotlin/code/TestPropertiesTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.code
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.ExperimentalKotlinTestApi
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * [TESTS_PATH] contains a `TestCompilePaths` object that declares properties used in our tests.
+ * [GRADLE_PATH] contains a `TestCompilePaths` object that exposes the same properties for the build,
+ * so one can use [GRADLE_PATH] to set the property value and [TESTS_PATH] to read it.
+ *
+ * Both of these objects should contain the same list of properties with the same values. This test ensures
+ * that they are indeed the same.
+ */
+class TestPropertiesTest {
+    companion object {
+        const val GRADLE_PATH = "repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/TestCompilePaths.kt"
+        const val TESTS_PATH =
+            "compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt"
+
+        val TEST_COMPILE_PATHS_REGEX = Regex("""object\s+TestCompilePaths\s+\{((\s*.*)*)}""")
+        val TEST_COMPILE_PATHS_PROPERTY_REGEX = Regex("""\s*const\s+val\s+([A-Z_\d]+)(\s*:\s+String)?\s*=\s*"(.*?)"\s*""")
+    }
+
+    private fun Path.extractTestCompilePathsProperties(): Map<String, String> {
+        val propertyLines = TEST_COMPILE_PATHS_REGEX.find(readText())?.groupValues?.getOrNull(1)
+            ?: fail("TestCompilePaths object not found in '$this'")
+        return propertyLines.lineSequence().mapNotNull { line ->
+            if (line.isBlank()) return@mapNotNull null
+            val property = TEST_COMPILE_PATHS_PROPERTY_REGEX.find(line)?.let { match ->
+                match.groupValues[1] to match.groupValues[3]
+            }
+            property ?: fail("'$this' contains unexpected property line: '$line'")
+        }.toMap()
+    }
+
+    @OptIn(ExperimentalKotlinTestApi::class)
+    @Test
+    fun `ensure TestCompilePaths are the same`() {
+        val gradleProperties = Path.of(GRADLE_PATH).extractTestCompilePathsProperties()
+        val codebaseProperties = Path.of(TESTS_PATH).extractTestCompilePathsProperties()
+
+        val allProperties = gradleProperties.keys.toSet() + codebaseProperties.keys.toSet()
+
+        val diff = mutableListOf<String>()
+        for (property in allProperties) {
+            val gradleValue = gradleProperties[property]
+            val codebaseValue = codebaseProperties[property]
+
+            if (gradleValue == null) {
+                diff += "`${property}` is not declared in repo/gradle-build-conventions/project-tests-convention"
+            } else if (codebaseValue == null) {
+                diff += "`${property}` is not declared in compiler/test-infrastructure-utils/testFixtures"
+            } else if (gradleValue != codebaseValue) {
+                diff += "`${property}`: values are different: \"$codebaseValue\" != \"$gradleValue\""
+            }
+        }
+        assertTrue(diff.isEmpty()) {
+            "TestCompilePaths.kt in $TESTS_PATH and $GRADLE_PATH are different:\n${diff.joinToString("\n")}"
+        }
+    }
+}

--- a/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/TestCompilePaths.kt
+++ b/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/TestCompilePaths.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-// This file is duplicated at compiler/test-infrastructure-utils/tests/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
+// This file is duplicated at compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
 object TestCompilePaths {
     const val KOTLIN_FULL_STDLIB_PATH: String = "kotlin.full.stdlib.path"
     const val KOTLIN_FULL_STDLIB_SOURCES_PATH: String = "kotlin.full.stdlib.sources.path"
@@ -17,6 +17,7 @@ object TestCompilePaths {
     const val KOTLIN_WEB_STDLIB_KLIB_PATH: String = "kotlin.web.stdlib.path"
     const val KOTLIN_JS_STDLIB_KLIB_PATH: String = "kotlin.js.stdlib.klib.path"
     const val KOTLIN_JKLIB_STDLIB_PATH: String = "kotlin.stdlib.jklib.for.test"
+    const val KOTLIN_WASM_STDLIB_KLIB_PATH: String = "kotlin.wasm-js.stdlib.path"
     const val KOTLIN_JS_REDUCED_STDLIB_PATH: String = "kotlin.js.reduced.stdlib.path"
     const val KOTLIN_JS_KOTLIN_TEST_KLIB_PATH: String = "kotlin.js.kotlin.test.klib.path"
 
@@ -54,4 +55,5 @@ object TestCompilePaths {
     const val NOARG_COMPILER_PLUGIN_JAR_PATH: String = "noarg.compiler.plugin.jar.path"
     const val MAIN_KTS_JAR_PATH: String = "main-kts.jar.path"
     const val KOTLIN_REFLECT_SHADOW_JAR_PATH: String = "kotlin.reflect.shadow.jar.path"
+    const val PARCELIZE_COMPILER_PLUGIN_CLASSPATH: String = "parcelizeRuntime.classpath"
 }

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/ModulesPrecompile.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/ModulesPrecompile.kt
@@ -15,6 +15,8 @@ import org.jetbrains.kotlin.cli.create
 import org.jetbrains.kotlin.cli.pipeline.ConfigurationPipelineArtifact
 import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmIrLoadingPipelinePhase
 import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmSingleModuleBackendPipelinePhase
+import org.jetbrains.kotlin.codegen.forTestCompile.TestCompilePaths.KOTLIN_WASM_JS_KOTLIN_TEST_KLIB_PATH
+import org.jetbrains.kotlin.codegen.forTestCompile.TestCompilePaths.KOTLIN_WASM_JS_STDLIB_KLIB_PATH
 import org.jetbrains.kotlin.config.AnalysisFlags.allowFullyQualifiedNameInKClass
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.languageVersionSettings
@@ -29,9 +31,9 @@ import java.io.File
 private val outputDir: File
     get() = File(System.getProperty("kotlin.wasm.test.root.out.dir") ?: testInfraError("Please set output dir path"))
 private val stdlibPath =
-    File(System.getProperty("kotlin.wasm-js.stdlib.path") ?: testInfraError("Please set stdlib path")).canonicalPath
+    File(System.getProperty(KOTLIN_WASM_JS_STDLIB_KLIB_PATH) ?: testInfraError("Please set stdlib path")).canonicalPath
 private val kotlinTestPath =
-    File(System.getProperty("kotlin.wasm-js.kotlin.test.path") ?: testInfraError("Please set kotlin-test path")).canonicalPath
+    File(System.getProperty(KOTLIN_WASM_JS_KOTLIN_TEST_KLIB_PATH) ?: testInfraError("Please set kotlin-test path")).canonicalPath
 
 const val precompiledStdlibOutputName: String = "kotlin-kotlin-stdlib"
 const val precompiledKotlinTestOutputName: String = "kotlin-kotlin-test"


### PR DESCRIPTION
`TestCompilePaths.kt` in compiler/test-infrastructure-utils/testFixtures declares a list of properties used by our tests. `TestCompilePaths.kt` in repo/gradle-build-conventions/project-tests-convention exposes the same  properties for the build. In theory, their contents should be the same. In practice, this was never enforced before.

* This commit adds a new test that ensures that the declared properties and their values are the same in both files
* This commit also fixes the existing divergence in the two properties files