### PR TITLE
[K/N][perf] Upgrade kotlinx-benchmark to 0.5.0

### DIFF
--- a/kotlin-native/performance/buildSrc/build.gradle.kts
+++ b/kotlin-native/performance/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ sourceSets["main"].kotlin {
 
 dependencies {
     val kotlinVersion = project.bootstrapKotlinVersion
-    val kotlinxBenchmarkVersion = "0.4.17"
+    val kotlinxBenchmarkVersion = "0.5.0"
 
     compileOnly(gradleApi())
 


### PR DESCRIPTION
kotlinx-benchmark 0.5.0 migrated from using Kotlin compiler APIs to KSP.

^KT-87662