### PR TITLE
KT-87989 Deprecate the legacy Swift Export DSL and provide migration diagnostics

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.native
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
@@ -152,6 +153,60 @@ class ExportDslIT : KGPBaseTest() {
             ) {
                 assertTasksExecuted(":iosArm64DebugSwiftExport")
                 assertTasksExecuted(":$EMBED_SWIFT_EXPORT_TASK_NAME")
+            }
+        }
+    }
+
+    @DisplayName("A legacy swiftExport build still configures and reports the deprecation")
+    @GradleTest
+    fun testLegacyDslStillWorksAndReportsDeprecation(
+        gradleVersion: GradleVersion,
+    ) {
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                }
+                swiftExport.moduleName.set("Legacy")
+            }
+
+            build("help") {
+                assertHasDiagnostic(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+                assertNoDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+            }
+
+            assertTrue(isEmbedSwiftExportTaskRegistered())
+        }
+    }
+
+    @DisplayName("Configuring both Swift Export DSLs fails the build")
+    @GradleTest
+    fun testConfiguringBothDslsFailsTheBuild(
+        gradleVersion: GradleVersion,
+    ) {
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                }
+                swiftExport.moduleName.set("Legacy")
+                export.swift {
+                    moduleName.set("Shared")
+                    xcodeIntegration()
+                }
+            }
+
+            buildAndFail(":compileKotlinIosArm64") {
+                assertHasDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+                assertNoDiagnostic(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
+@file:Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
+
 package org.jetbrains.kotlin.gradle.native
 
 import org.gradle.kotlin.dsl.kotlin

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportIT.kt
@@ -692,6 +692,7 @@ class SwiftExportIT : KGPBaseTest() {
 
     @DisplayName("embedSwiftExport overrides the version of an external dependency defined in Swift Export DSL with highest on classpath")
     @GradleTest
+    @Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
     fun testSwiftExportDSLWithExternalDependencyVersionResolution(
         gradleVersion: GradleVersion,
         @TempDir testBuildDir: Path,
@@ -809,6 +810,7 @@ class SwiftExportIT : KGPBaseTest() {
     @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalSwiftExportDsl::class)
     @DisplayName("KT-86015: swiftPMDependencies cinterop klib is visible to Swift Export binary link task")
     @GradleTest
+    @Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
     fun testMainCinteropKlibIsLinkedInSwiftExportBinary(
         gradleVersion: GradleVersion,
         @TempDir testBuildDir: Path,
@@ -949,6 +951,7 @@ class SwiftExportIT : KGPBaseTest() {
     @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalSwiftExportDsl::class)
     @DisplayName("KT-80632: a SwiftPM-import cinterop klib is reexported through Swift Export")
     @GradleTest
+    @Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
     fun testSwiftPMImportCinteropIsReexportedThroughSwiftExport(
         gradleVersion: GradleVersion,
         @TempDir testBuildDir: Path,
@@ -1060,6 +1063,7 @@ class SwiftExportIT : KGPBaseTest() {
     @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalSwiftExportDsl::class)
     @DisplayName("KT-80632: Swift Export without swiftPMDependencies emits no cinterop package dependency")
     @GradleTest
+    @Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
     fun testSwiftExportWithoutSwiftPMImportHasNoCinteropDependency(
         gradleVersion: GradleVersion,
         @TempDir testBuildDir: Path,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportXCIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportXCIT.kt
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
+@file:Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
+
 package org.jetbrains.kotlin.gradle.native
 
 import org.gradle.kotlin.dsl.kotlin

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testGradleBuildInjection.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testGradleBuildInjection.kt
@@ -264,6 +264,8 @@ class GradleProjectBuildScriptInjectionContext(
     val kotlinMultiplatform get() = project.extensions.getByName("kotlin") as KotlinMultiplatformExtension
     val kotlinJvm get() = project.extensions.getByName("kotlin") as KotlinJvmProjectExtension
     val cocoapods get() = kotlinMultiplatform.extensions.getByName("cocoapods") as CocoapodsExtension
+
+    @Suppress("DEPRECATION") // Tests of the deprecated legacy Swift Export DSL reach it through this accessor.
     val swiftExport get() = kotlinMultiplatform.swiftExport
     val export get() = kotlinMultiplatform.extensions.getByName("export") as ExportExtension
     val swiftImport get() = kotlinMultiplatform.extensions.getByName(SwiftPMImportExtension.EXTENSION_NAME) as SwiftPMImportExtension

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinMultiplatformExtension.kt
@@ -315,10 +315,39 @@ internal constructor(
      * Accessing this property causes Swift Export to be requested for this project and the corresponding tasks
      * to be created.
      *
-     * Note that this DSL is experimental, and it will likely change in future versions until it is stable.
+     * This DSL is deprecated in favour of `export { swift { } }`:
      *
+     * ```kotlin
+     * // Before
+     * kotlin {
+     *     swiftExport {
+     *         moduleName = "Shared"
+     *         flattenPackage = "com.example.shared"
+     *     }
+     * }
+     *
+     * // After
+     * kotlin {
+     *     export {
+     *         swift {
+     *             moduleName = "Shared"
+     *             rootPackage = "com.example.shared"
+     *             xcodeIntegration()
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * `flattenPackage` is renamed to `rootPackage`, and the Xcode integration is no longer implicit: call
+     * `xcodeIntegration()` to register the task that embeds Swift Export's output into your Xcode project.
+     *
+     * @see org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension.swift
      * @since 2.1.0
      */
+    @Deprecated(
+        message = swiftExportDslDeprecationMessage,
+        level = DeprecationLevel.WARNING,
+    )
     val swiftExport: SwiftExportExtension
         get() {
             isSwiftExportRequested = true
@@ -331,8 +360,30 @@ internal constructor(
      * Calling this function causes Swift Export to be requested for this project and the corresponding tasks
      * to be created.
      *
+     * This DSL is deprecated in favour of `export { swift { xcodeIntegration() } }`:
+     *
+     * ```kotlin
+     * // Before
+     * kotlin {
+     *     swiftExport()
+     * }
+     *
+     * // After
+     * kotlin {
+     *     export {
+     *         swift {
+     *             xcodeIntegration()
+     *         }
+     *     }
+     * }
+     * ```
+     *
      * @since 2.1.0
      */
+    @Deprecated(
+        message = swiftExportDslDeprecationMessage,
+        level = DeprecationLevel.WARNING,
+    )
     fun swiftExport() {
         isSwiftExportRequested = true
     }
@@ -340,21 +391,44 @@ internal constructor(
     /**
      * Requests and configures Swift Export for this project.
      *
+     * Calling this function causes Swift Export to be requested for this project and the corresponding tasks
+     * to be created.
+     *
+     * This DSL is deprecated in favour of `export { swift { } }`:
+     *
      * ```kotlin
+     * // Before
      * kotlin {
      *     swiftExport {
-     *         // Your Swift Export configuration
+     *         moduleName = "Shared"
+     *         flattenPackage = "com.example.shared"
+     *     }
+     * }
+     *
+     * // After
+     * kotlin {
+     *     export {
+     *         swift {
+     *             moduleName = "Shared"
+     *             rootPackage = "com.example.shared"
+     *             xcodeIntegration()
+     *         }
      *     }
      * }
      * ```
      *
-     * Calling this function causes Swift Export to be requested for this project and the corresponding tasks
-     * to be created.
+     * `flattenPackage` is renamed to `rootPackage`, and the Xcode integration is no longer implicit: call
+     * `xcodeIntegration()` to register the task that embeds Swift Export's output into your Xcode project.
      *
      * @since 2.1.0
      */
+    @Deprecated(
+        message = swiftExportDslDeprecationMessage,
+        level = DeprecationLevel.WARNING,
+    )
     fun swiftExport(configure: SwiftExportExtension.() -> Unit) {
         // Note: `swiftExport.configure()` would resolve to SwiftExportExtension.configure() instead of this parameter.
+        @Suppress("DEPRECATION")
         configure(swiftExport)
     }
 
@@ -364,12 +438,46 @@ internal constructor(
      * Calling this function causes Swift Export to be requested for this project and the corresponding tasks
      * to be created.
      *
+     * This DSL is deprecated in favour of `export { swift { } }`:
+     *
+     * ```kotlin
+     * // Before
+     * kotlin {
+     *     swiftExport {
+     *         moduleName = "Shared"
+     *         flattenPackage = "com.example.shared"
+     *     }
+     * }
+     *
+     * // After
+     * kotlin {
+     *     export {
+     *         swift {
+     *             moduleName = "Shared"
+     *             rootPackage = "com.example.shared"
+     *             xcodeIntegration()
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * `flattenPackage` is renamed to `rootPackage`, and the Xcode integration is no longer implicit: call
+     * `xcodeIntegration()` to register the task that embeds Swift Export's output into your Xcode project.
+     *
      * @since 2.1.0
      */
+    @Deprecated(
+        message = swiftExportDslDeprecationMessage,
+        level = DeprecationLevel.WARNING,
+    )
+    @Suppress("DEPRECATION")
     fun swiftExport(configure: Action<SwiftExportExtension>) = swiftExport {
         configure.execute(this)
     }
 }
+
+private const val swiftExportDslDeprecationMessage =
+    "Use the 'export { swift { } }' DSL instead. Scheduled for removal in Kotlin 2.7."
 
 private const val targetsExtensionDeprecationMessage =
     "Usages of this DSL are deprecated, please migrate to top-level 'kotlin {}' extension."

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -1971,6 +1971,32 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    internal object DeprecatedSwiftExportDsl : ToolingDiagnosticFactory(WARNING, DiagnosticGroup.Kgp.Deprecation) {
+        operator fun invoke() = build {
+            title("Deprecated 'swiftExport { }' DSL")
+                .description("The 'swiftExport { }' DSL is deprecated and will be removed in Kotlin 2.7.")
+                .solution(
+                    "Move the configuration to 'export { swift { } }'. Rename 'flattenPackage' to 'rootPackage' " +
+                            "and call 'xcodeIntegration()' to register the task that embeds Swift Export's " +
+                            "output into your Xcode project."
+                )
+                .documentationLink(URI("https://kotl.in/swift-export-dsl-migration"))
+        }
+    }
+
+    internal object ConflictingSwiftExportDsls : ToolingDiagnosticFactory(ERROR, DiagnosticGroup.Kgp.Misconfiguration) {
+        operator fun invoke(projectPath: String) = build {
+            title("Both Swift Export DSLs are configured")
+                .description(
+                    "Project '$projectPath' configures both the deprecated 'swiftExport { }' DSL and the " +
+                            "'export { swift { } }' DSL. Only one of them is applied, so part of the " +
+                            "configuration is silently ignored."
+                )
+                .solution("Remove the 'swiftExport { }' block and keep the configuration in 'export { swift { } }'.")
+                .documentationLink(URI("https://kotl.in/swift-export-dsl-migration"))
+        }
+    }
+
     object SwiftPMLocalPackageDirectoryNotFound : ToolingDiagnosticFactory(ERROR, DiagnosticGroup.Kgp.Misconfiguration) {
         operator fun invoke(resolvedPath: String, originalPath: String) = build {
             title("Local SwiftPM Package Directory Not Found")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/SwiftExportDslDeprecationChecker.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/SwiftExportDslDeprecationChecker.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.diagnostics.checkers
+
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle.Stage.AfterFinaliseDsl
+import org.jetbrains.kotlin.gradle.plugin.await
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinGradleProjectChecker
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinGradleProjectCheckerContext
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnosticsCollector
+import org.jetbrains.kotlin.gradle.plugin.findExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportDSLConstants
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
+
+/**
+ * Reports the deprecation of the legacy `swiftExport { }` DSL, and rejects a project that configures both
+ * it and the `export { swift { } }` DSL.
+ *
+ * The two DSLs activate the Xcode integration differently: the legacy one turns it on just by being used,
+ * the new one needs an explicit `xcodeIntegration()` call. Applying only one DSL and silently dropping the
+ * other's configuration would be worse than failing the build, so the conflict is reported as an ERROR: that
+ * fails every build that compiles Kotlin, which any build that produces Swift Export output does.
+ *
+ * Awaits [AfterFinaliseDsl] so that the order of the DSL calls in the build script doesn't matter.
+ */
+internal object SwiftExportDslDeprecationChecker : KotlinGradleProjectChecker {
+
+    override suspend fun KotlinGradleProjectCheckerContext.runChecks(collector: KotlinToolingDiagnosticsCollector) {
+        AfterFinaliseDsl.await()
+
+        val mppExtension = multiplatformExtension ?: return
+        val legacyExtension = mppExtension.findExtension<SwiftExportExtension>(
+            SwiftExportDSLConstants.SWIFT_EXPORT_EXTENSION_NAME
+        ) ?: return
+
+        val legacyDslUsed = mppExtension.isSwiftExportRequested || legacyExtension.isConfigured
+        if (!legacyDslUsed) return
+
+        val exportDslUsed = mppExtension
+            .findExtension<ExportExtension>(EXPORT_EXTENSION_NAME)
+            ?.isSwiftExportConfigured == true
+
+        if (exportDslUsed) {
+            collector.report(diagnosticsContext, KotlinToolingDiagnostics.ConflictingSwiftExportDsls(projectPath))
+        } else {
+            collector.report(diagnosticsContext, KotlinToolingDiagnostics.DeprecatedSwiftExportDsl())
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -86,8 +86,9 @@ internal fun KotlinMultiplatformExtension.isSwiftExportXcodeIntegrationActivated
 
     if (isSwiftExportRequested) return true
 
-    // TODO(KT-87989): Return false here once the legacy `swiftExport { }` DSL is deprecated. Until then projects that
-    //  never ask for Swift Export keep the integration that is set up for every project with Apple targets today.
+    // TODO(KT-89151): Return false here once the legacy `swiftExport { }` DSL is removed in Kotlin 2.7.
+    //  Un-registering `embedSwiftExportForXcode` now would silently break a project whose Xcode build phase
+    //  already invokes that task without a `swiftExport { }` block. Keep the integration until the DSL is gone.
     return true
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExportExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExportExtension.kt
@@ -108,10 +108,30 @@ abstract class SwiftExportExtension @Inject constructor(
     private val projectByPath: ProjectByPath,
 ) : SwiftExportedModuleMetadata {
     /**
+     * Whether this DSL was configured in this project.
+     *
+     * True if a DSL function set it directly, or if [moduleName] or [flattenPackage] is present. Those are
+     * plain [Property] instances with no invocation hook, so presence is checked instead. Only meaningful
+     * once the DSL is finalised.
+     *
+     * Unlike [org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension.isSwiftExportRequested], this
+     * also catches a Groovy script reaching the extension directly through the Gradle extension container.
+     *
+     * One gap: an empty `swiftExport { }` block sets nothing, and
+     * [isSwiftExportXcodeIntegrationActivated] turns on Xcode integration for Apple targets regardless,
+     * so that block looks the same as no block at all.
+     */
+    internal val isConfigured: Boolean
+        get() = wasConfigured || moduleName.isPresent || flattenPackage.isPresent
+
+    private var wasConfigured = false
+
+    /**
      * Configure Link task.
      */
     @ExperimentalSwiftExportDsl
     fun linkTask(configure: KotlinNativeLink.() -> Unit = {}) {
+        wasConfigured = true
         forAllSwiftExportBinaries {
             linkTaskProvider.configure { linkTask ->
                 configure(linkTask)
@@ -132,6 +152,7 @@ abstract class SwiftExportExtension @Inject constructor(
      */
     @ExperimentalSwiftExportDsl
     fun configure(configure: SwiftExportAdvancedConfiguration.() -> Unit = {}) {
+        wasConfigured = true
         advancedConfiguration.configure()
     }
 
@@ -148,6 +169,7 @@ abstract class SwiftExportExtension @Inject constructor(
      */
     @ExperimentalSwiftExportDsl
     fun export(dependency: Any, configure: SwiftExportedModuleMetadata.() -> Unit = {}) {
+        wasConfigured = true
         when (dependency) {
             is Provider<*> -> {
                 addDependencyToExportConfiguration(dependency.map { dep ->

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/registerKotlinPluginExtensions.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/registerKotlinPluginExtensions.kt
@@ -203,6 +203,7 @@ internal fun Project.registerKotlinPluginExtensions() {
             register(project, DeprecatedNativeHostChecker)
             register(project, MultipleSourceSetRootsInCompilationChecker)
             register(project, SwiftExportModuleNameChecker)
+            register(project, SwiftExportDslDeprecationChecker)
             register(project, CinteropCrossCompilationChecker)
             register(project, NativeBinaryConfigurationChecker)
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -187,6 +187,7 @@ class ExportExtensionXcodeIntegrationTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated legacy Swift Export DSL on purpose.
     fun `test embed task is registered when the legacy swift export dsl is used`() {
         val project = exportDslProject {
             kotlin {
@@ -200,6 +201,7 @@ class ExportExtensionXcodeIntegrationTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated legacy Swift Export DSL on purpose.
     fun `test configuring both dsls reports a conflict and keeps the export dsl precedence`() {
         val project = exportDslProject {
             kotlin {
@@ -275,6 +277,7 @@ class LegacySwiftExportDslDiagnosticsTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated legacy Swift Export DSL on purpose.
     fun `test the deprecation is reported when the legacy dsl is used through the kotlin entry point`() {
         val project = legacyDslProject {
             kotlin {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -15,15 +15,18 @@ import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import org.jetbrains.kotlin.gradle.util.exportDslProject
 import org.jetbrains.kotlin.gradle.util.exportExtension
 import org.jetbrains.kotlin.gradle.util.kotlin
+import org.jetbrains.kotlin.gradle.util.legacySwiftExportExtension
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.junit.jupiter.api.Assumptions
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class ExportExtensionUnitTests {
 
@@ -205,5 +208,56 @@ class ExportExtensionXcodeIntegrationTests {
         }
 
         assertNull(project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME))
+    }
+}
+
+class LegacySwiftExportDslDetectionTests {
+
+    @Test
+    fun `test the legacy dsl is not reported as configured on a fresh project`() {
+        val project = buildProjectWithMPP()
+        assertFalse(project.legacySwiftExportExtension.isConfigured)
+    }
+
+    @Test
+    fun `test setting the module name marks the legacy dsl as configured`() {
+        val project = buildProjectWithMPP()
+        project.legacySwiftExportExtension.moduleName.set("Legacy")
+
+        assertTrue(project.legacySwiftExportExtension.isConfigured)
+    }
+
+    @Test
+    fun `test setting the flatten package marks the legacy dsl as configured`() {
+        val project = buildProjectWithMPP()
+        project.legacySwiftExportExtension.flattenPackage.set("com.example.legacy")
+
+        assertTrue(project.legacySwiftExportExtension.isConfigured)
+    }
+
+    @Test
+    fun `test configuring advanced parameters marks the legacy dsl as configured`() {
+        val project = buildProjectWithMPP()
+        project.legacySwiftExportExtension.configure {
+            freeCompilerArgs.add("-Xbinary=bundleId=com.example")
+        }
+
+        assertTrue(project.legacySwiftExportExtension.isConfigured)
+    }
+
+    @Test
+    fun `test configuring the link task marks the legacy dsl as configured`() {
+        val project = buildProjectWithMPP()
+        project.legacySwiftExportExtension.linkTask { }
+
+        assertTrue(project.legacySwiftExportExtension.isConfigured)
+    }
+
+    @Test
+    fun `test exporting a dependency marks the legacy dsl as configured`() {
+        val project = buildProjectWithMPP()
+        project.legacySwiftExportExtension.export("org.example:lib:1.0")
+
+        assertTrue(project.legacySwiftExportExtension.isConfigured)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -8,8 +8,13 @@
 package org.jetbrains.kotlin.gradle.unitTests
 
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import org.jetbrains.kotlin.gradle.util.assertContainsDiagnostic
+import org.jetbrains.kotlin.gradle.util.assertNoDiagnostics
 import org.jetbrains.kotlin.gradle.util.EMBED_SWIFT_EXPORT_TASK_NAME
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import org.jetbrains.kotlin.gradle.util.exportDslProject
@@ -195,7 +200,7 @@ class ExportExtensionXcodeIntegrationTests {
     }
 
     @Test
-    fun `test the export dsl takes precedence over the legacy swift export dsl`() {
+    fun `test configuring both dsls reports a conflict and keeps the export dsl precedence`() {
         val project = exportDslProject {
             kotlin {
                 swiftExport {
@@ -207,8 +212,90 @@ class ExportExtensionXcodeIntegrationTests {
             }
         }
 
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
         assertNull(project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME))
     }
+}
+
+class LegacySwiftExportDslDiagnosticsTests {
+
+    @Test
+    fun `test no diagnostics are reported when neither dsl is used`() {
+        val project = legacyDslProject { }
+
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+    }
+
+    @Test
+    fun `test no diagnostics are reported when only the export dsl is used`() {
+        val project = legacyDslProject {
+            exportExtension.swift {
+                moduleName.set("Shared")
+            }
+        }
+
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+    }
+
+    @Test
+    fun `test the deprecation is reported when only the legacy dsl is used`() {
+        val project = legacyDslProject {
+            legacySwiftExportExtension.moduleName.set("Legacy")
+        }
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+    }
+
+    @Test
+    fun `test the conflict is reported when both dsls are used`() {
+        val project = legacyDslProject {
+            legacySwiftExportExtension.moduleName.set("Legacy")
+            exportExtension.swift {
+                moduleName.set("Shared")
+            }
+        }
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+    }
+
+    @Test
+    fun `test the deprecation is reported regardless of the dsl call order`() {
+        val project = legacyDslProject {
+            exportExtension.swift {
+                xcodeIntegration()
+            }
+            legacySwiftExportExtension.moduleName.set("Legacy")
+        }
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+    }
+
+    @Test
+    fun `test the deprecation is reported when the legacy dsl is used through the kotlin entry point`() {
+        val project = legacyDslProject {
+            kotlin {
+                swiftExport()
+            }
+        }
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+    }
+
+    /**
+     * JVM-only so these tests stay host-independent: the diagnostics only depend on which DSL was
+     * configured, and the Xcode wiring itself is only exercised for Apple targets, which needs macOS.
+     */
+    private fun legacyDslProject(configure: Project.() -> Unit): ProjectInternal =
+        buildProjectWithMPP(
+            code = {
+                kotlin { jvm() }
+                configure()
+            }
+        ).also { it.evaluate() }
 }
 
 class LegacySwiftExportDslDetectionTests {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -7,15 +7,15 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
-import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import org.jetbrains.kotlin.gradle.util.EMBED_SWIFT_EXPORT_TASK_NAME
 import org.jetbrains.kotlin.gradle.util.assertContainsDiagnostic
 import org.jetbrains.kotlin.gradle.util.assertNoDiagnostics
-import org.jetbrains.kotlin.gradle.util.EMBED_SWIFT_EXPORT_TASK_NAME
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import org.jetbrains.kotlin.gradle.util.exportDslProject
 import org.jetbrains.kotlin.gradle.util.exportExtension
@@ -265,7 +265,7 @@ class LegacySwiftExportDslDiagnosticsTests {
     }
 
     @Test
-    fun `test the deprecation is reported regardless of the dsl call order`() {
+    fun `test the conflict is reported regardless of the dsl call order`() {
         val project = legacyDslProject {
             exportExtension.swift {
                 xcodeIntegration()
@@ -274,6 +274,20 @@ class LegacySwiftExportDslDiagnosticsTests {
         }
 
         project.assertContainsDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+    }
+
+    @Test
+    fun `test the deprecation is reported when the legacy dsl is configured before the targets`() {
+        val project = buildProjectWithMPP(
+            code = {
+                legacySwiftExportExtension.moduleName.set("Legacy")
+                kotlin { jvm() }
+            }
+        ).also { it.evaluate() }
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
@@ -1268,6 +1268,7 @@ private fun multiModuleSwiftExportProject(
     return listOf(project) + projectDependencies
 }
 
+@Suppress("DEPRECATION") // Exercises the deprecated legacy Swift Export DSL on purpose.
 private fun swiftExportProject(
     configuration: String = "DEBUG",
     sdk: String = "iphonesimulator",
@@ -1297,6 +1298,7 @@ private fun swiftExportProject(
     }
 )
 
+@Suppress("DEPRECATION") // Exercises the deprecated legacy Swift Export DSL on purpose.
 private fun ProjectInternal.setupForSwiftExport(
     configuration: String = "DEBUG",
     sdk: String = "iphonesimulator",

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/exportDslUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/exportDslUtils.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.jetbrains.kotlin.gradle.plugin.getExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportDSLConstants
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
 import org.jetbrains.kotlin.gradle.unitTests.utils.applyEmbedAndSignEnvironment
@@ -25,6 +27,16 @@ internal val Project.exportExtension: ExportExtension
     get() = assertNotNull(
         multiplatformExtension.getExtension(EXPORT_EXTENSION_NAME),
         "Expected the `$EXPORT_EXTENSION_NAME` extension to be registered on the multiplatform extension"
+    )
+
+/**
+ * The legacy `swiftExport { }` extension, read through the Gradle extension container so that reading it
+ * does not itself mark Swift Export as requested.
+ */
+internal val Project.legacySwiftExportExtension: SwiftExportExtension
+    get() = assertNotNull(
+        multiplatformExtension.getExtension(SwiftExportDSLConstants.SWIFT_EXPORT_EXTENSION_NAME),
+        "Expected the `${SwiftExportDSLConstants.SWIFT_EXPORT_EXTENSION_NAME}` extension to be registered on the multiplatform extension"
     )
 
 /**


### PR DESCRIPTION
This pull request deprecates the legacy `swiftExport { }` DSL in favor of the newer `export { swift { } }` DSL for Swift Export in Kotlin Multiplatform projects. It introduces new diagnostics to warn users about the deprecation and to fail the build if both DSLs are configured simultaneously. The changes include updates to documentation, diagnostics, and test coverage to ensure a smooth migration path and clear communication to users.

**Deprecation and Migration to New DSL:**

- Marked the `swiftExport` property and related functions in `KotlinMultiplatformExtension` as deprecated, with detailed KDoc explaining the migration to the new `export { swift { } }` DSL, including code samples and parameter renaming (`flattenPackage` → `rootPackage`). [[1]](diffhunk://#diff-c547d62a6c9706b69c4ac9102078cf371b475c2593ce56ea1183f9898266489aL318-R350) [[2]](diffhunk://#diff-c547d62a6c9706b69c4ac9102078cf371b475c2593ce56ea1183f9898266489aR363-R431) [[3]](diffhunk://#diff-c547d62a6c9706b69c4ac9102078cf371b475c2593ce56ea1183f9898266489aR441-R481)

**Diagnostics and Build Checks:**

- Added new diagnostic factories `DeprecatedSwiftExportDsl` (warning) and `ConflictingSwiftExportDsls` (error) to `KotlinToolingDiagnostics`, with migration guidance and documentation links.
- Implemented `SwiftExportDslDeprecationChecker` to emit the appropriate diagnostic if the legacy DSL is used and to fail the build if both DSLs are configured in the same project.

**Swift Export Extension Enhancements:**

- Added an `isConfigured` property to `SwiftExportExtension` to track if the legacy DSL was actually configured, improving detection in diagnostics and migration logic. [[1]](diffhunk://#diff-cea798c886f37efb8972c248f19ccbca8d28349b9775f62c5ea11da220c4167cR110-R134) [[2]](diffhunk://#diff-cea798c886f37efb8972c248f19ccbca8d28349b9775f62c5ea11da220c4167cR155)

**Test Updates:**

- Expanded integration tests to verify that the deprecation warning/error is reported, and that using both DSLs fails the build. Suppressed deprecation warnings in test files where the legacy DSL is intentionally used. [[1]](diffhunk://#diff-92a95f0050e23aa99ecc1c16a3c6578e90f99e767a7c09baa90a51380c352a26R11-R12) [[2]](diffhunk://#diff-92a95f0050e23aa99ecc1c16a3c6578e90f99e767a7c09baa90a51380c352a26R161-R220) [[3]](diffhunk://#diff-6bd16e0d7a933b6196ad9b725b4cc362aa02e22d0a4d6de50581e31b376d4d37R6-R7) [[4]](diffhunk://#diff-d6191d6adfa55bdd1a39c6ad785e115dafbafc90d835275f0e3cf65ee8fe9785R6-R7) [[5]](diffhunk://#diff-a2049152d6803419280665c6760c11200571e5d5920604ca611d72909040f072R695) [[6]](diffhunk://#diff-a2049152d6803419280665c6760c11200571e5d5920604ca611d72909040f072R813) [[7]](diffhunk://#diff-a2049152d6803419280665c6760c11200571e5d5920604ca611d72909040f072R954) [[8]](diffhunk://#diff-a2049152d6803419280665c6760c11200571e5d5920604ca611d72909040f072R1066) [[9]](diffhunk://#diff-e995a036a5d5e4503cbf237696ff9c3727520b1d8e14da3ec8a32489dffd060fR267-R268)