### PR TITLE
[stdlib] Add text-specific samples for find, zipWithNext, mapNotNull, filterTo

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -50,7 +50,7 @@ public inline fun CharSequence.elementAtOrNull(index: Int): Char? {
 /**
  * Returns the first character matching the given [predicate], or `null` if no such character was found.
  * 
- * @sample samples.collections.Collections.Elements.find
+ * @sample samples.text.Strings.find
  */
 @kotlin.internal.InlineOnly
 public inline fun CharSequence.find(predicate: (Char) -> Boolean): Char? {
@@ -510,7 +510,7 @@ public inline fun <C : Appendable> CharSequence.filterNotTo(destination: C, pred
 /**
  * Appends all characters matching the given [predicate] to the given [destination].
  * 
- * @sample samples.collections.Collections.Filtering.filterTo
+ * @sample samples.text.Strings.filterTo
  */
 @IgnorableReturnValue
 public inline fun <C : Appendable> CharSequence.filterTo(destination: C, predicate: (Char) -> Boolean): C {
@@ -1044,7 +1044,7 @@ public inline fun <R, C : MutableCollection<in R>> CharSequence.mapIndexedTo(des
  * Returns a list containing only the non-null results of applying the given [transform] function
  * to each character in the original char sequence.
  * 
- * @sample samples.collections.Collections.Transformations.mapNotNull
+ * @sample samples.text.Strings.mapNotNull
  */
 public inline fun <R : Any> CharSequence.mapNotNull(transform: (Char) -> R?): List<R> {
     return mapNotNullTo(ArrayList<R>(), transform)
@@ -2543,7 +2543,7 @@ public inline fun <V> CharSequence.zip(other: CharSequence, transform: (a: Char,
  * 
  * The returned list is empty if this char sequence contains less than two characters.
  * 
- * @sample samples.collections.Collections.Transformations.zipWithNext
+ * @sample samples.text.Strings.zipWithNext
  */
 @SinceKotlin("1.2")
 public fun CharSequence.zipWithNext(): List<Pair<Char, Char>> {
@@ -2556,7 +2556,7 @@ public fun CharSequence.zipWithNext(): List<Pair<Char, Char>> {
  * 
  * The returned list is empty if this char sequence contains less than two characters.
  * 
- * @sample samples.collections.Collections.Transformations.zipWithNextToFindDeltas
+ * @sample samples.text.Strings.zipWithNextToFindRepeats
  */
 @SinceKotlin("1.2")
 public inline fun <R> CharSequence.zipWithNext(transform: (a: Char, b: Char) -> R): List<R> {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -163,6 +163,28 @@ class Strings {
     }
 
     @Sample
+    fun filterTo() {
+        val text = "a1b2c3d4"
+        val letters = StringBuilder()
+        val digits = StringBuilder()
+        assertPrints(letters, "")
+
+        text.filterTo(letters) { it.isLetter() }
+        text.filterNotTo(digits) { it.isLetter() }
+
+        assertPrints(letters, "abcd")
+        assertPrints(digits, "1234")
+    }
+
+    @Sample
+    fun find() {
+        val text = "a1b2c3d4e5"
+        assertPrints(text.find { it.isDigit() }, "1")
+        assertPrints(text.find { it.isUpperCase() }, "null")
+        assertPrints("".find { it.isLowerCase() }, "null")
+    }
+
+    @Sample
     fun findLast() {
         val text = "a1b2c3d4e5"
 
@@ -184,6 +206,28 @@ class Strings {
         val stringB = "zyx"
         val result = stringA.zip(stringB) { a, b -> "$a$b" }
         assertPrints(result, "[az, by, cx]")
+    }
+
+    @Sample
+    fun zipWithNext() {
+        val text = "abbcccd"
+        val pairs = text.zipWithNext()
+        assertPrints(pairs, "[(a, b), (b, b), (b, c), (c, c), (c, c), (c, d)]")
+    }
+
+    @Sample
+    fun zipWithNextToFindRepeats() {
+        val text = "abbcccd"
+        val repeatedPositions = text.zipWithNext { a, b -> a == b }
+        assertPrints(repeatedPositions, "[false, true, false, true, true, false]")
+    }
+
+    @Sample
+    fun mapNotNull() {
+        val text = "1a2b3c4"
+        val digits = text.mapNotNull { it.digitToIntOrNull() }
+        assertPrints(digits, "[1, 2, 3, 4]")
+        assertPrints(digits.sum(), "10")
     }
 
     @Sample

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
@@ -641,6 +641,9 @@ object Elements : TemplateGroupBase() {
         inline(Inline.Only)
         doc { "Returns the first ${f.element} matching the given [predicate], or `null` if no such ${f.element} was found." }
         sample("samples.collections.Collections.Elements.find")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.find")
+        }
         returns("T?")
         body { "return firstOrNull(predicate)"}
     }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
@@ -614,6 +614,9 @@ object Filtering : TemplateGroupBase() {
 
         doc { "Appends all ${f.element.pluralize()} matching the given [predicate] to the given [destination]." }
         sample("samples.collections.Collections.Filtering.filterTo")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.filterTo")
+        }
         annotation("@IgnorableReturnValue")
         typeParam("C : TCollection")
         returns("C")

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
@@ -931,6 +931,9 @@ object Generators : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Collections.Transformations.zipWithNextToFindDeltas")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.zipWithNextToFindRepeats")
+        }
         returns("List<R>")
         inline()
         body {
@@ -992,6 +995,9 @@ object Generators : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Collections.Transformations.zipWithNext")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.zipWithNext")
+        }
         sequenceClassification(intermediate, stateless)
         specialFor(Sequences) { returns("Sequence<Pair<T, T>>") }
         body {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
@@ -147,6 +147,9 @@ object Mapping : TemplateGroupBase() {
             else -> "samples.collections.Collections.Transformations"
         }
         sample("${sampleClass(f)}.mapNotNull")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.mapNotNull")
+        }
 
         body {
             "return mapNotNullTo(ArrayList<R>(), transform)"


### PR DESCRIPTION
Replaces the generic `kotlin.collections` samples with string-focused examples for four `kotlin.text` extension functions: `find`, `zipWithNext` (plain and transform overloads), `mapNotNull`, `filterTo`.

Related issue: [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867/kotlin.text-extension-function-samples-should-be-specialized-for-strings)

Scoped to these 4 functions; the rest of the ~29 listed in the issue are left for follow-up PRs, same as prior contributors did.