### PR TITLE
Klib Loading: Permit loading Klibs only starting from ABI version 1.6.0 (~ compiler version 1.6.0)

### DIFF
--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
@@ -33,6 +33,7 @@ fun loadWebKlibs(
     val result = KlibLoader {
         libraryPaths(configuration.libraries)
         platformChecker(platformChecker)
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
     }.load()

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.js.config.friendLibraries
 import org.jetbrains.kotlin.js.config.includes
 import org.jetbrains.kotlin.js.config.libraries
 import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_COMPILER_VERSION
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.KlibPlatformChecker
 
@@ -33,7 +34,7 @@ fun loadWebKlibs(
     val result = KlibLoader {
         libraryPaths(configuration.libraries)
         platformChecker(platformChecker)
-        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
     }.load()

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -65,6 +65,7 @@ fun loadNativeKlibs(
         libraryProviders(distributionLibrariesProvider)
         libraryPaths(configuration.konanLibraries)
         platformChecker(platformChecker)
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
         manifestTransformer(KlibNativeManifestTransformer(nativeTarget))

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.konan.library.KlibNativeManifestTransformer
 import org.jetbrains.kotlin.konan.library.isFromKotlinNativeDistribution
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_COMPILER_VERSION
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.irProviderName
 import org.jetbrains.kotlin.library.loader.KlibLoader
@@ -65,7 +66,7 @@ fun loadNativeKlibs(
         libraryProviders(distributionLibrariesProvider)
         libraryPaths(configuration.konanLibraries)
         platformChecker(platformChecker)
-        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
         manifestTransformer(KlibNativeManifestTransformer(nativeTarget))

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
@@ -91,6 +91,14 @@ data class KotlinAbiVersion(val major: Int, val minor: Int, val patch: Int) {
         val CURRENT = KotlinAbiVersion(2, 5, 0)
 
         /**
+         * The oldest ABI version supported by  the compiler.
+         *
+         * Note: At the moment this is 1.6.0 (corresponds to the compiler versions 1.6.x). But we are going to raise this limit
+         * at least up to 1.8.0 (compiler 1.9.20) in the future releases.
+         */
+        val FIRST_SUPPORTED = KotlinAbiVersion(1, 6, 0)
+
+        /**
          * Versions before 1.4.1 were the active development phase.
          * Starting with 1.4.1 we are trying to maintain experimental backward compatibility.
          */

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
@@ -99,6 +99,12 @@ data class KotlinAbiVersion(val major: Int, val minor: Int, val patch: Int) {
         val FIRST_SUPPORTED = KotlinAbiVersion(1, 6, 0)
 
         /**
+         * The oldest version of the compiler that can produce KLIBs consumable by the current compiler version.
+         * See [FIRST_SUPPORTED].
+         */
+        const val FIRST_SUPPORTED_COMPILER_VERSION = "1.6.0"
+
+        /**
          * Versions before 1.4.1 were the active development phase.
          * Starting with 1.4.1 we are trying to maintain experimental backward compatibility.
          */

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoader.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoader.kt
@@ -44,6 +44,7 @@ class KlibLoader(init: KlibLoaderSpec.() -> Unit) {
     private val libraryProviders = ArrayList<KlibLibraryProvider>()
     private val libraryPaths = ArrayList<String>()
     private var platformChecker: KlibPlatformChecker? = null
+    private var minPermittedAbiVersion: KotlinAbiVersion? = null
     private var maxPermittedAbiVersion: KotlinAbiVersion? = null
     private var zipFileSystemAccessor: ZipFileSystemAccessor? = null
     private var manifestTransformer: KlibManifestTransformer? = null
@@ -78,6 +79,10 @@ class KlibLoader(init: KlibLoaderSpec.() -> Unit) {
                 platformChecker = checker
             }
 
+            override fun minPermittedAbiVersion(abiVersion: KotlinAbiVersion) {
+                minPermittedAbiVersion = abiVersion
+            }
+
             override fun maxPermittedAbiVersion(abiVersion: KotlinAbiVersion) {
                 maxPermittedAbiVersion = abiVersion
             }
@@ -102,6 +107,7 @@ class KlibLoader(init: KlibLoaderSpec.() -> Unit) {
         return KlibLoaderImpl(
             libraryProviders = libraryProviders,
             platformChecker = platformChecker,
+            minPermittedAbiVersion = minPermittedAbiVersion,
             maxPermittedAbiVersion = maxPermittedAbiVersion,
             zipFileSystemAccessor = zipFileSystemAccessor ?: ZipFileSystemInPlaceAccessor,
             manifestTransformer = manifestTransformer
@@ -119,6 +125,7 @@ interface KlibLoaderSpec {
     fun libraryPaths(vararg paths: Path)
 
     fun platformChecker(checker: KlibPlatformChecker)
+    fun minPermittedAbiVersion(abiVersion: KotlinAbiVersion)
     fun maxPermittedAbiVersion(abiVersion: KotlinAbiVersion)
     fun zipFileSystemAccessor(accessor: ZipFileSystemAccessor)
 
@@ -128,6 +135,7 @@ interface KlibLoaderSpec {
 private class KlibLoaderImpl(
     private val libraryProviders: List<KlibLibraryProvider>,
     private val platformChecker: KlibPlatformChecker?,
+    private val minPermittedAbiVersion: KotlinAbiVersion?,
     private val maxPermittedAbiVersion: KotlinAbiVersion?,
     private val zipFileSystemAccessor: ZipFileSystemAccessor,
     private val manifestTransformer: KlibManifestTransformer?,
@@ -266,15 +274,18 @@ private class KlibLoaderImpl(
             return LibraryStatus.FailedToLoad(ProblematicLibrary(rawPath, platformCheckMismatch))
         }
 
-        if (maxPermittedAbiVersion != null && library.hasAbi) {
+        if ((minPermittedAbiVersion != null || maxPermittedAbiVersion != null) && library.hasAbi) {
             val libraryAbiVersion: KotlinAbiVersion? = library.versions.abiVersion
-            if (libraryAbiVersion == null || !libraryAbiVersion.isAtMost(maxPermittedAbiVersion)) {
+            if (libraryAbiVersion == null
+                || (minPermittedAbiVersion != null && !libraryAbiVersion.isAtLeast(minPermittedAbiVersion))
+                || (maxPermittedAbiVersion != null && !libraryAbiVersion.isAtMost(maxPermittedAbiVersion))
+            ) {
                 return LibraryStatus.FailedToLoad(
                     ProblematicLibrary(
                         libraryPath = rawPath,
                         problemCase = IncompatibleAbiVersion(
                             libraryVersions = library.versions,
-                            minPermittedAbiVersion = null,
+                            minPermittedAbiVersion = minPermittedAbiVersion,
                             maxPermittedAbiVersion = maxPermittedAbiVersion
                         )
                     )

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoader.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoader.kt
@@ -46,6 +46,7 @@ class KlibLoader(init: KlibLoaderSpec.() -> Unit) {
     private var platformChecker: KlibPlatformChecker? = null
     private var minPermittedAbiVersion: KotlinAbiVersion? = null
     private var maxPermittedAbiVersion: KotlinAbiVersion? = null
+    private var minSupportedCompilerVersionHint: String? = null
     private var zipFileSystemAccessor: ZipFileSystemAccessor? = null
     private var manifestTransformer: KlibManifestTransformer? = null
 
@@ -79,8 +80,9 @@ class KlibLoader(init: KlibLoaderSpec.() -> Unit) {
                 platformChecker = checker
             }
 
-            override fun minPermittedAbiVersion(abiVersion: KotlinAbiVersion) {
+            override fun minPermittedAbiVersion(abiVersion: KotlinAbiVersion, compilerVersion: String?) {
                 minPermittedAbiVersion = abiVersion
+                minSupportedCompilerVersionHint = compilerVersion
             }
 
             override fun maxPermittedAbiVersion(abiVersion: KotlinAbiVersion) {
@@ -109,6 +111,7 @@ class KlibLoader(init: KlibLoaderSpec.() -> Unit) {
             platformChecker = platformChecker,
             minPermittedAbiVersion = minPermittedAbiVersion,
             maxPermittedAbiVersion = maxPermittedAbiVersion,
+            minSupportedCompilerVersionHint = minSupportedCompilerVersionHint,
             zipFileSystemAccessor = zipFileSystemAccessor ?: ZipFileSystemInPlaceAccessor,
             manifestTransformer = manifestTransformer
         ).loadLibraries()
@@ -125,7 +128,7 @@ interface KlibLoaderSpec {
     fun libraryPaths(vararg paths: Path)
 
     fun platformChecker(checker: KlibPlatformChecker)
-    fun minPermittedAbiVersion(abiVersion: KotlinAbiVersion)
+    fun minPermittedAbiVersion(abiVersion: KotlinAbiVersion, compilerVersion: String?)
     fun maxPermittedAbiVersion(abiVersion: KotlinAbiVersion)
     fun zipFileSystemAccessor(accessor: ZipFileSystemAccessor)
 
@@ -137,6 +140,7 @@ private class KlibLoaderImpl(
     private val platformChecker: KlibPlatformChecker?,
     private val minPermittedAbiVersion: KotlinAbiVersion?,
     private val maxPermittedAbiVersion: KotlinAbiVersion?,
+    private val minSupportedCompilerVersionHint: String?,
     private val zipFileSystemAccessor: ZipFileSystemAccessor,
     private val manifestTransformer: KlibManifestTransformer?,
 ) {
@@ -286,7 +290,8 @@ private class KlibLoaderImpl(
                         problemCase = IncompatibleAbiVersion(
                             libraryVersions = library.versions,
                             minPermittedAbiVersion = minPermittedAbiVersion,
-                            maxPermittedAbiVersion = maxPermittedAbiVersion
+                            maxPermittedAbiVersion = maxPermittedAbiVersion,
+                            minSupportedCompilerVersionHint = minSupportedCompilerVersionHint,
                         )
                     )
                 )

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
@@ -97,12 +97,19 @@ class KlibLoaderResult(
          *  [KlibLoaderSpec.minPermittedAbiVersion] call.
          * @property maxPermittedAbiVersion The max permitted ABI version set in [KlibLoader] via
          *  [KlibLoaderSpec.maxPermittedAbiVersion] call.
+         * @property minSupportedCompilerVersionHint The oldest known compiler version that can produce KLIB
+         *  artifacts that can be consumed by the current compiler.
          */
         class IncompatibleAbiVersion(
             val libraryVersions: KotlinLibraryVersioning,
             val minPermittedAbiVersion: KotlinAbiVersion?,
             val maxPermittedAbiVersion: KotlinAbiVersion?,
-        ) : ExistingKlibProblem()
+            val minSupportedCompilerVersionHint: String?
+        ) : ExistingKlibProblem() {
+            init {
+                require(minSupportedCompilerVersionHint == null || minPermittedAbiVersion != null)
+            }
+        }
 
         /**
          * The library does not pass some other (custom) check that was not set in [KlibLoaderSpec].
@@ -153,24 +160,41 @@ private fun ProblematicLibrary.computeMessageText(): String {
         is IncompatibleAbiVersion -> with(problemCase) {
             val libraryCompilerLine: String? = libraryVersions.compilerVersion?.let { "The library was produced by $it compiler." }
 
+            val libraryAbiVersion: KotlinAbiVersion? = libraryVersions.abiVersion
+
+            val isLowerBoundaryExceeded = minPermittedAbiVersion != null
+                    && libraryAbiVersion != null
+                    && !libraryAbiVersion.isAtLeast(minPermittedAbiVersion)
+
             val abiVersionCheckExplanation: String = when {
+                isLowerBoundaryExceeded && minSupportedCompilerVersionHint != null ->
+                    "produced by at least $minSupportedCompilerVersionHint compiler"
+
                 minPermittedAbiVersion != null && maxPermittedAbiVersion != null ->
-                    "ABI version in the range [$minPermittedAbiVersion, $maxPermittedAbiVersion]"
+                    "having ABI version in the range [$minPermittedAbiVersion, $maxPermittedAbiVersion]"
 
                 maxPermittedAbiVersion != null ->
-                    "ABI version <= $maxPermittedAbiVersion"
+                    "having ABI version <= $maxPermittedAbiVersion"
 
-                else /*if (minPermittedAbiVersion != null)*/ ->
-                    "ABI version >= $minPermittedAbiVersion"
+                else /* minPermittedAbiVersion != null */ ->
+                    "having ABI version >= $minPermittedAbiVersion"
             }
 
-            val libraryAbiVersion: KotlinAbiVersion? = libraryVersions.abiVersion
             val lines: List<String> = if (libraryAbiVersion != null) {
+                val actionText = when {
+                    isLowerBoundaryExceeded -> buildString {
+                        append("Please upgrade the library to a newer version ")
+                        if (minSupportedCompilerVersionHint != null) append("compatible with $minSupportedCompilerVersionHint compiler ")
+                        append("(ABI version $minPermittedAbiVersion or higher).")
+                    }
+                    else -> "Please upgrade your Kotlin compiler version to consume this library."
+                }
+
                 listOfNotNull(
                     "Incompatible ABI version $libraryAbiVersion in library: $libraryPath",
                     libraryCompilerLine,
-                    "The current Kotlin compiler can consume libraries having $abiVersionCheckExplanation",
-                    "Please upgrade your Kotlin compiler version to consume this library."
+                    "The current Kotlin compiler can consume libraries $abiVersionCheckExplanation.",
+                    actionText,
                 )
             } else {
                 // This message is not very actionable. However, we shouldn't have to worry about it because
@@ -178,7 +202,7 @@ private fun ProblematicLibrary.computeMessageText(): String {
                 listOfNotNull(
                     "Library with unknown ABI version: $libraryPath",
                     libraryCompilerLine,
-                    "The current Kotlin compiler can consume libraries having $abiVersionCheckExplanation, but it's not possible to determine the exact ABI version."
+                    "The current Kotlin compiler can consume libraries $abiVersionCheckExplanation, but it's not possible to determine the exact ABI version."
                 )
             }
 

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
@@ -89,12 +89,14 @@ class KlibLoaderResult(
         ) : ExistingKlibProblem()
 
         /**
-         * The library does not match the ABI version requirements that were set in [KlibLoaderSpec.maxPermittedAbiVersion].
+         * The library does not match the ABI version requirements that were set in [KlibLoaderSpec.minPermittedAbiVersion]
+         * or in [KlibLoaderSpec.maxPermittedAbiVersion].
          *
          * @property libraryVersions The actual versions (including the ABI version) in a KLIB.
+         * @property minPermittedAbiVersion The min permitted ABI version set in [KlibLoader] via
+         *  [KlibLoaderSpec.minPermittedAbiVersion] call.
          * @property maxPermittedAbiVersion The max permitted ABI version set in [KlibLoader] via
          *  [KlibLoaderSpec.maxPermittedAbiVersion] call.
-         * @property minPermittedAbiVersion The min permitted ABI version (reserved for the future).
          */
         class IncompatibleAbiVersion(
             val libraryVersions: KotlinLibraryVersioning,

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
@@ -431,6 +431,43 @@ abstract class AbstractKlibLoaderTest {
     }
 
     @Test
+    fun testMinPermittedAbiVersion() {
+        // This list of ABI versions only starts from the current version.
+        // Thus, it contains 4 more versions that are definitely not supported by the current compiler.
+        val abiVersionsStartingFromCurrent: List<KotlinAbiVersion> =
+            generateSequence(KotlinAbiVersion.CURRENT) { it.prev() }.take(5).toList()
+
+        val abiVersionsToLibraryPaths: List<Pair<KotlinAbiVersion, String>> = abiVersionsStartingFromCurrent.map { abiVersion ->
+            val library = generateNewKlib(asFile = false, fileExtension = "", abiVersion = abiVersion)
+            abiVersion to library
+        }
+
+        val libraryPaths: List<String> = abiVersionsToLibraryPaths.map { (_, libraryPath) -> libraryPath }
+
+        // Load without ABI version check.
+        KlibLoader {
+            libraryPaths(libraryPaths)
+        }.load()
+            .assertLoadedLibraries(libraryPaths) // All libraries are loaded.
+            .assertNoProblematicLibraries()
+            .run {
+                // Check that the requested ABI versions are indeed written to KLIBs.
+                (abiVersionsStartingFromCurrent zip librariesStdlibFirst).forEach { (abiVersion, library) ->
+                    assertEquals(abiVersion, library.versions.abiVersion)
+                }
+            }
+
+        for (i in abiVersionsStartingFromCurrent.indices) {
+            KlibLoader {
+                libraryPaths(libraryPaths)
+                minPermittedAbiVersion(abiVersionsStartingFromCurrent[i])
+            }.load()
+                .assertLoadedLibraries(libraryPaths.take(i + 1))
+                .assertProblematicLibraries(incompatibleAbiVersionPaths = libraryPaths.drop(i + 1))
+        }
+    }
+
+    @Test
     fun testMaxPermittedAbiVersion() {
         // This list of ABI versions only starts from the current version.
         // Thus, it contains 4 more versions that are definitely not supported by the current compiler.
@@ -600,6 +637,9 @@ abstract class AbstractKlibLoaderTest {
 
     protected abstract val ownPlatformCheckers: List<KlibPlatformChecker>
     protected abstract val alienPlatformCheckers: List<KlibPlatformChecker>
+
+    private fun KotlinAbiVersion.prev() =
+        if (minor > 0) KotlinAbiVersion(major, minor - 1, patch) else KotlinAbiVersion(major - 1, 255, 0)
 
     private fun KotlinAbiVersion.next() = KotlinAbiVersion(major, minor + 1, patch)
 

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
@@ -505,6 +505,89 @@ abstract class AbstractKlibLoaderTest {
     }
 
     @Test
+    fun testAllKnownAbiVersionsAreTreatedAsExpected() {
+        for (abiVersion in findAllKnownUnsupportedAbiVersions()) {
+            val libraryPath = generateNewKlib(asFile = false, fileExtension = "", abiVersion = abiVersion)
+
+            // First, try it without restrictions on the ABI version.
+            KlibLoader {
+                libraryPaths(libraryPath)
+            }.load()
+                .assertLoadedLibraries(listOf(libraryPath))
+                .assertNoProblematicLibraries()
+
+            // ... and now with.
+            KlibLoader {
+                libraryPaths(libraryPath)
+                minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+                maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
+            }.load()
+                .assertNoLoadedLibraries()
+                .assertProblematicLibraries(incompatibleAbiVersionPaths = listOf(libraryPath))
+        }
+
+        for (abiVersion in findAllKnownSupportedAbiVersions()) {
+            val libraryPath = generateNewKlib(asFile = false, fileExtension = "", abiVersion = abiVersion)
+
+            KlibLoader {
+                libraryPaths(libraryPath)
+                minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+                maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
+            }.load()
+                .assertLoadedLibraries(listOf(libraryPath))
+                .assertNoProblematicLibraries()
+        }
+    }
+
+    private fun findAllKnownUnsupportedAbiVersions(): List<KotlinAbiVersion> {
+        val knownUnsupportedSingleDigitAbiVersions = listOf(1, 2, 5, 8, 9, 14, 17, 22).map { KotlinAbiVersion(it) }
+
+        // Sanity: Make sure that all are unique.
+        assertEquals(knownUnsupportedSingleDigitAbiVersions.size, knownUnsupportedSingleDigitAbiVersions.toSet().size)
+
+        val knownUnsupportedThreeDigitAbiVersions = listOf(
+            KotlinAbiVersion(1, 4, 0),
+            KotlinAbiVersion(1, 4, 1),
+            KotlinAbiVersion(1, 4, 2),
+            KotlinAbiVersion(1, 5, 0),
+        )
+
+        // Sanity: Make sure that all are unique.
+        assertEquals(knownUnsupportedThreeDigitAbiVersions.size, knownUnsupportedThreeDigitAbiVersions.toSet().size)
+
+        // Sanity: Make sure that they don't intersect with `knownLegacySingleDigitAbiVersions`.
+        assertEquals(emptySet<KotlinAbiVersion>(), knownUnsupportedSingleDigitAbiVersions.toSet() intersect knownUnsupportedThreeDigitAbiVersions.toSet())
+
+        // Sanity: Make sure that the next version after `knownLegacyThreeDigitAbiVersions` is exactly `KotlinAbiVersion.FIRST_SUPPORTED`.
+        assertEquals(KotlinAbiVersion.FIRST_SUPPORTED, knownUnsupportedThreeDigitAbiVersions.last().next())
+
+        return knownUnsupportedSingleDigitAbiVersions + knownUnsupportedThreeDigitAbiVersions
+    }
+
+    private fun findAllKnownSupportedAbiVersions(): List<KotlinAbiVersion> {
+        val knownSupportedAbiVersions = buildList {
+            this += KotlinAbiVersion(1, 6, 0)
+            this += KotlinAbiVersion(1, 7, 0)
+            this += KotlinAbiVersion(1, 8, 0)
+            this += KotlinAbiVersion(1, 201, 0)
+
+            generateSequence(KotlinAbiVersion(2, 2, 0)) { it.next() }
+                .takeWhile { it.isAtMost(KotlinAbiVersion.CURRENT) }
+                .mapTo(this) { it }
+        }
+
+        // Sanity: Make sure that all are unique.
+        assertEquals(knownSupportedAbiVersions.size, knownSupportedAbiVersions.toSet().size)
+
+        // Sanity: The first element in `knownSupportedAbiVersions` is exactly `KotlinAbiVersion.FIRST_SUPPORTED`,
+        // and the last element is exactly `KotlinAbiVersion.CURRENT`.
+        assertEquals(KotlinAbiVersion.FIRST_SUPPORTED, knownSupportedAbiVersions.first())
+        assertEquals(KotlinAbiVersion.CURRENT, knownSupportedAbiVersions.last())
+
+        return knownSupportedAbiVersions
+    }
+
+    @Test
     fun testMaxPermittedAbiVersionAndNoAbiVersionInManifest() {
         // This list of ABI versions only starts from the current version.
         // Thus, it contains 4 more versions that are definitely not supported by the current compiler.

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
@@ -9,11 +9,13 @@ import org.jetbrains.kotlin.io.canonicalPathString
 import org.jetbrains.kotlin.io.readProperties
 import org.jetbrains.kotlin.io.writeProperties
 import org.jetbrains.kotlin.io.zipDirAs
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_COMPILER_VERSION
 import org.jetbrains.kotlin.library.loader.DefaultKlibLibraryProvider
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase
 import org.jetbrains.kotlin.library.loader.KlibPlatformChecker
+import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -460,7 +462,7 @@ abstract class AbstractKlibLoaderTest {
         for (i in abiVersionsStartingFromCurrent.indices) {
             KlibLoader {
                 libraryPaths(libraryPaths)
-                minPermittedAbiVersion(abiVersionsStartingFromCurrent[i])
+                minPermittedAbiVersion(abiVersionsStartingFromCurrent[i], null)
             }.load()
                 .assertLoadedLibraries(libraryPaths.take(i + 1))
                 .assertProblematicLibraries(incompatibleAbiVersionPaths = libraryPaths.drop(i + 1))
@@ -519,7 +521,7 @@ abstract class AbstractKlibLoaderTest {
             // ... and now with.
             KlibLoader {
                 libraryPaths(libraryPath)
-                minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+                minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
                 maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
             }.load()
                 .assertNoLoadedLibraries()
@@ -531,12 +533,92 @@ abstract class AbstractKlibLoaderTest {
 
             KlibLoader {
                 libraryPaths(libraryPath)
-                minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+                minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
                 maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
             }.load()
                 .assertLoadedLibraries(listOf(libraryPath))
                 .assertNoProblematicLibraries()
         }
+    }
+
+    @Test
+    fun testCompilerVersionHintsForObsoleteAbiVersions() {
+        val obsoleteAbiVersion = KotlinAbiVersion.FIRST_SUPPORTED.prev()
+
+        val libraryPath = generateNewKlib(asFile = false, fileExtension = "", abiVersion = obsoleteAbiVersion)
+
+        fun KlibLoaderResult.assertInvalidAbiMessage(expectedMessage: String) {
+            var errorMessagesReported = 0
+            reportLoadingProblemsIfAny { _, actualMessage ->
+                errorMessagesReported++
+
+                val actualFilteredMessage = actualMessage.lineSequence()
+                    .filterNot { it.startsWith("The library was produced by ") && it.endsWith(" compiler.") } // this line might be absent in the reported message
+                    .joinToString(separator = "\n")
+
+                assertEquals(expectedMessage, actualFilteredMessage)
+            }
+
+            assertEquals(1, errorMessagesReported)
+        }
+
+        KlibLoader {
+            libraryPaths(libraryPath)
+            minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, compilerVersion = null)
+        }.load()
+            .assertNoLoadedLibraries()
+            .assertProblematicLibraries(incompatibleAbiVersionPaths = listOf(libraryPath))
+            .assertInvalidAbiMessage(
+                """
+                    KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
+                    The current Kotlin compiler can consume libraries having ABI version >= ${KotlinAbiVersion.FIRST_SUPPORTED}.
+                    Please upgrade the library to a newer version (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                """.trimIndent()
+            )
+
+        KlibLoader {
+            libraryPaths(libraryPath)
+            minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, compilerVersion = null)
+            maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
+        }.load()
+            .assertNoLoadedLibraries()
+            .assertProblematicLibraries(incompatibleAbiVersionPaths = listOf(libraryPath))
+            .assertInvalidAbiMessage(
+                """
+                    KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
+                    The current Kotlin compiler can consume libraries having ABI version in the range [${KotlinAbiVersion.FIRST_SUPPORTED}, ${KotlinAbiVersion.CURRENT}].
+                    Please upgrade the library to a newer version (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                """.trimIndent()
+            )
+
+        KlibLoader {
+            libraryPaths(libraryPath)
+            minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, compilerVersion = FIRST_SUPPORTED_COMPILER_VERSION)
+        }.load()
+            .assertNoLoadedLibraries()
+            .assertProblematicLibraries(incompatibleAbiVersionPaths = listOf(libraryPath))
+            .assertInvalidAbiMessage(
+                """
+                    KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
+                    The current Kotlin compiler can consume libraries produced by at least $FIRST_SUPPORTED_COMPILER_VERSION compiler.
+                    Please upgrade the library to a newer version compatible with $FIRST_SUPPORTED_COMPILER_VERSION compiler (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                """.trimIndent()
+            )
+
+        KlibLoader {
+            libraryPaths(libraryPath)
+            minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, compilerVersion = FIRST_SUPPORTED_COMPILER_VERSION)
+            maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
+        }.load()
+            .assertNoLoadedLibraries()
+            .assertProblematicLibraries(incompatibleAbiVersionPaths = listOf(libraryPath))
+            .assertInvalidAbiMessage(
+                """
+                    KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
+                    The current Kotlin compiler can consume libraries produced by at least $FIRST_SUPPORTED_COMPILER_VERSION compiler.
+                    Please upgrade the library to a newer version compatible with $FIRST_SUPPORTED_COMPILER_VERSION compiler (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                """.trimIndent()
+            )
     }
 
     private fun findAllKnownUnsupportedAbiVersions(): List<KotlinAbiVersion> {

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -595,6 +595,7 @@ private fun loadLibraries(cinteropArguments: CInteropArguments, target: KonanTar
                 }
         )
         platformChecker(KlibPlatformChecker.Native(target.name))
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         manifestTransformer(KlibNativeManifestTransformer(target))
     }.load()

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.DefFile
 import org.jetbrains.kotlin.library.*
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_COMPILER_VERSION
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult
 import org.jetbrains.kotlin.library.loader.KlibPlatformChecker
@@ -595,7 +596,7 @@ private fun loadLibraries(cinteropArguments: CInteropArguments, target: KonanTar
                 }
         )
         platformChecker(KlibPlatformChecker.Native(target.name))
-        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         manifestTransformer(KlibNativeManifestTransformer(target))
     }.load()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -67,6 +67,7 @@ class KonanDriver(
                 configuration.makePerFileCache -> {
                     val result = KlibLoader {
                         libraryPaths(libPath)
+                        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
                         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
                         configuration.zipFileSystemAccessor?.let(::zipFileSystemAccessor)
                     }.load()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_COMPILER_VERSION
 import org.jetbrains.kotlin.library.components.irOrFail
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.uniqueName
@@ -67,7 +68,7 @@ class KonanDriver(
                 configuration.makePerFileCache -> {
                     val result = KlibLoader {
                         libraryPaths(libPath)
-                        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+                        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
                         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
                         configuration.zipFileSystemAccessor?.let(::zipFileSystemAccessor)
                     }.load()

--- a/native/commonizer/tests/org/jetbrains/kotlin/commonizer/utils/metadataCompilation.kt
+++ b/native/commonizer/tests/org/jetbrains/kotlin/commonizer/utils/metadataCompilation.kt
@@ -66,6 +66,7 @@ fun loadStdlibMetadata() = loadStdlibMetadata(KotlinTestUtils.newConfiguration()
 fun loadStdlibMetadata(configuration: CompilerConfiguration): NamedMetadata {
     val kotlinLoaderResult = KlibLoader {
         libraryPaths(stdlibPath())
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
     }.load()
         .apply { reportLoadingProblemsIfAny(configuration, allAsErrors = true) }

--- a/native/commonizer/tests/org/jetbrains/kotlin/commonizer/utils/metadataCompilation.kt
+++ b/native/commonizer/tests/org/jetbrains/kotlin/commonizer/utils/metadataCompilation.kt
@@ -28,9 +28,9 @@ import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.config.phaser.CompilerPhase
 import org.jetbrains.kotlin.config.phaser.PhaseConfig
 import org.jetbrains.kotlin.config.phaser.invokeToplevel
-import org.jetbrains.kotlin.diagnostics.impl.DiagnosticsCollectorImpl
 import org.jetbrains.kotlin.ir.backend.js.moduleName
 import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_COMPILER_VERSION
 import org.jetbrains.kotlin.library.SerializedMetadata
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.name.Name
@@ -66,7 +66,7 @@ fun loadStdlibMetadata() = loadStdlibMetadata(KotlinTestUtils.newConfiguration()
 fun loadStdlibMetadata(configuration: CompilerConfiguration): NamedMetadata {
     val kotlinLoaderResult = KlibLoader {
         libraryPaths(stdlibPath())
-        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED)
+        minPermittedAbiVersion(KotlinAbiVersion.FIRST_SUPPORTED, FIRST_SUPPORTED_COMPILER_VERSION)
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
     }.load()
         .apply { reportLoadingProblemsIfAny(configuration, allAsErrors = true) }


### PR DESCRIPTION
Next step: https://github.com/JetBrains/kotlin/pull/7986