### PR TITLE
[Swift Export][tests] Fix the golden data for kotlinx-coroutines-core

### DIFF
--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-coroutines-core/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -941,7 +941,7 @@ extension ExportedKotlinPackages.kotlin.coroutines {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    @available(*, deprecated, message: "Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage depending on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.") @_spi(kotlin$ExperimentalStdlibApi)
+    @available(*, deprecated, message: "Polymorphic coroutine context keys are error-prone, difficult to implement correctly, and can encourage users to depend on implementation details. Prefer retrieving the element by its base key and casting it explicitly when needed or introducing a dedicated extension property.") @_spi(kotlin$ExperimentalStdlibApi)
     open class AbstractCoroutineContextKey: KotlinRuntime.KotlinBase {
         @_spi(kotlin$ExperimentalStdlibApi)
         public init(


### PR DESCRIPTION
d720bff updates a deprecation message in stdlib.
Swift Export tests named "kotlinx-coroutines-core" capture the changed declaration. So, the golden data for those tests contains the deprecation message and needed to be updated.

~~It wasn't updated, and this went undetected by the Safe Merge, presumably because of a test federation misconfiguration.~~
The problem wasn't detected by the Safe Merge because of a cross-push: the Safe Merge for d720bff was started before the `kotlinx-coroutines-core` test was merged but landed after that.