### PR TITLE
[Parcelize] Minor: Update FIR checkers to be stateless

### DIFF
--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeCheckersExtension.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeCheckersExtension.kt
@@ -10,30 +10,17 @@ import org.jetbrains.kotlin.fir.analysis.checkers.declaration.*
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirAnnotationCallChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.parcelize.fir.diagnostics.*
 
-class FirParcelizeCheckersExtension(
-    session: FirSession,
-    val parcelizeAnnotations: List<ClassId>,
-    val experimentalCodeGeneration: Boolean,
-) : FirAdditionalCheckersExtension(session) {
+class FirParcelizeCheckersExtension(session: FirSession) : FirAdditionalCheckersExtension(session) {
     override val expressionCheckers: ExpressionCheckers = object : ExpressionCheckers() {
-        override val annotationCallCheckers: Set<FirAnnotationCallChecker>
-            get() = setOf(FirParcelizeAnnotationChecker(parcelizeAnnotations))
+        override val annotationCallCheckers: Set<FirAnnotationCallChecker> = setOf(FirParcelizeAnnotationChecker)
     }
 
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
-        override val classCheckers: Set<FirClassChecker>
-            get() = setOf(FirParcelizeClassChecker(parcelizeAnnotations), FirPolymorphicSealedClassChecker(parcelizeAnnotations))
-
-        override val propertyCheckers: Set<FirPropertyChecker>
-            get() = setOf(FirParcelizePropertyChecker(parcelizeAnnotations))
-
-        override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
-            get() = setOf(FirParcelizeFunctionChecker(parcelizeAnnotations))
-
-        override val constructorCheckers: Set<FirConstructorChecker>
-            get() = setOf(FirParcelizeConstructorChecker(parcelizeAnnotations, experimentalCodeGeneration))
+        override val classCheckers: Set<FirClassChecker> = setOf(FirParcelizeClassChecker, FirPolymorphicSealedClassChecker)
+        override val propertyCheckers: Set<FirPropertyChecker> = setOf(FirParcelizePropertyChecker)
+        override val namedFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(FirParcelizeFunctionChecker)
+        override val constructorCheckers: Set<FirConstructorChecker> = setOf(FirParcelizeConstructorChecker)
     }
 }

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeExtensionRegistrar.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeExtensionRegistrar.kt
@@ -16,13 +16,10 @@ class FirParcelizeExtensionRegistrar(
     private val experimentalCodeGeneration: Boolean = false,
 ) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
+        +FirParcelizeService.getFactory(parcelizeAnnotationFqNames, experimentalCodeGeneration)
         +::FirParcelizeDeclarationGenerator.bind(parcelizeAnnotationFqNames)
-        +::firParcelizeCheckersExtension
+        +::FirParcelizeCheckersExtension
 
         registerDiagnosticContainers(KtErrorsParcelize)
     }
-
-    private fun firParcelizeCheckersExtension(session: FirSession) =
-        FirParcelizeCheckersExtension(session, parcelizeAnnotationFqNames.map { ClassId.topLevel(it) }, experimentalCodeGeneration)
-
 }

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeService.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeService.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.parcelize.fir
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+class FirParcelizeService(
+    session: FirSession,
+    val parcelizeAnnotations: List<ClassId>,
+    val experimentalCodeGeneration: Boolean,
+) : FirExtensionSessionComponent(session) {
+    companion object {
+        fun getFactory(parcelizeAnnotationFqNames: List<FqName>, experimentalCodeGeneration: Boolean): Factory {
+            return Factory { session ->
+                FirParcelizeService(
+                    session = session,
+                    parcelizeAnnotations = parcelizeAnnotationFqNames.map { ClassId.topLevel(it) },
+                    experimentalCodeGeneration = experimentalCodeGeneration,
+                )
+            }
+        }
+    }
+}
+
+val FirSession.parcelizeService: FirParcelizeService by FirSession.sessionComponentAccessor()

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeAnnotationChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeAnnotationChecker.kt
@@ -30,14 +30,15 @@ import org.jetbrains.kotlin.parcelize.ParcelizeNames.POLYMORPHIC_SEALED_CLASS_ID
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.RAW_VALUE_ANNOTATION_CLASS_IDS
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.TYPE_PARCELER_CLASS_IDS
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.WRITE_WITH_CLASS_IDS
+import org.jetbrains.kotlin.parcelize.fir.parcelizeService
 
 // TODO: extract common checker for expect interfaces
-class FirParcelizeAnnotationChecker(private val parcelizeAnnotationClassIds: List<ClassId>) :
-    FirAnnotationCallChecker(MppCheckerKind.Platform) {
+object FirParcelizeAnnotationChecker : FirAnnotationCallChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirAnnotationCall) {
         val annotationType = expression.annotationTypeRef.coneType.fullyExpandedType() as? ConeClassLikeType ?: return
         val resolvedAnnotationSymbol = annotationType.lookupTag.toRegularClassSymbol() ?: return
+        val parcelizeAnnotationClassIds = context.session.parcelizeService.parcelizeAnnotations
         when (val annotationClassId = resolvedAnnotationSymbol.classId) {
             in TYPE_PARCELER_CLASS_IDS -> {
                 if (checkDeprecatedAnnotations(expression, annotationClassId, context, reporter, isForbidden = true)) {
@@ -158,7 +159,7 @@ class FirParcelizeAnnotationChecker(private val parcelizeAnnotationClassIds: Lis
     private fun checkIfTheContainingClassIsParcelize(annotationCall: FirAnnotationCall, context: CheckerContext, reporter: DiagnosticReporter) {
         val enclosingClass = context.findClosestClassOrObject() ?: return
 
-        if (!enclosingClass.isParcelize(context.session, parcelizeAnnotationClassIds)) {
+        if (!enclosingClass.isParcelize(context.session)) {
             val reportElement = annotationCall.calleeReference.source ?: annotationCall.source
             reporter.reportOn(reportElement, KtErrorsParcelize.CLASS_SHOULD_BE_PARCELIZE, enclosingClass, context)
         }

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeClassChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeClassChecker.kt
@@ -15,23 +15,25 @@ import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
 import org.jetbrains.kotlin.fir.declarations.*
-import org.jetbrains.kotlin.fir.declarations.utils.*
+import org.jetbrains.kotlin.fir.declarations.utils.isAbstract
+import org.jetbrains.kotlin.fir.declarations.utils.isCompanion
+import org.jetbrains.kotlin.fir.declarations.utils.isInner
+import org.jetbrains.kotlin.fir.declarations.utils.isSealed
 import org.jetbrains.kotlin.fir.resolve.isSubclassOf
 import org.jetbrains.kotlin.fir.resolve.lookupSuperTypes
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.types.*
-import org.jetbrains.kotlin.fir.types.ConeClassLikeTypeImpl
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.CREATOR_NAME
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.OLD_PARCELER_ID
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELABLE_ID
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELER_CLASS_IDS
+import org.jetbrains.kotlin.parcelize.fir.parcelizeService
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-class FirParcelizeClassChecker(private val parcelizeAnnotations: List<ClassId>) : FirClassChecker(MppCheckerKind.Platform) {
+object FirParcelizeClassChecker : FirClassChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirClass) {
         checkParcelableClass(declaration, context, reporter)
@@ -40,7 +42,7 @@ class FirParcelizeClassChecker(private val parcelizeAnnotations: List<ClassId>) 
 
     private fun checkParcelableClass(klass: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
         val symbol = klass.symbol
-        if (!symbol.isParcelize(context.session, parcelizeAnnotations)) return
+        if (!symbol.isParcelize(context.session)) return
         val source = klass.source ?: return
         val classKind = klass.classKind
 
@@ -122,12 +124,13 @@ class FirParcelizeClassChecker(private val parcelizeAnnotations: List<ClassId>) 
 }
 
 @OptIn(ExperimentalContracts::class)
-fun FirClassSymbol<*>?.isParcelize(session: FirSession, parcelizeAnnotations: List<ClassId>): Boolean {
+fun FirClassSymbol<*>?.isParcelize(session: FirSession): Boolean {
     contract {
         returns(true) implies (this@isParcelize != null)
     }
 
     if (this == null) return false
+    val parcelizeAnnotations = session.parcelizeService.parcelizeAnnotations
     return checkParcelizeClassSymbols(this, session) { symbol ->
         symbol.resolvedAnnotationsWithClassIds.any { it.toAnnotationClassId(session) in parcelizeAnnotations }
     }

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeConstructorChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeConstructorChecker.kt
@@ -25,13 +25,10 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.parcelize.ParcelizeNames
+import org.jetbrains.kotlin.parcelize.fir.parcelizeService
 
-class FirParcelizeConstructorChecker(
-    private val parcelizeAnnotations: List<ClassId>,
-    private val experimentalCodeGeneration: Boolean
-) : FirConstructorChecker(MppCheckerKind.Platform) {
+object FirParcelizeConstructorChecker : FirConstructorChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirConstructor) {
         if (!declaration.isPrimary) return
@@ -41,7 +38,7 @@ class FirParcelizeConstructorChecker(
 
         @OptIn(SymbolInternals::class)
         val containingClass = containingClassSymbol.fir
-        if (!containingClassSymbol.isParcelize(context.session, parcelizeAnnotations)
+        if (!containingClassSymbol.isParcelize(context.session)
             || containingClass.hasCustomParceler(context.session)) {
             return
         }
@@ -68,8 +65,9 @@ class FirParcelizeConstructorChecker(
             }
         }
         val superIsParcelize = containingClass.superTypeRefs.any {
-            it.toRegularClassSymbol(context.session)?.isParcelize(context.session, parcelizeAnnotations) == true
+            it.toRegularClassSymbol(context.session)?.isParcelize(context.session) == true
         }
+        val experimentalCodeGeneration = context.session.parcelizeService.experimentalCodeGeneration
         val allowBareValueArguments = experimentalCodeGeneration
                 && superIsParcelize
                 && !containingClassSymbol.hasParcelerCompanionInChain(context.session)
@@ -94,7 +92,7 @@ class FirParcelizeConstructorChecker(
     }
 
     private fun FirRegularClassSymbol.hasParcelerCompanionInChain(session: FirSession): Boolean {
-        if (!isParcelize(session, parcelizeAnnotations)) return false
+        if (!isParcelize(session)) return false
         return hasCustomParceler(session) || this.resolvedSuperTypeRefs.any {
             it.toRegularClassSymbol(session)?.hasParcelerCompanionInChain(session) == true
         }

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeFunctionChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeFunctionChecker.kt
@@ -17,13 +17,12 @@ import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.isInt
 import org.jetbrains.kotlin.fir.types.isUnit
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
-import org.jetbrains.kotlin.name.ClassId
 
-class FirParcelizeFunctionChecker(private val parcelizeAnnotations: List<ClassId>) : FirNamedFunctionChecker(MppCheckerKind.Platform) {
+object FirParcelizeFunctionChecker : FirNamedFunctionChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         val containingClassSymbol = declaration.dispatchReceiverType?.toRegularClassSymbol()
-        if (!containingClassSymbol.isParcelize(context.session, parcelizeAnnotations)) return
+        if (!containingClassSymbol.isParcelize(context.session)) return
         if (declaration.origin != FirDeclarationOrigin.Source) return
         if (declaration.isWriteToParcel() && declaration.isOverride) {
             reporter.reportOn(declaration.source, KtErrorsParcelize.OVERRIDING_WRITE_TO_PARCEL_IS_NOT_ALLOWED)

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizePropertyChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizePropertyChecker.kt
@@ -33,20 +33,19 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.fir.visibilityChecker
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.parcelize.BuiltinParcelableTypes
 import org.jetbrains.kotlin.parcelize.ParcelizeNames
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.CREATOR_NAME
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.IGNORED_ON_PARCEL_FQ_NAMES
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELER_ID
 
-class FirParcelizePropertyChecker(private val parcelizeAnnotations: List<ClassId>) : FirPropertyChecker(MppCheckerKind.Platform) {
+object FirParcelizePropertyChecker : FirPropertyChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirProperty) {
         val session = context.session
         val containingClassSymbol = declaration.dispatchReceiverType?.toRegularClassSymbol() ?: return
 
-        if (containingClassSymbol.isParcelize(session, parcelizeAnnotations)) {
+        if (containingClassSymbol.isParcelize(session)) {
             val fromPrimaryConstructor = declaration.fromPrimaryConstructor ?: false
             if (
                 !fromPrimaryConstructor &&
@@ -63,7 +62,7 @@ class FirParcelizePropertyChecker(private val parcelizeAnnotations: List<ClassId
 
         if (declaration.name == CREATOR_NAME && containingClassSymbol.isCompanion && declaration.hasJvmFieldAnnotation(session)) {
             val outerClass = context.containingDeclarations.asReversed().getOrNull(1) as? FirRegularClassSymbol
-            if (outerClass != null && outerClass.isParcelize(session, parcelizeAnnotations)) {
+            if (outerClass != null && outerClass.isParcelize(session)) {
                 reporter.reportOn(declaration.source, KtErrorsParcelize.CREATOR_DEFINITION_IS_NOT_ALLOWED)
             }
         }

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirPolymorphicSealedClassChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirPolymorphicSealedClassChecker.kt
@@ -22,12 +22,12 @@ import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.coneType
-import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCEL_TAG_CLASS_IDS
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.POLYMORPHIC_SEALED_CLASS_IDS
+import org.jetbrains.kotlin.parcelize.fir.parcelizeService
 
-class FirPolymorphicSealedClassChecker(private val parcelizeAnnotations: List<ClassId>) : FirClassChecker(MppCheckerKind.Platform) {
+object FirPolymorphicSealedClassChecker : FirClassChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirClass) {
         checkPolymorphicSealedDeclaration(declaration, context, reporter)
@@ -44,6 +44,7 @@ class FirPolymorphicSealedClassChecker(private val parcelizeAnnotations: List<Cl
             return
         }
 
+        val parcelizeAnnotations = context.session.parcelizeService.parcelizeAnnotations
         val hasParcelize = klass.symbol.resolvedAnnotationsWithClassIds.any {
             it.toAnnotationClassId(context.session) in parcelizeAnnotations
         }


### PR DESCRIPTION
According to `compiler/fir/checkers/module.md`,
FIR checkers must be stateless objects.