### PR TITLE
[stdlib] Return false from empty addAll(index) on a stale sub list

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/collections/builders/ListBuilder.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/builders/ListBuilder.kt
@@ -395,19 +395,21 @@ internal class ListBuilder<E>(initialCapacity: Int = 10) : MutableList<E>, Rando
 
         override fun addAll(elements: Collection<E>): Boolean {
             checkIsMutable()
-            checkForComodification()
             val n = elements.size
+            if (n == 0) return false
+            checkForComodification()
             addAllInternal(offset + length, elements, n)
-            return n > 0
+            return true
         }
 
         override fun addAll(index: Int, elements: Collection<E>): Boolean {
             checkIsMutable()
-            checkForComodification()
             AbstractList.checkPositionIndex(index, length)
             val n = elements.size
+            if (n == 0) return false
+            checkForComodification()
             addAllInternal(offset + index, elements, n)
-            return n > 0
+            return true
         }
 
         override fun clear() {

--- a/libraries/stdlib/native-wasm/src/kotlin/collections/AbstractMutableList.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/collections/AbstractMutableList.kt
@@ -211,6 +211,18 @@ public actual abstract class AbstractMutableList<E> protected actual constructor
             modCount = list.modCount
         }
 
+        override fun addAll(index: Int, elements: Collection<E>): Boolean {
+            AbstractList.checkPositionIndex(index, _size)
+            val n = elements.size
+            if (n == 0) return false
+            checkForComodification()
+
+            list.addAll(fromIndex + index, elements)
+            _size += n
+            modCount = list.modCount
+            return true
+        }
+
         override fun get(index: Int): E {
             checkForComodification()
             AbstractList.checkElementIndex(index, _size)

--- a/libraries/stdlib/native-wasm/src/kotlin/collections/ArrayList.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/collections/ArrayList.kt
@@ -488,19 +488,21 @@ public actual constructor(initialCapacity: Int) : MutableList<E>, RandomAccess, 
 
         override fun addAll(elements: Collection<E>): Boolean {
             checkIsMutable()
-            checkForComodification()
             val n = elements.size
+            if (n == 0) return false
+            checkForComodification()
             addAllInternal(offset + length, elements, n)
-            return n > 0
+            return true
         }
 
         override fun addAll(index: Int, elements: Collection<E>): Boolean {
             checkIsMutable()
-            checkForComodification()
             AbstractList.checkPositionIndex(index, length)
             val n = elements.size
+            if (n == 0) return false
+            checkForComodification()
             addAllInternal(offset + index, elements, n)
-            return n > 0
+            return true
         }
 
         override fun clear() {

--- a/libraries/stdlib/test/collections/ArrayDequeTest.kt
+++ b/libraries/stdlib/test/collections/ArrayDequeTest.kt
@@ -667,6 +667,17 @@ class ArrayDequeTest {
     }
 
     @Test
+    fun subListInsertAll() {
+        val deque = ArrayDeque(listOf(0, 1, 2, 3, 4, 5))
+        val outer = deque.subList(1, 5)
+        val inner = outer.subList(1, 3)
+        assertTrue(inner.addAll(1, listOf(100, 101)))
+        assertEquals(listOf(2, 100, 101, 3), inner)
+        assertEquals(listOf(1, 2, 100, 101, 3, 4), outer)
+        assertEquals(listOf(0, 1, 2, 100, 101, 3, 4, 5), deque)
+    }
+
+    @Test
     fun removeRange() = testArrayDeque { bufferSize: Int, dequeSize: Int, head: Int, tail: Int ->
         for (fromIndex in 0..dequeSize) {
             for (toIndex in fromIndex..dequeSize) {

--- a/libraries/stdlib/test/collections/ConcurrentModificationTest.kt
+++ b/libraries/stdlib/test/collections/ConcurrentModificationTest.kt
@@ -13,6 +13,7 @@ import test.collections.js.stringSetOf
 import test.current
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -96,11 +97,11 @@ class ConcurrentModificationTest {
         if (TestPlatform.current == TestPlatform.Js) return
 
         /**
-         * Some operations should register a modification by contract, but java ArrayList,
-         * whose implementation we can't change, do not register.
+         * Some operations should not register a modification by contract, but java ArrayList,
+         * whose implementation we can't change, registers one anyway.
          * @param isJavaArrayListBehavior specifies whether to test java ArrayList behavior or the behavior by contract.
          */
-        fun operations(isJavaArrayListBehavior: Boolean) = listOf<CollectionOperation<MutableList<String>>>(
+        fun directOperations(isJavaArrayListBehavior: Boolean) = listOf<CollectionOperation<MutableList<String>>>(
             CollectionOperation("set()", throwsCME = false) { set(2, "e") },
 
             CollectionOperation("add()") { add("e") },
@@ -126,11 +127,14 @@ class ConcurrentModificationTest {
 
             CollectionOperation("clear()") { clear() },
             CollectionOperation("iterator.remove()") { iterator().apply { next(); remove() } },
-        ).also { ops ->
-            ops + ops.map {
-                CollectionOperation("subList(1, size)." + it.description, it.throwsCME) { it.function.invoke(subList(1, size)) }
+        )
+
+        // Sub-lists never register a modification when adding an empty collection, even when the root list does,
+        // so the subList op variants always use the by-contract expectations.
+        fun operations(isJavaArrayListBehavior: Boolean): List<CollectionOperation<MutableList<String>>> =
+            directOperations(isJavaArrayListBehavior) + directOperations(isJavaArrayListBehavior = false).map { op ->
+                CollectionOperation("subList(1, size)." + op.description, op.throwsCME) { op.function.invoke(subList(1, size)) }
             }
-        }
 
         fun testThrowsCME(isJavaArrayListBehavior: Boolean = true, withMutableList: WithCollection<MutableList<String>>) {
             testIteratorThrowsCME(withMutableList, operations(isJavaArrayListBehavior))
@@ -282,6 +286,7 @@ class ConcurrentModificationTest {
             CollectionOperation("removeAt()") { removeAt(2) },
 
             CollectionOperation("addAll()") { addAll(listOf("e", "f")) },
+            CollectionOperation("addAll(emptyList())", throwsCME = false) { addAll(emptyList()) },
             CollectionOperation("addAll(index)") { addAll(2, listOf("e", "f")) },
 
             CollectionOperation("removeAll()") { removeAll(listOf("d", "e")) },
@@ -332,6 +337,18 @@ class ConcurrentModificationTest {
         assertFailsWith<ConcurrentModificationException> {
             val arrayDeque = ArrayDeque(listOf("a", "b", "c", "d"))
             for (e in arrayDeque.subList(1, 3)) arrayDeque.remove(e)
+        }
+
+        val arrayList = arrayListOf("a", "b", "c", "d")
+        val subList = arrayList.subList(0, arrayList.size)
+        arrayList.add("e")
+        assertFalse(subList.addAll(1, emptyList()))
+
+        buildList {
+            addAll(listOf("a", "b", "c", "d"))
+            val subList = subList(0, size)
+            add("e")
+            assertFalse(subList.addAll(1, emptyList()))
         }
     }
 

--- a/libraries/stdlib/test/collections/ConcurrentModificationTest.kt
+++ b/libraries/stdlib/test/collections/ConcurrentModificationTest.kt
@@ -288,6 +288,7 @@ class ConcurrentModificationTest {
             CollectionOperation("addAll()") { addAll(listOf("e", "f")) },
             CollectionOperation("addAll(emptyList())", throwsCME = false) { addAll(emptyList()) },
             CollectionOperation("addAll(index)") { addAll(2, listOf("e", "f")) },
+            CollectionOperation("addAll(index, emptyList())", throwsCME = false) { addAll(2, emptyList()) },
 
             CollectionOperation("removeAll()") { removeAll(listOf("d", "e")) },
 
@@ -343,13 +344,21 @@ class ConcurrentModificationTest {
         val subList = arrayList.subList(0, arrayList.size)
         arrayList.add("e")
         assertFalse(subList.addAll(1, emptyList()))
+        assertFailsWith<IndexOutOfBoundsException> { subList.addAll(5, emptyList()) }
 
         buildList {
             addAll(listOf("a", "b", "c", "d"))
             val subList = subList(0, size)
             add("e")
             assertFalse(subList.addAll(1, emptyList()))
+            assertFailsWith<IndexOutOfBoundsException> { subList.addAll(5, emptyList()) }
         }
+
+        val arrayDeque = ArrayDeque(listOf("a", "b", "c", "d"))
+        val dequeSubList = arrayDeque.subList(0, arrayDeque.size)
+        arrayDeque.add("e")
+        assertFalse(dequeSubList.addAll(1, emptyList()))
+        assertFailsWith<IndexOutOfBoundsException> { dequeSubList.addAll(5, emptyList()) }
     }
 
     @Test


### PR DESCRIPTION
The Native/Wasm `AbstractMutableList.SubList` had no indexed `addAll` of its own, unlike `ArraySubList` and `BuilderSubList`, so the inherited one checked the index against the `size` getter, which checks for comodification, before looking at the collection. The fix is to override it with the JDK order of checks, as KT-89006 did for the other 2 sub lists.

^KT-89031 Fixed
