### PR TITLE
Reflection: fix annotations on `@JvmStatic` function parameters

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/annotations/jvmStatic.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/annotations/jvmStatic.kt
@@ -1,0 +1,39 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+
+package test
+
+import kotlin.reflect.KCallable
+import kotlin.test.assertEquals
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class Ann(val who: String)
+
+object O {
+    fun f(@Ann("on-x") x: Int, @Ann("on-y") y: String) {}
+
+    @JvmStatic
+    fun g(@Ann("on-x") x: Int, @Ann("on-y") y: String) {}
+}
+
+class C {
+    companion object {
+        fun v(@Ann("on-x") x: Int, @Ann("on-y") y: String) {}
+
+        @JvmStatic
+        fun w(@Ann("on-x") x: Int, @Ann("on-y") y: String) {}
+    }
+}
+
+private fun check(expected: String, unbound: KCallable<*>, bound: KCallable<*>) {
+    assertEquals(expected, unbound.parameters.map { it.annotations.map { (it as Ann).who } }.joinToString())
+    assertEquals(expected.substringAfter(", "), bound.parameters.map { it.annotations.map { (it as Ann).who } }.joinToString())
+}
+
+fun box(): String {
+    check("[], [on-x], [on-y]", O::class.members.single { it.name == "f" }, O::f)
+    check("[], [on-x], [on-y]", O::class.members.single { it.name == "g" }, O::g)
+    check("[], [on-x], [on-y]", C.Companion::class.members.single { it.name == "v" }, C.Companion::v)
+    check("[], [on-x], [on-y]", C.Companion::class.members.single { it.name == "w" }, C.Companion::w)
+    return "OK"
+}

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectKParameter.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectKParameter.kt
@@ -9,13 +9,13 @@ import org.jetbrains.kotlin.descriptors.runtime.structure.safeClassLoader
 import java.lang.reflect.Constructor
 import java.lang.reflect.Member
 import java.lang.reflect.Method
-import java.lang.reflect.Modifier
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.full.createDefaultType
+import kotlin.reflect.full.instanceParameter
 
 internal abstract class ReflectKParameter : KParameter {
     abstract val callable: ReflectKCallable<*>
@@ -94,23 +94,23 @@ internal class DefaultSetterValueParameter(private val property: ReflectKPropert
 internal class JavaParameter(val callable: Member, val index: Int)
 
 internal val ReflectKParameter.javaParameter: JavaParameter?
-    get() = when (val callable = callable.caller.member) {
+    get() = when (val member = callable.caller.member) {
         is Method -> {
-            JavaParameter(callable, index + (if (Modifier.isStatic(callable.modifiers)) 0 else -1))
+            JavaParameter(member, index + (if (callable.instanceParameter == null) 0 else -1))
         }
         is Constructor<*> -> {
             val shift = when {
                 // Inner class constructors before JDK 9 did not have the outer class parameter in `parameterAnnotations`, see
                 // https://bugs.java.com/bugdatabase/view_bug?bug_id=8074977.
-                callable.declaringClass.kotlin.isInner && isJdk8() -> -1
+                member.declaringClass.kotlin.isInner && isJdk8() -> -1
                 // Enum constructors before JDK 17 did not have additional name/ordinal parameters in case there was at least one annotation
                 // on any constructor parameter. (Probably some fixed bug in the JDK as well.)
-                callable.declaringClass.isEnum -> callable.parameterAnnotations.size - callable.parameterTypes.size + 2
+                member.declaringClass.isEnum -> member.parameterAnnotations.size - member.parameterTypes.size + 2
                 else -> 0
             }
-            JavaParameter(callable, index + shift)
+            JavaParameter(member, index + shift)
         }
-        else -> throw KotlinReflectionInternalError("Unsupported parameter owner: $callable")
+        else -> throw KotlinReflectionInternalError("Unsupported parameter owner: $member")
     }
 
 private fun isJdk8(): Boolean =


### PR DESCRIPTION
`@JvmStatic` function in object still has an instance receiver in `parameters`, even though the underlying Java reflection object is static.

 #KT-88939 Fixed