### PR TITLE
KT-88565 Strip Xcframework of symbols

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/XCFrameworkIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/XCFrameworkIT.kt
@@ -13,6 +13,9 @@ import org.jetbrains.kotlin.gradle.util.replaceText
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.condition.OS
 import kotlin.io.path.deleteRecursively
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @OsCondition(supportedOn = [OS.MAC], enabledOnCI = [OS.MAC])
 @DisplayName("Tests for K/N with apple XCFramework")
@@ -148,6 +151,82 @@ class XCFrameworkIT : KGPBaseTest() {
                     ":shared:assembleSha-redReleaseXCFramework",
                 )
                 assertOutputDoesNotContain("differs from inner frameworks name")
+            }
+        }
+    }
+
+    /**
+     * KT-88565: a release binary has no DWARF, but `nm` still shows mangled Kotlin names by default.
+     *
+     * Release Apple binaries are stripped with `strip -S` (`stripFlags` in `konan.properties`), which only drops
+     * the debug map. Removing non-global symbols needs `strip -x`, as Xcode does for its own frameworks by
+     * default; a user can already opt into that today by overriding `stripFlags` via `-Xoverride-konan-properties`.
+     */
+    @DisplayName("Release XCFramework binary keeps mangled Kotlin names in its symbol table, unless stripFlags is overridden")
+    @GradleTest
+    fun shouldKeepKotlinSymbolsInReleaseXCFrameworkBinaryUnlessStripFlagsOverridden(gradleVersion: GradleVersion) {
+        project("appleXCFramework", gradleVersion) {
+            val binary = projectPath
+                .resolve("shared/build/XCFrameworks/release/other.xcframework/ios-arm64/shared.framework/shared")
+
+            build(":shared:assembleOtherReleaseXCFramework") {
+                val symbols = machOSymbols(binary)
+
+                // No DWARF is left in the binary: `dsymutil` moved it into the .dSYM bundle next to the framework
+                assertEquals(
+                    emptyList(),
+                    machOSectionNames(binary).filter { it.startsWith("__debug") },
+                    "release binary is expected to have no DWARF sections"
+                )
+                assertEquals(
+                    emptyList(),
+                    symbols.filter { it.isDebugMapEntry }.map { it.name },
+                    "release binary is expected to have no debug map entries"
+                )
+
+                // ...but the mangled Kotlin names are still there as non-global symbols
+                val kotlinSymbols = symbols.filter { it.isLocal && it.name.startsWith("_kfun:") }
+                assertNotEquals(
+                    emptyList(),
+                    kotlinSymbols,
+                    "release binary is expected to keep non-global Kotlin symbols, but the symbol table has none"
+                )
+
+                // The declarations of the framework itself are named by their ObjC bridges and their type info.
+                // Global symbols are not checked: the ObjC metadata of an exported class has to stay in any case.
+                assertEquals(
+                    listOf(
+                        "_kclass:com.github.jetbrains.myapplication.Greeting",
+                        "_kifacetable:com.github.jetbrains.myapplication.Greeting",
+                        "_ktypew:com.github.jetbrains.myapplication.Greeting",
+                        "_objc2kotlin_kfun:com.github.jetbrains.myapplication.Greeting#<init>(){}",
+                        "_objc2kotlin_kfun:com.github.jetbrains.myapplication.Greeting#greeting(){}kotlin.String",
+                    ),
+                    symbols.filter { it.isLocal && "myapplication" in it.name }.map { it.name }.sorted(),
+                )
+            }
+
+            subProject("shared")
+                .buildGradleKts
+                .replaceFirst(
+                    "baseName = \"shared\"",
+                    "baseName = \"shared\"\n" +
+                            "            freeCompilerArgs += listOf(\"-Xoverride-konan-properties=stripFlags.ios_arm64=-S -x;stripFlags.iosSimulatorArm64=-S -x\")",
+                )
+
+            build(":shared:assembleOtherReleaseXCFramework") {
+                val symbols = machOSymbols(binary)
+
+                assertEquals(
+                    emptyList(),
+                    symbols.filter { it.isLocal && it.name.startsWith("_kfun:") }.map { it.name },
+                    "release binary is expected to have no non-global Kotlin symbols with an overridden stripFlags"
+                )
+                assertEquals(
+                    emptyList(),
+                    symbols.filter { it.isLocal && "myapplication" in it.name }.map { it.name },
+                    "release binary is expected to have no non-global myapplication symbols with an overridden stripFlags"
+                )
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/machOTestHelpers.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/machOTestHelpers.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.testbase
+
+import org.jetbrains.kotlin.gradle.util.assertProcessRunResult
+import org.jetbrains.kotlin.gradle.util.runProcess
+import java.nio.file.Path
+import kotlin.io.path.pathString
+import kotlin.test.assertTrue
+
+internal data class MachOSymbol(val type: String, val name: String) {
+    /** Debug map (STABS) entries are printed by `nm -a` with a `-` type. */
+    val isDebugMapEntry get() = type == "-"
+
+    /** `nm` prints global symbols in upper case and non-global ones in lower case. */
+    val isLocal get() = type.first().isLowerCase()
+}
+
+internal fun TestProject.machOSymbols(binary: Path): List<MachOSymbol> =
+    runTool("nm", "-a", "-P", binary.pathString).mapNotNull { line ->
+        // '-P' prints '<name> <type> <value> <size>'; a name may contain spaces, so take the fields from the right
+        val fields = line.split(" ")
+        if (fields.size < 4) return@mapNotNull null
+        MachOSymbol(type = fields[fields.size - 3], name = fields.dropLast(3).joinToString(" "))
+    }
+
+internal fun TestProject.machOSectionNames(binary: Path): List<String> =
+    runTool("otool", "-l", binary.pathString).mapNotNull {
+        it.trim().substringAfter("sectname ", missingDelimiterValue = "").ifEmpty { null }
+    }
+
+internal fun TestProject.runTool(vararg command: String): List<String> {
+    val result = runProcess(command.toList(), projectPath.toFile())
+    result.assertProcessRunResult { assertTrue(isSuccessful, "'${command.joinToString(" ")}' failed") }
+    return result.output.lines()
+}


### PR DESCRIPTION
This pull request adds a new integration test and supporting helper functions to verify how Kotlin/Native handles symbol stripping in Apple XCFramework release binaries. The test ensures that, by default, non-global mangled Kotlin symbols remain in the binary's symbol table unless the `stripFlags` property is explicitly overridden. The most important changes are:

### New test for symbol stripping behavior

* Added a test (`shouldKeepKotlinSymbolsInReleaseXCFrameworkBinaryUnlessStripFlagsOverridden`) to `XCFrameworkIT.kt` that verifies release binaries keep non-global Kotlin symbols unless `stripFlags` is overridden, and checks for the absence of DWARF sections and debug map entries. The test also modifies the build to override `stripFlags` and checks that non-global Kotlin symbols are removed as expected.

### Test utilities for Mach-O analysis

* Introduced a new helper file `machOTestHelpers.kt` containing utility functions and a data class:
  * `MachOSymbol` data class to represent Mach-O symbol table entries, with helpers to identify debug map entries and local (non-global) symbols.
  * `machOSymbols()` to parse symbols from a Mach-O binary using `nm`.
  * `machOSectionNames()` to list section names using `otool`.
  * `runTool()` to run external tools and assert successful execution.