### PR TITLE
[stdlib] Improve the docs of deprecated common k.jvm.Synchronized

### DIFF
--- a/libraries/stdlib/common/src/kotlin/JvmAnnotationsH.kt
+++ b/libraries/stdlib/common/src/kotlin/JvmAnnotationsH.kt
@@ -196,6 +196,16 @@ public expect annotation class Strictfp()
  *
  * Note that for an extension function, the monitor of the facade class, where it gets compiled to a static method, is used.
  * Therefore, this annotation is recommended to be applied only to member functions and properties.
+ *
+ * If you need to annotate a common method as JVM-synchronized, add a new [OptionalExpectation] annotation in your common code:
+ * ```kotlin
+ * @OptionalExpectation
+ * expect annotation class JvmSynchronized
+ * ```
+ * Then, in your JVM code, actualize it:
+ * ```kotlin
+ * actual typealias JvmSynchronized = kotlin.jvm.Synchronized
+ * ```
  */
 @Target(FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
 @MustBeDocumented

--- a/libraries/stdlib/common/src/kotlin/JvmAnnotationsH.kt
+++ b/libraries/stdlib/common/src/kotlin/JvmAnnotationsH.kt
@@ -197,7 +197,7 @@ public expect annotation class Strictfp()
  * Note that for an extension function, the monitor of the facade class, where it gets compiled to a static method, is used.
  * Therefore, this annotation is recommended to be applied only to member functions and properties.
  *
- * If you need to annotate a common method as JVM-synchronized, add a new [OptionalExpectation] annotation in your common code:
+ * If you need to annotate a common method as JVM-synchronized, introduce a new annotation marked with [OptionalExpectation] in your common code:
  * ```kotlin
  * @OptionalExpectation
  * expect annotation class JvmSynchronized


### PR DESCRIPTION
Current docs: https://kotlinlang.org/api/core/2.4/kotlin-stdlib/kotlin.jvm/-synchronized/index.html

This commit elaborates on the deprecation message by showing in a code snippet how users can create their own annotations to replace the deprecated common one.

Unfortunately it's not possible to add KDoc straight to the deprecation message (see Kotlin/dokka#2635), making extending the actual type doc comment the only option.

Initially I considered putting the new piece at the beginning of the doc comment for it to appear straight under the "Deprecated" block in the rendered documentation, sadly this approach:
- makes the doc comment look silly when seen in the code, because there's no big "Deprecated" block above it
- makes the new block show as a preview in the package type list page, which makes zero sense

Checklist:
- [x] generate the HTML documentation locally to confirm it looks fine
- [x] confirm on a sample project that the provided code snippet does indeed achieve the desired outcome

^KT-83957 Fixed.