### PR TITLE
[Tests] KT-86081: PL cases with companion members moved to parent class

### DIFF
--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
@@ -72,13 +72,16 @@ companion fun TA.aliasFun() = "aliasFun"
 companion fun TA.aliasToClassFun() = "aliasToClassFun"
 companion fun B.classToAliasFun() = "classToAliasFun"
 
-open class BaseClass {}
+open class Grandparent {}
+open class BaseClass : Grandparent() {}
 interface Interface {}
 class Derived : BaseClass(), Interface {
    companion {
-       fun funMovedToParentClass() = "moved"
+       fun funMovedToParentClass() = "moved.v1"
        val propMovedToParentClass = 42
-       fun funMovedToParentInterface() = "moved"
+       fun funMovedToGrandparentClass() = "moved.v1"
+       val propMovedToGrandparentClass = 42
+       fun funMovedToParentInterface() = "moved.v1"
        val propMovedToParentInterface = 42
    }
 }

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
@@ -76,16 +76,22 @@ companion fun TA.aliasFun() = "aliasFun"
 companion fun A.aliasToClassFun() = "aliasToClassFun"
 companion fun TA.classToAliasFun() = "classToAliasFun"
 
-open class BaseClass {
+open class Grandparent {
     companion {
-        fun funMovedToParentClass() = "moved"
-        val propMovedToParentClass = 42
+        fun funMovedToGrandparentClass() = "moved.v2"
+        val propMovedToGrandparentClass = 43
+    }
+}
+open class BaseClass : Grandparent() {
+    companion {
+        fun funMovedToParentClass() = "moved.v2"
+        val propMovedToParentClass = 43
     }
 }
 interface Interface {
     companion {
-        fun funMovedToParentInterface() = "moved"
-        val propMovedToParentInterface = 42
+        fun funMovedToParentInterface() = "moved.v2"
+        val propMovedToParentInterface = 43
     }
 }
 class Derived : BaseClass(), Interface {}

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
@@ -70,5 +70,13 @@ fun classToAliasFunCall() = B.classToAliasFun()
 
 fun funMovedToParentClass() = Derived.funMovedToParentClass()
 fun propMovedToParentClass() = Derived.propMovedToParentClass
+val funMovedToParentClassRef = Derived::funMovedToParentClass
+val propMovedToParentClassRef = Derived::propMovedToParentClass
+fun funMovedToGrandparentClass() = Derived.funMovedToGrandparentClass()
+fun propMovedToGrandparentClass() = Derived.propMovedToGrandparentClass
+val funMovedToGrandparentClassRef = Derived::funMovedToGrandparentClass
+val propMovedToGrandparentClassRef = Derived::propMovedToGrandparentClass
 fun funMovedToParentInterface() = Derived.funMovedToParentInterface()
 fun propMovedToParentInterface() = Derived.propMovedToParentInterface
+val funMovedToParentInterfaceRef = Derived::funMovedToParentInterface
+val propMovedToParentInterfaceRef = Derived::propMovedToParentInterface

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
@@ -67,8 +67,16 @@ fun box() = abiTest {
     expectSuccess("classToAliasFun") { classToAliasFunCall() }
 
     // To follow the JVM rules, moving companion members to a superclass is ABI compatible, but moving to a superinterface is not.
-    expectSuccess("moved") { funMovedToParentClass() }
-    expectSuccess(42) { propMovedToParentClass() }
+    expectSuccess("moved.v2") { funMovedToParentClass() }
+    expectSuccess(43) { propMovedToParentClass() }
+    expectSuccess("moved.v2") { funMovedToParentClassRef.invoke() }
+    expectSuccess(43) { propMovedToParentClassRef.invoke() }
+    expectSuccess("moved.v2") { funMovedToGrandparentClass() }
+    expectSuccess(43) { propMovedToGrandparentClass() }
+    expectSuccess("moved.v2") { funMovedToGrandparentClassRef.invoke() }
+    expectSuccess(43) { propMovedToGrandparentClassRef.invoke() }
     expectFailure(linkage("Function 'funMovedToParentInterface' can not be called: No function found for symbol '/Derived.funMovedToParentInterface'")) { funMovedToParentInterface() }
     expectFailure(linkage("Property accessor 'propMovedToParentInterface.<get-propMovedToParentInterface>' can not be called: No property accessor found for symbol '/Derived.propMovedToParentInterface.<get-propMovedToParentInterface>'")) { propMovedToParentInterface() }
+    expectFailure(linkage("Function 'funMovedToParentInterface' can not be called: No function found for symbol '/Derived.funMovedToParentInterface'")) { funMovedToParentInterfaceRef.invoke() }
+    expectFailure(linkage("Property accessor 'propMovedToParentInterface.<get-propMovedToParentInterface>' can not be called: No property accessor found for symbol '/Derived.propMovedToParentInterface.<get-propMovedToParentInterface>'")) { propMovedToParentInterfaceRef.invoke() }
 }


### PR DESCRIPTION
Cases with a grandparent class and callable references

^KT-86081