### PR TITLE
Reflection: add `useK1ImplementationForMembers` system property

### DIFF
--- a/compiler/fir/fir2ir/testFixtures/org/jetbrains/kotlin/test/TestGeneratorForFir2IrTests.kt
+++ b/compiler/fir/fir2ir/testFixtures/org/jetbrains/kotlin/test/TestGeneratorForFir2IrTests.kt
@@ -60,6 +60,11 @@ fun main(args: Array<String>) {
                 model("boxJvm/reflection")
             }
 
+            testClass<AbstractReflectionK1MembersImplementationTest> {
+                model("box/reflection")
+                model("boxJvm/reflection")
+            }
+
             testClass<AbstractReflectionLoadMetadataDirectlyTest> {
                 model("box/reflection")
                 model("boxJvm/reflection")

--- a/compiler/testData/codegen/boxJvm/reflection/annotations/annotationParameter.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/annotations/annotationParameter.kt
@@ -11,25 +11,18 @@ annotation class Anno(val value: Int)
 annotation class A(val x: String, @Anno(1) val y: String)
 
 fun box(): String {
-    if (Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt").getMethod("getUseK1Implementation").invoke(null) == true) {
-        // K1 did not support annotations on annotation parameters.
-        assertEquals(
-            "[[], []]",
-            A::class.members.filter { it is KProperty1<*, *> }.map { it.annotations }.toString(),
-        )
-        assertEquals(
-            "[[], []]",
-            A::class.constructors.single().parameters.map { it.annotations }.toString(),
-        )
-    } else {
-        assertEquals(
-            "[[], [@test.Anno(value=1)]]",
-            A::class.members.filter { it is KProperty1<*, *> }.map { it.annotations }.toString(),
-        )
-        assertEquals(
-            "[[], [@test.Anno(value=1)]]",
-            A::class.constructors.single().parameters.map { it.annotations }.toString(),
-        )
-    }
+    val systemProperties = Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt")
+    val useK1 = systemProperties.getMethod("getUseK1Implementation").invoke(null) == true
+    val useK1ForMembers = useK1 || systemProperties.getMethod("getUseK1ImplementationForMembers").invoke(null) == true
+
+    // K1 did not support annotations on annotation parameters.
+    assertEquals(
+        if (useK1ForMembers) "[[], []]" else "[[], [@test.Anno(value=1)]]",
+        A::class.members.filter { it is KProperty1<*, *> }.map { it.annotations }.toString(),
+    )
+    assertEquals(
+        if (useK1) "[[], []]" else "[[], [@test.Anno(value=1)]]",
+        A::class.constructors.single().parameters.map { it.annotations }.toString(),
+    )
     return "OK"
 }

--- a/compiler/testData/codegen/boxJvm/reflection/implementationClasses.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/implementationClasses.kt
@@ -1,0 +1,197 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+// FILE: test/J.java
+package test;
+
+public class J {
+    public String memberField = "";
+    public static String staticField = "";
+    public static final String staticFinalField = "";
+
+    public J(String value) {}
+
+    public void memberFun() {}
+
+    public static void staticFun() {}
+}
+
+// FILE: test/JOverride.java
+package test;
+
+public class JOverride extends KBase {
+    private String storage;
+
+    @Override
+    public String getOverriddenVal() {
+        return storage;
+    }
+
+    @Override
+    public String getOverriddenVar() {
+        return storage;
+    }
+
+    @Override
+    public void setOverriddenVar(String value) {
+        storage = value;
+    }
+}
+
+// FILE: test/JEnum.java
+package test;
+
+public enum JEnum {
+    ENTRY
+}
+
+// FILE: test/JAnno.java
+package test;
+
+public @interface JAnno {
+    String value();
+}
+
+// FILE: test.kt
+package test
+
+import kotlin.reflect.KCallable
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+class K(val constructorVal: Int) {
+    val memberVal: String = ""
+    var memberVar: String = ""
+    fun memberFun() {}
+}
+
+abstract class KBase {
+    abstract val overriddenVal: String?
+    abstract var overriddenVar: String?
+}
+
+val topLevelVal = ""
+var topLevelVar = ""
+fun topLevelFun() {}
+
+private val systemProperties = Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt")
+private val useK1 = systemProperties.getMethod("getUseK1Implementation").invoke(null) == true
+private val useK1ForMembers = useK1 || systemProperties.getMethod("getUseK1ImplementationForMembers").invoke(null) == true
+
+private val errors = StringBuilder()
+
+private fun implementationClassName(callable: KCallable<*>): String {
+    var result: Any = callable
+    if (result is kotlin.jvm.internal.CallableReference) {
+        result = result.compute()
+    }
+    // Property references are wrapped in kotlin.reflect.jvm.internal.LazyKPropertyN/LazyKMutablePropertyN.
+    while (result.javaClass.simpleName.startsWith("LazyK")) {
+        val getDelegate = result.javaClass.methods.single { method ->
+            method.name == "getDelegate" && method.parameterTypes.isEmpty() && KProperty::class.java.isAssignableFrom(method.returnType)
+        }
+        result = getDelegate.invoke(result)!!
+    }
+    return result.javaClass.simpleName
+}
+
+private fun check(description: String, callable: KCallable<*>, new: String, k1ForMembers: String = new, k1: String) {
+    val expected = when {
+        useK1 -> k1
+        useK1ForMembers -> k1ForMembers
+        else -> new
+    }
+    val actual = implementationClassName(callable)
+    if (expected != actual) {
+        errors.append("$description: expected $expected, actual $actual\n")
+    }
+}
+
+private fun member(klass: KClass<*>, name: String): KCallable<*> = klass.members.single { it.name == name }
+
+fun box(): String {
+    // Kotlin member properties and functions.
+    check("K::memberVal", K::memberVal, new = "KotlinKProperty1", k1ForMembers = "DescriptorKProperty1", k1 = "DescriptorKProperty1")
+    check(
+        "K::memberVar", K::memberVar,
+        new = "KotlinKMutableProperty1", k1ForMembers = "DescriptorKMutableProperty1", k1 = "DescriptorKMutableProperty1",
+    )
+    check("K::memberFun", K::memberFun, new = "KotlinKNamedFunction", k1ForMembers = "DescriptorKFunction", k1 = "DescriptorKFunction")
+    check(
+        "K::class.members['memberVal']", member(K::class, "memberVal"),
+        new = "KotlinKProperty1", k1ForMembers = "DescriptorKProperty1", k1 = "DescriptorKProperty1",
+    )
+    check(
+        "K::class.members['memberVar']", member(K::class, "memberVar"),
+        new = "KotlinKMutableProperty1", k1ForMembers = "DescriptorKMutableProperty1", k1 = "DescriptorKMutableProperty1",
+    )
+    check(
+        "K::class.members['memberFun']", member(K::class, "memberFun"),
+        new = "KotlinKNamedFunction", k1ForMembers = "DescriptorKFunction", k1 = "DescriptorKFunction",
+    )
+
+    // Kotlin constructors.
+    check("::K", ::K, new = "KotlinKConstructor", k1 = "DescriptorKFunction")
+    check("K::class.constructors", K::class.constructors.single(), new = "KotlinKConstructor", k1 = "DescriptorKFunction")
+
+    // Kotlin top-level properties and functions.
+    check("::topLevelVal", ::topLevelVal, new = "KotlinKProperty0", k1 = "DescriptorKProperty0")
+    check("::topLevelVar", ::topLevelVar, new = "KotlinKMutableProperty0", k1 = "DescriptorKMutableProperty0")
+    check("::topLevelFun", ::topLevelFun, new = "KotlinKNamedFunction", k1 = "DescriptorKFunction")
+
+    // Java member properties and functions.
+    check(
+        "J::memberField", J::memberField,
+        new = "JavaFieldKMutableProperty1", k1ForMembers = "DescriptorKMutableProperty1", k1 = "DescriptorKMutableProperty1",
+    )
+    check("J::memberFun", J::memberFun, new = "JavaKNamedFunction", k1 = "DescriptorKFunction")
+    check(
+        "J::class.members['memberField']", member(J::class, "memberField"),
+        new = "JavaFieldKMutableProperty1", k1ForMembers = "DescriptorKMutableProperty1", k1 = "DescriptorKMutableProperty1",
+    )
+    check("J::class.members['memberFun']", member(J::class, "memberFun"), new = "JavaKNamedFunction", k1 = "DescriptorKFunction")
+
+    // Java constructors.
+    check("::J", ::J, new = "JavaKConstructor", k1 = "DescriptorKFunction")
+    check("J::class.constructors", J::class.constructors.single(), new = "JavaKConstructor", k1 = "DescriptorKFunction")
+
+    // Java static properties and functions.
+    check("J::staticField", J::staticField, new = "JavaFieldKMutableProperty0", k1 = "DescriptorKMutableProperty0")
+    check("J::staticFinalField", J::staticFinalField, new = "JavaFieldKProperty0", k1 = "DescriptorKProperty0")
+    check("J::staticFun", J::staticFun, new = "JavaKNamedFunction", k1 = "DescriptorKFunction")
+    check(
+        "J::class.members['staticField']", member(J::class, "staticField"),
+        new = "JavaFieldKMutableProperty0", k1 = "DescriptorKMutableProperty0",
+    )
+    check(
+        "J::class.members['staticFinalField']", member(J::class, "staticFinalField"),
+        new = "JavaFieldKProperty0", k1 = "DescriptorKProperty0",
+    )
+    check("J::class.members['staticFun']", member(J::class, "staticFun"), new = "JavaKNamedFunction", k1 = "DescriptorKFunction")
+
+    // Properties declared in Kotlin and overridden by methods in Java.
+    // Note that callable references to such properties are not supported yet, see KT-87863.
+    check(
+        "JOverride::class.members['overriddenVal']", member(JOverride::class, "overriddenVal"),
+        new = "JavaForKotlinOverrideKProperty1", k1ForMembers = "DescriptorKProperty1", k1 = "DescriptorKProperty1",
+    )
+    check(
+        "JOverride::class.members['overriddenVar']", member(JOverride::class, "overriddenVar"),
+        new = "JavaForKotlinOverrideKMutableProperty1", k1ForMembers = "DescriptorKMutableProperty1", k1 = "DescriptorKMutableProperty1",
+    )
+
+    // Java annotation methods, represented as properties.
+    // Note that `JAnno::value` is a reference to a synthetic Java property, which does not use kotlin-reflect at all, see KT-55980.
+    check(
+        "JAnno::class.members['value']", member(JAnno::class, "value"),
+        new = "JavaAnnotationMethodKProperty1", k1ForMembers = "DescriptorKProperty1", k1 = "DescriptorKProperty1",
+    )
+
+    // The synthetic `entries` property of a Java enum class.
+    check("JEnum::entries", JEnum::entries, new = "JavaEnumEntriesKProperty", k1 = "DescriptorKProperty0")
+    check(
+        "JEnum::class.members['entries']", member(JEnum::class, "entries"),
+        new = "JavaEnumEntriesKProperty", k1 = "DescriptorKProperty0",
+    )
+
+    return if (errors.isEmpty()) "OK" else "Fail:\n$errors"
+}

--- a/compiler/testData/codegen/boxJvm/reflection/java/javaForKotlinOverrideKProperty/javaForKotlinOverrideKProperty.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/java/javaForKotlinOverrideKProperty/javaForKotlinOverrideKProperty.kt
@@ -161,7 +161,10 @@ private fun check(p: KProperty1<*, *>, isMutable: Boolean, name: String) {
 
         val valueParam = setter.parameters[1]
         assertEquals(null, valueParam.name)
-        if (Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt").getMethod("getUseK1Implementation").invoke(null) == true) {
+        val systemProperties = Class.forName("kotlin.reflect.jvm.internal.SystemPropertiesKt")
+        if (systemProperties.getMethod("getUseK1Implementation").invoke(null) == true ||
+            systemProperties.getMethod("getUseK1ImplementationForMembers").invoke(null) == true
+        ) {
             // Setter parameter type is flexible in K1 implementation for some reason.
             checkType(valueParam.type, flexible = true)
         } else {

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/JvmBoxRunner.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/JvmBoxRunner.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.RESULT_OUTPUT_
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.REQUIRES_SEPARATE_PROCESS
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.JDK_KIND
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.LOAD_METADATA_DIRECTLY_IN_REFLECTION
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.USE_LEGACY_REFLECTION_IMPLEMENTATION
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.ENABLE_JVM_PREVIEW
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.PREFER_IN_TEST_OVER_STDLIB
@@ -270,6 +271,9 @@ open class JvmBoxRunner(testServices: TestServices) : JvmBinaryArtifactHandler(t
         checkTestInfrastructure(USE_LEGACY_REFLECTION_IMPLEMENTATION !in module.directives) {
             "$USE_LEGACY_REFLECTION_IMPLEMENTATION is not supported when running the box test in a separate JVM process"
         }
+        checkTestInfrastructure(USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS !in module.directives) {
+            "$USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS is not supported when running the box test in a separate JVM process"
+        }
         val command = listOfNotNull(
             javaExe.absolutePath,
             runIf(ATTACH_DEBUGGER in module.directives) { "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" },
@@ -359,6 +363,9 @@ fun generatedTestClassLoader(
         checkTestInfrastructure(USE_LEGACY_REFLECTION_IMPLEMENTATION !in module.directives) {
             "$USE_LEGACY_REFLECTION_IMPLEMENTATION is incompatible with $PREFER_IN_TEST_OVER_STDLIB"
         }
+        checkTestInfrastructure(USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS !in module.directives) {
+            "$USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS is incompatible with $PREFER_IN_TEST_OVER_STDLIB"
+        }
         val libPathProvider = testServices.standardLibrariesPathProvider
         classpath += libPathProvider.runtimeJarForTests()
         if (withReflection) {
@@ -374,6 +381,8 @@ fun generatedTestClassLoader(
                 testServices.standardLibrariesPathProvider.getRuntimeAndReflectWithLoadMetadataDirectlyClassLoader()
             USE_LEGACY_REFLECTION_IMPLEMENTATION in module.directives ->
                 testServices.standardLibrariesPathProvider.getRuntimeAndK1ReflectJarClassLoader()
+            USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS in module.directives ->
+                testServices.standardLibrariesPathProvider.getRuntimeAndK1MembersReflectJarClassLoader()
             else -> testServices.standardLibrariesPathProvider.getRuntimeAndReflectJarClassLoader()
         }
         return GeneratedClassLoader(classFileFactory, parentClassLoader, *classpath.map { it.toURI().toURL() }.toTypedArray())

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/directives/JvmEnvironmentConfigurationDirectives.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/directives/JvmEnvironmentConfigurationDirectives.kt
@@ -73,6 +73,10 @@ object JvmEnvironmentConfigurationDirectives : SimpleDirectivesContainer() {
     )
 
     val USE_LEGACY_REFLECTION_IMPLEMENTATION by directive("Use legacy reflection implementation based on K1 compiler code")
+    val USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS by directive(
+        "Use legacy reflection implementation based on K1 compiler code only for Kotlin member functions, " +
+                "Kotlin member properties and Java member properties"
+    )
     val LOAD_METADATA_DIRECTLY_IN_REFLECTION by directive(
         "Read metadata in kotlin-reflect directly, without first wrapping it in descriptors, " +
                 "like how it eventually will work after the K1-based implementation is removed"

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/runners/codegen/AbstractReflectionK1MembersImplementationTest.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/runners/codegen/AbstractReflectionK1MembersImplementationTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.test.runners.codegen
+
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS
+
+open class AbstractReflectionK1MembersImplementationTest : AbstractFirLightTreeBlackBoxCodegenTest() {
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        with(builder) {
+            defaultDirectives {
+                +USE_K1_REFLECTION_IMPLEMENTATION_FOR_MEMBERS
+            }
+        }
+    }
+}

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/KotlinStandardLibrariesPathProvider.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/KotlinStandardLibrariesPathProvider.kt
@@ -35,6 +35,9 @@ interface KotlinStandardLibrariesPathProvider : TestService {
         @Volatile
         private var k1ReflectJarClassLoader: SoftReference<ClassLoader?> = SoftReference(null)
 
+        @Volatile
+        private var k1MembersReflectJarClassLoader: SoftReference<ClassLoader?> = SoftReference(null)
+
         private fun createClassLoader(vararg files: File): ClassLoader {
             val urls: MutableList<URL> = ArrayList(2)
             for (file in files) {
@@ -126,14 +129,16 @@ interface KotlinStandardLibrariesPathProvider : TestService {
 
     fun getRuntimeAndReflectJarClassLoader(): ClassLoader =
         getOrCreateClassLoader(::reflectJarClassLoader).also { loader ->
-            val useK1 = loader.loadClass("kotlin.reflect.jvm.internal.SystemPropertiesKt")
-                .getMethod("getUseK1Implementation")
-                .invoke(null)
-            check(useK1 == false)
+            val systemProperties = loader.loadClass("kotlin.reflect.jvm.internal.SystemPropertiesKt")
+            check(systemProperties.getMethod("getUseK1Implementation").invoke(null) == false)
+            check(systemProperties.getMethod("getUseK1ImplementationForMembers").invoke(null) == false)
         }
 
     fun getRuntimeAndK1ReflectJarClassLoader(): ClassLoader =
         getOrCreateClassLoader(::k1ReflectJarClassLoader, "useK1Implementation")
+
+    fun getRuntimeAndK1MembersReflectJarClassLoader(): ClassLoader =
+        getOrCreateClassLoader(::k1MembersReflectJarClassLoader, "useK1ImplementationForMembers")
 
     fun getRuntimeAndReflectWithLoadMetadataDirectlyClassLoader(): ClassLoader =
         getOrCreateClassLoader(::reflectWithLoadMetadataDirectlyClassLoader, "loadMetadataDirectly")

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKCallable.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKCallable.kt
@@ -22,7 +22,6 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
-import kotlin.reflect.jvm.internal.types.DescriptorKType
 import org.jetbrains.kotlin.descriptors.Modality as DescriptorModality
 
 internal abstract class DescriptorKCallable<out R>(
@@ -30,7 +29,7 @@ internal abstract class DescriptorKCallable<out R>(
 ) : ReflectKCallableImpl<R>(overriddenStorage) {
     abstract val descriptor: CallableMemberDescriptor
 
-    protected abstract fun computeReturnType(): DescriptorKType
+    protected abstract fun computeReturnType(): KType
 
     private val _annotations = ReflectProperties.lazySoft { descriptor.computeAnnotations() }
 
@@ -115,7 +114,8 @@ internal abstract class DescriptorKCallable<out R>(
     private val _typeParameters = ReflectProperties.lazySoft {
         val typeParametersWithNotYetSubstitutedUpperBounds =
             descriptor.typeParameters.map { descriptor -> KTypeParameterImpl(unbindAllReceivers(), descriptor) }
-        val substitutor = overriddenStorage.getTypeSubstitutor(typeParametersWithNotYetSubstitutedUpperBounds, memberNameForDebug = name)
+        val substitutor = propertyIfAccessor.overriddenStorage
+            .getTypeSubstitutor(typeParametersWithNotYetSubstitutedUpperBounds, memberNameForDebug = name)
         for (typeParameter in typeParametersWithNotYetSubstitutedUpperBounds) {
             typeParameter.upperBounds = typeParameter.upperBounds.map { type ->
                 substitutor.substituteTopLevelType(type, name)

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKFunction.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKFunction.kt
@@ -28,6 +28,7 @@ import java.lang.reflect.Modifier
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.jvm.internal.CallableReference
 import kotlin.jvm.internal.FunctionBase
+import kotlin.reflect.KType
 import kotlin.reflect.jvm.internal.JvmFunctionSignature.*
 import kotlin.reflect.jvm.internal.calls.*
 import kotlin.reflect.jvm.internal.calls.AnnotationConstructorCaller.CallMode.CALL_BY_NAME
@@ -214,7 +215,7 @@ internal class DescriptorKFunction private constructor(
         }
     }
 
-    override fun computeReturnType(): DescriptorKType =
+    override fun computeReturnType(): KType =
         DescriptorKType(descriptor.returnType!!) {
             extractContinuationArgument() ?: caller.returnType
         }

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKParameter.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKParameter.kt
@@ -45,12 +45,14 @@ internal class DescriptorKParameter(
 
     override val type: KType
         get() {
+            val propertyIfAccessor = callable.propertyIfAccessor
             val type = DescriptorKType(descriptor.type) {
                 val descriptor = descriptor
 
                 if (descriptor is ReceiverParameterDescriptor &&
                     callable.instanceReceiverParameter == descriptor &&
-                    (callable.overriddenStorage.isFakeOverride || callable.descriptor.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE)
+                    (propertyIfAccessor.overriddenStorage.isFakeOverride ||
+                            callable.descriptor.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE)
                 ) {
                     (callable.container as? KClassImpl<*>)?.java
                         ?: throw KotlinReflectionInternalError("Cannot determine receiver Java type of inherited declaration: $descriptor")
@@ -58,7 +60,7 @@ internal class DescriptorKParameter(
                     callable.caller.parameterTypes[index]
                 }
             }
-            return if (kind == KParameter.Kind.INSTANCE) type else callable.substituteType(type)
+            return if (kind == KParameter.Kind.INSTANCE) type else propertyIfAccessor.substituteType(type)
         }
 
     override val isOptional: Boolean

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKProperty.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/DescriptorKProperty.kt
@@ -25,6 +25,7 @@ import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.reflect.KFunction
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KProperty
+import kotlin.reflect.KType
 import kotlin.reflect.jvm.internal.JvmPropertySignature.*
 import kotlin.reflect.jvm.internal.calls.*
 import kotlin.reflect.jvm.internal.types.DescriptorKType
@@ -105,7 +106,7 @@ internal abstract class DescriptorKProperty<out V> private constructor(
 
     override val callerWithDefaults: Caller<*>? get() = getter.callerWithDefaults
 
-    override fun computeReturnType(): DescriptorKType =
+    override fun computeReturnType(): KType =
         DescriptorKType(descriptor.returnType!!, if (isLocalDelegated) null else fun(): Type {
             return caller.returnType
         })
@@ -170,8 +171,8 @@ internal abstract class DescriptorKProperty<out V> private constructor(
             computeCallerForAccessor(isGetter = true)
         }
 
-        override fun computeReturnType(): DescriptorKType =
-            property.returnType as DescriptorKType
+        override fun computeReturnType(): KType =
+            property.returnType
 
         override fun toString(): String = "getter of $property"
 
@@ -193,7 +194,7 @@ internal abstract class DescriptorKProperty<out V> private constructor(
             computeCallerForAccessor(isGetter = false)
         }
 
-        override fun computeReturnType(): DescriptorKType =
+        override fun computeReturnType(): KType =
             DescriptorKType(descriptor.builtIns.unitType) { Void.TYPE }
 
         override fun toString(): String = "setter of $property"

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassMembers.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassMembers.kt
@@ -63,7 +63,7 @@ private fun KClassImpl<*>.collectDeclaredMemberNamesTransitively(result: Mutable
 
 internal fun KClassImpl<*>.computeDeclaredMembersByName(name: String): Collection<ReflectKCallable<*>> = buildList {
     val kClass = this@computeDeclaredMembersByName
-    if (useK1Implementation || isComplicatedBuiltinSubclass) {
+    if (useK1Implementation || isComplicatedBuiltinSubclass || (useK1ImplementationForMembers && kmClass != null)) {
         addAll(getDescriptorBasedFunctions(memberScope, DECLARED, name))
         addAll(getDescriptorBasedProperties(memberScope, DECLARED, name))
         addAll(getDescriptorBasedFunctions(staticScope, DECLARED, name))
@@ -90,6 +90,9 @@ internal fun KClassImpl<*>.computeDeclaredMembersByName(name: String): Collectio
         data.value.additionalFunctions.filterTo(this) { it.name == name }
     } else {
         getDeclaredNonStaticMethodsFromJavaClass(name).filterTo(this) { isVisibleAsFunctionInCurrentClass(it) }
+        if (useK1ImplementationForMembers) {
+            addAll(getDescriptorBasedProperties(memberScope, DECLARED, name))
+        }
         for (method in jClass.declaredMethods) {
             if (method.name == name && Modifier.isStatic(method.modifiers) && !method.isSynthetic) {
                 add(JavaKNamedFunction(kClass, method, NO_RECEIVER, KCallableOverriddenStorage.EMPTY))
@@ -98,6 +101,7 @@ internal fun KClassImpl<*>.computeDeclaredMembersByName(name: String): Collectio
 
         for (field in jClass.declaredFields) {
             if (field.isEnumConstant || field.isSynthetic || field.name != name) continue
+            if (useK1ImplementationForMembers && !Modifier.isStatic(field.modifiers)) continue
             when {
                 Modifier.isStatic(field.modifiers) -> when {
                     Modifier.isFinal(field.modifiers) ->
@@ -114,15 +118,18 @@ internal fun KClassImpl<*>.computeDeclaredMembersByName(name: String): Collectio
             }
         }
 
-        val propertiesFromSupertypes = getPropertiesFromSupertypes(name)
-        if (propertiesFromSupertypes.isNotEmpty()) {
-            val handledProperties = hashSetOf<KProperty1<*, *>>()
-            addPropertyOverrideByMethod(propertiesFromSupertypes, this, handledProperties) {
-                getDeclaredNonStaticMethodsFromJavaClass(it)
+        if (!useK1ImplementationForMembers) {
+            val propertiesFromSupertypes = getPropertiesFromSupertypes(name)
+            if (propertiesFromSupertypes.isNotEmpty()) {
+                val handledProperties = hashSetOf<KProperty1<*, *>>()
+                addPropertyOverrideByMethod(propertiesFromSupertypes, this, handledProperties) {
+                    getDeclaredNonStaticMethodsFromJavaClass(it)
+                }
+                // K1 also had logic about properties in supertypes, see `LazyJavaClassMemberScope.computeNonDeclaredProperties`.
+                // However, the only test where it can be observed
+                // `compiler/testData/ir/irText/firProblems/TypeParameterInClashingAccessor.kt` never worked in K1 reflection because of
+                // other problems: KT-81029.
             }
-            // K1 also had logic about properties in supertypes, see `LazyJavaClassMemberScope.computeNonDeclaredProperties`.
-            // However, the only test where it can be observed `compiler/testData/ir/irText/firProblems/TypeParameterInClashingAccessor.kt`
-            // never worked in K1 reflection because of other problems: KT-81029.
         }
 
         if (jClass.isEnum && name == ENUM_ENTRIES_PROPERTY_NAME) {
@@ -130,7 +137,7 @@ internal fun KClassImpl<*>.computeDeclaredMembersByName(name: String): Collectio
             add(JavaEnumEntriesKProperty(kClass as KClassImpl<out Enum<*>>))
         }
 
-        if (jClass.isAnnotation) {
+        if (jClass.isAnnotation && !useK1ImplementationForMembers) {
             for (method in jClass.declaredMethods) {
                 if (method.name == name && !method.isSynthetic) {
                     add(JavaAnnotationMethodKProperty1<Any?, Any?>(kClass, method, NO_RECEIVER, KCallableOverriddenStorage.EMPTY))

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectionFactoryImpl.java
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/ReflectionFactoryImpl.java
@@ -78,8 +78,7 @@ public class ReflectionFactoryImpl extends ReflectionFactory {
         Object boundReceiver = f.getBoundReceiver();
         if (!SystemPropertiesKt.getUseK1Implementation()) {
             if (name.equals("<init>")) {
-                if (container.getJClass().getAnnotation(Metadata.class) == null &&
-                    !ConvertFromJavaKt.isMappedBuiltin((KClass<?>) container)) {
+                if (isJavaClass(container)) {
                     Constructor<?> constructor = container.findJavaConstructor(signature);
                     return new JavaKConstructor(container, constructor, boundReceiver);
                 }
@@ -92,7 +91,8 @@ public class ReflectionFactoryImpl extends ReflectionFactory {
                 KmFunction kmFunction = container.findFunctionMetadata(name, signature);
                 return new KotlinKNamedFunction(container, signature, boundReceiver, kmFunction, KCallableOverriddenStorage.EMPTY);
             }
-            else if (container instanceof KClassImpl<?> && !((KClassImpl<?>) container).isComplicatedBuiltinSubclass()) {
+            else if (container instanceof KClassImpl<?> && !((KClassImpl<?>) container).isComplicatedBuiltinSubclass() &&
+                     (!SystemPropertiesKt.getUseK1ImplementationForMembers() || isJavaClass(container))) {
                 ReflectKFunction result = (ReflectKFunction) CollectionsKt.firstOrNull(
                         ((KClassImpl<?>) container).getData().getValue().getMembersByName(name),
                         it -> it instanceof ReflectKFunction && ((ReflectKFunction) it).getSignature().equals(signature)
@@ -176,7 +176,8 @@ public class ReflectionFactoryImpl extends ReflectionFactory {
                     KmProperty kmProperty = container.findPropertyMetadata(name, signature);
                     return new KotlinKProperty1(container, signature, boundReceiver, kmProperty, KCallableOverriddenStorage.EMPTY);
                 }
-                else if (container instanceof KClassImpl && !((KClassImpl<?>) container).isComplicatedBuiltinSubclass()) {
+                else if (!SystemPropertiesKt.getUseK1ImplementationForMembers() &&
+                         container instanceof KClassImpl && !((KClassImpl<?>) container).isComplicatedBuiltinSubclass()) {
                     return findProperty((KClassImpl<?>) container, name, signature, boundReceiver);
                 }
                 return new DescriptorKProperty1(container, name, signature, boundReceiver);
@@ -197,7 +198,8 @@ public class ReflectionFactoryImpl extends ReflectionFactory {
                     KmProperty kmProperty = container.findPropertyMetadata(name, signature);
                     return new KotlinKMutableProperty1(container, signature, boundReceiver, kmProperty, KCallableOverriddenStorage.EMPTY);
                 }
-                else if (container instanceof KClassImpl && !((KClassImpl<?>) container).isComplicatedBuiltinSubclass()) {
+                else if (!SystemPropertiesKt.getUseK1ImplementationForMembers() &&
+                         container instanceof KClassImpl && !((KClassImpl<?>) container).isComplicatedBuiltinSubclass()) {
                     return findProperty((KClassImpl<?>) container, name, signature, boundReceiver);
                 }
                 return new DescriptorKMutableProperty1(container, name, signature, boundReceiver);
@@ -219,6 +221,11 @@ public class ReflectionFactoryImpl extends ReflectionFactory {
     private static KDeclarationContainerImpl getOwner(CallableReference reference) {
         KDeclarationContainer owner = reference.getOwner();
         return owner instanceof KDeclarationContainerImpl ? ((KDeclarationContainerImpl) owner) : EmptyContainerForLocal.INSTANCE;
+    }
+
+    private static boolean isJavaClass(KDeclarationContainerImpl container) {
+        return container.getJClass().getAnnotation(Metadata.class) == null &&
+               !ConvertFromJavaKt.isMappedBuiltin((KClass<?>) container);
     }
 
     private static ReflectKProperty<?> findProperty(KClassImpl<?> container, String name, String signature, Object boundReceiver) {

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/SystemProperties.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/SystemProperties.kt
@@ -21,6 +21,26 @@ internal var useK1Implementation = runCatching {
 }.getOrNull()?.toBoolean() == true
 
 /**
+ * True if the system property `kotlin.reflect.jvm.useK1ImplementationForMembers` is set to true.
+ *
+ * This system property is a more fine-grained version of `kotlin.reflect.jvm.useK1Implementation`. It changes kotlin-reflect
+ * implementation to the legacy one, based on parts of the K1 compiler, only for the kinds of callables which were migrated to the new
+ * implementation in 2.5.0: Kotlin member functions, Kotlin member properties, and Java member properties. All other kinds of
+ * callables (constructors, top-level functions and properties, local delegated properties, Java member functions, Java static functions
+ * and properties, ...) still use the new implementation, based on kotlin-metadata-jvm and Java reflection.
+ *
+ * Note that if [useK1Implementation] is enabled, this property is ignored and all callables use the K1-based implementation.
+ *
+ * Changing the value of the system property after it has been read (i.e., after any non-trivial operation in kotlin-reflect)
+ * is not supported and might lead to unexpected or incorrect behavior.
+ *
+ * See KT-80710 and related issues for more information.
+ */
+internal var useK1ImplementationForMembers = runCatching {
+    System.getProperty("kotlin.reflect.jvm.useK1ImplementationForMembers")
+}.getOrNull()?.toBoolean() == true
+
+/**
  * True if the system property `kotlin.reflect.jvm.loadMetadataDirectly` is set to true.
  *
  * This system property can be used to instruct the kotlin-reflect implementation to avoid using K1 compiler representation unless

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/util.kt
@@ -319,9 +319,11 @@ internal fun Any?.asReflectCallable(): ReflectKCallable<*>? = when (this) {
 internal val DescriptorKCallable<*>.instanceReceiverParameter: ReceiverParameterDescriptor?
     get() {
         val descriptor = descriptor
+        val propertyIfAccessor = propertyIfAccessor
         return when {
-            overriddenStorage.isFakeOverride && isStatic -> null
-            overriddenStorage.isFakeOverride && !isStatic -> (this.container as? KClassImpl<*>)?.descriptor?.thisAsReceiverParameter
+            propertyIfAccessor.overriddenStorage.isFakeOverride ->
+                if (propertyIfAccessor.isStatic) null
+                else (this.container as? KClassImpl<*>)?.descriptor?.thisAsReceiverParameter
             descriptor is ConstructorDescriptor -> descriptor.dispatchReceiverParameter
             descriptor.dispatchReceiverParameter != null -> (descriptor.containingDeclaration as ClassDescriptor).thisAsReceiverParameter
             else -> null


### PR DESCRIPTION
The only point of this property is to be able to revert it quickly in 2.5.0-Beta2/RC in case we find major regressions in 2.5.0-Beta1/Beta2. The new test runner `AbstractReflectionK1MembersImplementationTest` ensures that kotlin-reflect tests work if we change default implementaiton for members back to K1.

Co-authored-by: Junie <junie@jetbrains.com>

 #KT-80710