### PR TITLE
[Gradle] Export module dependencies to Swift Export

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/AppleXcodeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/AppleXcodeTasks.kt
@@ -16,6 +16,7 @@ import org.gradle.internal.extensions.core.serviceOf
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.dsl.KotlinNativeBinaryContainer
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnosticsCollector
@@ -27,6 +28,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.FrameworkCopy.Companion.dsymFile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportConstants
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportDSLConstants
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.registerSwiftExportTask
 import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
 import org.jetbrains.kotlin.gradle.tasks.dependsOn
@@ -37,6 +39,7 @@ import org.jetbrains.kotlin.gradle.utils.lowerCamelCaseName
 import org.jetbrains.kotlin.gradle.utils.mapToFile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject.Companion.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
 import org.jetbrains.kotlin.gradle.utils.reportXcodeError
 import java.io.File
@@ -193,7 +196,8 @@ private fun isRequestedBinary(binary: NativeBinary, environment: XcodeEnvironmen
 internal fun Project.registerEmbedSwiftExportTask(
     target: KotlinNativeTarget,
     environment: XcodeEnvironment,
-    swiftExportConfiguration: SwiftExportConfigurationCompat,
+    swiftExportExtension: SwiftExportExtension,
+    exportExtension: ExportExtension,
 ) {
     val envTargets = environment.targets
     val binaryTaskName = embedSwiftExportTaskName()
@@ -240,6 +244,23 @@ internal fun Project.registerEmbedSwiftExportTask(
 
     val sandBoxTask = checkSandboxAndWriteProtectionTask(environment, environment.userScriptSandboxingEnabled)
 
+    val kotlinNativeCompilation = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME)
+    val swiftExportConfiguration = if (exportExtension.isSwiftExportConfigured) {
+        SwiftExportConfigurationCompat.from(
+            configuration = exportExtension.swiftExportConfiguration,
+            kotlinNativeCompilation = kotlinNativeCompilation,
+            providers = providers,
+            objects = objects,
+        )
+    } else {
+        SwiftExportConfigurationCompat.from(
+            extension = swiftExportExtension,
+            target = target,
+            buildType = envBuildType,
+            kotlinNativeCompilation = kotlinNativeCompilation,
+            providers = providers,
+        )
+    }
     val swiftExportTask = registerSwiftExportTask(
         swiftExportConfiguration,
         SwiftExportDSLConstants.TASK_GROUP,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -26,11 +26,11 @@ internal object SwiftExportDSLConstants {
 }
 
 internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
-    val swiftExportExtension = multiplatformExtension.swiftExportInternal
+    val legacySwiftExportExtension = multiplatformExtension.swiftExportInternal
 
     multiplatformExtension.addExtension(
         SwiftExportDSLConstants.SWIFT_EXPORT_EXTENSION_NAME,
-        swiftExportExtension
+        legacySwiftExportExtension
     )
 
     // TODO: Move to a more generic SetUpExportAction.
@@ -57,7 +57,7 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
     if (!multiplatformExtension.isSwiftExportXcodeIntegrationActivated()) return@KotlinProjectSetupCoroutine
 
     initSwiftExportClasspathConfigurations()
-    registerSwiftExportPipeline(swiftExportExtension, exportExtension)
+    registerSwiftExportPipeline(legacySwiftExportExtension, exportExtension)
 }
 
 /**
@@ -86,7 +86,7 @@ internal fun KotlinMultiplatformExtension.isSwiftExportXcodeIntegrationActivated
 }
 
 private fun Project.registerSwiftExportPipeline(
-    swiftExportExtension: SwiftExportExtension,
+    legacySwiftExportExtension: SwiftExportExtension,
     exportExtension: ExportExtension,
 ) {
     val environment = XcodeEnvironment(project)
@@ -94,6 +94,6 @@ private fun Project.registerSwiftExportPipeline(
     multiplatformExtension
         .supportedAppleTargets()
         .configureEach { target ->
-            registerEmbedSwiftExportTask(target, environment, swiftExportExtension, exportExtension)
+            registerEmbedSwiftExportTask(target, environment, legacySwiftExportExtension, exportExtension)
         }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -9,7 +9,6 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.supportedAppleTargets
-import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinProjectSetupCoroutine
 import org.jetbrains.kotlin.gradle.plugin.addExtension
 import org.jetbrains.kotlin.gradle.plugin.findExtension
@@ -19,7 +18,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.registerEmbedSwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.initSwiftExportClasspathConfigurations
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
-import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration
 
 internal object SwiftExportDSLConstants {
@@ -96,16 +94,6 @@ private fun Project.registerSwiftExportPipeline(
     multiplatformExtension
         .supportedAppleTargets()
         .configureEach { target ->
-            val swiftExportConfiguration = if (exportExtension.isSwiftExportConfigured) {
-                SwiftExportConfigurationCompat.from(
-                    configuration = exportExtension.swiftExportConfiguration,
-                    kotlinNativeCompilation = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME),
-                    providers = providers,
-                    objects = objects,
-                )
-            } else {
-                SwiftExportConfigurationCompat.from(swiftExportExtension, providers)
-            }
-            registerEmbedSwiftExportTask(target, environment, swiftExportConfiguration)
+            registerEmbedSwiftExportTask(target, environment, swiftExportExtension, exportExtension)
         }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.supportedAppleTargets
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinProjectSetupCoroutine
 import org.jetbrains.kotlin.gradle.plugin.addExtension
 import org.jetbrains.kotlin.gradle.plugin.findExtension
@@ -58,13 +59,7 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
     if (!multiplatformExtension.isSwiftExportXcodeIntegrationActivated()) return@KotlinProjectSetupCoroutine
 
     initSwiftExportClasspathConfigurations()
-    registerSwiftExportPipeline(
-        if (exportExtension.isSwiftExportConfigured) {
-            SwiftExportConfigurationCompat.from(exportExtension.swiftExportConfiguration, providers, objects)
-        } else {
-            SwiftExportConfigurationCompat.from(swiftExportExtension)
-        }
-    )
+    registerSwiftExportPipeline(swiftExportExtension, exportExtension)
 }
 
 /**
@@ -93,21 +88,24 @@ internal fun KotlinMultiplatformExtension.isSwiftExportXcodeIntegrationActivated
 }
 
 private fun Project.registerSwiftExportPipeline(
-    swiftExportConfiguration: SwiftExportConfigurationCompat,
+    swiftExportExtension: SwiftExportExtension,
+    exportExtension: ExportExtension,
 ) {
     val environment = XcodeEnvironment(project)
 
     multiplatformExtension
         .supportedAppleTargets()
         .configureEach { target ->
-            setupSwiftExport(target, environment, swiftExportConfiguration)
+            val swiftExportConfiguration = if (exportExtension.isSwiftExportConfigured) {
+                SwiftExportConfigurationCompat.from(
+                    configuration = exportExtension.swiftExportConfiguration,
+                    kotlinNativeCompilation = target.compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME),
+                    providers = providers,
+                    objects = objects,
+                )
+            } else {
+                SwiftExportConfigurationCompat.from(swiftExportExtension, providers)
+            }
+            registerEmbedSwiftExportTask(target, environment, swiftExportConfiguration)
         }
-}
-
-private fun Project.setupSwiftExport(
-    target: KotlinNativeTarget,
-    environment: XcodeEnvironment,
-    swiftExportConfiguration: SwiftExportConfigurationCompat,
-) {
-    registerEmbedSwiftExportTask(target, environment, swiftExportConfiguration)
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -76,6 +76,7 @@ internal fun Project.registerSwiftExportTask(
             buildType,
             mainCompilation.internal.configurations.compileDependencyConfiguration
         ),
+        apiConfiguration = swiftExportConfiguration.apiConfiguration.orNull,
         mainCompilation = mainCompilation,
         swiftApiFlattenPackage = swiftExportConfiguration.rootPackage,
         exportedModules = swiftExportConfiguration.exportedModules,
@@ -166,6 +167,7 @@ private fun Project.registerSwiftExportRun(
     configuration: String,
     swiftApiModuleName: Provider<String>,
     exportConfiguration: Configuration,
+    apiConfiguration: Configuration?,
     mainCompilation: KotlinNativeCompilation,
     swiftApiFlattenPackage: Provider<String>,
     exportedModules: Provider<Set<SwiftExportedDependency>>,
@@ -179,13 +181,17 @@ private fun Project.registerSwiftExportRun(
     val outputs = layout.buildDirectory.dir("SwiftExport/${target.name}/$configuration")
     val files = outputs.map { it.dir("files") }
     val serializedModules = outputs.map { it.dir("modules").file("${swiftApiModuleName.get()}.json") }
-    val configurationProvider = provider { LazyResolvedConfigurationWithArtifacts(exportConfiguration) }
+    val exportedConfigurationProvider = provider { LazyResolvedConfigurationWithArtifacts(exportConfiguration) }
+    val apiConfigurationProvider = provider { apiConfiguration?.let(::LazyResolvedConfigurationWithArtifacts) }
 
     return locateOrRegisterTask<SwiftExportTask>(swiftExportTaskName) { task ->
         task.description = "Run $taskNamePrefix Swift Export process"
         task.group = taskGroup
 
         task.inputs.files(exportConfiguration)
+        if (apiConfiguration != null) {
+            task.inputs.files(apiConfiguration)
+        }
         task.inputs.files(mainCompilation.compileTaskProvider.map { it.outputs.files })
 
         // Input
@@ -195,7 +201,8 @@ private fun Project.registerSwiftExportRun(
         task.parameters.swiftExportSettings.set(customSetting)
         task.parameters.swiftModules.set(
             collectModules(
-                configurationProvider,
+                exportedConfigurationProvider,
+                apiConfigurationProvider,
                 exportedModules
             )
         )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -20,12 +20,10 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.appleTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.configuration
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportClasspathResolvableConfiguration
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.exportedSwiftExportApiConfiguration
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.normalizedSwiftExportModuleName
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.whenSwiftPMImportAvailable
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
-import org.jetbrains.kotlin.gradle.plugin.mpp.internal
 import org.jetbrains.kotlin.gradle.tasks.locateOrRegisterTask
 import org.jetbrains.kotlin.gradle.utils.*
 import org.jetbrains.kotlin.konan.target.Distribution
@@ -72,10 +70,7 @@ internal fun Project.registerSwiftExportTask(
         target = target,
         configuration = buildConfiguration,
         swiftApiModuleName = swiftApiModuleName,
-        exportConfiguration = target.exportedSwiftExportApiConfiguration(
-            buildType,
-            mainCompilation.internal.configurations.compileDependencyConfiguration
-        ),
+        exportConfiguration = swiftExportConfiguration.exportConfiguration.get(),
         apiConfiguration = swiftExportConfiguration.apiConfiguration.orNull,
         mainCompilation = mainCompilation,
         swiftApiFlattenPackage = swiftExportConfiguration.rootPackage,
@@ -181,7 +176,7 @@ private fun Project.registerSwiftExportRun(
     val outputs = layout.buildDirectory.dir("SwiftExport/${target.name}/$configuration")
     val files = outputs.map { it.dir("files") }
     val serializedModules = outputs.map { it.dir("modules").file("${swiftApiModuleName.get()}.json") }
-    val exportedConfigurationProvider = provider { LazyResolvedConfigurationWithArtifacts(exportConfiguration) }
+    val exportConfigurationProvider = provider { LazyResolvedConfigurationWithArtifacts(exportConfiguration) }
     val apiConfigurationProvider = provider { apiConfiguration?.let(::LazyResolvedConfigurationWithArtifacts) }
 
     return locateOrRegisterTask<SwiftExportTask>(swiftExportTaskName) { task ->
@@ -201,7 +196,7 @@ private fun Project.registerSwiftExportRun(
         task.parameters.swiftExportSettings.set(customSetting)
         task.parameters.swiftModules.set(
             collectModules(
-                exportedConfigurationProvider,
+                exportConfigurationProvider,
                 apiConfigurationProvider,
                 exportedModules
             )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -75,6 +75,7 @@ private class ResolvedArtifactWithVersionIdentifier(
     val moduleVersion: ModuleVersionIdentifier,
     val artifact: ResolvedArtifactResult
 ) : Serializable {
+    private val artifactFilePath: String get() = artifact.file.absolutePath
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -82,11 +83,11 @@ private class ResolvedArtifactWithVersionIdentifier(
 
         other as ResolvedArtifactWithVersionIdentifier
 
-        return artifact == other.artifact
+        return artifactFilePath == other.artifactFilePath
     }
 
     override fun hashCode(): Int {
-        return 31 * artifact.hashCode()
+        return 31 * artifactFilePath.hashCode()
     }
 
     fun defaultExportedModuleName(): String {
@@ -104,8 +105,13 @@ private fun Project.swiftExportedModules(
     exportedModules: Set<SwiftExportedDependency>,
 ) = findAndCreateSwiftExportedModules(
     exportedModules = exportedModules,
-    resolvedExportArtifacts = exportConfiguration.filteredArtifacts(LazyResolvedConfigurationWithArtifacts::allResolvedDependencies),
-    resolvedDirectApiArtifacts = apiConfiguration?.filteredArtifacts { root.dependencies.filterIsInstance<ResolvedDependencyResult>() }
+    resolvedExportArtifacts = exportConfiguration.filteredArtifacts { allResolvedDependencies },
+    resolvedDirectApiArtifacts = apiConfiguration
+        ?.filteredArtifacts {
+            root.dependencies
+                .filterIsInstance<ResolvedDependencyResult>()
+                .filterNot { it.isConstraint }
+        }
         ?: emptySet(),
 )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -7,8 +7,10 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
@@ -58,10 +60,16 @@ internal fun createTransitiveSwiftExportedModule(
 
 internal fun Project.collectModules(
     swiftExportConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts>,
+    apiConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
     exportedModulesProvider: Provider<Set<SwiftExportedDependency>>,
-): Provider<List<SwiftExportedModule>> = swiftExportConfigurationProvider.zip(exportedModulesProvider) { configuration, modules ->
-    configuration.swiftExportedModules(modules, project)
-}
+): Provider<List<SwiftExportedModule>> = swiftExportConfigurationProvider
+    .map { exportConfiguration ->
+        val apiConfiguration = apiConfigurationProvider.orNull
+        return@map exportConfiguration to apiConfiguration
+    }
+    .zip(exportedModulesProvider) { (exportConfiguration, apiConfiguration), modules ->
+        project.swiftExportedModules(exportConfiguration, apiConfiguration, modules)
+    }
 
 private class ResolvedArtifactWithVersionIdentifier(
     val moduleVersion: ModuleVersionIdentifier,
@@ -80,15 +88,31 @@ private class ResolvedArtifactWithVersionIdentifier(
     override fun hashCode(): Int {
         return 31 * artifact.hashCode()
     }
+
+    fun defaultExportedModuleName(): String {
+        return when (val componentId = artifact.id.componentIdentifier) {
+            is ProjectComponentIdentifier -> componentId.projectPath
+            is ModuleComponentIdentifier -> moduleVersion.inheritedName
+            else -> error("Unexpected component identifier type: ${componentId::class}")
+        }
+    }
 }
 
-private fun LazyResolvedConfigurationWithArtifacts.swiftExportedModules(
+private fun Project.swiftExportedModules(
+    exportConfiguration: LazyResolvedConfigurationWithArtifacts,
+    apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
     exportedModules: Set<SwiftExportedDependency>,
-    project: Project,
-) = project.findAndCreateSwiftExportedModules(exportedModules, filteredArtifacts())
+) = findAndCreateSwiftExportedModules(
+    exportedModules = exportedModules,
+    resolvedExportArtifacts = exportConfiguration.filteredArtifacts(LazyResolvedConfigurationWithArtifacts::allResolvedDependencies),
+    resolvedDirectApiArtifacts = apiConfiguration?.filteredArtifacts { root.dependencies.filterIsInstance<ResolvedDependencyResult>() }
+        ?: emptySet(),
+)
 
-private fun LazyResolvedConfigurationWithArtifacts.filteredArtifacts(): Set<ResolvedArtifactWithVersionIdentifier> {
-    return allResolvedDependencies.mapNotNullTo(mutableSetOf()) { dependency ->
+private fun LazyResolvedConfigurationWithArtifacts.filteredArtifacts(
+    dependenciesSelector: LazyResolvedConfigurationWithArtifacts.() -> Iterable<ResolvedDependencyResult>
+): Set<ResolvedArtifactWithVersionIdentifier> {
+    return dependenciesSelector().mapNotNullTo(mutableSetOf()) { dependency ->
         val artifacts = getArtifacts(dependency.selected).filterNot {
             it.file.isCinteropKlib || it.file.isJavaJar
         }
@@ -108,7 +132,8 @@ private val File.isJavaJar get() = extension == "jar"
 
 private fun Project.findAndCreateSwiftExportedModules(
     exportedModules: Set<SwiftExportedDependency>,
-    resolvedArtifacts: Set<ResolvedArtifactWithVersionIdentifier>,
+    resolvedExportArtifacts: Set<ResolvedArtifactWithVersionIdentifier>,
+    resolvedDirectApiArtifacts: Set<ResolvedArtifactWithVersionIdentifier>,
 ): List<SwiftExportedModule> {
     val result = mutableListOf<SwiftExportedModule>()
     val processedComponents = mutableSetOf<ResolvedArtifactWithVersionIdentifier>()
@@ -116,7 +141,7 @@ private fun Project.findAndCreateSwiftExportedModules(
 
     // Process all explicitly exported modules
     for (explicitModule in exportedModules) {
-        val matchingArtifact = resolvedArtifacts.find { artifact ->
+        val matchingArtifact = resolvedExportArtifacts.find { artifact ->
             val componentId = artifact.artifact.id.componentIdentifier
 
             when (explicitModule) {
@@ -163,8 +188,21 @@ private fun Project.findAndCreateSwiftExportedModules(
         )
     }
 
+    for (artifact in resolvedDirectApiArtifacts) {
+        if (artifact in processedComponents) continue
+        result.add(
+            createFullyExportedSwiftExportedModule(
+                moduleName = artifact.defaultExportedModuleName().normalizedSwiftExportModuleName,
+                flattenPackage = null,
+                artifact = artifact.artifact.file,
+            )
+        )
+        // Track which components we've processed
+        processedComponents.add(artifact)
+    }
+
     // Then process remaining components as transitive
-    resolvedArtifacts
+    resolvedExportArtifacts
         .filterNot { artifact -> artifact in processedComponents }
         .forEach { artifact ->
             result.add(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -59,10 +59,10 @@ internal fun createTransitiveSwiftExportedModule(
 }
 
 internal fun Project.collectModules(
-    swiftExportConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts>,
+    exportConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts>,
     apiConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
     exportedModulesProvider: Provider<Set<SwiftExportedDependency>>,
-): Provider<List<SwiftExportedModule>> = swiftExportConfigurationProvider
+): Provider<List<SwiftExportedModule>> = exportConfigurationProvider
     .map { exportConfiguration ->
         val apiConfiguration = apiConfigurationProvider.orNull
         return@map exportConfiguration to apiConfiguration

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -14,8 +14,12 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractNativeLibrary
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.exportedSwiftExportApiConfiguration
+import org.jetbrains.kotlin.gradle.plugin.mpp.internal
 import org.jetbrains.kotlin.gradle.targets.native.resolvableApiConfiguration
 
 /**
@@ -35,10 +39,15 @@ internal interface SwiftExportConfigurationCompat {
     val rootPackage: Property<String>
 
     /**
-     * Provider for a resolvable api configuration from which dependencies will be exported. Implementations that don't export api
-     * dependencies should return an empty provider.
+     * Provider for a resolvable api configuration from which dependencies will be fully exported. Implementations that don't export direct
+     * api dependencies should return an empty provider.
      */
     val apiConfiguration: Provider<Configuration?>
+
+    /**
+     * Provider for a resolvable configuration from which dependencies will be transitively exported.
+     */
+    val exportConfiguration: Provider<Configuration>
 
     /**
      * Returns a list of exported modules.
@@ -71,6 +80,9 @@ internal interface SwiftExportConfigurationCompat {
                 override val apiConfiguration: Provider<Configuration?>
                     get() = providers.provider { kotlinNativeCompilation.resolvableApiConfiguration() }
 
+                override val exportConfiguration: Provider<Configuration>
+                    get() = providers.provider { kotlinNativeCompilation.internal.configurations.compileDependencyConfiguration }
+
                 override val exportedModules: Provider<Set<SwiftExportedDependency>>
                     get() = providers.provider { emptySet() } // TODO: KT-85687
                 override val settings: MapProperty<String, String>
@@ -85,6 +97,9 @@ internal interface SwiftExportConfigurationCompat {
 
         fun from(
             extension: SwiftExportExtension,
+            target: KotlinNativeTarget,
+            kotlinNativeCompilation: KotlinNativeCompilation,
+            buildType: NativeBuildType,
             providers: ProviderFactory,
         ): SwiftExportConfigurationCompat =
             object : SwiftExportConfigurationCompat {
@@ -94,6 +109,14 @@ internal interface SwiftExportConfigurationCompat {
 
                 override val apiConfiguration: Provider<Configuration?>
                     get() = providers.provider { null }
+
+                override val exportConfiguration: Provider<Configuration>
+                    get() = providers.provider {
+                        target.exportedSwiftExportApiConfiguration(
+                            buildType,
+                            kotlinNativeCompilation.internal.configurations.compileDependencyConfiguration
+                        )
+                    }
 
                 override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings
                 override val freeCompilerArgs: ListProperty<String> get() = extension.advancedConfiguration.freeCompilerArgs

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -79,6 +79,10 @@ internal interface SwiftExportConfigurationCompat {
 
                 override val apiConfiguration: Provider<Configuration?>
                     get() = providers.provider { kotlinNativeCompilation.resolvableApiConfiguration() }
+                        .zip(exportConfiguration) { apiConfiguration, exportConfiguration ->
+                            // Make sure direct api dependencies and the rest of the compile dependency graph are resolved consistently.
+                            apiConfiguration.shouldResolveConsistentlyWith(exportConfiguration)
+                        }
 
                 override val exportConfiguration: Provider<Configuration>
                     get() = providers.provider { kotlinNativeCompilation.internal.configurations.compileDependencyConfiguration }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.plugin.mpp.export
 
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -12,8 +13,10 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractNativeLibrary
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
+import org.jetbrains.kotlin.gradle.targets.native.resolvableApiConfiguration
 
 /**
  * A common interface for [SwiftExportConfiguration] and [org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension]
@@ -30,6 +33,12 @@ internal interface SwiftExportConfigurationCompat {
      * This module's root package.
      */
     val rootPackage: Property<String>
+
+    /**
+     * Provider for a resolvable api configuration from which dependencies will be exported. Implementations that don't export api
+     * dependencies should return an empty provider.
+     */
+    val apiConfiguration: Provider<Configuration?>
 
     /**
      * Returns a list of exported modules.
@@ -51,12 +60,17 @@ internal interface SwiftExportConfigurationCompat {
     companion object {
         fun from(
             configuration: SwiftExportConfiguration,
+            kotlinNativeCompilation: KotlinNativeCompilation,
             providers: ProviderFactory,
             objects: ObjectFactory,
         ): SwiftExportConfigurationCompat =
             object : SwiftExportConfigurationCompat {
                 override val moduleName: Property<String> get() = configuration.moduleName
                 override val rootPackage: Property<String> get() = configuration.rootPackage
+
+                override val apiConfiguration: Provider<Configuration?>
+                    get() = providers.provider { kotlinNativeCompilation.resolvableApiConfiguration() }
+
                 override val exportedModules: Provider<Set<SwiftExportedDependency>>
                     get() = providers.provider { emptySet() } // TODO: KT-85687
                 override val settings: MapProperty<String, String>
@@ -69,11 +83,18 @@ internal interface SwiftExportConfigurationCompat {
                 }
             }
 
-        fun from(extension: SwiftExportExtension): SwiftExportConfigurationCompat =
+        fun from(
+            extension: SwiftExportExtension,
+            providers: ProviderFactory,
+        ): SwiftExportConfigurationCompat =
             object : SwiftExportConfigurationCompat {
                 override val moduleName: Property<String> get() = extension.moduleName
                 override val rootPackage: Property<String> get() = extension.flattenPackage
                 override val exportedModules: Provider<Set<SwiftExportedDependency>> get() = extension.exportedModules
+
+                override val apiConfiguration: Provider<Configuration?>
+                    get() = providers.provider { null }
+
                 override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings
                 override val freeCompilerArgs: ListProperty<String> get() = extension.advancedConfiguration.freeCompilerArgs
                 override fun addBinary(binary: AbstractNativeLibrary) {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -7,7 +7,6 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
-import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -9,10 +9,18 @@ package org.jetbrains.kotlin.gradle.unitTests
 
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SwiftExportTask
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationDsl
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import org.jetbrains.kotlin.gradle.unitTests.utils.applyEmbedAndSignEnvironment
+import org.jetbrains.kotlin.gradle.util.*
 import org.jetbrains.kotlin.gradle.util.EMBED_SWIFT_EXPORT_TASK_NAME
 import org.jetbrains.kotlin.gradle.util.assertContainsDiagnostic
 import org.jetbrains.kotlin.gradle.util.assertNoDiagnostics
@@ -22,6 +30,7 @@ import org.jetbrains.kotlin.gradle.util.exportExtension
 import org.jetbrains.kotlin.gradle.util.kotlin
 import org.jetbrains.kotlin.gradle.util.legacySwiftExportExtension
 import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.utils.mapToSetOrEmpty
 import org.junit.jupiter.api.Assumptions
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -365,3 +374,564 @@ class LegacySwiftExportDslDetectionTests {
         assertTrue(project.legacySwiftExportExtension.isConfigured)
     }
 }
+
+class ExportExtensionSwiftExportTests {
+    @BeforeTest
+    fun runOnMacOSOnly() {
+        Assumptions.assumeTrue(HostManager.hostIsMac, "macOS host required for this test")
+    }
+
+    @Test
+    fun `direct external api dependency exported fully`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                shouldBeFullyExported = true
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `direct external implementation dependency exported transitively`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                shouldBeFullyExported = false
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `direct project api dependency exported fully`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api(projectDependency)
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "Subproject",
+                artifactName = "subproject",
+                shouldBeFullyExported = true
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `direct project implementation dependency exported transitively`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation(projectDependency)
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "SharedSubproject",
+                artifactName = "subproject",
+                shouldBeFullyExported = false
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `direct project api dependency exported fully, its dependencies exported transitively`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+            sourceSets.commonMain.dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+            }
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api(projectDependency)
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxAtomicfu",
+                artifactName = "atomicfu.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
+                artifactName = "kotlinx-coroutines-core.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxDatetime",
+                artifactName = "kotlinx-datetime.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxSerializationCore",
+                artifactName = "kotlinx-serialization-core.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "Subproject",
+                artifactName = "subproject",
+                shouldBeFullyExported = true
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `jvm dependency is not exported`() {
+        val project = swiftExportProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.glassfish:jakarta.json:2.0.1")
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        assertTrue(actualModules.isEmpty(), "No modules should be exported for JVM dependencies")
+    }
+
+    @Test
+    fun `exporting transitive dependencies with different versions (dependency in subproject has greater version)`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+            sourceSets.commonMain.dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.0")
+            }
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation(projectDependency)
+                    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxAtomicfu",
+                artifactName = "atomicfu.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
+                artifactName = "kotlinx-coroutines-core-iosSimulatorArm64Main-1.10.0.klib",
+                shouldBeFullyExported = true
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "SharedSubproject",
+                artifactName = "subproject",
+                shouldBeFullyExported = false
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `exporting transitive dependencies with different versions (dependency in subproject has lower version)`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+            sourceSets.commonMain.dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+            }
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation(projectDependency)
+                    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.0")
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxAtomicfu",
+                artifactName = "atomicfu.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
+                artifactName = "kotlinx-coroutines-core-iosSimulatorArm64Main-1.10.0.klib",
+                shouldBeFullyExported = true
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "SharedSubproject",
+                artifactName = "subproject",
+                shouldBeFullyExported = false
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `exporting two runtime modules`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("app.cash.sqldelight:runtime:2.1.0")
+                    api("org.jetbrains.compose.runtime:runtime:1.8.2")
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "AppCashSqldelightRuntime",
+                artifactName = "runtime.klib",
+                shouldBeFullyExported = true
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsComposeRuntimeRuntime",
+                artifactName = "runtime-uikitSimArm64Main-1.8.2.klib",
+                shouldBeFullyExported = true
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxAtomicfu",
+                artifactName = "atomicfu.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
+                artifactName = "kotlinx-coroutines-core.klib",
+                shouldBeFullyExported = false
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `excluded transitive dependencies not exported`() {
+        val project = buildProject(
+            projectBuilder = {
+                withName("shared")
+            },
+            configureProject = {
+                configureRepositoriesForTests()
+            }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+            sourceSets.commonMain.dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2") {
+                    exclude(mapOf("group" to "org.jetbrains.kotlinx", "module" to "kotlinx-serialization-core"))
+                }
+            }
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api(projectDependency)
+                    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0") {
+                        exclude(mapOf("group" to "org.jetbrains.kotlinx", "module" to "atomicfu"))
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+
+        val expectedModules = setOf(
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
+                artifactName = "kotlinx-coroutines-core.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "OrgJetbrainsKotlinxKotlinxDatetime",
+                artifactName = "kotlinx-datetime.klib",
+                shouldBeFullyExported = false
+            ),
+            ExportedSwiftModuleForAssertion(
+                moduleName = "Subproject",
+                artifactName = "subproject",
+                shouldBeFullyExported = true
+            ),
+        )
+
+        assertSetsEqual(
+            expectedModules,
+            actualModules.toModulesForAssertion(),
+        )
+    }
+}
+
+private fun swiftExportProject(
+    configuration: String = "DEBUG",
+    sdk: String = "iphonesimulator",
+    archs: String = "arm64",
+    projectBuilder: ProjectBuilder.() -> Unit = { },
+    multiplatform: KotlinMultiplatformExtension.() -> Unit = {
+        iosSimulatorArm64()
+    },
+    swiftExport: SwiftExportConfigurationDsl.() -> Unit = {},
+): ProjectInternal = buildProjectWithMPP(
+    projectBuilder = projectBuilder,
+    preApplyCode = {
+        applyEmbedAndSignEnvironment(
+            configuration = configuration,
+            sdk = sdk,
+            archs = archs,
+        )
+        configureRepositoriesForTests()
+    },
+    code = {
+        kotlin {
+            multiplatform()
+        }
+        exportExtension.swift {
+            xcodeIntegration()
+            swiftExport()
+        }
+    }
+)
+
+private fun ProjectInternal.setupForSwiftExport(
+    configuration: String = "DEBUG",
+    sdk: String = "iphonesimulator",
+    archs: String = "arm64",
+    multiplatform: KotlinMultiplatformExtension.() -> Unit = {
+        iosSimulatorArm64()
+    },
+    swiftExport: SwiftExportConfigurationDsl.() -> Unit = {},
+) {
+    applyEmbedAndSignEnvironment(
+        configuration = configuration,
+        sdk = sdk,
+        archs = archs,
+    )
+    applyMultiplatformPlugin()
+    kotlin {
+        multiplatform()
+    }
+    exportExtension.swift {
+        xcodeIntegration()
+        swiftExport()
+    }
+}
+
+private fun ProjectInternal.subProject(
+    name: String,
+    multiplatform: KotlinMultiplatformExtension.() -> Unit = { iosSimulatorArm64() },
+): ProjectInternal = buildProjectWithMPP(
+    projectBuilder = {
+        withParent(this@subProject)
+        withName(name)
+    },
+    code = {
+        kotlin {
+            multiplatform()
+        }
+    }
+)
+
+/**
+ * Asserts that two sets are equal, but renders each set as a vertical, alphabetically sorted list of the string
+ * representations of its elements. This makes the failure message much easier to eyeball and diff than the default
+ * [Set.toString], because both sets are presented line-by-line in the same order.
+ */
+private fun <T> assertSetsEqual(expected: Set<T>, actual: Set<T>, message: String? = null) {
+    fun Set<T>.renderAsSortedLines() = map { it.toString() }.sorted().joinToString(separator = "\n")
+    assertEquals(expected.renderAsSortedLines(), actual.renderAsSortedLines(), message)
+}
+
+private fun List<SwiftExportedModule>.toModulesForAssertion() = mapToSetOrEmpty { module ->
+    ExportedSwiftModuleForAssertion(
+        module.moduleName,
+        module.artifact.name,
+        module.shouldBeFullyExported
+    )
+}
+
+private data class ExportedSwiftModuleForAssertion(
+    val moduleName: String,
+    val artifactName: String,
+    val shouldBeFullyExported: Boolean,
+)

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -7,6 +7,7 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests


### PR DESCRIPTION
This change pulls dependencies from an exported module's configurations and prepares them for Swift Export, according to the rules described in KT-88853. In short:

- The module's direct api dependencies are set up to be exported fully.
- The module's direct implementation dependencies and any transitive dependencies, are set up to be exported transitively.
- The mechanism relies on Gradle's dependency resolution to ensure rules such as dependency exclusions and consistent version resolution are honoured.

The change is accompanied by functional tests that verify correct dependency processing.

^KT-88853 Verification Pending