### PR TITLE
KT-87986 Publish Swift Export metadata

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataPublishingIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataPublishingIT.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.native
+
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.uklibs.*
+import org.jetbrains.kotlin.gradle.util.assertSwiftExportMetadataVariantExistsInRootComponent
+import org.jetbrains.kotlin.gradle.util.assertSwiftExportMetadataVariantMissingInRootComponent
+import org.jetbrains.kotlin.gradle.util.parseJsonToMap
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Serializing Swift Export metadata doesn't need Xcode, so unlike [SwiftExportDslIT] these tests run on any host.
+ */
+@DisplayName("Tests for Swift Export metadata publication with the export DSL")
+@SwiftExportGradlePluginTests
+@OptIn(ExperimentalExportDsl::class, ExperimentalSwiftExportDsl::class)
+class SwiftExportMetadataPublishingIT : KGPBaseTest() {
+
+    @DisplayName("swiftExport metadata is published into the root component when module name and root package are defined")
+    @GradleTest
+    fun testSwiftExportMetadataPublication(
+        gradleVersion: GradleVersion,
+    ) {
+        val publishedProject = project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                }
+                export.swift {
+                    moduleName.set("Foo")
+                    rootPackage.set("org.bar.foo")
+                }
+            }
+        }.publish()
+
+        val metadataFile = publishedProject.rootComponent.swiftExportMetadata
+        assertFileExists(metadataFile.toPath())
+
+        val metadata = parseJsonToMap(metadataFile.toPath())
+        assertEquals(1, metadata["schemaVersion"]?.jsonPrimitive?.int)
+        assertEquals("Foo", metadata["moduleName"]?.jsonPrimitive?.content)
+        assertEquals("org.bar.foo", metadata["rootPackage"]?.jsonPrimitive?.content)
+
+        publishedProject.assertSwiftExportMetadataVariantExistsInRootComponent()
+    }
+
+    @DisplayName("swiftExport metadata omits the module name when only the root package is defined")
+    @GradleTest
+    fun testSwiftExportMetadataWithoutModuleName(
+        gradleVersion: GradleVersion,
+    ) {
+        val publishedProject = project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                }
+                export.swift {
+                    rootPackage.set("org.bar.foo")
+                }
+            }
+        }.publish()
+
+        val metadata = parseJsonToMap(publishedProject.rootComponent.swiftExportMetadata.toPath())
+        assertNull(metadata["moduleName"])
+        assertEquals("org.bar.foo", metadata["rootPackage"]?.jsonPrimitive?.content)
+    }
+
+    @DisplayName("swiftExport metadata is not published when neither module name nor root package is defined")
+    @GradleTest
+    fun testSwiftExportMetadataIsNotPublishedWithoutConfiguration(
+        gradleVersion: GradleVersion,
+    ) {
+        val publishedProject = project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                }
+            }
+        }.publish()
+
+        assertFileNotExists(publishedProject.rootComponent.swiftExportMetadata.toPath())
+        publishedProject.assertSwiftExportMetadataVariantMissingInRootComponent()
+    }
+
+    @DisplayName("swiftExport metadata is not published when the project has no apple targets")
+    @GradleTest
+    fun testSwiftExportMetadataIsNotPublishedWithoutAppleTargets(
+        gradleVersion: GradleVersion,
+    ) {
+        val publishedProject = project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    jvm()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                }
+                export.swift {
+                    moduleName.set("Foo")
+                    rootPackage.set("org.bar.foo")
+                }
+            }
+        }.publish()
+
+        assertFileNotExists(publishedProject.rootComponent.swiftExportMetadata.toPath())
+        publishedProject.assertSwiftExportMetadataVariantMissingInRootComponent()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/uklibs/uklibTestingUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/uklibs/uklibTestingUtils.kt
@@ -65,6 +65,7 @@ data class PublishedProject(
         val psmJar: File get() = path.resolve("${artifactsPrefix}-psm.jar")
         val gradleMetadata: File get() = path.resolve("${artifactsPrefix}.module")
         val swiftPmMetadata: File get() = path.resolve("${artifactsPrefix}-swiftpm-metadata.json")
+        val swiftExportMetadata: File get() = path.resolve("${artifactsPrefix}-swift-export-metadata.json")
     }
 
     val rootCoordinate: String = "$group:$name:$version"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/SwiftExportUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/SwiftExportUtils.kt
@@ -5,7 +5,15 @@
 
 package org.jetbrains.kotlin.gradle.util
 
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -22,16 +30,14 @@ import org.jetbrains.kotlin.gradle.testbase.compileStubSourceWithSourceSetName
 import org.jetbrains.kotlin.gradle.testbase.plugins
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.testbase.settingsBuildScriptInjection
+import org.jetbrains.kotlin.gradle.testing.prettyPrinted
+import org.jetbrains.kotlin.gradle.uklibs.GradleMetadata
 import org.jetbrains.kotlin.gradle.uklibs.PublishedProject
 import org.jetbrains.kotlin.gradle.uklibs.PublisherConfiguration
+import org.jetbrains.kotlin.gradle.uklibs.Variant
+import org.jetbrains.kotlin.gradle.uklibs.VariantFile
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.jetbrains.kotlin.gradle.uklibs.publish
-import java.io.File
-import java.nio.file.Path
-import kotlin.io.path.absolutePathString
-import kotlin.io.path.readText
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(EnvironmentalVariablesOverride::class)
 internal fun GradleProject.swiftExportEmbedAndSignEnvVariables(
@@ -331,4 +337,47 @@ internal fun assertAllSwiftModuleSymbols(
     }
 
     assertEquals(expectedSymbolsByModule, actualSymbolsByModule)
+}
+
+private val gradleMetadataJson = Json { ignoreUnknownKeys = true }
+
+private const val SWIFT_EXPORT_METADATA_ELEMENTS = "swiftExportMetadataElements"
+
+private fun PublishedProject.rootComponentVariants(): Set<Variant> = gradleMetadataJson
+    .decodeFromString<GradleMetadata>(rootComponent.gradleMetadata.readText())
+    .variants
+
+/**
+ * Asserts that the published root component declares the Swift Export metadata variant with the attributes
+ * consumers match on, and that it carries the metadata artifact.
+ */
+internal fun PublishedProject.assertSwiftExportMetadataVariantExistsInRootComponent() {
+    assertEquals(
+        Variant(
+            name = SWIFT_EXPORT_METADATA_ELEMENTS,
+            attributes = mapOf(
+                "org.gradle.category" to "library",
+                "org.gradle.usage" to "swiftExportMetadata",
+            ),
+            availableAt = null,
+            files = listOf(
+                VariantFile(
+                    name = "swiftExportMetadata",
+                    url = "$name-$version-swift-export-metadata.json",
+                )
+            ),
+        ).prettyPrinted,
+        rootComponentVariants().single { it.name == SWIFT_EXPORT_METADATA_ELEMENTS }.prettyPrinted
+    )
+}
+
+/**
+ * Stronger than checking that the artifact is missing, which also passes when the variant is published with a
+ * different file.
+ */
+internal fun PublishedProject.assertSwiftExportMetadataVariantMissingInRootComponent() {
+    assertNull(
+        rootComponentVariants().find { it.name == SWIFT_EXPORT_METADATA_ELEMENTS },
+        "The root component should not declare a $SWIFT_EXPORT_METADATA_ELEMENTS variant"
+    )
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.initSwi
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration
 
 internal object SwiftExportDSLConstants {
     const val SWIFT_EXPORT_EXTENSION_NAME = "swiftExport"
@@ -44,6 +45,14 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
         .matching { it.konanTarget.family.isAppleFamily }
 
     if (appleTargets.isEmpty()) return@KotlinProjectSetupCoroutine
+
+    // Runs before isSwiftExportXcodeIntegrationActivated()'s early return: publishing metadata is independent
+    // of the Xcode integration. AfterFinaliseDsl still precedes any afterEvaluate {} a build script registers,
+    // so configuring the DSL from there publishes nothing.
+    val swiftExportConfiguration = exportExtension.swiftExportConfiguration
+    if (swiftExportConfiguration.moduleName.isPresent || swiftExportConfiguration.rootPackage.isPresent) {
+        locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(swiftExportConfiguration)
+    }
 
     // The targets are awaited above, so the DSL is finalised by now and the activation is order-independent.
     if (!multiplatformExtension.isSwiftExportXcodeIntegrationActivated()) return@KotlinProjectSetupCoroutine

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportMetadata.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Usage
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.internal.json.KgpJson
+import org.jetbrains.kotlin.gradle.plugin.categoryByName
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.SerializeSwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.usageByName
+import org.jetbrains.kotlin.gradle.utils.createConsumable
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.Serializable
+
+private const val SWIFT_EXPORT_METADATA_USAGE = "swiftExportMetadata"
+
+/**
+ * Version of the [SwiftExportMetadata] serialization format. Bump it whenever the serialized shape changes.
+ */
+internal const val SWIFT_EXPORT_METADATA_SCHEMA_VERSION = 1
+
+/**
+ * How a library configured with the `export { swift { } }` DSL exposes itself to Swift. Only the module-level part
+ * of the DSL is published; the rest of it (e.g. Xcode integration settings) is about the producer's own build.
+ */
+@kotlinx.serialization.Serializable
+internal data class SwiftExportMetadata(
+    val schemaVersion: Int = SWIFT_EXPORT_METADATA_SCHEMA_VERSION,
+    val moduleName: String?,
+    val rootPackage: String?,
+) : Serializable
+
+internal fun deserializeSwiftExportMetadata(inputStream: InputStream) =
+    KgpJson.default.decodeFromStream<SwiftExportMetadata>(inputStream)
+
+internal fun SwiftExportMetadata.serializeSwiftExportMetadata(outputStream: OutputStream) =
+    KgpJson.default.encodeToStream(this, outputStream)
+
+/**
+ * Consumable configuration that carries the Swift Export metadata artifact.
+ */
+internal fun Project.registerSwiftExportMetadataApiElements(
+    swiftExportMetadata: TaskProvider<SerializeSwiftExportMetadata>,
+): Configuration {
+    return project.configurations.createConsumable("swiftExportMetadataElements") {
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, project.usageByName(SWIFT_EXPORT_METADATA_USAGE))
+        attributes.attribute(Category.CATEGORY_ATTRIBUTE, project.categoryByName(Category.LIBRARY))
+        outgoing.artifact(swiftExportMetadata) {
+            it.classifier = "swift-export-metadata"
+            it.extension = "json"
+        }
+    }.get()
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/tasks/SerializeSwiftExportMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/tasks/SerializeSwiftExportMetadata.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.work.DisableCachingByDefault
+import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfiguration
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.registerSwiftExportMetadataApiElements
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.serializeSwiftExportMetadata
+import org.jetbrains.kotlin.gradle.tasks.locateOrRegisterTask
+import org.jetbrains.kotlin.gradle.tasks.locateTask
+
+/**
+ * Registers the [SerializeSwiftExportMetadata] task and the consumable configuration that puts its output into the
+ * root component of the publication. Returns the existing task if it was already registered.
+ */
+internal fun Project.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(
+    swiftExportConfiguration: SwiftExportConfiguration,
+): TaskProvider<SerializeSwiftExportMetadata> {
+    // The consumable configuration can only be registered once, so guard the whole function rather than the task.
+    val existingTask = project.locateTask<SerializeSwiftExportMetadata>(SerializeSwiftExportMetadata.TASK_NAME)
+    if (existingTask != null) return existingTask
+
+    val swiftExportMetadata = project.locateOrRegisterTask<SerializeSwiftExportMetadata>(
+        SerializeSwiftExportMetadata.TASK_NAME,
+    ) {
+        it.configureWith(swiftExportConfiguration)
+    }
+    val swiftExportMetadataApiElements = registerSwiftExportMetadataApiElements(swiftExportMetadata)
+    project.multiplatformExtension.publishing.adhocSoftwareComponent.addVariantsFromConfiguration(
+        swiftExportMetadataApiElements
+    ) {}
+    return swiftExportMetadata
+}
+
+@DisableCachingByDefault(because = "This task does lightweight serialization that is not worth caching")
+internal abstract class SerializeSwiftExportMetadata : DefaultTask() {
+
+    @get:Optional
+    @get:Input
+    protected abstract val moduleName: Property<String>
+
+    @get:Optional
+    @get:Input
+    protected abstract val rootPackage: Property<String>
+
+    @get:OutputFile
+    protected val metadataFile: Provider<RegularFile> = project.layout.buildDirectory.file("kotlin/swiftExportMetadata")
+
+    fun configureWith(swiftExportConfiguration: SwiftExportConfiguration) {
+        moduleName.set(swiftExportConfiguration.moduleName)
+        rootPackage.set(swiftExportConfiguration.rootPackage)
+    }
+
+    @TaskAction
+    fun serialize() {
+        metadataFile.get().asFile.outputStream().use { file ->
+            swiftExportMetadata().serializeSwiftExportMetadata(file)
+        }
+    }
+
+    internal fun swiftExportMetadata() = SwiftExportMetadata(
+        moduleName = moduleName.orNull,
+        rootPackage = rootPackage.orNull,
+    )
+
+    companion object {
+        const val TASK_NAME = "serializeSwiftExportMetadata"
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -7,19 +7,13 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
-import org.gradle.api.Project
-import org.gradle.api.internal.project.ProjectInternal
-import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
-import org.jetbrains.kotlin.gradle.plugin.getExtension
-import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
-import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
-import org.jetbrains.kotlin.gradle.unitTests.utils.applyEmbedAndSignEnvironment
+import org.jetbrains.kotlin.gradle.util.EMBED_SWIFT_EXPORT_TASK_NAME
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.jetbrains.kotlin.gradle.util.exportDslProject
+import org.jetbrains.kotlin.gradle.util.exportExtension
 import org.jetbrains.kotlin.gradle.util.kotlin
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.junit.jupiter.api.Assumptions
@@ -107,12 +101,6 @@ class ExportExtensionUnitTests {
         assertSame(integration, project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
         assertEquals(mapOf("first" to "1", "second" to "2"), integration.settings.get())
     }
-
-    private val Project.exportExtension: ExportExtension
-        get() = assertNotNull(
-            multiplatformExtension.getExtension(EXPORT_EXTENSION_NAME),
-            "Expected the `$EXPORT_EXTENSION_NAME` extension to be registered on the multiplatform extension"
-        )
 }
 
 class ExportExtensionXcodeIntegrationTests {
@@ -124,7 +112,7 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test embed task is registered when the xcode integration is activated`() {
-        val project = appleProject {
+        val project = exportDslProject {
             exportExtension.swift {
                 moduleName.set("Shared")
                 xcodeIntegration()
@@ -136,7 +124,7 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test embed task is not registered when the export dsl is used without the xcode integration`() {
-        val project = appleProject {
+        val project = exportDslProject {
             exportExtension.swift {
                 moduleName.set("Shared")
             }
@@ -147,14 +135,14 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test embed task is registered when the export dsl is not used at all`() {
-        val project = appleProject()
+        val project = exportDslProject()
 
         assertNotNull(project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME))
     }
 
     @Test
     fun `test the xcode integration can be activated after the module is configured`() {
-        val project = appleProject {
+        val project = exportDslProject {
             exportExtension.swift {
                 moduleName.set("Shared")
             }
@@ -168,7 +156,7 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test the pipeline is registered for an activated project in the xcode environment`() {
-        val project = appleProject(withXcodeEnvironment = true) {
+        val project = exportDslProject(withXcodeEnvironment = true) {
             exportExtension.swift {
                 xcodeIntegration()
             }
@@ -180,7 +168,7 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test the pipeline is not registered for a project that opted out of the xcode integration`() {
-        val project = appleProject(withXcodeEnvironment = true) {
+        val project = exportDslProject(withXcodeEnvironment = true) {
             exportExtension.swift {
                 moduleName.set("Shared")
             }
@@ -192,7 +180,7 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test embed task is registered when the legacy swift export dsl is used`() {
-        val project = appleProject {
+        val project = exportDslProject {
             kotlin {
                 swiftExport {
                     moduleName.set("Legacy")
@@ -205,7 +193,7 @@ class ExportExtensionXcodeIntegrationTests {
 
     @Test
     fun `test the export dsl takes precedence over the legacy swift export dsl`() {
-        val project = appleProject {
+        val project = exportDslProject {
             kotlin {
                 swiftExport {
                     moduleName.set("Legacy")
@@ -217,29 +205,5 @@ class ExportExtensionXcodeIntegrationTests {
         }
 
         assertNull(project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME))
-    }
-
-    private fun appleProject(
-        withXcodeEnvironment: Boolean = false,
-        multiplatform: KotlinMultiplatformExtension.() -> Unit = { iosSimulatorArm64() },
-        configureExport: Project.() -> Unit = {},
-    ): ProjectInternal = buildProjectWithMPP(
-        preApplyCode = {
-            if (withXcodeEnvironment) {
-                applyEmbedAndSignEnvironment(configuration = "DEBUG", sdk = "iphonesimulator", archs = "arm64")
-            }
-            configureRepositoriesForTests()
-        },
-        code = {
-            kotlin { multiplatform() }
-            configureExport()
-        }
-    ).also { it.evaluate() }
-
-    private val Project.exportExtension: ExportExtension
-        get() = assertNotNull(multiplatformExtension.getExtension(EXPORT_EXTENSION_NAME))
-
-    private companion object {
-        const val EMBED_SWIFT_EXPORT_TASK_NAME = "embedSwiftExportForXcode"
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportMetadataPublishingUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportMetadataPublishingUnitTests.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalExportDsl::class, ExperimentalSwiftExportDsl::class)
+
+package org.jetbrains.kotlin.gradle.unitTests
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_SCHEMA_VERSION
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.deserializeSwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.serializeSwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.SerializeSwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration
+import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import org.jetbrains.kotlin.gradle.util.EMBED_SWIFT_EXPORT_TASK_NAME
+import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.jetbrains.kotlin.gradle.util.exportDslProject
+import org.jetbrains.kotlin.gradle.util.exportExtension
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * None of these tests need a macOS host: publishing depends on the project having an Apple target, which
+ * `KonanTarget.family` reports regardless of the host.
+ */
+class SwiftExportMetadataPublishingUnitTests {
+
+    private fun SwiftExportMetadata.roundTrip(): SwiftExportMetadata {
+        val serialized = ByteArrayOutputStream()
+        serializeSwiftExportMetadata(serialized)
+        return deserializeSwiftExportMetadata(ByteArrayInputStream(serialized.toByteArray()))
+    }
+
+    @Test
+    fun `swift export metadata round-trips module name and root package`() {
+        val metadata = SwiftExportMetadata(moduleName = "Foo", rootPackage = "org.bar.foo")
+        assertEquals(metadata, metadata.roundTrip())
+    }
+
+    @Test
+    fun `swift export metadata round-trips with absent root package`() {
+        val metadata = SwiftExportMetadata(moduleName = "Foo", rootPackage = null)
+        assertEquals(metadata, metadata.roundTrip())
+    }
+
+    @Test
+    fun `swift export metadata round-trips with absent module name`() {
+        val metadata = SwiftExportMetadata(moduleName = null, rootPackage = "org.bar.foo")
+        assertEquals(metadata, metadata.roundTrip())
+    }
+
+    @Test
+    fun `swift export metadata is serialized with the current schema version`() {
+        val serialized = ByteArrayOutputStream()
+        SwiftExportMetadata(moduleName = "Foo", rootPackage = "org.bar.foo").serializeSwiftExportMetadata(serialized)
+
+        val schemaVersion = Json.parseToJsonElement(serialized.toString(Charsets.UTF_8.name()))
+            .jsonObject["schemaVersion"]?.jsonPrimitive?.int
+        assertEquals(SWIFT_EXPORT_METADATA_SCHEMA_VERSION, schemaVersion)
+    }
+
+    @Test
+    fun `deserialization reports the schema version written by the producer`() {
+        val foreignVersion = SWIFT_EXPORT_METADATA_SCHEMA_VERSION + 1
+        val payload = """{"schemaVersion":$foreignVersion,"moduleName":"Foo","rootPackage":"org.bar.foo"}"""
+
+        val metadata = deserializeSwiftExportMetadata(ByteArrayInputStream(payload.toByteArray()))
+        assertEquals(foreignVersion, metadata.schemaVersion)
+    }
+
+    @Test
+    fun `registering the metadata task creates the consumable configuration`() {
+        val project = buildProjectWithMPP()
+        project.exportExtension.swift {
+            moduleName.set("Foo")
+            rootPackage.set("org.bar.foo")
+        }
+
+        project.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(
+            project.exportExtension.swiftExportConfiguration
+        )
+
+        assertNotNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "$SWIFT_EXPORT_METADATA_ELEMENTS configuration should be created when the metadata task is registered"
+        )
+
+        val serializeTask = project.tasks.withType(SerializeSwiftExportMetadata::class.java).single()
+        assertEquals(
+            SwiftExportMetadata(moduleName = "Foo", rootPackage = "org.bar.foo"),
+            serializeTask.swiftExportMetadata()
+        )
+    }
+
+    @Test
+    fun `registering the metadata task twice reuses the existing task and configuration`() {
+        val project = buildProjectWithMPP()
+        project.exportExtension.swift {
+            moduleName.set("Foo")
+        }
+        val configuration = project.exportExtension.swiftExportConfiguration
+
+        val first = project.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(configuration)
+        val second = project.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(configuration)
+
+        assertEquals(first.name, second.name)
+        assertEquals(1, project.tasks.withType(SerializeSwiftExportMetadata::class.java).size)
+    }
+
+    @Test
+    fun `swift export metadata variant is published when the export DSL configures a module name`() {
+        val project = exportDslProject(multiplatform = { iosArm64() }) {
+            exportExtension.swift {
+                moduleName.set("Foo")
+                rootPackage.set("org.bar.foo")
+            }
+        }
+
+        assertNotNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "$SWIFT_EXPORT_METADATA_ELEMENTS configuration should be created when the export DSL configures moduleName"
+        )
+
+        val serializeTask = project.tasks.withType(SerializeSwiftExportMetadata::class.java).single()
+        assertEquals(
+            SwiftExportMetadata(moduleName = "Foo", rootPackage = "org.bar.foo"),
+            serializeTask.swiftExportMetadata()
+        )
+    }
+
+    @Test
+    fun `swift export metadata variant is published when only the root package is configured`() {
+        val project = exportDslProject(multiplatform = { iosArm64() }) {
+            exportExtension.swift {
+                rootPackage.set("org.bar.foo")
+            }
+        }
+
+        assertNotNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "$SWIFT_EXPORT_METADATA_ELEMENTS configuration should be created when only rootPackage is configured"
+        )
+
+        val serializeTask = project.tasks.withType(SerializeSwiftExportMetadata::class.java).single()
+        assertEquals(
+            SwiftExportMetadata(moduleName = null, rootPackage = "org.bar.foo"),
+            serializeTask.swiftExportMetadata()
+        )
+    }
+
+    @Test
+    fun `swift export metadata variant is not published when the export DSL is never used`() {
+        val project = exportDslProject(multiplatform = { iosArm64() })
+
+        assertNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "$SWIFT_EXPORT_METADATA_ELEMENTS configuration should not be created when the export DSL is never used"
+        )
+    }
+
+    @Test
+    fun `swift export metadata variant is not published when swift block leaves both properties unset`() {
+        val project = exportDslProject(multiplatform = { iosArm64() }) {
+            exportExtension.swift { }
+        }
+
+        assertNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "$SWIFT_EXPORT_METADATA_ELEMENTS configuration should not be created when swift {} sets neither property"
+        )
+    }
+
+    @Test
+    fun `swift export metadata variant is not published without apple targets`() {
+        val project = exportDslProject(multiplatform = { jvm() }) {
+            exportExtension.swift {
+                moduleName.set("Foo")
+                rootPackage.set("org.bar.foo")
+            }
+        }
+
+        assertNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "Swift Export only works for apple targets, so no metadata variant should be created without them"
+        )
+    }
+
+    @Test
+    fun `swift export metadata publication does not activate the xcode integration`() {
+        val project = exportDslProject {
+            exportExtension.swift {
+                moduleName.set("Foo")
+            }
+        }
+
+        assertNotNull(
+            project.configurations.findByName(SWIFT_EXPORT_METADATA_ELEMENTS),
+            "Metadata should still be published even though the Xcode integration was never activated"
+        )
+        assertNull(
+            project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME),
+            "Publishing metadata must not activate the Xcode integration pipeline"
+        )
+    }
+
+    private companion object {
+        const val SWIFT_EXPORT_METADATA_ELEMENTS = "swiftExportMetadataElements"
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/exportDslUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/exportDslUtils.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalExportDsl::class)
+
+package org.jetbrains.kotlin.gradle.util
+
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.plugin.getExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
+import org.jetbrains.kotlin.gradle.unitTests.utils.applyEmbedAndSignEnvironment
+import kotlin.test.assertNotNull
+
+internal const val EMBED_SWIFT_EXPORT_TASK_NAME = "embedSwiftExportForXcode"
+
+internal val Project.exportExtension: ExportExtension
+    get() = assertNotNull(
+        multiplatformExtension.getExtension(EXPORT_EXTENSION_NAME),
+        "Expected the `$EXPORT_EXTENSION_NAME` extension to be registered on the multiplatform extension"
+    )
+
+/**
+ * An evaluated multiplatform project for testing the `export { }` DSL.
+ *
+ * The default target is `iosSimulatorArm64` because [applyEmbedAndSignEnvironment] uses the matching sdk and archs.
+ */
+internal fun exportDslProject(
+    withXcodeEnvironment: Boolean = false,
+    multiplatform: KotlinMultiplatformExtension.() -> Unit = { iosSimulatorArm64() },
+    configureExport: Project.() -> Unit = {},
+): ProjectInternal = buildProjectWithMPP(
+    preApplyCode = {
+        if (withXcodeEnvironment) {
+            applyEmbedAndSignEnvironment(configuration = "DEBUG", sdk = "iphonesimulator", archs = "arm64")
+        }
+        configureRepositoriesForTests()
+    },
+    code = {
+        kotlin { multiplatform() }
+        configureExport()
+    }
+).also { it.evaluate() }


### PR DESCRIPTION
This pull request introduces support for publishing Swift Export metadata from Kotlin Multiplatform projects using the export DSL. It adds a new metadata artifact describing how a library is exposed to Swift, ensures this artifact is published only when relevant configuration is present, and provides thorough integration and utility tests to verify correct behavior. The changes are grouped into new feature implementation, integration tests, and utility improvements.

**Swift Export Metadata Publication:**

* Added a new `SwiftExportMetadata` data structure and serialization logic, along with a Gradle task (`SerializeSwiftExportMetadata`) to generate a JSON artifact describing the module name and root package for Swift consumers. This artifact is published via a new consumable configuration and included in the root component of the library. [[1]](diffhunk://#diff-e6ebb8c602cae80bcedde1bcaf692776485906d2f7c4dc7ccec847e78e8a667aR1-R65) [[2]](diffhunk://#diff-4fa16b7c26ba92561d41ecd0357369286b56ca24b68f0497888d86deceecc3bfR1-R84)

* Updated the Swift export DSL setup to register the metadata publication logic only when either the module name or root package is defined, and independently of Xcode integration. [[1]](diffhunk://#diff-3cd1bf4b086dbb3c29c9bb7c6ae2e3272adf68056c91b2222e368a0f56e22d9cR21) [[2]](diffhunk://#diff-3cd1bf4b086dbb3c29c9bb7c6ae2e3272adf68056c91b2222e368a0f56e22d9cR48-R55)

**Integration Tests and Utilities:**

* Added comprehensive integration tests in `SwiftExportMetadataPublishingIT.kt` to verify that the Swift Export metadata artifact is published under the correct conditions and omitted otherwise.

* Enhanced the `PublishedProject` test utility to provide access to the new metadata artifact and added utility methods for asserting the presence or absence of the Swift Export metadata variant in the published root component. [[1]](diffhunk://#diff-af8a3cc2457dfe6e593c2609118b13cbb6b865fa0a38ff0457eb4bd020ff502fR68) [[2]](diffhunk://#diff-100dd7e825f9153282645b01c39f94a046578264b94ea85e33705d452a6511ccR341-R383)

* Improved test utilities and imports to support new test scenarios and streamline project setup for export DSL testing. [[1]](diffhunk://#diff-100dd7e825f9153282645b01c39f94a046578264b94ea85e33705d452a6511ccR8-R16) [[2]](diffhunk://#diff-100dd7e825f9153282645b01c39f94a046578264b94ea85e33705d452a6511ccR33-L34) [[3]](diffhunk://#diff-075767df3e622e7ac5fb94cf271a6e1b79a490502c63d8ee4320db0e940c3e1eL10-R16) [[4]](diffhunk://#diff-075767df3e622e7ac5fb94cf271a6e1b79a490502c63d8ee4320db0e940c3e1eL110-L115) [[5]](diffhunk://#diff-075767df3e622e7ac5fb94cf271a6e1b79a490502c63d8ee4320db0e940c3e1eL127-R115) [[6]](diffhunk://#diff-075767df3e622e7ac5fb94cf271a6e1b79a490502c63d8ee4320db0e940c3e1eL139-R127) [[7]](diffhunk://#diff-075767df3e622e7ac5fb94cf271a6e1b79a490502c63d8ee4320db0e940c3e1eL150-R145)