### PR TITLE
Introduce 'possibleSmartCasts' in 'KaScopeContext'

### DIFF
--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirScopeProvider.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirScopeProvider.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.analysis.api.internals.KaInternalsScopeProvider
 import org.jetbrains.kotlin.analysis.api.lifetime.withValidityAssertion
 import org.jetbrains.kotlin.analysis.api.scopes.KaScope
 import org.jetbrains.kotlin.analysis.api.scopes.KaTypeScope
+import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaFileSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPackageSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KaDeclarationContainerSymbol
@@ -41,6 +42,7 @@ import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
 import org.jetbrains.kotlin.fir.resolve.ScopeSession
 import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticPropertiesScope
 import org.jetbrains.kotlin.fir.resolve.calls.referencedMemberSymbol
+import org.jetbrains.kotlin.fir.resolve.dfa.RealVariable
 import org.jetbrains.kotlin.fir.resolve.scope
 import org.jetbrains.kotlin.fir.resolve.scopeSessionKey
 import org.jetbrains.kotlin.fir.scopes.*
@@ -49,11 +51,13 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.fir.symbols.lazyResolveToPhaseWithCallableMembers
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.isSubtypeOf
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.types.SmartcastStability
 import org.jetbrains.kotlin.utils.exceptions.errorWithAttachment
 import org.jetbrains.kotlin.utils.exceptions.withPsiEntry
 
@@ -294,7 +298,13 @@ internal class KaFirScopeProvider(
             val firImportingScopesIndexed = firImportingScopes.asReversed().withIndex()
 
             val ktScopesWithKinds = createScopesWithKind(firImportingScopesIndexed)
-            return KaBaseScopeContext(ktScopesWithKinds, implicitValues = emptyList(), token)
+
+            return KaBaseScopeContext(
+                scopes = ktScopesWithKinds,
+                implicitValues = emptyList(),
+                possibleSmartCasts = emptyList(),
+                token
+            )
         }
 
     // Do not check the file's psi validity as it is not used
@@ -355,9 +365,43 @@ internal class KaFirScopeProvider(
                 .flatMap { flattenFirScope(it) }
             availableScopes.map { IndexedValue(index, it) }
         }
-        val ktScopesWithKinds = createScopesWithKind(firScopes)
 
-        return KaBaseScopeContext(ktScopesWithKinds, implicitValues, token)
+        return KaBaseScopeContext(
+            scopes = createScopesWithKind(firScopes),
+            implicitValues = implicitValues,
+            possibleSmartCasts = computeSmartCastPossibilities(context),
+            token = token
+        )
+    }
+
+    private fun computeSmartCastPossibilities(context: ContextCollector.Context): List<KaSmartCastPossibility> {
+        return context.smartCasts.mapNotNull { smartCast ->
+            val source = computeSmartCastSource(smartCast.realVariable) ?: return@mapNotNull null
+
+            // 'upperTypes' may contain types to which the variable already conforms, such as 'Any' for a variable of a non-nullable type.
+            // Such types can never produce an actual smart cast, so they are filtered out.
+            val originalType = smartCast.realVariable.originalType
+            val narrowingTypes = smartCast.upperTypes.filterNot { originalType.isSubtypeOf(it, analysisSession.firSession) }
+            if (narrowingTypes.isEmpty()) {
+                return@mapNotNull null
+            }
+
+            KaBaseSmartCastPossibility(
+                source = source,
+                smartCastTypes = narrowingTypes.map { firSymbolBuilder.typeBuilder.buildKtType(it) },
+                isStable = smartCast.stability == SmartcastStability.STABLE_VALUE
+            )
+        }
+    }
+
+    private fun computeSmartCastSource(realVariable: RealVariable): KaSmartCastSource? {
+        val symbol = firSymbolBuilder.buildSymbol(realVariable.symbol) as? KaDeclarationSymbol ?: return null
+        return KaBaseSmartCastSource(
+            symbol = symbol,
+            dispatchReceiver = realVariable.dispatchReceiver?.let(::computeSmartCastSource),
+            extensionReceiver = realVariable.extensionReceiver?.let(::computeSmartCastSource),
+            originalType = firSymbolBuilder.typeBuilder.buildKtType(realVariable.originalType),
+        )
     }
 
     private fun createScopesWithKind(firScopes: Iterable<IndexedValue<FirScope>>): List<KaScopeWithKind> {

--- a/analysis/analysis-api-fir/tests-gen/org/jetbrains/kotlin/analysis/api/fir/test/cases/generated/cases/components/scopeProvider/FirIdeDependentAnalysisSourceLikeModuleScopeContextForPositionTestGenerated.java
+++ b/analysis/analysis-api-fir/tests-gen/org/jetbrains/kotlin/analysis/api/fir/test/cases/generated/cases/components/scopeProvider/FirIdeDependentAnalysisSourceLikeModuleScopeContextForPositionTestGenerated.java
@@ -533,6 +533,158 @@ public class FirIdeDependentAnalysisSourceLikeModuleScopeContextForPositionTestG
   }
 
   @Nested
+  @TestMetadata("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts")
+  @TestDataPath("$PROJECT_ROOT")
+  public class SmartCasts {
+    private void run(String fileName) {
+      runTest("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInSmartCasts() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts"), Pattern.compile("^(.+)\\.(kt|kts)$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("bound.kt")
+    public void testBound() {
+      run("bound.kt");
+    }
+
+    @Test
+    @TestMetadata("breakFromInfiniteLoop.kt")
+    public void testBreakFromInfiniteLoop() {
+      run("breakFromInfiniteLoop.kt");
+    }
+
+    @Test
+    @TestMetadata("directSink.kt")
+    public void testDirectSink() {
+      run("directSink.kt");
+    }
+
+    @Test
+    @TestMetadata("directSinkBad.kt")
+    public void testDirectSinkBad() {
+      run("directSinkBad.kt");
+    }
+
+    @Test
+    @TestMetadata("directSinkBad_callsInPlace.kt")
+    public void testDirectSinkBad_callsInPlace() {
+      run("directSinkBad_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("directSink_callsInPlace.kt")
+    public void testDirectSink_callsInPlace() {
+      run("directSink_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("doWhile.kt")
+    public void testDoWhile() {
+      run("doWhile.kt");
+    }
+
+    @Test
+    @TestMetadata("doWhile2.kt")
+    public void testDoWhile2() {
+      run("doWhile2.kt");
+    }
+
+    @Test
+    @TestMetadata("localVariable.kt")
+    public void testLocalVariable() {
+      run("localVariable.kt");
+    }
+
+    @Test
+    @TestMetadata("localVariableMutable.kt")
+    public void testLocalVariableMutable() {
+      run("localVariableMutable.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSink.kt")
+    public void testNestedSink() {
+      run("nestedSink.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad.kt")
+    public void testNestedSinkBad() {
+      run("nestedSinkBad.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad2.kt")
+    public void testNestedSinkBad2() {
+      run("nestedSinkBad2.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad2_callsInPlace.kt")
+    public void testNestedSinkBad2_callsInPlace() {
+      run("nestedSinkBad2_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad_callsInPlace.kt")
+    public void testNestedSinkBad_callsInPlace() {
+      run("nestedSinkBad_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSink_callsInPlace.kt")
+    public void testNestedSink_callsInPlace() {
+      run("nestedSink_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("noSmartCastInInference.kt")
+    public void testNoSmartCastInInference() {
+      run("noSmartCastInInference.kt");
+    }
+
+    @Test
+    @TestMetadata("parameterSimple.kt")
+    public void testParameterSimple() {
+      run("parameterSimple.kt");
+    }
+
+    @Test
+    @TestMetadata("qualifiedReference.kt")
+    public void testQualifiedReference() {
+      run("qualifiedReference.kt");
+    }
+
+    @Test
+    @TestMetadata("qualifiedReferenceNested.kt")
+    public void testQualifiedReferenceNested() {
+      run("qualifiedReferenceNested.kt");
+    }
+
+    @Test
+    @TestMetadata("smartCastInInference.kt")
+    public void testSmartCastInInference() {
+      run("smartCastInInference.kt");
+    }
+
+    @Test
+    @TestMetadata("thisDispatch.kt")
+    public void testThisDispatch() {
+      run("thisDispatch.kt");
+    }
+
+    @Test
+    @TestMetadata("thisExtension.kt")
+    public void testThisExtension() {
+      run("thisExtension.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/withTestCompilerPluginEnabled")
   @TestDataPath("$PROJECT_ROOT")
   public class WithTestCompilerPluginEnabled {

--- a/analysis/analysis-api-fir/tests-gen/org/jetbrains/kotlin/analysis/api/fir/test/cases/generated/cases/components/scopeProvider/FirIdeNormalAnalysisSourceLikeModuleScopeContextForPositionTestGenerated.java
+++ b/analysis/analysis-api-fir/tests-gen/org/jetbrains/kotlin/analysis/api/fir/test/cases/generated/cases/components/scopeProvider/FirIdeNormalAnalysisSourceLikeModuleScopeContextForPositionTestGenerated.java
@@ -533,6 +533,158 @@ public class FirIdeNormalAnalysisSourceLikeModuleScopeContextForPositionTestGene
   }
 
   @Nested
+  @TestMetadata("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts")
+  @TestDataPath("$PROJECT_ROOT")
+  public class SmartCasts {
+    private void run(String fileName) {
+      runTest("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInSmartCasts() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts"), Pattern.compile("^(.+)\\.(kt|kts)$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("bound.kt")
+    public void testBound() {
+      run("bound.kt");
+    }
+
+    @Test
+    @TestMetadata("breakFromInfiniteLoop.kt")
+    public void testBreakFromInfiniteLoop() {
+      run("breakFromInfiniteLoop.kt");
+    }
+
+    @Test
+    @TestMetadata("directSink.kt")
+    public void testDirectSink() {
+      run("directSink.kt");
+    }
+
+    @Test
+    @TestMetadata("directSinkBad.kt")
+    public void testDirectSinkBad() {
+      run("directSinkBad.kt");
+    }
+
+    @Test
+    @TestMetadata("directSinkBad_callsInPlace.kt")
+    public void testDirectSinkBad_callsInPlace() {
+      run("directSinkBad_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("directSink_callsInPlace.kt")
+    public void testDirectSink_callsInPlace() {
+      run("directSink_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("doWhile.kt")
+    public void testDoWhile() {
+      run("doWhile.kt");
+    }
+
+    @Test
+    @TestMetadata("doWhile2.kt")
+    public void testDoWhile2() {
+      run("doWhile2.kt");
+    }
+
+    @Test
+    @TestMetadata("localVariable.kt")
+    public void testLocalVariable() {
+      run("localVariable.kt");
+    }
+
+    @Test
+    @TestMetadata("localVariableMutable.kt")
+    public void testLocalVariableMutable() {
+      run("localVariableMutable.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSink.kt")
+    public void testNestedSink() {
+      run("nestedSink.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad.kt")
+    public void testNestedSinkBad() {
+      run("nestedSinkBad.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad2.kt")
+    public void testNestedSinkBad2() {
+      run("nestedSinkBad2.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad2_callsInPlace.kt")
+    public void testNestedSinkBad2_callsInPlace() {
+      run("nestedSinkBad2_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad_callsInPlace.kt")
+    public void testNestedSinkBad_callsInPlace() {
+      run("nestedSinkBad_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSink_callsInPlace.kt")
+    public void testNestedSink_callsInPlace() {
+      run("nestedSink_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("noSmartCastInInference.kt")
+    public void testNoSmartCastInInference() {
+      run("noSmartCastInInference.kt");
+    }
+
+    @Test
+    @TestMetadata("parameterSimple.kt")
+    public void testParameterSimple() {
+      run("parameterSimple.kt");
+    }
+
+    @Test
+    @TestMetadata("qualifiedReference.kt")
+    public void testQualifiedReference() {
+      run("qualifiedReference.kt");
+    }
+
+    @Test
+    @TestMetadata("qualifiedReferenceNested.kt")
+    public void testQualifiedReferenceNested() {
+      run("qualifiedReferenceNested.kt");
+    }
+
+    @Test
+    @TestMetadata("smartCastInInference.kt")
+    public void testSmartCastInInference() {
+      run("smartCastInInference.kt");
+    }
+
+    @Test
+    @TestMetadata("thisDispatch.kt")
+    public void testThisDispatch() {
+      run("thisDispatch.kt");
+    }
+
+    @Test
+    @TestMetadata("thisExtension.kt")
+    public void testThisExtension() {
+      run("thisExtension.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/withTestCompilerPluginEnabled")
   @TestDataPath("$PROJECT_ROOT")
   public class WithTestCompilerPluginEnabled {

--- a/analysis/analysis-api-impl-base/src/org/jetbrains/kotlin/analysis/api/impl/base/components/KaBaseScopeProvider.kt
+++ b/analysis/analysis-api-impl-base/src/org/jetbrains/kotlin/analysis/api/impl/base/components/KaBaseScopeProvider.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.analysis.api.components.*
 import org.jetbrains.kotlin.analysis.api.lifetime.KaLifetimeToken
 import org.jetbrains.kotlin.analysis.api.lifetime.withValidityAssertion
 import org.jetbrains.kotlin.analysis.api.symbols.KaContextParameterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaType
 
@@ -17,13 +18,53 @@ import org.jetbrains.kotlin.analysis.api.types.KaType
 class KaBaseScopeContext(
     scopes: List<KaScopeWithKind>,
     implicitValues: List<KaScopeImplicitValue>,
+    possibleSmartCasts: List<KaSmartCastPossibility>,
     override val token: KaLifetimeToken,
 ) : KaScopeContext {
     private val backingImplicitValues: List<KaScopeImplicitValue> = implicitValues
     private val backingScopes: List<KaScopeWithKind> = scopes
+    private val backingPossibleSmartCasts: List<KaSmartCastPossibility> = possibleSmartCasts
 
     override val implicitValues: List<KaScopeImplicitValue> get() = withValidityAssertion { backingImplicitValues }
     override val scopes: List<KaScopeWithKind> get() = withValidityAssertion { backingScopes }
+    override val possibleSmartCasts: List<KaSmartCastPossibility> get() = withValidityAssertion { backingPossibleSmartCasts }
+}
+
+@KaImplementationDetail
+class KaBaseSmartCastPossibility(
+    source: KaSmartCastSource,
+    smartCastTypes: List<KaType>,
+    isStable: Boolean
+) : KaSmartCastPossibility {
+    private val backingSource: KaSmartCastSource = source
+    private val backingSmartCastTypes: List<KaType> = smartCastTypes
+    private val backingIsStable: Boolean = isStable
+
+    override val token: KaLifetimeToken get() = backingSource.token
+
+    override val source: KaSmartCastSource get() = withValidityAssertion { backingSource }
+    override val smartCastTypes: List<KaType> get() = withValidityAssertion { backingSmartCastTypes }
+    override val isStable: Boolean get() = withValidityAssertion { backingIsStable }
+}
+
+@KaImplementationDetail
+class KaBaseSmartCastSource(
+    symbol: KaDeclarationSymbol,
+    dispatchReceiver: KaSmartCastSource?,
+    extensionReceiver: KaSmartCastSource?,
+    originalType: KaType,
+) : KaSmartCastSource {
+    private val backingSymbol: KaDeclarationSymbol = symbol
+    private val backingDispatchReceiver: KaSmartCastSource? = dispatchReceiver
+    private val backingExtensionReceiver: KaSmartCastSource? = extensionReceiver
+    private val backingOriginalType: KaType = originalType
+
+    override val token: KaLifetimeToken get() = backingSymbol.token
+
+    override val symbol: KaDeclarationSymbol get() = withValidityAssertion { backingSymbol }
+    override val dispatchReceiver: KaSmartCastSource? get() = withValidityAssertion { backingDispatchReceiver }
+    override val extensionReceiver: KaSmartCastSource? get() = withValidityAssertion { backingExtensionReceiver }
+    override val originalType: KaType get() = withValidityAssertion { backingOriginalType }
 }
 
 @KaImplementationDetail

--- a/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/components/scopeProvider/AbstractScopeContextForPositionTest.kt
+++ b/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/components/scopeProvider/AbstractScopeContextForPositionTest.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.test.services.assertions
 
 abstract class AbstractScopeContextForPositionTest : AbstractAnalysisApiBasedTest() {
     override fun doTestByMainFile(mainFile: KtFile, mainModule: KtTestModule, testServices: TestServices) {
-        val element = testServices.expressionMarkerProvider.getTopmostSelectedElementOfType<KtElement>(mainFile)
+        val element = testServices.expressionMarkerProvider.getBottommostSelectedElementOfType<KtElement>(mainFile)
 
         copyAwareAnalyzeForTest(element) { contextElement ->
             val scopeContext = mainFile.scopeContext(contextElement)

--- a/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/components/scopeProvider/TestScopeRenderer.kt
+++ b/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/components/scopeProvider/TestScopeRenderer.kt
@@ -67,7 +67,42 @@ internal object TestScopeRenderer {
                 withIndent {
                     renderScopeContext(scopeContext, printer, printPretty, fullyPrintScope)
                 }
+
+                if (scopeContext.possibleSmartCasts.isNotEmpty()) {
+                    appendLine("possible smart casts:")
+                    withIndent {
+                        printCollection(scopeContext.possibleSmartCasts, separator = "\n\n") { smartCast ->
+                            appendSmartCastSource(KaSmartCastPossibility::source.name, smartCast.source, printer)
+                            append(KaSmartCastPossibility::isStable.name).append(" = ").append(smartCast.isStable.toString()).appendLine()
+                            append(KaSmartCastPossibility::smartCastTypes.name).appendLine(":")
+                            printCollection(smartCast.smartCastTypes, separator = "\n") { type ->
+                                withIndent {
+                                    append(renderType(type, printPretty))
+                                }
+                            }
+                        }
+                    }
+                }
             }
+        }
+    }
+
+    context(_: KaSession)
+    private fun appendSmartCastSource(propertyName: String, source: KaSmartCastSource, printer: PrettyPrinter): Unit = with(printer) {
+        append(propertyName).appendLine(":")
+        withIndent {
+            appendSymbol(KaSmartCastSource::symbol.name, printer, source.symbol)
+            appendLine()
+            source.dispatchReceiver?.let { dispatchReceiver ->
+                withIndent { appendSmartCastSource(KaSmartCastSource::dispatchReceiver.name, dispatchReceiver, printer) }
+            }
+            source.extensionReceiver?.let { extensionReceiver ->
+                withIndent { appendSmartCastSource(KaSmartCastSource::extensionReceiver.name, extensionReceiver, printer) }
+            }
+            append(KaSmartCastSource::originalType.name)
+                .append(" = ")
+                .append(renderType(source.originalType, printPretty = true))
+                .appendLine()
         }
     }
 

--- a/analysis/analysis-api-standalone/tests-gen/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/generated/cases/components/scopeProvider/FirStandaloneNormalAnalysisSourceModuleScopeContextForPositionTestGenerated.java
+++ b/analysis/analysis-api-standalone/tests-gen/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/generated/cases/components/scopeProvider/FirStandaloneNormalAnalysisSourceModuleScopeContextForPositionTestGenerated.java
@@ -533,6 +533,158 @@ public class FirStandaloneNormalAnalysisSourceModuleScopeContextForPositionTestG
   }
 
   @Nested
+  @TestMetadata("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts")
+  @TestDataPath("$PROJECT_ROOT")
+  public class SmartCasts {
+    private void run(String fileName) {
+      runTest("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInSmartCasts() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts"), Pattern.compile("^(.+)\\.(kt)$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("bound.kt")
+    public void testBound() {
+      run("bound.kt");
+    }
+
+    @Test
+    @TestMetadata("breakFromInfiniteLoop.kt")
+    public void testBreakFromInfiniteLoop() {
+      run("breakFromInfiniteLoop.kt");
+    }
+
+    @Test
+    @TestMetadata("directSink.kt")
+    public void testDirectSink() {
+      run("directSink.kt");
+    }
+
+    @Test
+    @TestMetadata("directSinkBad.kt")
+    public void testDirectSinkBad() {
+      run("directSinkBad.kt");
+    }
+
+    @Test
+    @TestMetadata("directSinkBad_callsInPlace.kt")
+    public void testDirectSinkBad_callsInPlace() {
+      run("directSinkBad_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("directSink_callsInPlace.kt")
+    public void testDirectSink_callsInPlace() {
+      run("directSink_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("doWhile.kt")
+    public void testDoWhile() {
+      run("doWhile.kt");
+    }
+
+    @Test
+    @TestMetadata("doWhile2.kt")
+    public void testDoWhile2() {
+      run("doWhile2.kt");
+    }
+
+    @Test
+    @TestMetadata("localVariable.kt")
+    public void testLocalVariable() {
+      run("localVariable.kt");
+    }
+
+    @Test
+    @TestMetadata("localVariableMutable.kt")
+    public void testLocalVariableMutable() {
+      run("localVariableMutable.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSink.kt")
+    public void testNestedSink() {
+      run("nestedSink.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad.kt")
+    public void testNestedSinkBad() {
+      run("nestedSinkBad.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad2.kt")
+    public void testNestedSinkBad2() {
+      run("nestedSinkBad2.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad2_callsInPlace.kt")
+    public void testNestedSinkBad2_callsInPlace() {
+      run("nestedSinkBad2_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSinkBad_callsInPlace.kt")
+    public void testNestedSinkBad_callsInPlace() {
+      run("nestedSinkBad_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("nestedSink_callsInPlace.kt")
+    public void testNestedSink_callsInPlace() {
+      run("nestedSink_callsInPlace.kt");
+    }
+
+    @Test
+    @TestMetadata("noSmartCastInInference.kt")
+    public void testNoSmartCastInInference() {
+      run("noSmartCastInInference.kt");
+    }
+
+    @Test
+    @TestMetadata("parameterSimple.kt")
+    public void testParameterSimple() {
+      run("parameterSimple.kt");
+    }
+
+    @Test
+    @TestMetadata("qualifiedReference.kt")
+    public void testQualifiedReference() {
+      run("qualifiedReference.kt");
+    }
+
+    @Test
+    @TestMetadata("qualifiedReferenceNested.kt")
+    public void testQualifiedReferenceNested() {
+      run("qualifiedReferenceNested.kt");
+    }
+
+    @Test
+    @TestMetadata("smartCastInInference.kt")
+    public void testSmartCastInInference() {
+      run("smartCastInInference.kt");
+    }
+
+    @Test
+    @TestMetadata("thisDispatch.kt")
+    public void testThisDispatch() {
+      run("thisDispatch.kt");
+    }
+
+    @Test
+    @TestMetadata("thisExtension.kt")
+    public void testThisExtension() {
+      run("thisExtension.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/withTestCompilerPluginEnabled")
   @TestDataPath("$PROJECT_ROOT")
   public class WithTestCompilerPluginEnabled {

--- a/analysis/analysis-api/api/analysis-api.legacy-surface
+++ b/analysis/analysis-api/api/analysis-api.legacy-surface
@@ -270,6 +270,7 @@ org.jetbrains.kotlin.analysis.api.components.KaReturnValueStatus.toString()
 org.jetbrains.kotlin.analysis.api.components.KaScopeContext
 org.jetbrains.kotlin.analysis.api.components.KaScopeContext.implicitReceivers
 org.jetbrains.kotlin.analysis.api.components.KaScopeContext.implicitValues
+org.jetbrains.kotlin.analysis.api.components.KaScopeContext.possibleSmartCasts
 org.jetbrains.kotlin.analysis.api.components.KaScopeContext.scopes
 org.jetbrains.kotlin.analysis.api.components.KaScopeImplicitArgumentValue
 org.jetbrains.kotlin.analysis.api.components.KaScopeImplicitArgumentValue.symbol
@@ -341,6 +342,15 @@ org.jetbrains.kotlin.analysis.api.components.KaSmartCastInfo
 org.jetbrains.kotlin.analysis.api.components.KaSmartCastInfo.isStable
 org.jetbrains.kotlin.analysis.api.components.KaSmartCastInfo.originalType
 org.jetbrains.kotlin.analysis.api.components.KaSmartCastInfo.smartCastType
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastPossibility
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastPossibility.isStable
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastPossibility.smartCastTypes
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastPossibility.source
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastSource
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastSource.dispatchReceiver
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastSource.extensionReceiver
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastSource.originalType
+org.jetbrains.kotlin.analysis.api.components.KaSmartCastSource.symbol
 org.jetbrains.kotlin.analysis.api.components.KaSourceProvider
 org.jetbrains.kotlin.analysis.api.components.KaSourceProvider.klibSourceFileName
 org.jetbrains.kotlin.analysis.api.components.KaStandardTypeClassIds

--- a/analysis/analysis-api/api/analysis-api.non-migrated-legacy-api
+++ b/analysis/analysis-api/api/analysis-api.non-migrated-legacy-api
@@ -22,6 +22,8 @@ KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.KaScopeKind
 KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.KaScopeKinds
 KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.KaScopeWithKind
 KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.KaScopeWithKindImpl
+KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.KaSmartCastPossibility
+KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.KaSmartCastSource
 KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.compositeScope((KaScopeKind) -> Boolean)
 KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.importingScopeContext
 KaScopeProvider: org.jetbrains.kotlin.analysis.api.components.scopeContext(KtElement)

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KaScopeProvider.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/components/KaScopeProvider.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.analysis.api.lifetime.withValidityAssertion
 import org.jetbrains.kotlin.analysis.api.scopes.KaScope
 import org.jetbrains.kotlin.analysis.api.scopes.KaTypeScope
 import org.jetbrains.kotlin.analysis.api.symbols.KaContextParameterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaFileSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPackageSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
@@ -302,6 +303,129 @@ public interface KaScopeContext : KaLifetimeOwner {
      * The list is sorted according to the order of scopes in the scope tower (from innermost to outermost).
      */
     public val scopes: List<KaScopeWithKind>
+
+    /**
+     * The list of smart casts available at the context position.
+     *
+     * Note that an actual smart cast will only appear if the original expression type does not match the expected type.
+     * For actual smart cast application, check [KaDataFlowProvider.smartCastInfo].
+     *
+     * The list has an arbitrary (but stable) order.
+     */
+    @KaExperimentalApi
+    public val possibleSmartCasts: List<KaSmartCastPossibility>
+}
+
+/**
+ * Represents a possible smart cast at a fixed context position.
+ *
+ * The word "possible" means that the compiler is allowed to produce smart casts for the [source] expression if there is a need to do so.
+ * Note that unless [isStable] is set, the smart cast will not be applied. In addition, the `SMARTCAST_IMPOSSIBLE` error is issued
+ * in certain cases.
+ */
+@KaExperimentalApi
+@SubclassOptInRequired(KaImplementationDetail::class)
+public interface KaSmartCastPossibility : KaLifetimeOwner {
+    /**
+     * A declaration to whose references a smart cast may be applied (if [isStable] is `true`).
+     */
+    public val source: KaSmartCastSource
+
+    /**
+     * Types that [source] may be automatically cast to.
+     */
+    public val smartCastTypes: List<KaType>
+
+    /**
+     * Whether the smart cast [source] is stable at the context position.
+     *
+     * The same [source] can have different smart cast stability depending on the context position.
+     * For example, in the code snippet below, a smart cast will be applied to the first usage of `value`. However, after the conditional
+     * expression, the compiler is not sure anymore that `value` is still set, so a compilation error is reported.
+     *
+     * ```
+     * fun test() {
+     *     var value: String? = System.getProperty("some.property")
+     *     if (value == null) {
+     *         return
+     *     }
+     *
+     *     value.length  // Smart cast is applied
+     *
+     *     if (Random.nextBoolean()) {
+     *         value = null
+     *     }
+     *
+     *     value.length  // UNSAFE_CALL
+     * }
+     * ```
+     *
+     * For more information on smart cast stability, check the Kotlin specification:
+     * [Smart cast sink stability](https://kotlinlang.org/spec/type-inference.html#smart-cast-sink-stability).
+     */
+    public val isStable: Boolean
+}
+
+/**
+ * Either a symbol for which a smart cast is generated, or one of its receivers.
+ */
+@KaExperimentalApi
+@SubclassOptInRequired(KaImplementationDetail::class)
+public interface KaSmartCastSource : KaLifetimeOwner {
+    /**
+     * A declaration participating in the smart cast path.
+     *
+     * Smart casts to the same declaration can be allowed or prohibited, depending on how that declaration is accessed.
+     * In the following example, the [symbol] will be `val value: Any`. However, a smart cast will only be produced for `a.value`.
+     *
+     * ```
+     * class Holder(val value: Any)
+     *
+     * fun test(a: Holder, b: Holder) {
+     *     if (a.value is String) {
+     *         a.value.length  // OK
+     *         b.value.length  // compilation error
+     *     }
+     * }
+     * ```
+     *
+     * For `a.value` from the example above, a [KaSmartCastSource] is generated whose [symbol] points to `val value: Any` (a property),
+     * and whose [dispatchReceiver] is the `a: Holder` value parameter.
+     *
+     * For `this`, the [symbol] may be either a [org.jetbrains.kotlin.analysis.api.symbols.KaReceiverParameterSymbol] (for an extension
+     * receiver parameter) or a [org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol] (if the cast occurs right inside a class).
+     */
+    public val symbol: KaDeclarationSymbol
+
+    /**
+     * The required dispatch receiver for this path component, if any.
+     *
+     * The [symbol] only participates in the smart cast if its dispatch receiver is the same as this one. E.g.:
+     *
+     * ```
+     * class Holder(val value: Any)
+     *
+     * fun test(holder: Holder) {
+     *     if (holder.value is String) {
+     *         holder.value.length  // Context position
+     *     }
+     * }
+     * ```
+     *
+     * In the example above, the `holder` parameter is a required dispatch receiver for `value`. If any other receiver is passed,
+     * such as `Holder().value`, the smart cast is not generated.
+     */
+    public val dispatchReceiver: KaSmartCastSource?
+
+    /**
+     * The required extension receiver for this path component, if any.
+     */
+    public val extensionReceiver: KaSmartCastSource?
+
+    /**
+     * The original type of the [symbol].
+     */
+    public val originalType: KaType
 }
 
 /**

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameter.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameter.pretty.txt
@@ -146,3 +146,14 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 18
+
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      a: T
+    originalType = T
+  isStable = true
+  smartCastTypes:
+    BaseA
+    kotlin.Any
+    A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameter.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameter.standalone.fir.txt
@@ -1121,3 +1121,23 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 18
+
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      a: T
+    originalType = T
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: BaseA
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameter.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameter.txt
@@ -1121,3 +1121,23 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 18
+
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      a: T
+    originalType = T
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: BaseA
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameterAfter.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameterAfter.pretty.txt
@@ -75,3 +75,12 @@ scopes:
 
   DefaultStarImportingScope, index = 10
 
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      a: T
+    originalType = T
+  isStable = true
+  smartCastTypes:
+    BaseA
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameterAfter.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/nestedContextParameterAfter.txt
@@ -716,3 +716,19 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      a: T
+    originalType = T
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: BaseA
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastFunction.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastFunction.pretty.txt
@@ -62,3 +62,11 @@ scopes:
 
   DefaultStarImportingScope, index = 9
 
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      c: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.Int

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastFunction.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastFunction.txt
@@ -359,3 +359,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      c: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Int

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastProperty.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastProperty.pretty.txt
@@ -62,3 +62,11 @@ scopes:
 
   DefaultStarImportingScope, index = 9
 
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      c: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.Int

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastProperty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/contextParameters/smartCastProperty.txt
@@ -349,3 +349,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaContextParameterSymbol:
+      c: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Int

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/simpleScopeContextForPosition.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/simpleScopeContextForPosition.pretty.txt
@@ -171,3 +171,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 19
+
+possible smart casts:
+  source:
+    symbol = KaValueParameterSymbol:
+      param: kotlin.String?
+    originalType = kotlin.String?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/simpleScopeContextForPosition.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/simpleScopeContextForPosition.standalone.fir.txt
@@ -1501,3 +1501,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 19
+
+possible smart casts:
+  source:
+    symbol = KaValueParameterSymbol:
+      param: kotlin.String?
+    originalType = kotlin.String?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/simpleScopeContextForPosition.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/simpleScopeContextForPosition.txt
@@ -1501,3 +1501,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 19
+
+possible smart casts:
+  source:
+    symbol = KaValueParameterSymbol:
+      param: kotlin.String?
+    originalType = kotlin.String?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunction.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunction.pretty.txt
@@ -80,3 +80,38 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 11
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunction.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunction.standalone.fir.txt
@@ -373,3 +373,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 11
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunction.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunction.txt
@@ -373,3 +373,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 11
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunctionInWhenEntry.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunctionInWhenEntry.pretty.txt
@@ -80,3 +80,38 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 11
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunctionInWhenEntry.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunctionInWhenEntry.standalone.fir.txt
@@ -373,3 +373,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 11
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunctionInWhenEntry.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInAnonymousFunctionInWhenEntry.txt
@@ -373,3 +373,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 11
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInWhenEntryCondition.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInWhenEntryCondition.pretty.txt
@@ -63,3 +63,38 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInWhenEntryCondition.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInWhenEntryCondition.standalone.fir.txt
@@ -378,3 +378,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInWhenEntryCondition.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCastInWhenEntryCondition.txt
@@ -378,3 +378,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: A

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.kt
@@ -1,0 +1,8 @@
+fun test() {
+    val a: Any? = 42
+    val b = a
+
+    if (b is Int) {
+        <expr>a.inc()</expr>
+    }
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.pretty.txt
@@ -1,0 +1,53 @@
+element: a.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 2
+      val a: kotlin.Any?
+      val b: kotlin.Any?
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.pretty.txt
@@ -51,3 +51,22 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      val a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Int
+    kotlin.Any
+
+  source:
+    symbol = KaLocalVariableSymbol:
+      val b: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Int
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.txt
@@ -1,0 +1,175 @@
+element: a.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 2
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: a
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: b
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/bound.txt
@@ -173,3 +173,34 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      val a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Int
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any
+
+  source:
+    symbol = KaLocalVariableSymbol:
+      val b: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Int
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.kt
@@ -1,0 +1,12 @@
+fun test() {
+    var a: Any? = null
+
+    while (true) {
+        if (a == null) return
+        if (foo()) break
+    }
+
+    <expr>a</expr>
+}
+
+fun foo(): Boolean = true

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.pretty.txt
@@ -1,0 +1,47 @@
+element: a
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var a: kotlin.Any?
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun foo(): kotlin.Boolean
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.pretty.txt
@@ -45,3 +45,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.txt
@@ -175,3 +175,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/breakFromInfiniteLoop.txt
@@ -1,0 +1,177 @@
+element: a
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: a
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /foo
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: foo
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Boolean
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.kt
@@ -1,0 +1,14 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    if (x != null)
+        <expr>x.inc()</expr>
+    run {
+        x = null
+    }
+}
+
+fun <R> run(block: () -> R) {
+    block()
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.pretty.txt
@@ -51,3 +51,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.pretty.txt
@@ -1,0 +1,53 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun <R> run(block: () -> R)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.txt
@@ -236,3 +236,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink.txt
@@ -1,0 +1,238 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /run
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: run
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: [
+          KaTypeParameterSymbol:
+            anchorPsi: KtTypeParameter
+            annotations: []
+            isActual: false
+            isExpect: false
+            isExternal: false
+            isReified: false
+            location: LOCAL
+            modality: FINAL
+            name: R
+            origin: SOURCE
+            psi: KtTypeParameter
+            realPsi: KtTypeParameter
+            upperBounds: []
+            variance: INVARIANT
+            visibility: LOCAL
+        ]
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: block
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaFunctionType:
+              annotations: []
+              typeArguments: [
+                KaTypeParameterType:
+                  annotations: []
+                  type: R
+              ]
+              type: () -> R
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.kt
@@ -1,0 +1,14 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    run {
+        x = null
+    }
+    if (x != null)
+        <expr>x.inc()</expr>
+}
+
+fun <R> run(block: () -> R) {
+    block()
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.pretty.txt
@@ -1,0 +1,53 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun <R> run(block: () -> R)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.pretty.txt
@@ -51,3 +51,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = false
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.txt
@@ -236,3 +236,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = false
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad.txt
@@ -1,0 +1,238 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /run
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: run
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: [
+          KaTypeParameterSymbol:
+            anchorPsi: KtTypeParameter
+            annotations: []
+            isActual: false
+            isExpect: false
+            isExternal: false
+            isReified: false
+            location: LOCAL
+            modality: FINAL
+            name: R
+            origin: SOURCE
+            psi: KtTypeParameter
+            realPsi: KtTypeParameter
+            upperBounds: []
+            variance: INVARIANT
+            visibility: LOCAL
+        ]
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: block
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaFunctionType:
+              annotations: []
+              typeArguments: [
+                KaTypeParameterType:
+                  annotations: []
+                  type: R
+              ]
+              type: () -> R
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.kt
@@ -1,0 +1,10 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    run {
+        x = null
+    }
+    if (x != null)
+        <expr>x.inc()</expr>
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.pretty.txt
@@ -50,3 +50,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.pretty.txt
@@ -1,0 +1,52 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.txt
@@ -1,0 +1,148 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSinkBad_callsInPlace.txt
@@ -146,3 +146,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.kt
@@ -1,0 +1,10 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    if (x != null)
+        <expr>x.inc()</expr>
+    run {
+        x = null
+    }
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.pretty.txt
@@ -50,3 +50,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.pretty.txt
@@ -1,0 +1,52 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.txt
@@ -1,0 +1,148 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 4
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 5
+
+  DefaultSimpleImportingScope, index = 6
+
+  ExplicitStarImportingScope, index = 7
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 8

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/directSink_callsInPlace.txt
@@ -146,3 +146,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 8
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.kt
@@ -1,0 +1,11 @@
+fun test() {
+    var a: Any? = null
+
+    do {
+        if (a == null) return
+    } while (foo())
+
+    <expr>a</expr>
+}
+
+fun foo(): Boolean = true

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.pretty.txt
@@ -1,0 +1,47 @@
+element: a
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var a: kotlin.Any?
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun foo(): kotlin.Boolean
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.pretty.txt
@@ -45,3 +45,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.txt
@@ -175,3 +175,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile.txt
@@ -1,0 +1,177 @@
+element: a
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: a
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /foo
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: foo
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Boolean
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.kt
@@ -1,0 +1,11 @@
+fun test() {
+    var a: Any? = null
+
+    do {
+        consume(a)
+    } while (a == null)
+
+    <expr>a</expr>
+}
+
+fun consume(obj: Any?) {}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.pretty.txt
@@ -1,0 +1,47 @@
+element: a
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var a: kotlin.Any?
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun consume(obj: kotlin.Any?)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.pretty.txt
@@ -45,3 +45,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.txt
@@ -1,0 +1,211 @@
+element: a
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: a
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /consume
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: consume
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: obj
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any?
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/doWhile2.txt
@@ -209,3 +209,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.kt
@@ -1,0 +1,8 @@
+fun test() {
+    val p: Any = "foo"
+    if (p !is String) {
+        return
+    }
+
+    <expr>Unit</expr>
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.pretty.txt
@@ -1,0 +1,46 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      val p: kotlin.Any
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.pretty.txt
@@ -44,3 +44,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      val p: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.String

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.txt
@@ -1,0 +1,142 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: p
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariable.txt
@@ -140,3 +140,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      val p: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/String

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.kt
@@ -1,0 +1,8 @@
+fun test() {
+    var p: Any = "foo"
+    if (p !is String) {
+        return
+    }
+
+    <expr>Unit</expr>
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.pretty.txt
@@ -1,0 +1,46 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var p: kotlin.Any
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.pretty.txt
@@ -44,3 +44,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var p: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.String

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.txt
@@ -140,3 +140,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var p: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/String

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/localVariableMutable.txt
@@ -1,0 +1,142 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: p
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.kt
@@ -1,0 +1,16 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    x = getNullableInt()
+    run {
+        if (x != null)
+            <expr>x.inc()</expr>
+    }
+}
+
+fun getNullableInt(): Int? = 0
+
+fun <R> run(block: () -> R) {
+    block()
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.pretty.txt
@@ -1,0 +1,66 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 3
+      fun test()
+      fun getNullableInt(): kotlin.Int?
+      fun <R> run(block: () -> R)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.pretty.txt
@@ -64,3 +64,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.txt
@@ -283,3 +283,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink.txt
@@ -1,0 +1,285 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 3
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /getNullableInt
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: getNullableInt
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /run
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: run
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: [
+          KaTypeParameterSymbol:
+            anchorPsi: KtTypeParameter
+            annotations: []
+            isActual: false
+            isExpect: false
+            isExternal: false
+            isReified: false
+            location: LOCAL
+            modality: FINAL
+            name: R
+            origin: SOURCE
+            psi: KtTypeParameter
+            realPsi: KtTypeParameter
+            upperBounds: []
+            variance: INVARIANT
+            visibility: LOCAL
+        ]
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: block
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaFunctionType:
+              annotations: []
+              typeArguments: [
+                KaTypeParameterType:
+                  annotations: []
+                  type: R
+              ]
+              type: () -> R
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.kt
@@ -1,0 +1,16 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    run {
+        if (x != null)
+            <expr>x.inc()</expr>
+    }
+    x = getNullableInt()
+}
+
+fun getNullableInt(): Int? = 0
+
+fun <R> run(block: () -> R) {
+    block()
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.pretty.txt
@@ -1,0 +1,66 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 3
+      fun test()
+      fun getNullableInt(): kotlin.Int?
+      fun <R> run(block: () -> R)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.pretty.txt
@@ -64,3 +64,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = false
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.txt
@@ -283,3 +283,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = false
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad.txt
@@ -1,0 +1,285 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 3
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /getNullableInt
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: getNullableInt
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /run
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: run
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: [
+          KaTypeParameterSymbol:
+            anchorPsi: KtTypeParameter
+            annotations: []
+            isActual: false
+            isExpect: false
+            isExternal: false
+            isReified: false
+            location: LOCAL
+            modality: FINAL
+            name: R
+            origin: SOURCE
+            psi: KtTypeParameter
+            realPsi: KtTypeParameter
+            upperBounds: []
+            variance: INVARIANT
+            visibility: LOCAL
+        ]
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: block
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaFunctionType:
+              annotations: []
+              typeArguments: [
+                KaTypeParameterType:
+                  annotations: []
+                  type: R
+              ]
+              type: () -> R
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.kt
@@ -1,0 +1,14 @@
+fun test() {
+    var x: Int? = 42
+    run {
+        x = null
+    }
+    run {
+        if (x != null)
+            <expr>x.inc()</expr>
+    }
+}
+
+fun <R> run(block: () -> R) {
+    block()
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.pretty.txt
@@ -1,0 +1,65 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun <R> run(block: () -> R)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.pretty.txt
@@ -63,3 +63,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = false
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.txt
@@ -1,0 +1,250 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /run
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: run
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: [
+          KaTypeParameterSymbol:
+            anchorPsi: KtTypeParameter
+            annotations: []
+            isActual: false
+            isExpect: false
+            isExternal: false
+            isReified: false
+            location: LOCAL
+            modality: FINAL
+            name: R
+            origin: SOURCE
+            psi: KtTypeParameter
+            realPsi: KtTypeParameter
+            upperBounds: []
+            variance: INVARIANT
+            visibility: LOCAL
+        ]
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: block
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaFunctionType:
+              annotations: []
+              typeArguments: [
+                KaTypeParameterType:
+                  annotations: []
+                  type: R
+              ]
+              type: () -> R
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2.txt
@@ -248,3 +248,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = false
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.kt
@@ -1,0 +1,12 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    run {
+        x = null
+    }
+    run {
+        if (x != null)
+            <expr>x.inc()</expr>
+    }
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.pretty.txt
@@ -1,0 +1,64 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.pretty.txt
@@ -62,3 +62,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.txt
@@ -1,0 +1,160 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad2_callsInPlace.txt
@@ -158,3 +158,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.kt
@@ -1,0 +1,12 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    run {
+        if (x != null)
+            <expr>x.inc()</expr>
+    }
+    x = getNullableInt()
+}
+
+fun getNullableInt(): Int? = 0

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.pretty.txt
@@ -63,3 +63,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.pretty.txt
@@ -1,0 +1,65 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun getNullableInt(): kotlin.Int?
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.txt
@@ -193,3 +193,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSinkBad_callsInPlace.txt
@@ -1,0 +1,195 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /getNullableInt
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: getNullableInt
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.kt
@@ -1,0 +1,12 @@
+// WITH_STDLIB
+
+fun test() {
+    var x: Int? = 42
+    x = getNullableInt()
+    run {
+        if (x != null)
+            <expr>x.inc()</expr>
+    }
+}
+
+fun getNullableInt(): Int? = 0

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.pretty.txt
@@ -63,3 +63,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.pretty.txt
@@ -1,0 +1,65 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      var x: kotlin.Int?
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun getNullableInt(): kotlin.Int?
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.txt
@@ -193,3 +193,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var x: kotlin.Int?
+    originalType = kotlin.Int?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/nestedSink_callsInPlace.txt
@@ -1,0 +1,195 @@
+element: x.inc()
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: x
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /getNullableInt
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: getNullableInt
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int?
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.kt
@@ -1,0 +1,7 @@
+fun test() {
+    var a: Any? = null
+    if (a == null) return
+
+    var c = a
+    <expr>c</expr>
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.pretty.txt
@@ -1,0 +1,47 @@
+element: c
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 2
+      var a: kotlin.Any?
+      var c: kotlin.Any?
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.pretty.txt
@@ -45,3 +45,20 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any
+
+  source:
+    symbol = KaLocalVariableSymbol:
+      var c: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.txt
@@ -1,0 +1,169 @@
+element: c
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 2
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: a
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: c
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/noSmartCastInInference.txt
@@ -167,3 +167,26 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any
+
+  source:
+    symbol = KaLocalVariableSymbol:
+      var c: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.kt
@@ -1,0 +1,7 @@
+fun test(p: Any) {
+    if (p !is String) {
+        return
+    }
+
+    <expr>Unit</expr>
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.pretty.txt
@@ -1,0 +1,46 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      p: kotlin.Any
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 1
+      fun test(p: kotlin.Any)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.pretty.txt
@@ -44,3 +44,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaValueParameterSymbol:
+      p: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.String

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.txt
@@ -1,0 +1,182 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaValueParameterSymbol:
+        anchorPsi: KtParameter
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        hasDeclaredDefaultValue: false
+        hasDefaultValue: false
+        isActual: false
+        isCompanion: false
+        isCrossinline: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isImplicitLambdaParameter: false
+        isNoinline: false
+        isVal: true
+        isVararg: false
+        location: LOCAL
+        modality: FINAL
+        name: p
+        origin: SOURCE
+        primaryConstructorProperty: null
+        psi: KtParameter
+        realPsi: KtParameter
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: p
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/parameterSimple.txt
@@ -180,3 +180,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaValueParameterSymbol:
+      p: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/String

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.kt
@@ -1,0 +1,9 @@
+fun test(foo: Any) {
+    if (foo is Foo) {
+        if (foo.a is String) {
+            <expr>Unit</expr>
+        }
+    }
+}
+
+class Foo(val a: Any)

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.pretty.txt
@@ -1,0 +1,59 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      foo: kotlin.Any
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 5
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 1
+      class Foo(a: kotlin.Any)
+    callables: 1
+      fun test(foo: kotlin.Any)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 6
+
+  DefaultSimpleImportingScope, index = 7
+
+  ExplicitStarImportingScope, index = 8
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 9

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.pretty.txt
@@ -57,3 +57,24 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaKotlinPropertySymbol:
+      val a: kotlin.Any
+      dispatchReceiver:
+        symbol = KaValueParameterSymbol:
+          foo: kotlin.Any
+        originalType = kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.String
+
+  source:
+    symbol = KaValueParameterSymbol:
+      foo: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.txt
@@ -1,0 +1,222 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaValueParameterSymbol:
+        anchorPsi: KtParameter
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        hasDeclaredDefaultValue: false
+        hasDefaultValue: false
+        isActual: false
+        isCompanion: false
+        isCrossinline: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isImplicitLambdaParameter: false
+        isNoinline: false
+        isVal: true
+        isVararg: false
+        location: LOCAL
+        modality: FINAL
+        name: foo
+        origin: SOURCE
+        primaryConstructorProperty: null
+        psi: KtParameter
+        realPsi: KtParameter
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 5
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 1
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Foo
+        classKind: CLASS
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: Foo
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: foo
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 6
+
+  DefaultSimpleImportingScope, index = 7
+
+  ExplicitStarImportingScope, index = 8
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 9

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReference.txt
@@ -220,3 +220,30 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaKotlinPropertySymbol:
+      val a: kotlin.Any
+      dispatchReceiver:
+        symbol = KaValueParameterSymbol:
+          foo: kotlin.Any
+        originalType = kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/String
+
+  source:
+    symbol = KaValueParameterSymbol:
+      foo: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.kt
@@ -1,0 +1,12 @@
+fun test(foo: Any) {
+    if (foo is Foo) {
+        if (foo.a is Bar) {
+            if (foo.a.b is String) {
+                <expr>Unit</expr>
+            }
+        }
+    }
+}
+
+class Foo(val a: Any)
+class Bar(val b: Any)

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.pretty.txt
@@ -1,0 +1,66 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 1
+      foo: kotlin.Any
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 2
+      class Foo(a: kotlin.Any)
+      class Bar(b: kotlin.Any)
+    callables: 1
+      fun test(foo: kotlin.Any)
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.pretty.txt
@@ -64,3 +64,40 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaKotlinPropertySymbol:
+      val a: kotlin.Any
+      dispatchReceiver:
+        symbol = KaValueParameterSymbol:
+          foo: kotlin.Any
+        originalType = kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    Bar
+
+  source:
+    symbol = KaKotlinPropertySymbol:
+      val b: kotlin.Any
+      dispatchReceiver:
+        symbol = KaKotlinPropertySymbol:
+          val a: kotlin.Any
+          dispatchReceiver:
+            symbol = KaValueParameterSymbol:
+              foo: kotlin.Any
+            originalType = kotlin.Any
+        originalType = kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    kotlin.String
+
+  source:
+    symbol = KaValueParameterSymbol:
+      foo: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.txt
@@ -254,3 +254,49 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaKotlinPropertySymbol:
+      val a: kotlin.Any
+      dispatchReceiver:
+        symbol = KaValueParameterSymbol:
+          foo: kotlin.Any
+        originalType = kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Bar
+
+  source:
+    symbol = KaKotlinPropertySymbol:
+      val b: kotlin.Any
+      dispatchReceiver:
+        symbol = KaKotlinPropertySymbol:
+          val a: kotlin.Any
+          dispatchReceiver:
+            symbol = KaValueParameterSymbol:
+              foo: kotlin.Any
+            originalType = kotlin.Any
+        originalType = kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/String
+
+  source:
+    symbol = KaValueParameterSymbol:
+      foo: kotlin.Any
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/qualifiedReferenceNested.txt
@@ -1,0 +1,256 @@
+element: Unit
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 1
+      KaValueParameterSymbol:
+        anchorPsi: KtParameter
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        hasDeclaredDefaultValue: false
+        hasDefaultValue: false
+        isActual: false
+        isCompanion: false
+        isCrossinline: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isImplicitLambdaParameter: false
+        isNoinline: false
+        isVal: true
+        isVararg: false
+        location: LOCAL
+        modality: FINAL
+        name: foo
+        origin: SOURCE
+        primaryConstructorProperty: null
+        psi: KtParameter
+        realPsi: KtParameter
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 2
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Foo
+        classKind: CLASS
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: Foo
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Bar
+        classKind: CLASS
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: Bar
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: foo
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.kt
@@ -1,0 +1,9 @@
+fun test() {
+    var a: Any? = null
+    if (a == null) return
+
+    var c = id(a)
+    <expr>c</expr>
+}
+
+fun <T> id(a: T): T = a

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.pretty.txt
@@ -1,0 +1,48 @@
+element: c
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 2
+      var a: kotlin.Any?
+      var c: kotlin.Any
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 0
+    callables: 2
+      fun test()
+      fun <T> id(a: T): T
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.pretty.txt
@@ -46,3 +46,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    kotlin.Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.txt
@@ -251,3 +251,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 7
+
+possible smart casts:
+  source:
+    symbol = KaLocalVariableSymbol:
+      var a: kotlin.Any?
+    originalType = kotlin.Any?
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: kotlin/Any

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/smartCastInInference.txt
@@ -1,0 +1,253 @@
+element: c
+implicit values:
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 2
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: a
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any?
+        typeParameters: []
+        visibility: LOCAL
+      KaLocalVariableSymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isVal: false
+        location: LOCAL
+        modality: FINAL
+        name: c
+        origin: SOURCE
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: LOCAL
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 3
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 0
+    callables: 2
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /id
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: id
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaTypeParameterType:
+          annotations: []
+          type: T
+        typeParameters: [
+          KaTypeParameterSymbol:
+            anchorPsi: KtTypeParameter
+            annotations: []
+            isActual: false
+            isExpect: false
+            isExternal: false
+            isReified: false
+            location: LOCAL
+            modality: FINAL
+            name: T
+            origin: SOURCE
+            psi: KtTypeParameter
+            realPsi: KtTypeParameter
+            upperBounds: []
+            variance: INVARIANT
+            visibility: LOCAL
+        ]
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: a
+            origin: SOURCE
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaTypeParameterType:
+              annotations: []
+              type: T
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 4
+
+  DefaultSimpleImportingScope, index = 5
+
+  ExplicitStarImportingScope, index = 6
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 7

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.kt
@@ -1,0 +1,11 @@
+interface Foo {
+    fun test() {
+        if (this is Impl) {
+            <expr>boo</expr>
+        }
+    }
+}
+
+interface Impl : Foo {
+    val boo: Int
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.pretty.txt
@@ -1,0 +1,71 @@
+element: boo
+implicit values:
+  KaImplicitReceiver:
+    scopeIndexInTower = 3
+    type = Impl
+    ownerSymbol = KaNamedClassSymbol:
+      /Foo
+    label = Foo
+
+
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  TypeScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 5
+      val boo: kotlin.Int
+      fun test()
+      fun equals(other: kotlin.Any?): kotlin.Boolean
+      fun hashCode(): kotlin.Int
+      fun toString(): kotlin.String
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 2
+      interface Foo
+      interface Impl : Foo
+    callables: 0
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.pretty.txt
@@ -69,3 +69,12 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaNamedClassSymbol:
+      /Foo
+    originalType = Foo
+  isStable = true
+  smartCastTypes:
+    Impl

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.standalone.fir.txt
@@ -423,3 +423,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaNamedClassSymbol:
+      /Foo
+    originalType = Foo
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Impl

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.standalone.fir.txt
@@ -1,0 +1,425 @@
+element: boo
+implicit values:
+  KaImplicitReceiver:
+    scopeIndexInTower = 3
+    type = KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Impl
+    ownerSymbol = KaNamedClassSymbol:
+      /Foo
+    label = Foo
+
+
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  TypeScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 5
+      KaKotlinPropertySymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        backingFieldSymbol: KaBackingFieldSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          isActual: false
+          isCompanion: false
+          isDelegated: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isNotDefault: false
+          isVal: true
+          location: PROPERTY
+          modality: FINAL
+          name: field
+          origin: PROPERTY_BACKING_FIELD
+          owningProperty: KaKotlinPropertySymbol(/Impl.boo)
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          visibility: PRIVATE
+        callableId: /Impl.boo
+        contextParameters: []
+        contextReceivers: []
+        getter: KaPropertyGetterSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          hasStableParameterNames: true
+          isActual: false
+          isCompanion: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isInline: false
+          isNotDefault: false
+          isOverride: false
+          location: PROPERTY
+          modality: ABSTRACT
+          origin: SOURCE
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          valueParameters: []
+          visibility: PUBLIC
+        hasBackingField: false
+        hasGetter: true
+        hasSetter: false
+        initializer: null
+        isActual: false
+        isCompanion: false
+        isConst: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isOverride: false
+        isStatic: false
+        isVal: true
+        location: CLASS
+        modality: ABSTRACT
+        name: boo
+        origin: SOURCE
+        primaryConstructorParameter: null
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        setter: null
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /Foo.test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: null
+        annotations: []
+        callableId: kotlin/Any.equals
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: true
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: equals
+        origin: LIBRARY
+        psi: null
+        realPsi: null
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Boolean
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: null
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: other
+            origin: LIBRARY
+            primaryConstructorProperty: null
+            psi: null
+            realPsi: null
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any?
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: null
+        annotations: []
+        callableId: kotlin/Any.hashCode
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: hashCode
+        origin: LIBRARY
+        psi: null
+        realPsi: null
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: null
+        annotations: []
+        callableId: kotlin/Any.toString
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: toString
+        origin: LIBRARY
+        psi: null
+        realPsi: null
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/String
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 2
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Foo
+        classKind: INTERFACE
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: ABSTRACT
+        name: Foo
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Impl
+        classKind: INTERFACE
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: ABSTRACT
+        name: Impl
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: Foo
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+    callables: 0
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.txt
@@ -423,3 +423,15 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 10
+
+possible smart casts:
+  source:
+    symbol = KaNamedClassSymbol:
+      /Foo
+    originalType = Foo
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Impl

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisDispatch.txt
@@ -1,0 +1,425 @@
+element: boo
+implicit values:
+  KaImplicitReceiver:
+    scopeIndexInTower = 3
+    type = KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Impl
+    ownerSymbol = KaNamedClassSymbol:
+      /Foo
+    label = Foo
+
+
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  TypeScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 5
+      KaKotlinPropertySymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        backingFieldSymbol: KaBackingFieldSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          isActual: false
+          isCompanion: false
+          isDelegated: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isNotDefault: false
+          isVal: true
+          location: PROPERTY
+          modality: FINAL
+          name: field
+          origin: PROPERTY_BACKING_FIELD
+          owningProperty: KaKotlinPropertySymbol(/Impl.boo)
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          visibility: PRIVATE
+        callableId: /Impl.boo
+        contextParameters: []
+        contextReceivers: []
+        getter: KaPropertyGetterSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          hasStableParameterNames: true
+          isActual: false
+          isCompanion: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isInline: false
+          isNotDefault: false
+          isOverride: false
+          location: PROPERTY
+          modality: ABSTRACT
+          origin: SOURCE
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          valueParameters: []
+          visibility: PUBLIC
+        hasBackingField: false
+        hasGetter: true
+        hasSetter: false
+        initializer: null
+        isActual: false
+        isCompanion: false
+        isConst: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isOverride: false
+        isStatic: false
+        isVal: true
+        location: CLASS
+        modality: ABSTRACT
+        name: boo
+        origin: SOURCE
+        primaryConstructorParameter: null
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        setter: null
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /Foo.test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: kotlin/Any.equals
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: true
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: equals
+        origin: LIBRARY
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Boolean
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: other
+            origin: LIBRARY
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any?
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: kotlin/Any.hashCode
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: hashCode
+        origin: LIBRARY
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: kotlin/Any.toString
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: toString
+        origin: LIBRARY
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/String
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 5
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 6
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 2
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Foo
+        classKind: INTERFACE
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: ABSTRACT
+        name: Foo
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Impl
+        classKind: INTERFACE
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: ABSTRACT
+        name: Impl
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: Foo
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+    callables: 0
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 7
+
+  DefaultSimpleImportingScope, index = 8
+
+  ExplicitStarImportingScope, index = 9
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 10

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.kt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.kt
@@ -1,0 +1,9 @@
+fun Any.test() {
+    if (this is Foo) {
+        <expr>boo</expr>
+    }
+}
+
+interface Foo {
+    val boo: Int
+}

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.pretty.txt
@@ -68,3 +68,38 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.pretty.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.pretty.txt
@@ -1,0 +1,70 @@
+element: boo
+implicit values:
+  KaImplicitReceiver:
+    scopeIndexInTower = 2
+    type = Foo
+    ownerSymbol = KaNamedFunctionSymbol:
+      /test(<extension receiver>: kotlin.Any): kotlin.Unit
+    label = test
+
+
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  TypeScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 4
+      val boo: kotlin.Int
+      fun equals(other: kotlin.Any?): kotlin.Boolean
+      fun hashCode(): kotlin.Int
+      fun toString(): kotlin.String
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 5
+    packages: 6
+      META-INF
+      java
+      javax
+      kotlin
+      org
+      sun
+    classifiers: 1
+      interface Foo
+    callables: 1
+      fun kotlin.Any.test()
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 6
+
+  DefaultSimpleImportingScope, index = 7
+
+  ExplicitStarImportingScope, index = 8
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 9

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.standalone.fir.txt
@@ -1,0 +1,423 @@
+element: boo
+implicit values:
+  KaImplicitReceiver:
+    scopeIndexInTower = 2
+    type = KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Foo
+    ownerSymbol = KaNamedFunctionSymbol:
+      /test(<extension receiver>: kotlin.Any): kotlin.Unit
+    label = test
+
+
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  TypeScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 4
+      KaKotlinPropertySymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        backingFieldSymbol: KaBackingFieldSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          isActual: false
+          isCompanion: false
+          isDelegated: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isNotDefault: false
+          isVal: true
+          location: PROPERTY
+          modality: FINAL
+          name: field
+          origin: PROPERTY_BACKING_FIELD
+          owningProperty: KaKotlinPropertySymbol(/Foo.boo)
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          visibility: PRIVATE
+        callableId: /Foo.boo
+        contextParameters: []
+        contextReceivers: []
+        getter: KaPropertyGetterSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          hasStableParameterNames: true
+          isActual: false
+          isCompanion: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isInline: false
+          isNotDefault: false
+          isOverride: false
+          location: PROPERTY
+          modality: ABSTRACT
+          origin: SOURCE
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          valueParameters: []
+          visibility: PUBLIC
+        hasBackingField: false
+        hasGetter: true
+        hasSetter: false
+        initializer: null
+        isActual: false
+        isCompanion: false
+        isConst: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isOverride: false
+        isStatic: false
+        isVal: true
+        location: CLASS
+        modality: ABSTRACT
+        name: boo
+        origin: SOURCE
+        primaryConstructorParameter: null
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        setter: null
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: null
+        annotations: []
+        callableId: kotlin/Any.equals
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: true
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: equals
+        origin: LIBRARY
+        psi: null
+        realPsi: null
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Boolean
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: null
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: other
+            origin: LIBRARY
+            primaryConstructorProperty: null
+            psi: null
+            realPsi: null
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any?
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: null
+        annotations: []
+        callableId: kotlin/Any.hashCode
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: hashCode
+        origin: LIBRARY
+        psi: null
+        realPsi: null
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: null
+        annotations: []
+        callableId: kotlin/Any.toString
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: toString
+        origin: LIBRARY
+        psi: null
+        realPsi: null
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/String
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 5
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 1
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Foo
+        classKind: INTERFACE
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: ABSTRACT
+        name: Foo
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: true
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: KaReceiverParameterSymbol:
+          anchorPsi: KtTypeReference
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          isActual: false
+          isCompanion: false
+          isDelegated: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isVal: true
+          location: LOCAL
+          modality: FINAL
+          name: <receiver>
+          origin: SOURCE
+          owningCallableSymbol: KaNamedFunctionSymbol(/test)
+          psi: KtTypeReference
+          realPsi: KtTypeReference
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+          typeParameters: []
+          visibility: PUBLIC
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 6
+
+  DefaultSimpleImportingScope, index = 7
+
+  ExplicitStarImportingScope, index = 8
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 9

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.standalone.fir.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.standalone.fir.txt
@@ -421,3 +421,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.txt
@@ -421,3 +421,41 @@ scopes:
     constructors: 0
 
   DefaultStarImportingScope, index = 9
+
+possible smart casts:
+  source:
+    symbol = KaReceiverParameterSymbol:
+      KaReceiverParameterSymbol:
+        anchorPsi: KtTypeReference
+        annotations: []
+        callableId: null
+        contextParameters: []
+        contextReceivers: []
+        isActual: false
+        isCompanion: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isVal: true
+        location: LOCAL
+        modality: FINAL
+        name: <receiver>
+        origin: SOURCE
+        owningCallableSymbol: KaNamedFunctionSymbol(/test)
+        psi: KtTypeReference
+        realPsi: KtTypeReference
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Any
+        typeParameters: []
+        visibility: PUBLIC
+    originalType = kotlin.Any
+  isStable = true
+  smartCastTypes:
+    KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Foo

--- a/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.txt
+++ b/analysis/analysis-api/testData/components/scopeProvider/scopeContextForPosition/smartCasts/thisExtension.txt
@@ -1,0 +1,423 @@
+element: boo
+implicit values:
+  KaImplicitReceiver:
+    scopeIndexInTower = 2
+    type = KaUsualClassType:
+      annotations: []
+      typeArguments: []
+      type: Foo
+    ownerSymbol = KaNamedFunctionSymbol:
+      /test(<extension receiver>: kotlin.Any): kotlin.Unit
+    label = test
+
+
+scopes:
+  LocalScope, index = 0
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  LocalScope, index = 1
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  TypeScope, index = 2
+    packages: 0
+    classifiers: 0
+    callables: 4
+      KaKotlinPropertySymbol:
+        anchorPsi: KtProperty
+        annotations: []
+        backingFieldSymbol: KaBackingFieldSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          isActual: false
+          isCompanion: false
+          isDelegated: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isNotDefault: false
+          isVal: true
+          location: PROPERTY
+          modality: FINAL
+          name: field
+          origin: PROPERTY_BACKING_FIELD
+          owningProperty: KaKotlinPropertySymbol(/Foo.boo)
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          visibility: PRIVATE
+        callableId: /Foo.boo
+        contextParameters: []
+        contextReceivers: []
+        getter: KaPropertyGetterSymbol:
+          anchorPsi: KtProperty
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          hasStableParameterNames: true
+          isActual: false
+          isCompanion: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isInline: false
+          isNotDefault: false
+          isOverride: false
+          location: PROPERTY
+          modality: ABSTRACT
+          origin: SOURCE
+          psi: null
+          realPsi: null
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Int
+          typeParameters: []
+          valueParameters: []
+          visibility: PUBLIC
+        hasBackingField: false
+        hasGetter: true
+        hasSetter: false
+        initializer: null
+        isActual: false
+        isCompanion: false
+        isConst: false
+        isDelegated: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isLateInit: false
+        isOverride: false
+        isStatic: false
+        isVal: true
+        location: CLASS
+        modality: ABSTRACT
+        name: boo
+        origin: SOURCE
+        primaryConstructorParameter: null
+        psi: KtProperty
+        realPsi: KtProperty
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        setter: null
+        typeParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: kotlin/Any.equals
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: true
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: equals
+        origin: LIBRARY
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Boolean
+        typeParameters: []
+        valueParameters: [
+          KaValueParameterSymbol:
+            anchorPsi: KtParameter
+            annotations: []
+            callableId: null
+            contextParameters: []
+            contextReceivers: []
+            hasDeclaredDefaultValue: false
+            hasDefaultValue: false
+            isActual: false
+            isCompanion: false
+            isCrossinline: false
+            isDelegated: false
+            isExpect: false
+            isExtension: false
+            isExternal: false
+            isImplicitLambdaParameter: false
+            isNoinline: false
+            isVal: true
+            isVararg: false
+            location: LOCAL
+            modality: FINAL
+            name: other
+            origin: LIBRARY
+            primaryConstructorProperty: null
+            psi: KtParameter
+            realPsi: KtParameter
+            receiverParameter: null
+            returnType: KaUsualClassType:
+              annotations: []
+              typeArguments: []
+              type: kotlin/Any?
+            typeParameters: []
+            visibility: PUBLIC
+        ]
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: kotlin/Any.hashCode
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: hashCode
+        origin: LIBRARY
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Int
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: kotlin/Any.toString
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: false
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: CLASS
+        modality: OPEN
+        name: toString
+        origin: LIBRARY
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: null
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/String
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  LocalScope, index = 3
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  ExplicitSimpleImportingScope, index = 4
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  PackageMemberScope, index = 5
+    packages: 6
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(META-INF)
+        fqName: META-INF
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(META-INF)
+        realPsi: PsiPackage(META-INF)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(java)
+        fqName: java
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(java)
+        realPsi: PsiPackage(java)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(javax)
+        fqName: javax
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(javax)
+        realPsi: PsiPackage(javax)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(kotlin)
+        fqName: kotlin
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(kotlin)
+        realPsi: PsiPackage(kotlin)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(org)
+        fqName: org
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(org)
+        realPsi: PsiPackage(org)
+      KaPackageSymbol:
+        anchorPsi: PsiPackage(sun)
+        fqName: sun
+        location: TOP_LEVEL
+        origin: SOURCE
+        psi: PsiPackage(sun)
+        realPsi: PsiPackage(sun)
+    classifiers: 1
+      KaNamedClassSymbol:
+        anchorPsi: KtClass
+        annotations: []
+        classId: Foo
+        classKind: INTERFACE
+        companionObject: null
+        contextReceivers: []
+        isActual: false
+        isData: false
+        isExpect: false
+        isExternal: false
+        isFun: false
+        isInline: false
+        isInner: false
+        location: TOP_LEVEL
+        modality: ABSTRACT
+        name: Foo
+        origin: SOURCE
+        psi: KtClass
+        realPsi: KtClass
+        superTypes: [
+          KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+        ]
+        typeParameters: []
+        visibility: PUBLIC
+    callables: 1
+      KaNamedFunctionSymbol:
+        anchorPsi: KtNamedFunction
+        annotations: []
+        callableId: /test
+        contextParameters: []
+        contextReceivers: []
+        contractEffects: []
+        hasStableParameterNames: true
+        isActual: false
+        isBuiltinFunctionInvoke: false
+        isCompanion: false
+        isExpect: false
+        isExtension: true
+        isExternal: false
+        isInfix: false
+        isInline: false
+        isOperator: false
+        isOverride: false
+        isStatic: false
+        isSuspend: false
+        isTailRec: false
+        location: TOP_LEVEL
+        modality: FINAL
+        name: test
+        origin: SOURCE
+        psi: KtNamedFunction
+        realPsi: KtNamedFunction
+        receiverParameter: KaReceiverParameterSymbol:
+          anchorPsi: KtTypeReference
+          annotations: []
+          callableId: null
+          contextParameters: []
+          contextReceivers: []
+          isActual: false
+          isCompanion: false
+          isDelegated: false
+          isExpect: false
+          isExtension: false
+          isExternal: false
+          isVal: true
+          location: LOCAL
+          modality: FINAL
+          name: <receiver>
+          origin: SOURCE
+          owningCallableSymbol: KaNamedFunctionSymbol(/test)
+          psi: KtTypeReference
+          realPsi: KtTypeReference
+          receiverParameter: null
+          returnType: KaUsualClassType:
+            annotations: []
+            typeArguments: []
+            type: kotlin/Any
+          typeParameters: []
+          visibility: PUBLIC
+        returnType: KaUsualClassType:
+          annotations: []
+          typeArguments: []
+          type: kotlin/Unit
+        typeParameters: []
+        valueParameters: []
+        visibility: PUBLIC
+    constructors: 0
+
+  DefaultSimpleImportingScope, index = 6
+
+  DefaultSimpleImportingScope, index = 7
+
+  ExplicitStarImportingScope, index = 8
+    packages: 0
+    classifiers: 0
+    callables: 0
+    constructors: 0
+
+  DefaultStarImportingScope, index = 9

--- a/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink.copy.txt
+++ b/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink.copy.txt
@@ -27,12 +27,13 @@ Smart Casts:
     FirLocalPropertySymbol lvar x: R|kotlin/Int?|
     Stability: STABLE_VALUE
     Types:
+        kotlin.Int?
         kotlin.Any
 
 FILE: [ResolvedTo(IMPORTS)] nestedSink.kt
     public final [ResolvedTo(BODY_RESOLVE)] fun test(): R|kotlin/Unit| {
         [ResolvedTo(BODY_RESOLVE)] lvar x: R|kotlin/Int?| = Int(42)
-        R|<local>/x| = <Unresolved name: getNullableInt>#()
+        R|<local>/x| = R|/getNullableInt|()
         R|/run|<R|kotlin/Unit|>(<L> = [ResolvedTo(BODY_RESOLVE)] run@fun <anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
             when () {
                 !=(R|<local>/x|, Null(null)) ->  {
@@ -43,4 +44,5 @@ FILE: [ResolvedTo(IMPORTS)] nestedSink.kt
         }
         )
     }
+    public? final? [ResolvedTo(RAW_FIR)] fun getNullableInt(): Int? { LAZY_BLOCK }
     public? final? [ResolvedTo(RAW_FIR)] fun <[ResolvedTo(RAW_FIR)] R> run([ResolvedTo(RAW_FIR)] block: ( () -> R )): R|kotlin/Unit| { LAZY_BLOCK }

--- a/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink.kt
+++ b/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink.kt
@@ -9,6 +9,8 @@ fun test() {
     }
 }
 
+fun getNullableInt(): Int? = 0
+
 fun <R> run(block: () -> R) {
     block()
 }

--- a/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSinkBad2_callsInPlace.kt
+++ b/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSinkBad2_callsInPlace.kt
@@ -1,3 +1,5 @@
+// WITH_STDLIB
+
 fun test() {
     var x: Int? = 42
     run {

--- a/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink_callsInPlace.copy.txt
+++ b/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink_callsInPlace.copy.txt
@@ -30,11 +30,11 @@ Smart Casts:
         kotlin.Int?
         kotlin.Any
 
-FILE: [ResolvedTo(IMPORTS)] nestedSink.kt
+FILE: [ResolvedTo(IMPORTS)] nestedSink_callsInPlace.kt
     public final [ResolvedTo(BODY_RESOLVE)] fun test(): R|kotlin/Unit| {
         [ResolvedTo(BODY_RESOLVE)] lvar x: R|kotlin/Int?| = Int(42)
         R|<local>/x| = R|/getNullableInt|()
-        R|/run|<R|kotlin/Unit|>(<L> = [ResolvedTo(BODY_RESOLVE)] run@fun <anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+        R|kotlin/run|<R|kotlin/Unit|>(<L> = [ResolvedTo(BODY_RESOLVE)] run@fun <anonymous>(): R|kotlin/Unit| <inline=Inline, kind=EXACTLY_ONCE>  {
             when () {
                 !=(R|<local>/x|, Null(null)) ->  {
                     R|<local>/x|.R|kotlin/Int.inc|()
@@ -44,5 +44,4 @@ FILE: [ResolvedTo(IMPORTS)] nestedSink.kt
         }
         )
     }
-    public final [ResolvedTo(STATUS)] fun getNullableInt(): R|kotlin/Int?| { LAZY_BLOCK }
-    public final [ResolvedTo(STATUS)] fun <[ResolvedTo(STATUS)] R> run([ResolvedTo(STATUS)] block: R|() -> R|): R|kotlin/Unit| { LAZY_BLOCK }
+    public? final? [ResolvedTo(RAW_FIR)] fun getNullableInt(): Int? { LAZY_BLOCK }

--- a/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink_callsInPlace.kt
+++ b/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink_callsInPlace.kt
@@ -8,3 +8,5 @@ fun test() {
             <expr>x.inc()</expr>
     }
 }
+
+fun getNullableInt(): Int? = 0

--- a/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink_callsInPlace.txt
+++ b/analysis/low-level-api-fir/testData/contextCollector/smartCasts/nestedSink_callsInPlace.txt
@@ -27,12 +27,13 @@ Smart Casts:
     FirLocalPropertySymbol lvar x: R|kotlin/Int?|
     Stability: STABLE_VALUE
     Types:
+        kotlin.Int?
         kotlin.Any
 
 FILE: [ResolvedTo(IMPORTS)] nestedSink_callsInPlace.kt
     public final [ResolvedTo(BODY_RESOLVE)] fun test(): R|kotlin/Unit| {
         [ResolvedTo(BODY_RESOLVE)] lvar x: R|kotlin/Int?| = Int(42)
-        R|<local>/x| = <Unresolved name: getNullableInt>#()
+        R|<local>/x| = R|/getNullableInt|()
         R|kotlin/run|<R|kotlin/Unit|>(<L> = [ResolvedTo(BODY_RESOLVE)] run@fun <anonymous>(): R|kotlin/Unit| <inline=Inline, kind=EXACTLY_ONCE>  {
             when () {
                 !=(R|<local>/x|, Null(null)) ->  {
@@ -43,3 +44,4 @@ FILE: [ResolvedTo(IMPORTS)] nestedSink_callsInPlace.kt
         }
         )
     }
+    public final [ResolvedTo(STATUS)] fun getNullableInt(): R|kotlin/Int?| { LAZY_BLOCK }


### PR DESCRIPTION
The new endpoint makes it possible to track potential smart casts in a particular position, even if a real cast isn't yet present in the source code.