### PR TITLE
[Native][Tests] Gate Objective-C-specific native.tests by test target

### DIFF
--- a/native/native.tests/gc-fuzzing-tests/engine/testFixtures/org/jetbrains/kotlin/konan/test/gcfuzzing/execution/runDSL.kt
+++ b/native/native.tests/gc-fuzzing-tests/engine/testFixtures/org/jetbrains/kotlin/konan/test/gcfuzzing/execution/runDSL.kt
@@ -22,11 +22,9 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.runner.TestRunCheck.Exec
 import org.jetbrains.kotlin.konan.test.blackbox.support.runner.TestRunCheck.ExitCode
 import org.jetbrains.kotlin.konan.test.blackbox.support.runner.TestRunCheck.TestFiltering
 import org.jetbrains.kotlin.konan.test.blackbox.support.runner.TestRunChecks
-import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
 import org.jetbrains.kotlin.konan.test.blackbox.support.util.TestOutputFilter
 import org.jetbrains.kotlin.konan.test.blackbox.support.util.compileWithClang
 import org.jetbrains.kotlin.konan.test.gcfuzzing.dsl.Output
-import org.junit.jupiter.api.Assumptions
 import java.io.File
 import kotlin.time.Duration
 
@@ -40,7 +38,6 @@ fun AbstractNativeSimpleTest.runDSL(
 ) {
     val baseDir = resolveTestBuildDir(testName)
     val dslGeneratedDir = resolveDslDir(testName)
-    Assumptions.assumeTrue(testRunSettings.get<KotlinNativeTargets>().hostTarget.family.isAppleFamily)
     val cinterop = cinteropToLibrary(
         dslGeneratedDir.resolve(dslOutput.cinterop.defFilename),
         baseDir,

--- a/native/native.tests/gc-fuzzing-tests/engine/tests/org/jetbrains/kotlin/konan/test/gcfuzzing/GCFuzzingDSLTest.kt
+++ b/native/native.tests/gc-fuzzing-tests/engine/tests/org/jetbrains/kotlin/konan/test/gcfuzzing/GCFuzzingDSLTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeSimpleTest
 import org.jetbrains.kotlin.konan.test.blackbox.support.ClassLevelProperty
 import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedProperty
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
 import org.jetbrains.kotlin.konan.test.blackbox.support.settings.Timeouts
 import org.jetbrains.kotlin.konan.test.gcfuzzing.dsl.*
 import org.jetbrains.kotlin.konan.test.gcfuzzing.execution.*
@@ -47,7 +48,9 @@ class GCFuzzingDSLTest : AbstractNativeSimpleTest() {
         output.save(dslGeneratedDir)
         val goldenDataDir = testDataDir.resolve(name)
         assertDirectoriesEqual(goldenDataDir, dslGeneratedDir)
-        runDSL(name, output, testRunSettings.get<Timeouts>().executionTimeout)
+        if (testRunSettings.get<KotlinNativeTargets>().testTarget.family.isAppleFamily) {
+            runDSL(name, output, testRunSettings.get<Timeouts>().executionTimeout)
+        }
     }
 
     private inline fun runTest(testInfo: TestInfo, block: () -> Program) = runTest(testInfo.testMethod.get().name, block())

--- a/native/native.tests/gc-fuzzing-tests/tests/org/jetbrains/kotlin/konan/test/gcfuzzing/GCFuzzingTest.kt
+++ b/native/native.tests/gc-fuzzing-tests/tests/org/jetbrains/kotlin/konan/test/gcfuzzing/GCFuzzingTest.kt
@@ -6,8 +6,10 @@
 package org.jetbrains.kotlin.konan.test.gcfuzzing
 
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeSimpleTest
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
 import org.jetbrains.kotlin.konan.test.gcfuzzing.fuzzer.*
 import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.TestFactory
 import java.util.stream.Stream
 import kotlin.time.TimeSource
@@ -19,6 +21,10 @@ class GCFuzzingTest : AbstractNativeSimpleTest() {
 
     @TestFactory
     fun simple(): Stream<DynamicTest> {
+        // GC fuzzing generates and runs an ObjC framework, so avoid creating any
+        // dynamic tests (including a single replay) for non-Apple targets.
+        Assumptions.assumeTrue(testRunSettings.get<KotlinNativeTargets>().testTarget.family.isAppleFamily)
+
         val executeSingleId = System.getProperty("gcfuzzing.single.id")
         if (executeSingleId != null) {
             val id = ProgramId.fromString(executeSingleId) ?: fail("Invalid program ID \"$executeSingleId\"")

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCInteropLibraryAbiReaderTest.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCInteropLibraryAbiReaderTest.kt
@@ -43,6 +43,8 @@ import java.io.File
 @OptIn(ExperimentalLibraryAbiReader::class)
 abstract class AbstractNativeCInteropLibraryAbiReaderTest : AbstractNativeSimpleTest() {
     fun runTest(localPath: String) {
+        assumeTrue(targets.testTarget.family.isAppleFamily) // ObjC tests can run only on Apple targets.
+
         val [sourceFile, dumpFiles] = computeTestFiles(localPath)
         val (moduleName, filters, klibAbiLevel) = parseDirectives(sourceFile)
 
@@ -81,8 +83,6 @@ abstract class AbstractNativeCInteropLibraryAbiReaderTest : AbstractNativeSimple
     }
 
     private fun produceCustomDependencies(sourceFile: File, klibAbiLevel: KlibAbiCompatibilityLevel?): List<TestCompilationArtifact.KLIB> {
-        assumeTrue(targets.hostTarget.family.isAppleFamily) // ObjC tests can run only on Apple targets.
-
         val defFile = sourceFile.withExtension(".def")
         assertTrue(defFile.isFile) { "Def file does not exist: $defFile" }
 

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CompilerOutputTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CompilerOutputTest.kt
@@ -293,7 +293,7 @@ abstract class CompilerOutputTestBase : AbstractNativeSimpleTest() {
     }
 
     private fun doBuildObjCFrameworkWithNameCollisions(rootDir: File, additionalOptions: List<String>): TestCompilationResult<out TestCompilationArtifact.ObjCFramework> {
-        Assumptions.assumeTrue(targets.hostTarget.family.isAppleFamily)
+        Assumptions.assumeTrue(targets.testTarget.family.isAppleFamily)
 
         val settings = testRunSettings
         val lib1 = compileLibrary(settings, rootDir.resolve("lib1.kt")).assertSuccess().resultingArtifact
@@ -322,7 +322,7 @@ abstract class CompilerOutputTestBase : AbstractNativeSimpleTest() {
         name: String,
         modules: Set<TestModule.Exclusive>,
     ) {
-        Assumptions.assumeTrue(targets.hostTarget.family.isAppleFamily)
+        Assumptions.assumeTrue(targets.testTarget.family.isAppleFamily)
         // https://youtrack.jetbrains.com/issue/KT-71097/Kotlin-Native-add-a-flag-to-catch-duplicating-symbols-in-caches
         Assumptions.assumeFalse(testRunSettings.get<CacheMode>().useStaticCacheForUserLibraries)
 

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/MacOSLinkerIncludedUniversalBinariesTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/MacOSLinkerIncludedUniversalBinariesTest.kt
@@ -76,7 +76,7 @@ class MacOSLinkerIncludedUniversalBinariesTest : AbstractNativeSimpleTest() {
         linkingFlags: List<String>,
         expectedMagic: List<Int>,
     ) {
-        Assumptions.assumeTrue(targets.hostTarget.family.isAppleFamily)
+        Assumptions.assumeTrue(targets.testTarget.family.isAppleFamily)
 
         val image = createUniversal(imageType = includedImageType)
 


### PR DESCRIPTION
Mac hosts can run native.tests with a non-Apple target, which must not execute ObjC framework test paths. Gate those paths on an Apple test target while retaining DSL golden-data validation for all targets.

KT-89140