### PR TITLE
[JVM] Hoist throwOnFailure out of SuspendLambda switch cases

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/CoroutineTransformerMethodVisitor.kt
@@ -82,6 +82,7 @@ class CoroutineTransformerMethodVisitor(
     private var dataIndex = if (isForNamedFunction) -1 else 1
 
     private var generatedCodeMarkers: GeneratedCodeMarkers? = null
+    private var shouldHoistThrowOnFailure: Boolean = false
 
     override fun performTransformations(methodNode: MethodNode) {
         if (config.enhancedCoroutinesDebugging) {
@@ -141,6 +142,8 @@ class CoroutineTransformerMethodVisitor(
         for (suspensionPoint in suspensionPoints) {
             splitTryCatchBlocksContainingSuspensionPoint(methodNode, suspensionPoint)
         }
+
+        shouldHoistThrowOnFailure = !isForNamedFunction && suspensionPoints.none { it.hasEnclosingTryCatch }
 
         // Actual max stack might be increased during the previous phases
         methodNode.updateMaxStack()
@@ -328,6 +331,11 @@ class CoroutineTransformerMethodVisitor(
                     // Allow debugger to stop on enter into suspend function
                     LineNumberNode(lineNumber, tableSwitchLabel),
                     VarInsnNode(Opcodes.ASTORE, suspendMarkerVarIndex),
+                    *withInstructionAdapter {
+                        if (shouldHoistThrowOnFailure) {
+                            generateResumeWithExceptionCheck(dataIndex)
+                        }
+                    }.toArray(),
                     VarInsnNode(Opcodes.ALOAD, continuationIndex),
                     *withInstructionAdapter { getLabel() }.toArray(),
                     TableSwitchInsnNode(
@@ -340,9 +348,11 @@ class CoroutineTransformerMethodVisitor(
                 )
             )
 
-            insert(firstStateLabel, withInstructionAdapter {
-                generateResumeWithExceptionCheck(dataIndex)
-            })
+            if (!shouldHoistThrowOnFailure) {
+                insert(firstStateLabel, withInstructionAdapter {
+                    generateResumeWithExceptionCheck(dataIndex)
+                })
+            }
 
             // Insert throw of an IllegalStateException if the resumption point is unknown. This code does not correspond to
             // anything in the input code. We give it the entry line number instead of letting it inherit the line number
@@ -1362,7 +1372,9 @@ class CoroutineTransformerMethodVisitor(
 
             insert(possibleTryCatchBlockStart, withInstructionAdapter {
                 nop()
-                generateResumeWithExceptionCheck(dataIndex)
+                if (!shouldHoistThrowOnFailure) {
+                    generateResumeWithExceptionCheck(dataIndex)
+                }
 
                 // Load continuation argument just like suspending function returns it
                 load(dataIndex, AsmTypes.OBJECT_TYPE)
@@ -1463,6 +1475,7 @@ class CoroutineTransformerMethodVisitor(
                     instructions.indexOf(it.start) < beginIndex && beginIndex < instructions.indexOf(it.end)
 
                 if (isContainingSuspensionPoint) {
+                    suspensionPoint.hasEnclosingTryCatch = true
                     assert(instructions.indexOf(it.start) < endIndex && endIndex < instructions.indexOf(it.end)) {
                         "Try catch block ${instructions.indexOf(it.start)}:${instructions.indexOf(it.end)} containing marker before " +
                                 "suspension point $beginIndex should also contain the marker after suspension point $endIndex"
@@ -1606,6 +1619,7 @@ internal class SuspensionPoint(
     // INVOKESTATIC InlineMarker.mark()
     val suspensionCallEnd: AbstractInsnNode
 ) {
+    var hasEnclosingTryCatch: Boolean = false
     lateinit var tryCatchBlocksContinuationLabel: LabelNode
 
     val stateLabel = LabelNode().linkWithLabel()

--- a/compiler/testData/codegen/box/coroutines/illegalStateOnInvalidLabel.kt
+++ b/compiler/testData/codegen/box/coroutines/illegalStateOnInvalidLabel.kt
@@ -1,0 +1,82 @@
+// TARGET_BACKEND: JVM
+// FULL_JDK
+// WITH_STDLIB
+// WITH_COROUTINES
+import helpers.*
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+suspend fun dummy() {}
+
+fun box(): String {
+    val lambda: suspend () -> Unit = {
+        dummy()
+        dummy()
+    }
+
+    val method = lambda.javaClass.getDeclaredMethod("invokeSuspend", Any::class.java)
+    method.isAccessible = true
+
+    var field: java.lang.reflect.Field? = null
+    var clazz: Class<*>? = lambda.javaClass
+    while (clazz != null) {
+        try {
+            field = clazz.getDeclaredField("label")
+            break
+        } catch (e: Exception) {
+            clazz = clazz.superclass
+        }
+    }
+    if (field == null) return "FAIL: label field not found"
+    field.isAccessible = true
+
+    // Test label > max label with Unit
+    field.setInt(lambda, 999)
+    try {
+        method.invoke(lambda, Unit)
+        return "FAIL: expected IllegalStateException for label 999"
+    } catch (e: Throwable) {
+        val cause = e.cause ?: e
+        if (cause !is IllegalStateException || cause.message != "call to 'resume' before 'invoke' with coroutine") {
+            return "FAIL: unexpected exception for label 999: $cause"
+        }
+    }
+
+    // Test boundary: max label is 2 (2 suspension points), so label = 3 must fail
+    field.setInt(lambda, 3)
+    try {
+        method.invoke(lambda, "arbitrary result")
+        return "FAIL: expected IllegalStateException for boundary label 3"
+    } catch (e: Throwable) {
+        val cause = e.cause ?: e
+        if (cause !is IllegalStateException || cause.message != "call to 'resume' before 'invoke' with coroutine") {
+            return "FAIL: unexpected exception for boundary label 3: $cause"
+        }
+    }
+
+    // Test label < 0 with Unit
+    field.setInt(lambda, -1)
+    try {
+        method.invoke(lambda, Unit)
+        return "FAIL: expected IllegalStateException for label -1"
+    } catch (e: Throwable) {
+        val cause = e.cause ?: e
+        if (cause !is IllegalStateException || cause.message != "call to 'resume' before 'invoke' with coroutine") {
+            return "FAIL: unexpected exception for label -1: $cause"
+        }
+    }
+
+    // Test label < 0 with non-Unit result
+    field.setInt(lambda, -42)
+    try {
+        method.invoke(lambda, "arbitrary result")
+        return "FAIL: expected IllegalStateException for label -42"
+    } catch (e: Throwable) {
+        val cause = e.cause ?: e
+        if (cause !is IllegalStateException || cause.message != "call to 'resume' before 'invoke' with coroutine") {
+            return "FAIL: unexpected exception for label -42: $cause"
+        }
+    }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/coroutines/throwOnFailureExecution.kt
+++ b/compiler/testData/codegen/box/coroutines/throwOnFailureExecution.kt
@@ -1,0 +1,140 @@
+// TARGET_BACKEND: JVM
+// WITH_STDLIB
+// WITH_COROUTINES
+import helpers.*
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+class TestException(message: String) : RuntimeException(message)
+
+var globalCont: Continuation<String>? = null
+
+suspend fun suspendString(): String = suspendCoroutine { cont ->
+    globalCont = cont
+}
+
+fun box(): String {
+    // 1. Suspension in catch block: normal completion
+    var result1 = ""
+    val l1: suspend () -> String = {
+        try {
+            throw TestException("inner")
+        } catch (e: TestException) {
+            suspendString() + " caught"
+        }
+    }
+    l1.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        result1 = res.getOrThrow()
+    })
+    globalCont?.resume("hello")
+    if (result1 != "hello caught") return "FAIL 1: $result1"
+
+    // 2. Suspension in catch block: resumed with failure propagates out
+    var thrown2: Throwable? = null
+    val l2: suspend () -> String = {
+        try {
+            throw TestException("inner")
+        } catch (e: TestException) {
+            suspendString()
+        }
+    }
+    l2.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        thrown2 = res.exceptionOrNull()
+    })
+    globalCont?.resumeWith(Result.failure(TestException("from resume")))
+    if (thrown2 !is TestException || thrown2?.message != "from resume") {
+        return "FAIL 2: $thrown2"
+    }
+
+    // 3. Suspension in catch block enclosed in outer try-catch: caught by outer catch
+    var result3 = ""
+    val l3: suspend () -> String = {
+        try {
+            try {
+                throw TestException("inner")
+            } catch (e: TestException) {
+                suspendString()
+            }
+        } catch (e: TestException) {
+            "outer caught: ${e.message}"
+        }
+    }
+    l3.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        result3 = res.getOrThrow()
+    })
+    globalCont?.resumeWith(Result.failure(TestException("from resume 3")))
+    if (result3 != "outer caught: from resume 3") return "FAIL 3: $result3"
+
+    // 4. Suspension in finally block: normal path resumed
+    var result4 = ""
+    var finallyRun4 = false
+    val l4: suspend () -> String = {
+        try {
+            "tryResult"
+        } finally {
+            val s = suspendString()
+            if (s == "resume4") {
+                finallyRun4 = true
+            }
+        }
+    }
+    l4.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        result4 = res.getOrThrow()
+    })
+    globalCont?.resume("resume4")
+    if (result4 != "tryResult" || !finallyRun4) return "FAIL 4: $result4, $finallyRun4"
+
+    // 5. Suspension in finally block: normal path resumed with failure propagates
+    var thrown5: Throwable? = null
+    val l5: suspend () -> String = {
+        try {
+            "tryResult"
+        } finally {
+            suspendString()
+        }
+    }
+    l5.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        thrown5 = res.exceptionOrNull()
+    })
+    globalCont?.resumeWith(Result.failure(TestException("finally failure")))
+    if (thrown5 !is TestException || thrown5?.message != "finally failure") {
+        return "FAIL 5: $thrown5"
+    }
+
+    // 6. Suspension in finally block on exceptional path: try exception propagates if finally succeeds
+    var thrown6: Throwable? = null
+    val l6: suspend () -> String = {
+        try {
+            throw TestException("try exception")
+        } finally {
+            suspendString()
+        }
+    }
+    l6.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        thrown6 = res.exceptionOrNull()
+    })
+    globalCont?.resume("ok")
+    if (thrown6 !is TestException || thrown6?.message != "try exception") {
+        return "FAIL 6: $thrown6"
+    }
+
+    // 7. Suspension in finally block on exceptional path: finally exception propagates if finally fails
+    var thrown7: Throwable? = null
+    val l7: suspend () -> String = {
+        try {
+            throw TestException("try exception")
+        } finally {
+            suspendString()
+        }
+    }
+    l7.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        thrown7 = res.exceptionOrNull()
+    })
+    globalCont?.resumeWith(Result.failure(TestException("finally failure on exceptional path")))
+    if (thrown7 !is TestException || thrown7?.message != "finally failure on exceptional path") {
+        return "FAIL 7: $thrown7"
+    }
+
+    return "OK"
+}
+

--- a/compiler/testData/codegen/bytecodeText/coroutines/debug/localVariableCorrectLabel.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/debug/localVariableCorrectLabel.kt
@@ -15,5 +15,5 @@ fun main(args: Array<String>) {
 @OptIn(ExperimentalTypeInference::class)
 suspend fun SequenceScope<Int>.awaitSeq(): Int = 42
 
-// 1 LINENUMBER 10 L11
+// 1 LINENUMBER 10 L[0-9]+
 // 1 LOCALVARIABLE a I L[0-9]+ L5

--- a/compiler/testData/codegen/bytecodeText/coroutines/kt78885.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/kt78885.kt
@@ -15,8 +15,8 @@ fun main() = runBlocking {
 private inline fun myInlineBlock(block: () -> Unit) = block()
 
 // Make sure, that $i$f variable comes _before_ $i$a variable in the code range for label=1
-// 1 LOCALVARIABLE \$i\$f\$myInlineBlock[\d\\]* I L10
-// 1 LOCALVARIABLE \$i\$a\$-myInlineBlock-Kt78885Kt\$main\$1\$1[\d\\]* I L11
+// 1 LOCALVARIABLE \$i\$f\$myInlineBlock[\d\\]* I L9
+// 1 LOCALVARIABLE \$i\$a\$-myInlineBlock-Kt78885Kt\$main\$1\$1[\d\\]* I L10
 
 // We have no variable to spill/unspill
 // 1 PUTFIELD .*label

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambda.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambda.kt
@@ -1,0 +1,16 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        foo()
+        bar()
+    }
+}
+
+// 1 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaFinallySuspensionOnly.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaFinallySuspensionOnly.kt
@@ -1,0 +1,22 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun dummy() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            dummy()
+        } finally {
+            foo()
+        }
+        bar()
+    }
+}
+
+// 1 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaInCatch.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaInCatch.kt
@@ -1,0 +1,22 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun dummy() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            dummy()
+        } catch (e: Exception) {
+            foo()
+        }
+        bar()
+    }
+}
+
+// 1 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaInCatchEnclosed.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaInCatchEnclosed.kt
@@ -1,0 +1,25 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun dummy() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            try {
+                dummy()
+            } catch (e: Exception) {
+                foo()
+            }
+        } catch (e: Exception) {
+        }
+        bar()
+    }
+}
+
+// 3 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaNoSuspension.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaNoSuspension.kt
@@ -1,0 +1,12 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        val x = 1
+    }
+}
+
+// 1 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaTryCatchOutside.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaTryCatchOutside.kt
@@ -1,0 +1,22 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun dummy() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            dummy()
+        } catch (e: Exception) {
+        }
+        foo()
+        bar()
+    }
+}
+
+// 1 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaTryFinallyOutside.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaTryFinallyOutside.kt
@@ -1,0 +1,23 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun dummy() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            dummy()
+        } finally {
+            dummy()
+        }
+        foo()
+        bar()
+    }
+}
+
+// 1 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaWithTryCatch.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaWithTryCatch.kt
@@ -1,0 +1,19 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            foo()
+        } catch (e: Exception) {
+        }
+        bar()
+    }
+}
+
+// 3 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V

--- a/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaWithTryFinally.kt
+++ b/compiler/testData/codegen/bytecodeText/coroutines/throwOnFailureSuspendLambdaWithTryFinally.kt
@@ -1,0 +1,22 @@
+// WITH_COROUTINES
+// TREAT_AS_ONE_FILE
+
+suspend fun foo() {}
+suspend fun bar() {}
+
+fun builder(c: suspend () -> Unit) {}
+
+fun test() {
+    builder {
+        try {
+            foo()
+        } finally {
+            bar()
+        }
+    }
+}
+
+// When a suspension point is inside try-finally, hoisting is disabled (hasEnclosingTryCatch = true).
+// Additionally, finally blocks with suspension points are duplicated for the exceptional handler path,
+// creating 3 suspension points (foo, bar on normal path, bar on exceptional path) + state 0 = 4 invocations.
+// 4 INVOKESTATIC kotlin/ResultKt.throwOnFailure \(Ljava/lang/Object;\)V


### PR DESCRIPTION
In SuspendLambda implementations, invokeSuspend previously emitted a call to ResultKt.throwOnFailure($result) inside every resumption case of the state dispatch switch. Because many Android and JVM applications contain large numbers of suspend lambdas, duplicating this check in each case unnecessarily bloats bytecode and DEX/ODEX size.

Hoist throwOnFailure immediately before TABLESWITCH dispatch when suspension points are not enclosed within try-catch or try-finally blocks. If any suspension point is enclosed in try-catch/try-finally, retain the per-case emission to ensure exception handler ranges remain strictly consistent. Debugger line number mapping remains preserved.

Note that hoisting changes the error priority when resuming with an invalid continuation label: previously, the TABLESWITCH default branch unconditionally threw IllegalStateException before any check. Now, if a continuation has an invalid label and is resumed with a failure result, throwOnFailure executes first and propagates the failure instead of throwing IllegalStateException. If resumed normally (success/Unit) with an invalid label, IllegalStateException continues to be thrown.

^KT-89131 Fixed