### PR TITLE
[JS, Wasm] fix initialization of `static_init_called` globals ^KT-89144

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/JsInitializersLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/JsInitializersLowering.kt
@@ -21,4 +21,10 @@ import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
 internal class JsInitializersLowering(context: JsIrBackendContext) : InitializersLowering(context)
 
 @PhasePrerequisites(JsInitializersLowering::class)
-internal class JsInitializersCleanupLowering(context: CommonBackendContext) : InitializersCleanupLowering(context)
+internal class JsInitializersCleanupLowering(context: CommonBackendContext) : InitializersCleanupLowering(
+    context,
+    shouldEraseFieldInitializer = {
+        it.correspondingPropertySymbol?.owner?.isConst != true &&
+                it.origin != WebStaticInitializersDeclarationLowering.STATIC_CLASS_INITIALIZER // We need to preserve initializers for `static_init_called` fields (KT-89144).
+    }
+)

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationPopupLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
 import org.jetbrains.kotlin.ir.backend.js.lower.PrimaryConstructorLowering
+import org.jetbrains.kotlin.ir.backend.js.lower.WebStaticInitializersDeclarationLowering
 
 @PhasePrerequisites(
     PrimaryConstructorLowering::class,
@@ -22,6 +23,8 @@ internal class WasmInitializersLowering(context: WasmBackendContext) : Initializ
 @PhasePrerequisites(WasmInitializersLowering::class)
 internal class WasmInitializersCleanupLowering(context: CommonBackendContext) : InitializersCleanupLowering(
     context,
-    // TODO: Remove this hack once https://github.com/JetBrains/kotlin/pull/6165 is merged.
-    shouldEraseFieldInitializer = { it.correspondingPropertySymbol?.owner?.isConst != true && !it.isStatic }
+    shouldEraseFieldInitializer = {
+        it.correspondingPropertySymbol?.owner?.isConst != true &&
+                it.origin != WebStaticInitializersDeclarationLowering.STATIC_CLASS_INITIALIZER // We need to preserve initializers for `static_init_called` fields (KT-89144).
+    }
 )


### PR DESCRIPTION
Currently `static_init_called` in `WebStaticInitializersDeclarationLowering` is created with a `parent = container`. However, as  the container is a Class, the initializer of this field is further removed by `InitializersCleanupLowering` (`JsInitializersCleanupLowering`).

So, `static_init_called` will be `undefined` when the execution first enters `static_init` function.

Wasm currently avoids the problems here because of the [hack](https://github.com/JetBrains/kotlin/blob/9bd824f4a6659ff1c92b4d3491324d406cc36cda/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt#L22-L27) in `WasmInitializersCleanupLowering`. 

1. We need to introduce similar hack for K/JS not to remove initializers for `it.origin == WebStaticInitializersDeclarationLowering.STATIC_CLASS_INITIALIZER`

2. In K/Wasm we need to limit the hack only for `it.origin == WebStaticInitializersDeclarationLowering.STATIC_CLASS_INITIALIZER` variables

This will allow us to do small optimizations and speculations about the state, as in https://github.com/JetBrains/kotlin/pull/7041.

```
val [staticInitCalledField, staticInitFunction] = context.irFactory.stageController.restrictTo(container) {
    val stateField = initializationGenerator.createStateField(
        name = Name.identifier(STATIC_INIT_CALLED_PROPERTY_NAME),
        origin = STATIC_CLASS_INITIALIZER,
    ).apply {
        parent = container
    }
...
```
fixes ^KT-89144