### PR TITLE
[FIR] Cache metadata package parts with soft values + Unmute the previously muted Native test runner due to OOM 

### DIFF
--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
@@ -61,7 +61,6 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
     private val cachedFragments: MutableMap<L, MutableMap<Pair<String, String>, ProtoBuf.PackageFragment>> = mutableMapOf()
 
-    private val fragmentToNameResolver = IdentityHashMap<ProtoBuf.PackageFragment, NameResolver>()
     private val fragmentToKlibMetadataClassDataFinder = IdentityHashMap<ProtoBuf.PackageFragment, KlibMetadataClassDataFinder>()
     private val fragmentToFileAnnotations = IdentityHashMap<ProtoBuf.PackageFragment, List<FirAnnotation>>()
 
@@ -78,15 +77,6 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
             mutableMapOf()
         }.getOrPut(packageStringName to packageMetadataPart) {
             parsePackageFragment(metadataProvider(resolvedLibrary).getPackageFragment(packageStringName, packageMetadataPart))
-        }
-    }
-
-    private fun getNameResolver(fragment: ProtoBuf.PackageFragment): NameResolver {
-        return fragmentToNameResolver.getOrPut(fragment) {
-            NameResolverImpl(
-                fragment.strings,
-                fragment.qualifiedNames,
-            )
         }
     }
 
@@ -111,7 +101,10 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
                 val packageProto = fragment.`package`
 
-                val nameResolver = getNameResolver(fragment)
+                val nameResolver = NameResolverImpl(
+                    fragment.strings,
+                    fragment.qualifiedNames,
+                )
 
                 PackagePartsCacheData(
                     packageProto,
@@ -205,7 +198,10 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
                 val fragment = getPackageFragment(resolvedLibrary, packageStringName, packageMetadataPart)
 
-                val nameResolver = getNameResolver(fragment)
+                val nameResolver = NameResolverImpl(
+                    fragment.strings,
+                    fragment.qualifiedNames,
+                )
 
                 f(resolvedLibrary, fragment, nameResolver)
             }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.protobuf.GeneratedMessageLite.GeneratedExtension
 import org.jetbrains.kotlin.resolve.CommonCompilerDeserializationConfiguration
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
 import org.jetbrains.kotlin.serialization.deserialization.getClassId
-import java.util.*
+import java.lang.ref.SoftReference
 
 abstract class MetadataLibraryBasedSymbolProvider<L>(
     session: FirSession,
@@ -48,6 +48,22 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 ) {
     private class MetadataLibraryPackagePartCacheDataExtra(val library: KotlinLibrary) : PackagePartsCacheData.Extra
 
+    private inner class CachedPackageFragment(
+        val proto: ProtoBuf.PackageFragment
+    ) {
+        val nameResolver: NameResolver
+            get() = NameResolverImpl(proto.strings, proto.qualifiedNames)
+
+        val classDataFinder by lazy {
+            // Assumes the fact that the nameResolver depends only on the fragment.
+            KlibMetadataClassDataFinder(proto, nameResolver)
+        }
+
+        val fileAnnotations: List<FirAnnotation> by lazy {
+            loadAnnotationsFromMetadata(session, proto.fileAnnotationList, nameResolver, AnnotationUseSiteTarget.FILE)
+        }
+    }
+
     protected abstract fun moduleData(library: L): FirModuleData?
 
     protected abstract val fragmentNamesInLibraries: Map<String, List<L>>
@@ -59,31 +75,25 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
     protected val deserializationConfiguration: CommonCompilerDeserializationConfiguration =
         CommonCompilerDeserializationConfiguration(session.languageVersionSettings)
 
-    private val cachedFragments: MutableMap<L, MutableMap<Pair<String, String>, ProtoBuf.PackageFragment>> = mutableMapOf()
-
-    private val fragmentToKlibMetadataClassDataFinder = IdentityHashMap<ProtoBuf.PackageFragment, KlibMetadataClassDataFinder>()
-    private val fragmentToFileAnnotations = IdentityHashMap<ProtoBuf.PackageFragment, List<FirAnnotation>>()
-
-    private fun getFileAnnotations(fragment: ProtoBuf.PackageFragment, nameResolver: NameResolver): List<FirAnnotation> {
-        return fragmentToFileAnnotations.getOrPut(fragment) {
-            loadAnnotationsFromMetadata(session, fragment.fileAnnotationList, nameResolver, AnnotationUseSiteTarget.FILE)
-        }
-    }
+    private val cachedFragments: MutableMap<L, MutableMap<Pair<String, String>, SoftReference<CachedPackageFragment>>> = mutableMapOf()
 
     private fun getPackageFragment(
         resolvedLibrary: L, packageStringName: String, packageMetadataPart: String
-    ): ProtoBuf.PackageFragment {
-        return cachedFragments.getOrPut(resolvedLibrary) {
-            mutableMapOf()
-        }.getOrPut(packageStringName to packageMetadataPart) {
-            parsePackageFragment(metadataProvider(resolvedLibrary).getPackageFragment(packageStringName, packageMetadataPart))
-        }
-    }
+    ): CachedPackageFragment {
+        val slice = cachedFragments.getOrPut(resolvedLibrary) { mutableMapOf() }
+        val key = packageStringName to packageMetadataPart
 
-    private fun getFinder(fragment: ProtoBuf.PackageFragment, resolver: NameResolver): KlibMetadataClassDataFinder {
-        return fragmentToKlibMetadataClassDataFinder.getOrPut(fragment) {
-            // Assumes the fact that the nameResolver depends only on the fragment.
-            KlibMetadataClassDataFinder(fragment, resolver)
+        return slice[key]?.get() ?: run {
+            val packageFragment = CachedPackageFragment(
+                parsePackageFragment(
+                    metadataProvider(resolvedLibrary).getPackageFragment(
+                        packageStringName,
+                        packageMetadataPart
+                    )
+                )
+            )
+            slice[key] = SoftReference(packageFragment)
+            packageFragment
         }
     }
 
@@ -99,17 +109,10 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
             metadataProvider(resolvedLibrary).getPackageFragmentNames(packageStringName).map {
                 val fragment = getPackageFragment(resolvedLibrary, packageStringName, it)
 
-                val packageProto = fragment.`package`
-
-                val nameResolver = NameResolverImpl(
-                    fragment.strings,
-                    fragment.qualifiedNames,
-                )
-
                 PackagePartsCacheData(
-                    packageProto,
+                    fragment.proto.`package`,
                     FirDeserializationContext.createForPackage(
-                        packageFqName, packageProto, nameResolver, moduleData,
+                        packageFqName, fragment.proto.`package`, fragment.nameResolver, moduleData,
                         annotationDeserializer,
                         flexibleTypeFactory,
                         constDeserializer,
@@ -117,7 +120,7 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
                         createDeserializedContainerSource(resolvedLibrary, packageFqName),
                     ),
                     (resolvedLibrary as? KotlinLibrary)?.let(::MetadataLibraryPackagePartCacheDataExtra),
-                    fileAnnotations = getFileAnnotations(fragment, nameResolver),
+                    fileAnnotations = fragment.fileAnnotations,
                 )
             }
         }
@@ -127,17 +130,17 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
     override fun knownTopLevelClassesInPackage(packageFqName: FqName): Set<String> =
         buildSet {
-            forEachFragmentInPackage(packageFqName) { _, fragment, nameResolver ->
-                for (classNameId in fragment.getExtension(KlibMetadataProtoBuf.className).orEmpty()) {
-                    add(nameResolver.getClassId(classNameId).shortClassName.asString())
+            forEachFragmentInPackage(packageFqName) { _, fragment ->
+                for (classNameId in fragment.proto.getExtension(KlibMetadataProtoBuf.className).orEmpty()) {
+                    add(fragment.nameResolver.getClassId(classNameId).shortClassName.asString())
                 }
             }
         }
 
     @OptIn(SymbolInternals::class)
     override fun extractClassMetadata(classId: ClassId, parentContext: FirDeserializationContext?): ClassMetadataFindResult? {
-        forEachFragmentInPackage(classId.packageFqName) { resolvedLibrary, fragment, nameResolver ->
-            val finder = getFinder(fragment, nameResolver)
+        forEachFragmentInPackage(classId.packageFqName) { resolvedLibrary, fragment ->
+            val finder = fragment.classDataFinder
             val classProto = finder.findClassData(classId)?.classProto ?: return@forEachFragmentInPackage
 
             val moduleData = moduleData(resolvedLibrary) ?: return null
@@ -152,7 +155,7 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
                     classId,
                     classProto,
                     symbol,
-                    nameResolver,
+                    fragment.nameResolver,
                     session,
                     moduleData,
                     annotationDeserializer,
@@ -169,13 +172,13 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
                 if (resolvedLibrary is KotlinLibrary) {
                     symbol.fir.klibSourceFile = loadKlibSourceFileExtensionOrNull(
-                        resolvedLibrary, nameResolver, classProto, KlibMetadataProtoBuf.classFile
+                        resolvedLibrary, fragment.nameResolver, classProto, KlibMetadataProtoBuf.classFile
                     )
                 }
 
                 symbol.fir.isNewPlaceForBodyGeneration = isNewPlaceForBodyGeneration(classProto)
 
-                val fileAnnotations = getFileAnnotations(fragment, nameResolver)
+                val fileAnnotations = fragment.fileAnnotations
                 if (fileAnnotations.isNotEmpty()) {
                     symbol.fir.klibFileAnnotations = fileAnnotations
                 }
@@ -187,7 +190,7 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
     private inline fun forEachFragmentInPackage(
         packageFqName: FqName,
-        f: (L, ProtoBuf.PackageFragment, NameResolver) -> Unit
+        f: (L, CachedPackageFragment) -> Unit
     ) {
         val packageStringName = packageFqName.asString()
 
@@ -198,12 +201,7 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
                 val fragment = getPackageFragment(resolvedLibrary, packageStringName, packageMetadataPart)
 
-                val nameResolver = NameResolverImpl(
-                    fragment.strings,
-                    fragment.qualifiedNames,
-                )
-
-                f(resolvedLibrary, fragment, nameResolver)
+                f(resolvedLibrary, fragment)
             }
         }
     }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
@@ -58,7 +58,9 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
     private val constDeserializer = FirConstDeserializer(KlibMetadataSerializerProtocol)
     protected val deserializationConfiguration: CommonCompilerDeserializationConfiguration =
         CommonCompilerDeserializationConfiguration(session.languageVersionSettings)
+
     private val cachedFragments: MutableMap<L, MutableMap<Pair<String, String>, ProtoBuf.PackageFragment>> = mutableMapOf()
+
     private val fragmentToNameResolver = IdentityHashMap<ProtoBuf.PackageFragment, NameResolver>()
     private val fragmentToKlibMetadataClassDataFinder = IdentityHashMap<ProtoBuf.PackageFragment, KlibMetadataClassDataFinder>()
     private val fragmentToFileAnnotations = IdentityHashMap<ProtoBuf.PackageFragment, List<FirAnnotation>>()

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
@@ -8,7 +8,9 @@ package org.jetbrains.kotlin.fir.deserialization
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.caches.FirCache
+import org.jetbrains.kotlin.fir.caches.FirCachesFactory.ValueReferenceStrength
 import org.jetbrains.kotlin.fir.caches.createCache
+import org.jetbrains.kotlin.fir.caches.createCacheWithSuggestedLimits
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.caches.getValue
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
@@ -171,7 +173,10 @@ abstract class AbstractFirDeserializedSymbolProvider(
             getPackageParts(fqName).flatMapTo(mutableSetOf()) { it.typeAliasNameIndex.keys }
         }
 
-    private val packagePartsCache = session.firCachesFactory.createCache(::tryComputePackagePartInfos)
+    private val packagePartsCache = session.firCachesFactory.createCacheWithSuggestedLimits(
+        valueHardness = ValueReferenceStrength.SOFT,
+        createValue = ::tryComputePackagePartInfos
+    )
 
     private val typeAliasCache: FirCache<ClassId, FirTypeAliasSymbol?, FirNestedTypeAliasDeserializationContext?> =
         session.firCachesFactory.createCacheWithPostCompute(

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
@@ -31,12 +31,9 @@ import org.jetbrains.kotlin.test.services.configuration.CommonEnvironmentConfigu
 import org.jetbrains.kotlin.test.services.configuration.NativeFirstStageEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.NativeSecondStageEnvironmentConfigurator
 import org.jetbrains.kotlin.utils.bind
-import org.junit.jupiter.api.Assumptions
 
 abstract class AbstractNativeCodegenBoxCoreTest : AbstractTwoStageNativeCoreTest() {
     override fun configure(builder: TwoStageTestConfigurationBuilder): Unit = with(builder) {
-        Assumptions.abort<Nothing>("temporarily muted because of OOM") // @Disabled annotation does not work on such tests somewhy!!!
-
         super.configure(builder)
         commonConfiguration {
             defaultDirectives {


### PR DESCRIPTION
After https://github.com/JetBrains/kotlin/pull/7888, the memory pressure caused by the retained metadata proto in `KlibBasedSymbolProvider` is reduced. So, we can unmute the test.