### PR TITLE
[BTA] Fix argument restrictions for Wasm/JS.

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/JsModule.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/JsModule.kt
@@ -94,6 +94,14 @@ class JsModule(
             compilerArguments[IR_OUTPUT_NAME] = moduleName
             compilerArguments[LIBRARIES] = dependencyFiles
             compilationConfigAction(this)
+
+            // TODO: workaround to be removed after KT-86169
+            if (compilerArguments[IR_OUTPUT_NAME] == null) {
+                compilerArguments[IR_OUTPUT_NAME] = moduleName
+            }
+            if (compilerArguments[LIBRARIES] == null) {
+                compilerArguments[LIBRARIES] = dependencyFiles
+            }
         }
         val result = compilationOperation.let {
             compilationAction(it)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/WasmModule.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/WasmModule.kt
@@ -80,6 +80,14 @@ class WasmModule(
             compilerArguments[IR_OUTPUT_NAME] = moduleName
             compilerArguments[LIBRARIES] = dependencyFiles
             compilationConfigAction(this)
+
+            // TODO: workaround to be removed after KT-86169
+            if (compilerArguments[IR_OUTPUT_NAME] == null) {
+                compilerArguments[IR_OUTPUT_NAME] = moduleName
+            }
+            if (compilerArguments[LIBRARIES] == null) {
+                compilerArguments[LIBRARIES] = dependencyFiles
+            }
         }
         val result = compilationOperation.let {
             compilationAction(it)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentProviders.kt
@@ -8,7 +8,6 @@
 package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm
 
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments
-import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.IR_OUTPUT_DIR
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.LIBRARIES
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_FRIEND_MODULES
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments
@@ -17,7 +16,6 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLink
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_EMBED_SOURCES
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_NAMES_POLICY
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_CACHE_DIRECTORY
-import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_INCLUDE
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_IR_DCE_RUNTIME_DIAGNOSTIC
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
@@ -105,19 +103,6 @@ private val testBaseDir: Path = Paths.get("").toAbsolutePath()
 @OptIn(ExperimentalCompilerArgument::class)
 private val commonJsAndWasmCompilerArguments: List<CommonJsAndWasmArgumentTestDescriptor<*>> = listOf(
     CommonJsAndWasmArgumentTestDescriptor(
-        argumentName = "ir-output-dir",
-        argument = IR_OUTPUT_DIR,
-        availableSinceVersion = IR_OUTPUT_DIR.availableSinceVersion,
-        operationKinds = listOf(JS_KLIB, WASM_KLIB),
-        argumentValues = listOf(testBaseDir.resolve("path/to/output")),
-        argumentRawValues = listOf(testBaseDir.resolve("path/to/output").toFile().absolutePath),
-        runsNullableTest = true,
-        valueString = { value -> value?.toFile()?.absolutePath },
-        expectedArgumentStringsFor = { value -> listOf("-ir-output-dir", value) },
-        setArgumentValue = { value -> (this as CommonJsAndWasmArguments.Builder)[IR_OUTPUT_DIR] = value },
-        getArgumentValue = { (this as CommonJsAndWasmArguments)[IR_OUTPUT_DIR] },
-    ),
-    CommonJsAndWasmArgumentTestDescriptor(
         argumentName = "libraries",
         argument = LIBRARIES,
         availableSinceVersion = LIBRARIES.availableSinceVersion,
@@ -168,19 +153,6 @@ private val commonJsAndWasmCompilerArguments: List<CommonJsAndWasmArgumentTestDe
         expectedArgumentStringsFor = { value -> listOf("-Xfriend-modules=$value") },
         setArgumentValue = { value -> (this as CommonJsAndWasmArguments.Builder)[X_FRIEND_MODULES] = value },
         getArgumentValue = { (this as CommonJsAndWasmArguments)[X_FRIEND_MODULES] },
-    ),
-    CommonJsAndWasmArgumentTestDescriptor(
-        argumentName = "Xinclude",
-        argument = X_INCLUDE,
-        availableSinceVersion = X_INCLUDE.availableSinceVersion,
-        operationKinds = listOf(JS_LINKING, WASM_LINKING),
-        argumentValues = listOf(testBaseDir.resolve("path/to/included.klib")),
-        argumentRawValues = listOf(testBaseDir.resolve("path/to/included.klib").toFile().absolutePath),
-        runsNullableTest = true,
-        valueString = { value -> value?.toFile()?.absolutePath },
-        expectedArgumentStringsFor = { value -> listOf("-Xinclude=$value") },
-        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[X_INCLUDE] = value },
-        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[X_INCLUDE] },
     ),
     CommonJsAndWasmArgumentTestDescriptor(
         argumentName = "Xcache-directory",

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testRestrictedArguments/kotlin/RestrictedArgumentsTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testRestrictedArguments/kotlin/RestrictedArgumentsTest.kt
@@ -51,9 +51,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
             val moduleFile = workingDirectory.resolve("some/path.xml")
-            module.checkRestrictedArgument(
-                "-Xbuild-file", "-module",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-Xbuild-file", "-module", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOfNotNull(additionalArg, "$argument=$moduleFile"),
                 expectedCompilationError = true,
             ) {
@@ -70,9 +69,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     fun testDestinationWarningDuringExecution(strategyConfig: CompilerExecutionStrategyConfiguration) {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-d",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-d", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOf("-d", "output/dir")
             ) {
                 assertLogContainsLines(
@@ -91,9 +89,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     fun testDestinationReportsDuringExecutionOnMetadata(strategyConfig: CompilerExecutionStrategyConfiguration) {
         metadataProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-d",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-d", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOf("-d", "output/dir")
             ) {
                 assertLogContainsLines(
@@ -112,9 +109,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     fun testLegacyMetadataJar(strategyConfig: CompilerExecutionStrategyConfiguration) {
         metadataProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-Xlegacy-metadata-jar-k2",
-                errorSince = KotlinReleaseVersion.v2_6_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-Xlegacy-metadata-jar-k2", errorSince = KotlinReleaseVersion.v2_6_0),
                 configuredArgs = listOf("-Xlegacy-metadata-jar-k2")
             )
         }
@@ -125,9 +121,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     fun testIncludeRuntimeWarningDuringExecution(strategyConfig: CompilerExecutionStrategyConfiguration) {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-include-runtime",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-include-runtime", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOf("-include-runtime")
             )
         }
@@ -148,9 +143,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     private fun testExpression(strategyConfig: CompilerExecutionStrategyConfiguration, actualArgs: List<String>) {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-expression", "-e",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-expression", "-e", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = actualArgs,
                 expectedCompilationError = true,
             ) {
@@ -164,9 +158,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     fun testXReplWarningDuringExecution(strategyConfig: CompilerExecutionStrategyConfiguration) {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-Xrepl",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-Xrepl", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOf("-Xrepl"),
                 expectedCompilationError = true,
             ) {
@@ -180,9 +173,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
     fun testEnableIncrementalCompilationWarningDuringExecution(strategyConfig: CompilerExecutionStrategyConfiguration) {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
-            module.checkRestrictedArgument(
-                "-Xenable-incremental-compilation",
-                errorSince = KotlinReleaseVersion.v2_5_0,
+            module.checkRestrictedArguments(
+                restrictedArg("-Xenable-incremental-compilation", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOf("-Xenable-incremental-compilation")
             ) {
                 assertLogContainsLines(
@@ -201,8 +193,8 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
         jvmProject(strategyConfig) {
             val module = module("basic-multimodule-project/module-1")
             module.checkRestrictedArguments(
-                listOf("-include-runtime") to KotlinReleaseVersion.v2_5_0,
-                listOf("-Xenable-incremental-compilation") to KotlinReleaseVersion.v2_5_0,
+                restrictedArg("-include-runtime", errorSince = KotlinReleaseVersion.v2_5_0),
+                restrictedArg("-Xenable-incremental-compilation", errorSince = KotlinReleaseVersion.v2_5_0),
                 configuredArgs = listOf("-include-runtime", "-Xenable-incremental-compilation"),
             )
         }
@@ -245,7 +237,7 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
             module.compile(compilationConfigAction = {
                 it.compilerArguments.applyArgumentStrings(listOf("-Xassertions=jVm"))
                 @OptIn(ExperimentalCompilerArgument::class)
-                assertEquals(it.compilerArguments[X_ASSERTIONS], AssertionsMode.JVM)
+                assertEquals(AssertionsMode.JVM, it.compilerArguments[X_ASSERTIONS])
             }) {
                 assertLogContainsLines(
                     LogLevel.WARN,
@@ -254,6 +246,109 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
             }
         }
     }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("JS klib compilation: -ir-output-dir emits a warning")
+    fun testJsIrOutputDirWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedArguments(
+                restrictedArg("-ir-output-dir", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-ir-output-dir", "output/dir"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("JS linking: -Xir-produce-js and -Xinclude emit warnings")
+    fun testJsLinkingRestrictedArgumentsWarnings(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedLinkingArguments(
+                restrictedArg("-Xir-produce-js", errorSince = KotlinReleaseVersion.v2_6_0),
+                restrictedArg("-Xinclude", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-Xir-produce-js", "-Xinclude=${module.outputDirectory}"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("Wasm klib compilation: -ir-output-dir emits a warning")
+    fun testWasmIrOutputDirWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        wasmProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedArguments(
+                restrictedArg("-ir-output-dir", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-ir-output-dir", "output/dir"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("Wasm linking: -Xir-produce-js and -Xinclude emit warnings")
+    fun testWasmLinkingRestrictedArgumentsWarnings(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        wasmProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedLinkingArguments(
+                restrictedArg("-Xir-produce-js", errorSince = KotlinReleaseVersion.v2_6_0),
+                restrictedArg("-Xinclude", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-Xir-produce-js", "-Xinclude=${module.outputDirectory}"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("JS klib compilation: -Xir-produce-klib-dir emits a warning")
+    fun testJsIrProduceKlibDirWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedArguments(
+                restrictedArg("-Xir-produce-klib-dir", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-Xir-produce-klib-dir"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("JS klib compilation: -Xir-produce-klib-file emits a warning")
+    fun testJsIrProduceKlibFileWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedArguments(
+                restrictedArg("-Xir-produce-klib-file", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-Xir-produce-klib-file"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("Wasm klib compilation: -Xir-produce-klib-dir emits a warning")
+    fun testWasmIrProduceKlibDirWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        wasmProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedArguments(
+                restrictedArg("-Xir-produce-klib-dir", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-Xir-produce-klib-dir"),
+            )
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("Wasm klib compilation: -Xir-produce-klib-file emits a warning")
+    fun testWasmIrProduceKlibFileWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        wasmProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.checkRestrictedArguments(
+                restrictedArg("-Xir-produce-klib-file", errorSince = KotlinReleaseVersion.v2_6_0),
+                configuredArgs = listOf("-Xir-produce-klib-file"),
+            )
+        }
+    }
+
+    private fun restrictedArg(
+        vararg argumentAliases: String,
+        errorSince: KotlinReleaseVersion,
+    ): Pair<List<String>, KotlinReleaseVersion> = argumentAliases.toList() to errorSince
 
     private fun CompilationOutcome.assertRestrictedArgWarning(
         argumentAliases: List<String>,
@@ -266,19 +361,6 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
         )
     }
 
-    private fun Module<out BaseCompilationOperation, *, *>.checkRestrictedArgument(
-        vararg argumentAliases: String,
-        errorSince: KotlinReleaseVersion,
-        configuredArgs: List<String>,
-        expectedCompilationError: Boolean = false,
-        additionalCompilationAssertions: CompilationOutcome.() -> Unit = {},
-    ) = checkRestrictedArguments(
-        argumentAliases.toList() to errorSince,
-        configuredArgs = configuredArgs,
-        expectedCompilationError = expectedCompilationError,
-        additionalCompilationAssertions = additionalCompilationAssertions,
-    )
-
     private fun Module<out BaseCompilationOperation, *, *>.checkRestrictedArguments(
         vararg restrictedArgs: Pair<List<String>, KotlinReleaseVersion>,
         configuredArgs: List<String>,
@@ -286,13 +368,57 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
         additionalCompilationAssertions: CompilationOutcome.() -> Unit = {},
     ) {
         val currentVersion = KotlinToolingVersion(project.kotlinToolchain.getCompilerVersion())
-        val firstErrorSince = restrictedArgs.minOf { it.second }
-        val isWarning = currentVersion < KotlinToolingVersion(firstErrorSince.major, firstErrorSince.minor, firstErrorSince.patch, "dev-1")
+        runRestrictedArgumentsCheck(
+            currentVersion = currentVersion,
+            restrictedArgs = restrictedArgs.toList(),
+            configuredArgs = configuredArgs,
+            expectedCompilationError = expectedCompilationError,
+            additionalCompilationAssertions = additionalCompilationAssertions,
+        ) { compilationConfigAction, assertions ->
+            compile(compilationConfigAction = compilationConfigAction) { assertions() }
+        }
+    }
 
-        if (isWarning) {
-            compile(compilationConfigAction = {
-                it.compilerArguments.applyArgumentStrings(configuredArgs)
-            }) {
+    private fun <O : BaseCompilationOperation, B : BaseCompilationOperation.Builder, M> M.checkRestrictedLinkingArguments(
+        vararg restrictedArgs: Pair<List<String>, KotlinReleaseVersion>,
+        configuredArgs: List<String>,
+        expectedCompilationError: Boolean = false,
+        additionalCompilationAssertions: CompilationOutcome.() -> Unit = {},
+    ) where M : Module<*, *, *>, M : LinkableModule<O, B> {
+        compile()
+        val currentVersion = KotlinToolingVersion(project.kotlinToolchain.getCompilerVersion())
+        runRestrictedArgumentsCheck(
+            currentVersion = currentVersion,
+            restrictedArgs = restrictedArgs.toList(),
+            configuredArgs = configuredArgs,
+            expectedCompilationError = expectedCompilationError,
+            additionalCompilationAssertions = additionalCompilationAssertions,
+        ) { compilationConfigAction, assertions ->
+            link(compilationConfigAction = compilationConfigAction) { assertions() }
+        }
+    }
+
+    private fun isWarningPhase(
+        currentVersion: KotlinToolingVersion,
+        restrictedArgs: List<Pair<List<String>, KotlinReleaseVersion>>,
+    ): Boolean {
+        val firstErrorSince = restrictedArgs.minOf { it.second }
+        return currentVersion < KotlinToolingVersion(firstErrorSince.major, firstErrorSince.minor, firstErrorSince.patch, "dev-1")
+    }
+
+    private fun runRestrictedArgumentsCheck(
+        currentVersion: KotlinToolingVersion,
+        restrictedArgs: List<Pair<List<String>, KotlinReleaseVersion>>,
+        configuredArgs: List<String>,
+        expectedCompilationError: Boolean,
+        additionalCompilationAssertions: CompilationOutcome.() -> Unit,
+        runOperation: (
+            compilationConfigAction: (BaseCompilationOperation.Builder) -> Unit,
+            assertions: CompilationOutcome.() -> Unit,
+        ) -> Unit,
+    ) {
+        if (isWarningPhase(currentVersion, restrictedArgs)) {
+            runOperation({ it.compilerArguments.applyArgumentStrings(configuredArgs) }) {
                 if (expectedCompilationError) {
                     expectFail()
                 }
@@ -303,24 +429,20 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
             }
         } else {
             // Error args require separate compilations because the first error throws an exception
-
-            val compilationBody = {
-                compile(compilationConfigAction = {
-                    it.compilerArguments.applyArgumentStrings(configuredArgs)
-                }) {
+            val exception = assertThrows<CompilerArgumentsParseException> {
+                runOperation({ it.compilerArguments.applyArgumentStrings(configuredArgs) }) {
                     if (expectedCompilationError) {
                         expectFail()
                     }
                     additionalCompilationAssertions()
                 }
             }
-            val exception = assertThrows<CompilerArgumentsParseException> { compilationBody() }
             assertTrue(
                 restrictedArgs.flatMap { it.first }.any { alias ->
                     exception.message?.contains("'$alias' is not supported in the Build Tools API.") == true
                 }
             ) {
-                "Exception was: \"${exception.message}\" and did not contain any of ${restrictedArgs.flatMap { it.first }.joinToString() }"
+                "Exception was: \"${exception.message}\" and did not contain any of ${restrictedArgs.flatMap { it.first }.joinToString()}"
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -564,7 +564,6 @@ public final class org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerA
 
 public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments : org/jetbrains/kotlin/buildtools/api/arguments/CommonKlibBasedArguments {
 	public static final field Companion Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments$Companion;
-	public static final field IR_OUTPUT_DIR Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments$CommonJsAndWasmArgument;
 	public static final field IR_OUTPUT_NAME Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments$CommonJsAndWasmArgument;
 	public static final field LIBRARIES Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments$CommonJsAndWasmArgument;
 	public static final field NOPACK Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments$CommonJsAndWasmArgument;
@@ -592,8 +591,6 @@ public final class org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasm
 public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments : org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments, org/jetbrains/kotlin/buildtools/api/arguments/CommonKlibBasedArgumentsKlibArguments {
 	public static final field Companion Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments$Companion;
 	public static final field X_IR_PER_MODULE_OUTPUT_NAME Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments$CommonJsAndWasmCompilerKlibArgument;
-	public static final field X_IR_PRODUCE_KLIB_DIR Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments$CommonJsAndWasmCompilerKlibArgument;
-	public static final field X_IR_PRODUCE_KLIB_FILE Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments$CommonJsAndWasmCompilerKlibArgument;
 	public abstract fun get (Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments$CommonJsAndWasmCompilerKlibArgument;)Ljava/lang/Object;
 }
 
@@ -622,11 +619,9 @@ public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/Co
 	public static final field SOURCE_MAP_PREFIX Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_CACHE_DIRECTORY Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_GENERATE_DTS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
-	public static final field X_INCLUDE Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_IR_DCE Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_IR_DCE_PRINT_REACHABILITY_INFO Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_IR_DCE_RUNTIME_DIAGNOSTIC Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
-	public static final field X_IR_PRODUCE_JS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_IR_PROPERTY_LAZY_INITIALIZATION Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public static final field X_STRICT_IMPLICIT_EXPORT_TYPES Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;
 	public abstract fun get (Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments$CommonJsAndWasmCompilerLinkingArgument;)Ljava/lang/Object;

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmArguments.kt
@@ -90,13 +90,6 @@ public interface CommonJsAndWasmArguments : CommonKlibBasedArguments {
         CommonJsAndWasmArgument("X_IR_MODULE_NAME", KotlinReleaseVersion(1, 4, 0))
 
     /**
-     * Destination for generated files.
-     */
-    @JvmField
-    public val IR_OUTPUT_DIR: CommonJsAndWasmArgument<Path?> =
-        CommonJsAndWasmArgument("IR_OUTPUT_DIR", KotlinReleaseVersion(1, 8, 20))
-
-    /**
      * Base name of generated files.
      */
     @JvmField

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerKlibArguments.kt
@@ -3,10 +3,8 @@
 
 package org.jetbrains.kotlin.buildtools.api.arguments
 
-import kotlin.Boolean
 import kotlin.String
 import kotlin.jvm.JvmField
-import org.jetbrains.kotlin.buildtools.api.DeprecatedCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
 
 /**
@@ -69,31 +67,5 @@ public interface CommonJsAndWasmCompilerKlibArguments : CommonJsAndWasmArguments
     @ExperimentalCompilerArgument
     public val X_IR_PER_MODULE_OUTPUT_NAME: CommonJsAndWasmCompilerKlibArgument<String?> =
         CommonJsAndWasmCompilerKlibArgument("X_IR_PER_MODULE_OUTPUT_NAME", KotlinReleaseVersion(1, 5, 30))
-
-    /**
-     * Generate an unpacked klib into the parent directory of the output JS file.
-     *
-     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
-     *
-     * Deprecated in Kotlin version 2.4.20.
-     */
-    @JvmField
-    @ExperimentalCompilerArgument
-    @DeprecatedCompilerArgument
-    public val X_IR_PRODUCE_KLIB_DIR: CommonJsAndWasmCompilerKlibArgument<Boolean?> =
-        CommonJsAndWasmCompilerKlibArgument("X_IR_PRODUCE_KLIB_DIR", KotlinReleaseVersion(1, 3, 70))
-
-    /**
-     * Generate a packed klib into the directory specified by '-ir-output-dir'.
-     *
-     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
-     *
-     * Deprecated in Kotlin version 2.4.20.
-     */
-    @JvmField
-    @ExperimentalCompilerArgument
-    @DeprecatedCompilerArgument
-    public val X_IR_PRODUCE_KLIB_FILE: CommonJsAndWasmCompilerKlibArgument<Boolean?> =
-        CommonJsAndWasmCompilerKlibArgument("X_IR_PRODUCE_KLIB_FILE", KotlinReleaseVersion(1, 3, 70))
   }
 }

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonJsAndWasmCompilerLinkingArguments.kt
@@ -86,16 +86,6 @@ public interface CommonJsAndWasmCompilerLinkingArguments : CommonJsAndWasmArgume
         CommonJsAndWasmCompilerLinkingArgument("X_GENERATE_DTS", KotlinReleaseVersion(1, 3, 70))
 
     /**
-     * Path to an intermediate library that should be processed in the same manner as source files.
-     *
-     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
-     */
-    @JvmField
-    @ExperimentalCompilerArgument
-    public val X_INCLUDE: CommonJsAndWasmCompilerLinkingArgument<Path?> =
-        CommonJsAndWasmCompilerLinkingArgument("X_INCLUDE", KotlinReleaseVersion(1, 4, 0))
-
-    /**
      * Perform experimental dead code elimination.
      *
      * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
@@ -125,16 +115,6 @@ public interface CommonJsAndWasmCompilerLinkingArguments : CommonJsAndWasmArgume
     public val X_IR_DCE_RUNTIME_DIAGNOSTIC:
         CommonJsAndWasmCompilerLinkingArgument<JsIrDiagnosticMode?> =
         CommonJsAndWasmCompilerLinkingArgument("X_IR_DCE_RUNTIME_DIAGNOSTIC", KotlinReleaseVersion(1, 5, 0))
-
-    /**
-     * Generate a JS file using the IR backend.
-     *
-     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
-     */
-    @JvmField
-    @ExperimentalCompilerArgument
-    public val X_IR_PRODUCE_JS: CommonJsAndWasmCompilerLinkingArgument<Boolean> =
-        CommonJsAndWasmCompilerLinkingArgument("X_IR_PRODUCE_JS", KotlinReleaseVersion(1, 3, 70))
 
     /**
      * Perform lazy initialization for properties.

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/Main.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/Main.kt
@@ -136,7 +136,6 @@ private fun generateBtaOptions(arguments: List<Array<String>>, genDir: Path, kot
             levelsToProcess += currentLevel.level.nestedLevels.flatMap { level ->
                 // "Skip" the deprecated and soon to be removed Wasm arguments level from the JS arguments hierarchy.
                 // There is a separate Wasm-only level in another arguments branch to avoid mixing JS and Wasm hierarchies.
-                println("AAA " + level.name)
                 if (level.name == CompilerArgumentsLevelNames.legacyWasmArguments) {
                     level.nestedLevels
                 } else {

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/Main.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/Main.kt
@@ -136,6 +136,7 @@ private fun generateBtaOptions(arguments: List<Array<String>>, genDir: Path, kot
             levelsToProcess += currentLevel.level.nestedLevels.flatMap { level ->
                 // "Skip" the deprecated and soon to be removed Wasm arguments level from the JS arguments hierarchy.
                 // There is a separate Wasm-only level in another arguments branch to avoid mixing JS and Wasm hierarchies.
+                println("AAA " + level.name)
                 if (level.name == CompilerArgumentsLevelNames.legacyWasmArguments) {
                     level.nestedLevels
                 } else {
@@ -177,21 +178,12 @@ private fun generateBtaVersion(localArgs: Array<String>, genDir: Path, kotlinVer
 private fun SyntheticArgumentInterface.toLevelWithParent(
     targetPackage: String,
 ): LevelWithParent = LevelWithParent(
-    KotlinCompilerArgumentsLevel(
-        name,
-        level.arguments.filter { it.restrictedToCompilerPhase == restrictedToCompilerPhase }.toSet(),
-        if (syntheticArgumentInterfaces.any { this in it.parentInterfaces }) {
-            setOf(DummyLevel)
-        } else emptySet(),
-        level.modifiers
-    ),
+    syntheticLevels.getValue(name),
     parentInterfaces.firstOrNull()?.let {
         ClassName(targetPackage, it.name)
     } ?: ClassName(targetPackage, "CommonCompilerArguments"),
     parentInterfaces.map { ClassName(targetPackage, it.name) }
 )
-
-val DummyLevel = KotlinCompilerArgumentsLevel("", emptySet(), emptySet(), emptySet())
 
 internal interface BtaOptionsGenerator {
     val targetPackage: String

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/SyntheticArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/SyntheticArguments.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.buildtools.generator
+
+import org.jetbrains.kotlin.arguments.description.CompilerArgumentsLevelNames
+import org.jetbrains.kotlin.arguments.description.kotlinCompilerArguments
+import org.jetbrains.kotlin.arguments.dsl.base.KotlinCompilerArgumentsLevel
+import org.jetbrains.kotlin.arguments.dsl.base.KotlinCompilerPhase
+
+internal class SyntheticArgumentInterface(
+    val name: String,
+    val level: KotlinCompilerArgumentsLevel,
+    val parentInterfaces: List<SyntheticArgumentInterface>,
+    val concreteClassName: String? = null,
+    val restrictedToCompilerPhase: KotlinCompilerPhase? = null,
+)
+
+private fun SyntheticArgumentInterface.toLevel(): KotlinCompilerArgumentsLevel =
+    KotlinCompilerArgumentsLevel(
+        name,
+        level.arguments.filter { it.restrictedToCompilerPhase == restrictedToCompilerPhase }.toSet(),
+        if (syntheticArgumentInterfaces.any { this in it.parentInterfaces }) {
+            setOf(DummyLevel)
+        } else emptySet(),
+        level.modifiers
+    )
+
+val DummyLevel = KotlinCompilerArgumentsLevel("", emptySet(), emptySet(), emptySet())
+
+/**
+ * Looks up the merged argument level (actual + removed arguments) by name from [kotlinCompilerArguments].
+ *
+ * The synthetic KLIB-based interfaces must use the merged level rather than the raw `actual*Arguments`
+ * objects, otherwise removed arguments (declared in the separate `removed*Arguments` levels and combined
+ * only via `mergeWith` in `compilerArguments.kt`) would never reach the API generator.
+ */
+private fun findMergedLevel(name: String): KotlinCompilerArgumentsLevel {
+    fun search(level: KotlinCompilerArgumentsLevel): KotlinCompilerArgumentsLevel? {
+        if (level.name == name) return level
+        for (nested in level.nestedLevels) {
+            search(nested)?.let { return it }
+        }
+        return null
+    }
+    return search(kotlinCompilerArguments.topLevel) ?: error("Merged level $name is not found in kotlinCompilerArguments")
+}
+
+object SyntheticArgumentNames {
+    const val commonKlibBasedArguments = "CommonKlibBasedArguments"
+    const val commonKlibBasedArgumentsKlibArguments = "CommonKlibBasedArgumentsKlibArguments"
+    const val commonKlibBasedArgumentsLinkingArguments = "CommonKlibBasedArgumentsLinkingArguments"
+    const val commonJsAndWasmArguments = "CommonJsAndWasmArguments"
+    const val commonJsAndWasmCompilerKlibArguments = "CommonJsAndWasmCompilerKlibArguments"
+    const val commonJsAndWasmCompilerLinkingArguments = "CommonJsAndWasmCompilerLinkingArguments"
+    const val jsCompilerArguments = "JsCompilerArguments"
+    const val jsCompilerKlibArguments = "JsCompilerKlibArguments"
+    const val jsCompilerLinkingArguments = "JsCompilerLinkingArguments"
+    const val wasmCompilerArguments = "WasmCompilerArguments"
+    const val wasmCompilerKlibArguments = "WasmCompilerKlibArguments"
+    const val wasmCompilerLinkingArguments = "WasmCompilerLinkingArguments"
+}
+
+internal val syntheticArgumentInterfaces = buildList {
+    val commonKlibBasedArguments = findMergedLevel(CompilerArgumentsLevelNames.commonKlibBasedArguments)
+    val commonJsAndWasmArguments = findMergedLevel(CompilerArgumentsLevelNames.commonJsAndWasmArguments)
+    val jsArguments = findMergedLevel(CompilerArgumentsLevelNames.jsArguments)
+    val wasmArguments = findMergedLevel(CompilerArgumentsLevelNames.wasmArguments)
+
+    val commonKlibBasedCompilerArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.commonKlibBasedArguments,
+        commonKlibBasedArguments,
+        emptyList(),
+        "CommonKlibBasedArgumentsImpl",
+    ).also(::add)
+    val commonKlibBasedCompilerKlibArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.commonKlibBasedArgumentsKlibArguments,
+        commonKlibBasedArguments,
+        listOf(commonKlibBasedCompilerArguments),
+        "CommonKlibBasedArgumentsImpl",
+        KotlinCompilerPhase.KLIB_COMPILATION
+    ).also(::add)
+    val commonKlibBasedCompilerLinkingArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.commonKlibBasedArgumentsLinkingArguments,
+        commonKlibBasedArguments,
+        listOf(commonKlibBasedCompilerArguments),
+        "CommonKlibBasedArgumentsImpl",
+        KotlinCompilerPhase.BACKEND_COMPILATION
+    ).also(::add)
+
+    val commonJsAndWasmCompilerArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.commonJsAndWasmArguments,
+        commonJsAndWasmArguments,
+        listOf(commonKlibBasedCompilerArguments),
+        "CommonJsAndWasmArgumentsImpl",
+    ).also(::add)
+
+    val commonJsAndWasmCompilerKlibArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.commonJsAndWasmCompilerKlibArguments,
+        commonJsAndWasmArguments,
+        listOf(commonJsAndWasmCompilerArguments, commonKlibBasedCompilerKlibArguments),
+        "CommonJsAndWasmArgumentsImpl",
+        KotlinCompilerPhase.KLIB_COMPILATION
+    ).also(::add)
+
+    val commonJsAndWasmCompilerLinkingArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.commonJsAndWasmCompilerLinkingArguments,
+        commonJsAndWasmArguments,
+        listOf(commonJsAndWasmCompilerArguments, commonKlibBasedCompilerLinkingArguments),
+        "CommonJsAndWasmArgumentsImpl",
+        KotlinCompilerPhase.BACKEND_COMPILATION
+    ).also(::add)
+
+    val jsCompilerArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.jsCompilerArguments,
+        jsArguments,
+        listOf(commonJsAndWasmCompilerArguments),
+        "JsArgumentsImpl",
+    ).also(::add)
+
+    SyntheticArgumentInterface(
+        SyntheticArgumentNames.jsCompilerKlibArguments,
+        jsArguments,
+        listOf(jsCompilerArguments, commonJsAndWasmCompilerKlibArguments),
+        "JsArgumentsImpl",
+        KotlinCompilerPhase.KLIB_COMPILATION
+    ).also(::add)
+
+    SyntheticArgumentInterface(
+        SyntheticArgumentNames.jsCompilerLinkingArguments,
+        jsArguments,
+        listOf(jsCompilerArguments, commonJsAndWasmCompilerLinkingArguments),
+        "JsArgumentsImpl",
+        KotlinCompilerPhase.BACKEND_COMPILATION
+    ).also(::add)
+
+    val wasmCompilerArguments = SyntheticArgumentInterface(
+        SyntheticArgumentNames.wasmCompilerArguments,
+        wasmArguments,
+        listOf(commonJsAndWasmCompilerArguments),
+        "WasmArgumentsImpl",
+    ).also(::add)
+
+    SyntheticArgumentInterface(
+        SyntheticArgumentNames.wasmCompilerKlibArguments,
+        wasmArguments,
+        listOf(wasmCompilerArguments, commonJsAndWasmCompilerKlibArguments),
+        "WasmArgumentsImpl",
+        KotlinCompilerPhase.KLIB_COMPILATION
+    ).also(::add)
+
+    SyntheticArgumentInterface(
+        SyntheticArgumentNames.wasmCompilerLinkingArguments,
+        wasmArguments,
+        listOf(wasmCompilerArguments, commonJsAndWasmCompilerLinkingArguments),
+        "WasmArgumentsImpl",
+        KotlinCompilerPhase.BACKEND_COMPILATION
+    ).also(::add)
+}
+
+internal val syntheticLevels = syntheticArgumentInterfaces.associate { it.name to it.toLevel() }

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/argumentTransforms.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/argumentTransforms.kt
@@ -131,11 +131,80 @@ private val levelsToArgumentTransforms: Map<String, Map<String, ArgumentTransfor
             drop("Xjavac-arguments")
         }
     })
+    put(SyntheticArgumentNames.commonJsAndWasmCompilerKlibArguments, buildMap {
+        with(syntheticLevels.getValue(SyntheticArgumentNames.commonJsAndWasmCompilerKlibArguments)) {
+            restrict(
+                "Xir-produce-klib-dir",
+                reason = "Producing packed/unpacked klib is controlled using the `nopack` argument.",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+            restrict(
+                "Xir-produce-klib-file",
+                reason = "Producing packed/unpacked klib is controlled using the `nopack` argument.",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+        }
+    })
+    put(SyntheticArgumentNames.commonJsAndWasmCompilerLinkingArguments, buildMap {
+        with(syntheticLevels.getValue(SyntheticArgumentNames.commonJsAndWasmCompilerLinkingArguments)) {
+            restrict(
+                "Xir-produce-js",
+                reason = "It is added automatically based on type of operation (klib vs linking).",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+            restrict(
+                "Xinclude",
+                reason = "It is overwritten with the klib property of the linking operation.",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+        }
+    })
+    put(SyntheticArgumentNames.commonJsAndWasmArguments, buildMap {
+        with(syntheticLevels.getValue(SyntheticArgumentNames.commonJsAndWasmArguments)) {
+            restrict(
+                "ir-output-dir",
+                reason = "It is overwritten with the destination property of the build operation. ",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+        }
+    })
     put(actualCommonJsAndWasmArguments.name, buildMap {
         with(actualCommonJsAndWasmArguments) {
-            drop("Xir-produce-js")
-            drop("Xir-produce-klib-dir")
-            drop("Xir-produce-klib-file")
+            restrict(
+                "Xir-produce-js",
+                reason = "It is added automatically based on type of operation (klib vs linking).",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+            restrict(
+                "ir-output-dir",
+                reason = "It is overwritten with the destination property of the build operation. ",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+            restrict(
+                "Xinclude",
+                reason = "It is overwritten with the klib property of the linking operation.",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+            restrict(
+                "Xir-produce-klib-dir",
+                reason = "Producing packed/unpacked klib is controlled using the `nopack` argument.",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
+            restrict(
+                "Xir-produce-klib-file",
+                reason = "Producing packed/unpacked klib is controlled using the `nopack` argument.",
+                warningSince = KotlinReleaseVersion.v2_5_0,
+                errorSince = KotlinReleaseVersion.v2_6_0
+            )
         }
     })
 }
@@ -259,127 +328,4 @@ private fun KotlinCompilerArgumentsLevel.findAncestorsTo(targetLevel: KotlinComp
         if (path != null) return listOf(this) + path
     }
     return null
-}
-
-internal class SyntheticArgumentInterface(
-    val name: String,
-    val level: KotlinCompilerArgumentsLevel,
-    val parentInterfaces: List<SyntheticArgumentInterface>,
-    val concreteClassName: String? = null,
-    val restrictedToCompilerPhase: KotlinCompilerPhase? = null,
-)
-
-/**
- * Looks up the merged argument level (actual + removed arguments) by name from [kotlinCompilerArguments].
- *
- * The synthetic KLIB-based interfaces must use the merged level rather than the raw `actual*Arguments`
- * objects, otherwise removed arguments (declared in the separate `removed*Arguments` levels and combined
- * only via `mergeWith` in `compilerArguments.kt`) would never reach the API generator.
- */
-private fun findMergedLevel(name: String): KotlinCompilerArgumentsLevel {
-    fun search(level: KotlinCompilerArgumentsLevel): KotlinCompilerArgumentsLevel? {
-        if (level.name == name) return level
-        for (nested in level.nestedLevels) {
-            search(nested)?.let { return it }
-        }
-        return null
-    }
-    return search(kotlinCompilerArguments.topLevel) ?: error("Merged level $name is not found in kotlinCompilerArguments")
-}
-
-internal val syntheticArgumentInterfaces = buildList {
-    val commonKlibBasedArguments = findMergedLevel(CompilerArgumentsLevelNames.commonKlibBasedArguments)
-    val commonJsAndWasmArguments = findMergedLevel(CompilerArgumentsLevelNames.commonJsAndWasmArguments)
-    val jsArguments = findMergedLevel(CompilerArgumentsLevelNames.jsArguments)
-    val wasmArguments = findMergedLevel(CompilerArgumentsLevelNames.wasmArguments)
-
-    val commonKlibBasedCompilerArguments = SyntheticArgumentInterface(
-        "CommonKlibBasedArguments",
-        commonKlibBasedArguments,
-        emptyList(),
-        "CommonKlibBasedArgumentsImpl",
-    ).also(::add)
-    val commonKlibBasedCompilerKlibArguments = SyntheticArgumentInterface(
-        "CommonKlibBasedArgumentsKlibArguments",
-        commonKlibBasedArguments,
-        listOf(commonKlibBasedCompilerArguments),
-        "CommonKlibBasedArgumentsImpl",
-        KotlinCompilerPhase.KLIB_COMPILATION
-    ).also(::add)
-    val commonKlibBasedCompilerLinkingArguments = SyntheticArgumentInterface(
-        "CommonKlibBasedArgumentsLinkingArguments",
-        commonKlibBasedArguments,
-        listOf(commonKlibBasedCompilerArguments),
-        "CommonKlibBasedArgumentsImpl",
-        KotlinCompilerPhase.BACKEND_COMPILATION
-    ).also(::add)
-
-    val commonJsAndWasmCompilerArguments = SyntheticArgumentInterface(
-        "CommonJsAndWasmArguments",
-        commonJsAndWasmArguments,
-        listOf(commonKlibBasedCompilerArguments),
-        "CommonJsAndWasmArgumentsImpl",
-    ).also(::add)
-
-    val commonJsAndWasmCompilerKlibArguments = SyntheticArgumentInterface(
-        "CommonJsAndWasmCompilerKlibArguments",
-        commonJsAndWasmArguments,
-        listOf(commonJsAndWasmCompilerArguments, commonKlibBasedCompilerKlibArguments),
-        "CommonJsAndWasmArgumentsImpl",
-        KotlinCompilerPhase.KLIB_COMPILATION
-    ).also(::add)
-
-    val commonJsAndWasmCompilerLinkingArguments = SyntheticArgumentInterface(
-        "CommonJsAndWasmCompilerLinkingArguments",
-        commonJsAndWasmArguments,
-        listOf(commonJsAndWasmCompilerArguments, commonKlibBasedCompilerLinkingArguments),
-        "CommonJsAndWasmArgumentsImpl",
-        KotlinCompilerPhase.BACKEND_COMPILATION
-    ).also(::add)
-
-    val jsCompilerArguments = SyntheticArgumentInterface(
-        "JsCompilerArguments",
-        jsArguments,
-        listOf(commonJsAndWasmCompilerArguments),
-        "JsArgumentsImpl",
-    ).also(::add)
-
-    SyntheticArgumentInterface(
-        "JsCompilerKlibArguments",
-        jsArguments,
-        listOf(jsCompilerArguments, commonJsAndWasmCompilerKlibArguments),
-        "JsArgumentsImpl",
-        KotlinCompilerPhase.KLIB_COMPILATION
-    ).also(::add)
-
-    SyntheticArgumentInterface(
-        "JsCompilerLinkingArguments",
-        jsArguments,
-        listOf(jsCompilerArguments, commonJsAndWasmCompilerLinkingArguments),
-        "JsArgumentsImpl",
-        KotlinCompilerPhase.BACKEND_COMPILATION
-    ).also(::add)
-
-    val wasmCompilerArguments = SyntheticArgumentInterface(
-        "WasmCompilerArguments",
-        wasmArguments,
-        listOf(commonJsAndWasmCompilerArguments),
-        "WasmArgumentsImpl",
-    ).also(::add)
-
-    SyntheticArgumentInterface(
-        "WasmCompilerKlibArguments",
-        wasmArguments,
-        listOf(wasmCompilerArguments, commonJsAndWasmCompilerKlibArguments),
-        "WasmArgumentsImpl",
-        KotlinCompilerPhase.KLIB_COMPILATION
-    ).also(::add)
-
-    SyntheticArgumentInterface(
-        "WasmCompilerLinkingArguments",
-        wasmArguments,
-        listOf(wasmCompilerArguments, commonJsAndWasmCompilerLinkingArguments),
-        "WasmArgumentsImpl",
-        KotlinCompilerPhase.BACKEND_COMPILATION
-    ).also(::add)
 }

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonJsAndWasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonJsAndWasmArgumentsImpl.kt
@@ -61,6 +61,7 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerKlib
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.cli.common.arguments.CommonJsAndWasmCompilerArguments
+import org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings as compilerToArgumentStrings
 import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KC_VERSION
 
@@ -233,6 +234,18 @@ internal abstract class CommonJsAndWasmArgumentsImpl(
     if (SOURCE_MAP_NAMES_POLICY in this) { arguments.sourceMapNamesPolicy = get(SOURCE_MAP_NAMES_POLICY)?.stringValue}
     if (SOURCE_MAP_PREFIX in this) { arguments.sourceMapPrefix = get(SOURCE_MAP_PREFIX)}
     return arguments
+  }
+
+  @Suppress("DEPRECATION")
+  internal override fun collectRestrictedArgViolations(compilerArgs: CommonToolArguments, defaultArgs: CommonToolArguments) {
+    super.collectRestrictedArgViolations(compilerArgs, defaultArgs)
+    val args = compilerArgs as CommonJsAndWasmCompilerArguments
+    val castedDefaults = defaultArgs as CommonJsAndWasmCompilerArguments
+    if (args.irProduceJs != castedDefaults.irProduceJs) _restrictedArgViolations.add(RestrictedArgViolation.Warning("Argument '-Xir-produce-js' is not supported in the Build Tools API. It is added automatically based on type of operation (klib vs linking). This warning will become an error starting from Kotlin 2.6.0."))
+    if (args.outputDir != castedDefaults.outputDir) _restrictedArgViolations.add(RestrictedArgViolation.Warning("Argument '-ir-output-dir' is not supported in the Build Tools API. It is overwritten with the destination property of the build operation.  This warning will become an error starting from Kotlin 2.6.0."))
+    if (args.includes != castedDefaults.includes) _restrictedArgViolations.add(RestrictedArgViolation.Warning("Argument '-Xinclude' is not supported in the Build Tools API. It is overwritten with the klib property of the linking operation. This warning will become an error starting from Kotlin 2.6.0."))
+    if (args.irProduceKlibDir != castedDefaults.irProduceKlibDir) _restrictedArgViolations.add(RestrictedArgViolation.Warning("Argument '-Xir-produce-klib-dir' is not supported in the Build Tools API. Producing packed/unpacked klib is controlled using the `nopack` argument. This warning will become an error starting from Kotlin 2.6.0."))
+    if (args.irProduceKlibFile != castedDefaults.irProduceKlibFile) _restrictedArgViolations.add(RestrictedArgViolation.Warning("Argument '-Xir-produce-klib-file' is not supported in the Build Tools API. Producing packed/unpacked klib is controlled using the `nopack` argument. This warning will become an error starting from Kotlin 2.6.0."))
   }
 
   public class CommonJsAndWasmArgument<V>(


### PR DESCRIPTION
The restrict() compiler argument transformation in the BTA generator didn't fully work for the synthetic Wasm/JS argument levels.

Dropped JS/Wasm compiler arguments were still present in the public BTA.

JS and Wasm klib compilation and linking operations silently ignored the IR_OUTPUT_DIR and X_INCLUDE compiler arguments.

^KT-88298 Verification Pending
^KT-88299 Verification Pending