### PR TITLE
[K/N] Fix release cache missing optimizations and wrong stdlib cache …

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -383,11 +383,12 @@ class CacheBuilder(
         configuration.reportLog("CACHING ${library.path}")
         filesToCache.forEach { configuration.reportLog("    $it") }
 
-        // Produce monolithic caches for external libraries for now, with the exception of the stdlib:
+        // Produce monolithic caches for external libraries for now, except debug stdlib:
         // its cache is per-file by default (see [NativeSecondStageCompilationConfig.perFileCacheForStdlib]),
         // so when it has to be rebuilt here it must match the per-file layout the distribution ships.
         val makePerFileCache = !library.isCInteropLibrary() &&
-                (!isExternal || (library.isNativeStdlib && config.perFileCacheForStdlib))
+                (!isExternal || (library.isNativeStdlib && config.perFileCacheForStdlib)) &&
+                !(library.isNativeStdlib && config.optimizationsEnabled)
 
         val libraryCacheDirectory = when {
             library.isImplicitlyLoadedFromKotlinNativeDistribution || library.isNativeStdlib -> config.systemCacheDirectory

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.cli.reportLog
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.nativeBinaryOptions.*
+import org.jetbrains.kotlin.config.phaseConfig
 import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.util.visibleName
@@ -260,6 +261,9 @@ private fun String.absoluteNormalizedFile() = java.io.File(this).absoluteFile.no
 internal fun CompilerConfiguration.setupCommonOptionsForCaches(config: NativeSecondStageCompilationConfig) = with(NativeConfigurationKeys) {
     konanTarget = config.target.toString()
     put(DEBUG, config.debug)
+    put(OPTIMIZATION, config.optimizationsEnabled)
+    put(BinaryOptions.enableReleaseBinaryCache, config.enableReleaseBinaryCache)
+    config.configuration.phaseConfig?.let { phaseConfig = it }
     setupPartialLinkageConfig(config.partialLinkageConfig)
     putIfNotNull(EXTERNAL_DEPENDENCIES, config.externalDependenciesFile?.absolutePathString())
     put(PROPERTY_LAZY_INITIALIZATION, config.propertyLazyInitialization)


### PR DESCRIPTION
[K/N] Fix release cache missing optimizations and wrong stdlib cache layout

^KT-89013 K/N: auto-built release compiler caches are compiled at O1, not O3

When linkRelease* builds dependency klib caches with enableReleaseBinaryCache, CacheBuilder.spawnLibraryCacheBuild spawns a child compiler with an empty CompilerConfiguration. setupCommonOptionsForCaches copies DEBUG but not OPTIMIZATION, enableReleaseBinaryCache, or phaseConfig. The child therefore runs the default pipeline (no -opt, no -g, LLVM -O1) instead of the release pipeline (LLVM -O3, Kotlin IR optimization phases). The resulting cache objects are linked into the release binary as-is.

Fix: pass OPTIMIZATION, enableReleaseBinaryCache and phaseConfig to the cache configuration in setupCommonOptionsForCaches so the spawned cache build matches the final compilation's optimization settings.

Additionally, when optimizationsEnabled is true the stdlib cache must use monolithic (per-klib) layout, not per-file. The per-file layout is incompatible with the optimized compilation pipeline: dist -opt stdlib caches are monolithic (KonanCacheTask.makePerFileCache = !withOptimizations), so a per-file rebuild here mismatches and fails.

