### PR TITLE
[KGP] Don't set BTA arguments that are restricted

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/js/JsBuildOperationFactory.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/js/JsBuildOperationFactory.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.compilerRunner.btapi.js
 
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
-import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsLinkingOperation
@@ -30,6 +29,13 @@ internal class JsKlibBuildOperationFactory(private val compilerArgs: List<String
         val destination = Path(requireNotNull(args.outputDir))
         val compilationOperationBuilder =
             kotlinToolchains.js.jsKlibCompilationOperationBuilder(extractSourceFiles(args.freeArgs), destination)
+
+        args.outputDir = null
+        @Suppress("DEPRECATION")
+        args.irProduceKlibDir = null
+        @Suppress("DEPRECATION")
+        args.irProduceKlibFile = null
+
         compilationOperationBuilder.compilerArguments.applyArgumentStrings(
             args.toArgumentStrings(
                 allowArgFileInValues = false
@@ -51,6 +57,11 @@ internal class JsLinkingBuildOperationFactory(private val compilerArgs: List<Str
         val destination = Path(requireNotNull(args.outputDir))
         val includes = Path(requireNotNull(args.includes))
         val compilationOperationBuilder = kotlinToolchains.js.jsLinkingOperationBuilder(includes, destination)
+
+        args.outputDir = null
+        args.irProduceJs = K2JSCompilerArguments().irProduceJs
+        args.includes = null
+
         compilationOperationBuilder.compilerArguments.applyArgumentStrings(
             args.toArgumentStrings(
                 allowArgFileInValues = false

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/wasm/WasmBuildOperationFactory.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/wasm/WasmBuildOperationFactory.kt
@@ -6,10 +6,10 @@
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
 
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
-import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.wasm.WasmPlatformToolchain.Companion.wasm
 import org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmLinkingOperation
+import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.KotlinWasmCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.compilerRunner.btapi.BuildOperationFactory
@@ -29,6 +29,13 @@ internal class WasmKlibBuildOperationFactory(private val compilerArgs: List<Stri
         val destination = Path(requireNotNull(args.outputDir))
         val compilationOperationBuilder =
             kotlinToolchains.wasm.wasmKlibCompilationOperationBuilder(extractSourceFiles(args.freeArgs), destination)
+
+        args.outputDir = null
+        @Suppress("DEPRECATION")
+        args.irProduceKlibDir = null
+        @Suppress("DEPRECATION")
+        args.irProduceKlibFile = null
+
         compilationOperationBuilder.compilerArguments.applyArgumentStrings(
             args.toArgumentStrings(
                 allowArgFileInValues = false
@@ -50,6 +57,11 @@ internal class WasmLinkingBuildOperationFactory(private val compilerArgs: List<S
         val destination = Path(requireNotNull(args.outputDir))
         val includes = Path(requireNotNull(args.includes))
         val compilationOperationBuilder = kotlinToolchains.wasm.wasmLinkingOperationBuilder(includes, destination)
+
+        args.outputDir = null
+        args.irProduceJs = K2JSCompilerArguments().irProduceJs
+        args.includes = null
+
         compilationOperationBuilder.compilerArguments.applyArgumentStrings(
             args.toArgumentStrings(
                 allowArgFileInValues = false


### PR DESCRIPTION
Arguments became restricted when KT-88299 was fixed, so KGP needs to unset them when compiling using BTA.