### PR TITLE
[Gradle] Introduce SwiftExportConfigurationCompat

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/AppleXcodeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/AppleXcodeTasks.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPro
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnosticsCollector
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnosticsContext
-import org.jetbrains.kotlin.gradle.plugin.diagnostics.kotlinToolingDiagnosticsCollector
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.kotlinToolingDiagnosticsCollectorProvider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.toolingDiagnosticsContext
@@ -28,7 +27,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.FrameworkCopy.Companion.dsymFile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportConstants
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportDSLConstants
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.registerSwiftExportTask
 import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
 import org.jetbrains.kotlin.gradle.tasks.dependsOn
@@ -39,12 +37,11 @@ import org.jetbrains.kotlin.gradle.utils.lowerCamelCaseName
 import org.jetbrains.kotlin.gradle.utils.mapToFile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject.Companion.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
 import org.jetbrains.kotlin.gradle.utils.reportXcodeError
 import java.io.File
 import java.nio.file.Paths
 import javax.inject.Inject
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 @Suppress("ConstPropertyName")
 internal object AppleXcodeTasks {
@@ -196,7 +193,7 @@ private fun isRequestedBinary(binary: NativeBinary, environment: XcodeEnvironmen
 internal fun Project.registerEmbedSwiftExportTask(
     target: KotlinNativeTarget,
     environment: XcodeEnvironment,
-    swiftExportExtension: SwiftExportExtension,
+    swiftExportConfiguration: SwiftExportConfigurationCompat,
 ) {
     val envTargets = environment.targets
     val binaryTaskName = embedSwiftExportTaskName()
@@ -244,7 +241,7 @@ internal fun Project.registerEmbedSwiftExportTask(
     val sandBoxTask = checkSandboxAndWriteProtectionTask(environment, environment.userScriptSandboxingEnabled)
 
     val swiftExportTask = registerSwiftExportTask(
-        swiftExportExtension,
+        swiftExportConfiguration,
         SwiftExportDSLConstants.TASK_GROUP,
         envBuildType,
         target

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.registerEmbedSwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.initSwiftExportClasspathConfigurations
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
 
 internal object SwiftExportDSLConstants {
     const val SWIFT_EXPORT_EXTENSION_NAME = "swiftExport"
@@ -48,7 +49,13 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
     if (!multiplatformExtension.isSwiftExportXcodeIntegrationActivated()) return@KotlinProjectSetupCoroutine
 
     initSwiftExportClasspathConfigurations()
-    registerSwiftExportPipeline(swiftExportExtension)
+    registerSwiftExportPipeline(
+        if (exportExtension.isSwiftExportConfigured) {
+            SwiftExportConfigurationCompat.from(exportExtension.swiftExportConfiguration, providers, objects)
+        } else {
+            SwiftExportConfigurationCompat.from(swiftExportExtension)
+        }
+    )
 }
 
 /**
@@ -76,21 +83,21 @@ internal fun KotlinMultiplatformExtension.isSwiftExportXcodeIntegrationActivated
 }
 
 private fun Project.registerSwiftExportPipeline(
-    swiftExportExtension: SwiftExportExtension,
+    swiftExportConfiguration: SwiftExportConfigurationCompat,
 ) {
     val environment = XcodeEnvironment(project)
 
     multiplatformExtension
         .supportedAppleTargets()
         .configureEach { target ->
-            setupSwiftExport(target, environment, swiftExportExtension)
+            setupSwiftExport(target, environment, swiftExportConfiguration)
         }
 }
 
 private fun Project.setupSwiftExport(
     target: KotlinNativeTarget,
     environment: XcodeEnvironment,
-    swiftExportExtension: SwiftExportExtension,
+    swiftExportConfiguration: SwiftExportConfigurationCompat,
 ) {
-    registerEmbedSwiftExportTask(target, environment, swiftExportExtension)
+    registerEmbedSwiftExportTask(target, environment, swiftExportConfiguration)
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.exporte
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.normalizedSwiftExportModuleName
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.whenSwiftPMImportAvailable
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
 import org.jetbrains.kotlin.gradle.plugin.mpp.internal
 import org.jetbrains.kotlin.gradle.tasks.locateOrRegisterTask
 import org.jetbrains.kotlin.gradle.utils.*
@@ -48,7 +49,7 @@ internal object SwiftExportConstants {
 }
 
 internal fun Project.registerSwiftExportTask(
-    swiftExportExtension: SwiftExportExtension,
+    swiftExportConfiguration: SwiftExportConfigurationCompat,
     taskGroup: String,
     buildType: NativeBuildType,
     target: KotlinNativeTarget,
@@ -56,7 +57,7 @@ internal fun Project.registerSwiftExportTask(
     val mainCompilation = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME)
     val buildConfiguration = buildType.configuration
 
-    val swiftApiModuleName = swiftExportExtension
+    val swiftApiModuleName = swiftExportConfiguration
         .moduleName
         .orElse(provider { project.name.normalizedSwiftExportModuleName.also { validateSwiftExportModuleName(it) } })
 
@@ -76,20 +77,20 @@ internal fun Project.registerSwiftExportTask(
             mainCompilation.internal.configurations.compileDependencyConfiguration
         ),
         mainCompilation = mainCompilation,
-        swiftApiFlattenPackage = swiftExportExtension.flattenPackage,
-        exportedModules = swiftExportExtension.exportedModules,
-        customSetting = swiftExportExtension.advancedConfiguration.settings
+        swiftApiFlattenPackage = swiftExportConfiguration.rootPackage,
+        exportedModules = swiftExportConfiguration.exportedModules,
+        customSetting = swiftExportConfiguration.settings
     )
 
     val staticLibrary = registerSwiftExportCompilationAndGetBinary(
         buildType = buildType,
         target = target,
         mainCompilation = mainCompilation,
-        freeCompilerArgs = swiftExportExtension.advancedConfiguration.freeCompilerArgs,
+        freeCompilerArgs = swiftExportConfiguration.freeCompilerArgs,
         swiftExportTask = swiftExportTask
     )
 
-    swiftExportExtension.addBinary(staticLibrary)
+    swiftExportConfiguration.addBinary(staticLibrary)
 
     val swiftApiLibraryName = swiftApiModuleName.map { it + "Library" }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractNativeLibrary
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
+
+/**
+ * A common interface for [SwiftExportConfiguration] and [org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension]
+ * used during the migration from the latter to the former. Will be removed once the legacy
+ * [org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension] is fully deprecated.
+ */
+internal interface SwiftExportConfigurationCompat {
+    /**
+     * The name of this module that will be used in Swift Export.
+     */
+    val moduleName: Property<String>
+
+    /**
+     * This module's root package.
+     */
+    val rootPackage: Property<String>
+
+    /**
+     * Returns a list of exported modules.
+     */
+    val exportedModules: Provider<Set<SwiftExportedDependency>>
+
+    /**
+     * Configure SwiftExportConfig.settings parameters
+     */
+    val settings: MapProperty<String, String>
+
+    /**
+     * Specifies additional compiler arguments to be passed to the compiler.
+     */
+    val freeCompilerArgs: ListProperty<String>
+
+    fun addBinary(binary: AbstractNativeLibrary)
+
+    companion object {
+        fun from(
+            configuration: SwiftExportConfiguration,
+            providers: ProviderFactory,
+            objects: ObjectFactory,
+        ): SwiftExportConfigurationCompat =
+            object : SwiftExportConfigurationCompat {
+                override val moduleName: Property<String> get() = configuration.moduleName
+                override val rootPackage: Property<String> get() = configuration.rootPackage
+                override val exportedModules: Provider<Set<SwiftExportedDependency>>
+                    get() = providers.provider { emptySet() } // TODO: KT-85687
+                override val settings: MapProperty<String, String>
+                    get() = objects.mapProperty(String::class.java, String::class.java) // TODO: KT-87890
+                override val freeCompilerArgs: ListProperty<String>
+                    get() = objects.listProperty(String::class.java) // TODO: KT-87890
+
+                override fun addBinary(binary: AbstractNativeLibrary) {
+                    // TODO: KT-87890
+                }
+            }
+
+        fun from(extension: SwiftExportExtension): SwiftExportConfigurationCompat =
+            object : SwiftExportConfigurationCompat {
+                override val moduleName: Property<String> get() = extension.moduleName
+                override val rootPackage: Property<String> get() = extension.flattenPackage
+                override val exportedModules: Provider<Set<SwiftExportedDependency>> get() = extension.exportedModules
+                override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings
+                override val freeCompilerArgs: ListProperty<String> get() = extension.advancedConfiguration.freeCompilerArgs
+                override fun addBinary(binary: AbstractNativeLibrary) {
+                    extension.addBinary(binary)
+                }
+            }
+    }
+}


### PR DESCRIPTION
This will serve as a compat bridge between the legacy SwiftExportExtension and the new
ExportExtension.SwiftExportConfiguration, so that the task-level code doesn't have to deal with both. It will be removed once we've fully migrated to SwiftExportConfiguration.

^KT-89059 Fixed