### PR TITLE
Reflection: use empty KmClass view for file facades / lambdas

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/syntheticClasses/syntheticClasses.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/syntheticClasses/syntheticClasses.kt
@@ -8,17 +8,14 @@ package test
 import kotlin.reflect.*
 import kotlin.test.*
 
-fun check(x: KClass<*>, expectedSupertypes: String = "[kotlin.Any]") {
-    // Mainly check that `members` doesn't crash for synthetic classes. The exact contents of `members` is not that important, except that
-    // it should probably contain equals, hashCode and toString.
-    val memberNames = x.members.mapTo(hashSetOf()) { it.name }
-    assertTrue(memberNames.containsAll(setOf("equals", "hashCode", "toString")), "Fail: $memberNames")
+fun check(x: KClass<*>) {
+    assertEquals(setOf("equals", "hashCode", "toString"), x.members.mapTo(hashSetOf()) { it.name })
 
     assertEquals(emptyList(), x.annotations)
     assertEquals(emptyList(), x.constructors)
     assertEquals(emptyList(), x.nestedClasses)
     assertEquals(null, x.objectInstance)
-    assertEquals(expectedSupertypes, x.supertypes.toString())
+    assertEquals("[kotlin.Any]", x.supertypes.toString())
     assertEquals(emptyList(), x.sealedSubclasses)
 
     assertEquals(KVisibility.PUBLIC, x.visibility)
@@ -70,16 +67,7 @@ fun checkKotlinLambda() {
 
     assertEquals(null, klass.qualifiedName)
 
-    check(
-        klass,
-        expectedSupertypes =
-            if (Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt").getMethod("getUseK1Implementation").invoke(null) == true)
-                // Legacy implementation uses a predefined class with the single supertype `Any`, see `KClassImpl.createSyntheticClass`.
-                "[kotlin.Any]"
-            else
-                // JVM backend generates a raw Lambda type as a superclass for non-indy lambdas.
-                "[kotlin.jvm.internal.Lambda<(raw) kotlin.Any!>, () -> kotlin.Unit!]"
-    )
+    check(klass)
 
     assertTrue(klass.isInstance(lambda))
     assertNotEquals(klass, (@JvmSerializableLambda {})::class)
@@ -90,15 +78,7 @@ fun checkKotlinLambda() {
 fun checkJavaLambda() {
     val lambda = JavaClass.lambda()
     val klass = lambda::class
-    check(
-        klass,
-        expectedSupertypes =
-            if (Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt").getMethod("getUseK1Implementation").invoke(null) == true)
-                // Legacy implementation uses a predefined class with the single supertype `Any`, see `KClassImpl.createSyntheticClass`.
-                "[kotlin.Any]"
-            else
-                "[java.lang.Runnable, kotlin.Any]"
-    )
+    check(klass)
 
     assertTrue(klass.isInstance(lambda))
     assertNotEquals(klass, Runnable {}::class)

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ConvertFromJava.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ConvertFromJava.kt
@@ -185,7 +185,7 @@ private fun createRawJavaType(
 }
 
 internal val KClass<*>.isMappedBuiltin: Boolean
-    get() = java.canonicalName != qualifiedName
+    get() = qualifiedName.let { it != null && java.canonicalName != it && it.startsWith("kotlin") }
 
 private fun SimpleKType.createMutableCollectionType(javaType: Type): SimpleKType? {
     val klass = classifier as? KClass<*> ?: return null

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt
@@ -74,10 +74,14 @@ internal class KClassImpl<T : Any>(
         val kmClass: KmClass? by lazy(PUBLICATION) {
             if (loadMetadataDirectly) {
                 val metadata = jClass.getAnnotation(Metadata::class.java)
-                if (metadata != null && classId.outerClassId !in CompanionObjectMapping.classIds)
-                    (KotlinClassMetadata.readLenient(metadata) as? KotlinClassMetadata.Class)?.kmClass
-                else
+                if (metadata != null && classId.outerClassId !in CompanionObjectMapping.classIds) {
+                    val metadata = KotlinClassMetadata.readLenient(metadata)
+                    (metadata as? KotlinClassMetadata.Class)?.kmClass ?: createEmptyKmClass()
+                } else if (jClass.isSynthetic) {
+                    createEmptyKmClass()
+                } else {
                     readBuiltinClassMetadata(classId)
+                }
             } else {
                 val descriptor = descriptor
                 if (descriptor is FunctionClassDescriptor) {
@@ -89,6 +93,9 @@ internal class KClassImpl<T : Any>(
                 }
                 if (jClass == Cloneable::class.java) {
                     return@lazy createCloneableKmClass()
+                }
+                if (descriptor is ClassDescriptorImpl) {
+                    return@lazy createEmptyKmClass()
                 }
                 (descriptor as? DeserializedClassDescriptor)?.let { descriptor ->
                     descriptor.classProto.toKmClass(descriptor.c.nameResolver)
@@ -681,6 +688,11 @@ internal class KClassImpl<T : Any>(
                 // Don't declare any functions in this class descriptor, only inherit equals/hashCode/toString from Any.
                 override fun computeDeclaredFunctions(): List<FunctionDescriptor> = emptyList()
             }, emptySet(), null)
+        }
+
+    private fun createEmptyKmClass(): KmClass =
+        KmClass().apply {
+            name = classId.asString()
         }
 
     companion object {


### PR DESCRIPTION
This makes the new implementation behave the same as the K1-based one, however the issue about file facades KT-81153 is still relevant. Ideally, there'd be no way in the API to create a `KClass` for a file facade, since there's no class from the Kotlin's point of view.

 #KT-81153
 #KT-89003 Fixed