### PR TITLE
[K/JS] Fix a broken `when` check on `JsPropertyInitializer` in codegen

### DIFF
--- a/js/js.ast/src/org/jetbrains/kotlin/js/backend/JsToStringGenerationVisitor.kt
+++ b/js/js.ast/src/org/jetbrains/kotlin/js/backend/JsToStringGenerationVisitor.kt
@@ -685,6 +685,7 @@ open class JsToStringGenerationVisitor(
                                 accept(item.valueExpr)
                                 if (wasEnclosed) rightParen()
                             }
+                            null -> {}
                         }
                     }
                 }


### PR DESCRIPTION
Fix a newly added compilation warning in a Java-Kotlin interop usage.

For some reason, the `WHEN_SUBJECT_CAN_BE_NULL_IN_JAVA` warning-as-error wasn't caught during merging of the original PR by a safe merge aggregate, which caused a red master state.