### PR TITLE
[Kotlin/JS] Pin Mocha version in EsmBundleKotlinJsTests tests

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/EsmBundleKotlinJsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/EsmBundleKotlinJsTests.kt
@@ -128,7 +128,7 @@ internal abstract class EsmBundleKotlinJsTests @Inject constructor(
                 oldValue = "<script src=\"tests.bundle.js\"></script>",
                 newValue = ""
             )
-        outputDirectory.file("test.html").get().asFile.writeText(testHtmlFileContent)
+        outputDirectory.file("test.html").get().asFile.writeText(pinMochaCdnUrls(testHtmlFileContent))
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/WebpackBundleKotlinJsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/WebpackBundleKotlinJsTests.kt
@@ -203,21 +203,23 @@ constructor(
         }
 
         val output = outputBundleDir.get().asFile.resolve(TEST_HTML_FILE_NAME)
-        output.writeText(
-            html
-                .replace(MOCHA_CSS_URL, PINNED_MOCHA_CSS_URL)
-                .replace(MOCHA_SCRIPT_URL, PINNED_MOCHA_SCRIPT_URL)
-        )
+        output.writeText(pinMochaCdnUrls(html))
     }
 
     companion object {
         private const val TEST_HTML_FILE_NAME = "test.html"
-        private const val MOCHA_CSS_URL = "https://unpkg.com/mocha/mocha.css"
-        private const val MOCHA_SCRIPT_URL = "https://unpkg.com/mocha/mocha.js"
-        private const val PINNED_MOCHA_CSS_URL = "https://unpkg.com/mocha@11.8.0/mocha.css"
-        private const val PINNED_MOCHA_SCRIPT_URL = "https://unpkg.com/mocha@11.8.0/mocha.js"
     }
 }
+
+internal fun pinMochaCdnUrls(html: String): String =
+    html
+        .replace(MOCHA_CSS_URL, PINNED_MOCHA_CSS_URL)
+        .replace(MOCHA_SCRIPT_URL, PINNED_MOCHA_SCRIPT_URL)
+
+private const val MOCHA_CSS_URL = "https://unpkg.com/mocha/mocha.css"
+private const val MOCHA_SCRIPT_URL = "https://unpkg.com/mocha/mocha.js"
+private const val PINNED_MOCHA_CSS_URL = "https://unpkg.com/mocha@11.8.0/mocha.css"
+private const val PINNED_MOCHA_SCRIPT_URL = "https://unpkg.com/mocha@11.8.0/mocha.js"
 
 internal fun KotlinJsIrCompilation.locateOrRegisterBrowserTestBundleTask(
     configure: WebpackBundleKotlinJsTests.() -> Unit


### PR DESCRIPTION
Follow-up commit for e12a48e8

^KT-89033 Fixed

This is second part, covering EsmBundleKotlinJsTests, because e12a48e8 fixed only WebpackBundleKotlinJsTests