### PR TITLE
[Wasm] inline `suspendCoroutineUninterceptedOrReturnIntrinsic` on the 2nd stage KT-88469

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/BackendWasmSymbols.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/BackendWasmSymbols.kt
@@ -274,6 +274,9 @@ class BackendWasmSymbols(
 
         val createSimpleCoroutineFromSuspendFunction by
         CallableIds.createSimpleCoroutineFromSuspendFunction.functionSymbol()
+
+        val suspendCoroutineUninterceptedOrReturnIntrinsicStateMachine by
+        CallableIds.suspendCoroutineUninterceptedOrReturnIntrinsicStateMachine.functionSymbol()
     }
 
     val createCoroutineUninterceptedIntrinsic0 by CallableIds.createCoroutineUninterceptedIntrinsic0.functionSymbol()
@@ -281,6 +284,8 @@ class BackendWasmSymbols(
 
     val suspendCoroutineUninterceptedOrReturnIntrinsic by
     CallableIds.suspendCoroutineUninterceptedOrReturnIntrinsic.functionSymbol()
+
+    val getCoroutineContextImpl by CallableIds.getCoroutineContextImpl.functionSymbol()
 
     // KProperty implementations
     val kLocalDelegatedPropertyImpl: IrClassSymbol = ClassIds.KLocalDelegatedPropertyImpl.classSymbol()
@@ -633,6 +638,9 @@ private object CallableIds {
 
     val suspendCoroutineUninterceptedOrReturnIntrinsic = "suspendCoroutineUninterceptedOrReturnIntrinsic".wasmCallableId
     val suspendCoroutineUninterceptedOrReturnIntrinsicStackSwitching = "suspendCoroutineUninterceptedOrReturnIntrinsicStackSwitching".wasmCallableId
+    val suspendCoroutineUninterceptedOrReturnIntrinsicStateMachine = "suspendCoroutineUninterceptedOrReturnIntrinsicStateMachine".wasmCallableId
+
+    val getCoroutineContextImpl = "getCoroutineContextImpl".wasmCallableId
 
     val suspendFunction0ToContref = "suspendFunction0ToContref".wasmCallableId
     val suspendFunction1ToContref = "suspendFunction1ToContref".wasmCallableId

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmBackendContext.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmBackendContext.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.phaseConfig
 import org.jetbrains.kotlin.config.phaser.PhaseConfig
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
 import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
@@ -30,6 +29,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFileSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.DescriptorlessExternalPackageFragmentSymbol
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContextImpl
@@ -188,3 +188,10 @@ class WasmBackendContext(
 
     val wasmUseStackSwitching = configuration.wasmUseStackSwitchingProposal
 }
+
+internal val WasmBackendContext.suspendCoroutineUninterceptedOrReturnIntrinsicByMode: IrSimpleFunctionSymbol
+    get() = if (wasmUseStackSwitching) {
+        symbols.coroutinesStackSwitchingIntrinsics!!.suspendCoroutineUninterceptedOrReturnIntrinsicStackSwitching
+    } else {
+        symbols.coroutinesStateMachineIntrinsics!!.suspendCoroutineUninterceptedOrReturnIntrinsicStateMachine
+    }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -92,7 +92,6 @@ val wasmLowerings: List<NamedCompilerPhase<WasmBackendContext, IrModuleFragment,
     ::createSharedVariablesLoweringPhase,
     ::LocalClassesInInlineLambdasLowering,
     ::ArrayConstructorLowering,
-    ::WasmCoroutinesSymbolsResolver,
     ::WasmPrivateFunctionInlining,
     ::OuterThisInInlineFunctionsSpecialAccessorLowering,
     ::createSyntheticAccessorGenerationPhase,
@@ -103,6 +102,8 @@ val wasmLowerings: List<NamedCompilerPhase<WasmBackendContext, IrModuleFragment,
     ::RedundantCastsRemoverLowering,
     ::IrValidationAfterInliningAllFunctionsKlibSecondStagePhase,
     // END: Common Native/JS/Wasm prefix.
+
+    ::WasmCoroutinesSymbolsResolver,
 
     ::createConstEvaluationPhase,
     ::createSpecializeSharedVariableBoxesPhase,

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmCoroutinesSymbolsResolver.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmCoroutinesSymbolsResolver.kt
@@ -49,8 +49,6 @@ private class WasmCoroutinesStackSwitchingIntrinsicsTransformer(
         val realOwner = symbol.owner.resolveFakeOverrideOrSelf()
 
         return when (realOwner.symbol) {
-            wasmSymbols.suspendCoroutineUninterceptedOrReturnIntrinsic ->
-                irCall(expression, stackSwitchingIntrinsics.suspendCoroutineUninterceptedOrReturnIntrinsicStackSwitching)
             wasmSymbols.createCoroutineUninterceptedIntrinsic0 ->
                 irCall(expression, stackSwitchingIntrinsics.createCoroutineUninterceptedIntrinsic0StackSwitching)
             wasmSymbols.createCoroutineUninterceptedIntrinsic1 ->

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmFunctionInlining.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmFunctionInlining.kt
@@ -6,15 +6,83 @@
 package org.jetbrains.kotlin.backend.wasm.lower
 
 import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrContainerExpression
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.inline.FunctionInlining
+import org.jetbrains.kotlin.ir.inline.InlineFunctionResolver
 import org.jetbrains.kotlin.ir.inline.InlineMode
+import org.jetbrains.kotlin.ir.util.resolveFakeOverrideOrSelf
 
-internal class WasmPrivateFunctionInlining(context: WasmBackendContext) : FunctionInlining(
+abstract class WasmFunctionInlining(
+    override val context: WasmBackendContext,
+    inlineFunctionResolver: InlineFunctionResolver,
+) : FunctionInlining(context, inlineFunctionResolver) {
+
+    // Track for containers and maintain a list of variables to be removed.
+    private val containerStack = ArrayDeque<Pair<IrContainerExpression, MutableList<IrVariable>>>()
+
+    override fun visitFunctionAccess(expression: IrFunctionAccessExpression, data: IrDeclaration): IrExpression {
+
+        val symbol = expression.symbol
+        if (!symbol.isBound) return super.visitFunctionAccess(expression, data)
+
+        val realOwner = symbol.owner.resolveFakeOverrideOrSelf()
+        if (realOwner == context.symbols.suspendCoroutineUninterceptedOrReturnIntrinsic.owner) {
+            expression.arguments[0] = unwrapTemporaryVariableChain(expression.arguments[0])
+        }
+
+        return super.visitFunctionAccess(expression, data)
+    }
+
+    // Eliminate IrGetValue chains for temporary variables storing the value of `block` passed to `suspendCoroutineUninterceptedOrReturn`.
+    // Replace temporary variable passed to `suspendCoroutineUninterceptedOrReturnIntrinsic` with the actual block that will be inlined.
+    private fun unwrapTemporaryVariableChain(expression: IrExpression?): IrExpression? {
+        var current = expression
+        while (current is IrGetValue) {
+            val temporary = current.symbol.owner as? IrVariable ?: break
+            current = temporary.initializer
+            addVariableToRemovalList(temporary)
+        }
+        return current
+    }
+
+    // Find the container of a variable and add it to container's removal list (usually only ~1-2 iterations).
+    private fun addVariableToRemovalList(variable: IrVariable) {
+        val it = containerStack.listIterator(containerStack.size)
+        while (it.hasPrevious()) {
+            val prev = it.previous()
+            if (prev.first.statements.contains(variable)) {
+                prev.second.add(variable)
+                return
+            }
+        }
+    }
+
+    override fun visitContainerExpression(expression: IrContainerExpression, data: IrDeclaration): IrExpression {
+        containerStack.addLast(expression to mutableListOf())
+        try {
+            super.visitContainerExpression(expression, data)
+        } finally {
+            containerStack.removeLast().let { [container, vars] ->
+                if (vars.isNotEmpty()) {
+                    container.statements.removeAll(vars)
+                }
+            }
+        }
+        return expression
+    }
+}
+
+internal class WasmPrivateFunctionInlining(context: WasmBackendContext) : WasmFunctionInlining(
     context,
     WasmInlineFunctionResolver(context, inlineMode = InlineMode.PRIVATE_INLINE_FUNCTIONS),
 )
 
-internal class WasmAllFunctionInlining(context: WasmBackendContext) : FunctionInlining(
+internal class WasmAllFunctionInlining(context: WasmBackendContext) : WasmFunctionInlining(
     context,
     WasmInlineFunctionResolver(context, inlineMode = InlineMode.ALL_INLINE_FUNCTIONS),
 )

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmFunctionInlining.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmFunctionInlining.kt
@@ -28,10 +28,7 @@ abstract class WasmFunctionInlining(
     override fun visitFunctionAccess(expression: IrFunctionAccessExpression, data: IrDeclaration): IrExpression {
 
         val symbol = expression.symbol
-        if (!symbol.isBound) return super.visitFunctionAccess(expression, data)
-
-        val realOwner = symbol.owner.resolveFakeOverrideOrSelf()
-        if (realOwner == context.symbols.suspendCoroutineUninterceptedOrReturnIntrinsic.owner) {
+        if (symbol == context.symbols.suspendCoroutineUninterceptedOrReturnIntrinsic) {
             expression.arguments[0] = unwrapTemporaryVariableChain(expression.arguments[0])
         }
 
@@ -64,15 +61,15 @@ abstract class WasmFunctionInlining(
 
     override fun visitContainerExpression(expression: IrContainerExpression, data: IrDeclaration): IrExpression {
         containerStack.addLast(expression to mutableListOf())
-        try {
-            super.visitContainerExpression(expression, data)
-        } finally {
-            containerStack.removeLast().let { [container, vars] ->
-                if (vars.isNotEmpty()) {
-                    container.statements.removeAll(vars)
-                }
+
+        super.visitContainerExpression(expression, data)
+
+        containerStack.removeLast().let { [container, vars] ->
+            if (vars.isNotEmpty()) {
+                container.statements.removeAll(vars)
             }
         }
+
         return expression
     }
 }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInlineFunctionResolver.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInlineFunctionResolver.kt
@@ -5,11 +5,49 @@
 
 package org.jetbrains.kotlin.backend.wasm.lower
 
-import org.jetbrains.kotlin.backend.common.LoweringContext
-import org.jetbrains.kotlin.ir.inline.InlineFunctionResolverReplacingCoroutineIntrinsics
+import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
+import org.jetbrains.kotlin.backend.wasm.suspendCoroutineUninterceptedOrReturnIntrinsicByMode
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.inline.InlineFunctionResolver
 import org.jetbrains.kotlin.ir.inline.InlineMode
+import org.jetbrains.kotlin.ir.overrides.isEffectivelyPrivate
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.util.isBuiltInSuspendCoroutineUninterceptedOrReturn
+import org.jetbrains.kotlin.ir.util.resolveFakeOverrideOrSelf
 
 class WasmInlineFunctionResolver(
-    context: LoweringContext,
-    inlineMode: InlineMode,
-) : InlineFunctionResolverReplacingCoroutineIntrinsics<LoweringContext>(context, inlineMode)
+    private val context: WasmBackendContext,
+    private val inlineMode: InlineMode,
+) : InlineFunctionResolver() {
+    override fun getFunctionDeclaration(symbol: IrFunctionSymbol): IrFunction? {
+        if (!symbol.isBound) return null
+        val realOwner = symbol.owner.resolveFakeOverrideOrSelf()
+
+        // Older klibs (before 2.5.0) contain `suspendCoroutineUninterceptedOrReturn` and  non-inlined.
+        // In newer klibs for K/Wasm (2.5.0 and after), `suspendCoroutineUninterceptedOrReturn` is inlined
+        // and its usages replaced with usages of `suspendCoroutineUninterceptedOrReturnIntrinsic`.
+        // See: libraries/stdlib/wasm/internal/kotlin/wasm/internal/Coroutines.kt
+
+        val isSuspendCoroutineUninterceptedOrReturn =
+            realOwner.isBuiltInSuspendCoroutineUninterceptedOrReturn() ||
+                    realOwner.symbol == context.symbols.suspendCoroutineUninterceptedOrReturnIntrinsic
+
+        // Older klibs (before 2.5.0) contain `getCoroutineContext` and  non-inlined.
+        // In newer klibs for K/Wasm (2.5.0 and after), `getCoroutineContext` is inlined
+        // and its usages replaced with usages of `getCoroutineContextImpl`.
+        // See: libraries/stdlib/wasm/internal/kotlin/wasm/internal/Coroutines.kt
+
+        val isCoroutineContextGetter =
+            realOwner.symbol == context.symbols.coroutineContextGetter || realOwner.symbol == context.symbols.coroutineGetContext
+
+        val result = when {
+            isSuspendCoroutineUninterceptedOrReturn -> context.suspendCoroutineUninterceptedOrReturnIntrinsicByMode.owner
+            isCoroutineContextGetter -> context.symbols.getCoroutineContextImpl.owner
+            realOwner.isInline -> realOwner
+            else -> return null
+        }
+
+        if (inlineMode == InlineMode.PRIVATE_INLINE_FUNCTIONS && !result.isEffectivelyPrivate()) return null
+        return result
+    }
+}

--- a/compiler/ir/ir.inline/src/org/jetbrains/kotlin/ir/inline/FunctionInlining.kt
+++ b/compiler/ir/ir.inline/src/org/jetbrains/kotlin/ir/inline/FunctionInlining.kt
@@ -41,8 +41,8 @@ import java.util.ArrayDeque
 //    InlineCallCycleCheckerLowering::class // only on the first stage
 )
 abstract class FunctionInlining(
-    val context: LoweringContext,
-    private val inlineFunctionResolver: InlineFunctionResolver,
+    open val context: LoweringContext,
+    protected val inlineFunctionResolver: InlineFunctionResolver,
 ) : IrTransformer<IrDeclaration>(), BodyLoweringPass {
     private val fileEntriesStack = ArrayDeque<IrFileEntry>()
 

--- a/compiler/ir/ir.inline/src/org/jetbrains/kotlin/ir/inline/FunctionInlining.kt
+++ b/compiler/ir/ir.inline/src/org/jetbrains/kotlin/ir/inline/FunctionInlining.kt
@@ -42,7 +42,7 @@ import java.util.ArrayDeque
 )
 abstract class FunctionInlining(
     open val context: LoweringContext,
-    protected val inlineFunctionResolver: InlineFunctionResolver,
+    private val inlineFunctionResolver: InlineFunctionResolver,
 ) : IrTransformer<IrDeclaration>(), BodyLoweringPass {
     private val fileEntriesStack = ArrayDeque<IrFileEntry>()
 

--- a/libraries/stdlib/wasm/internal/kotlin/wasm/internal/Coroutines.kt
+++ b/libraries/stdlib/wasm/internal/kotlin/wasm/internal/Coroutines.kt
@@ -27,6 +27,7 @@ internal suspend inline fun getCoroutineContext(): CoroutineContext =
     getCoroutineContextImpl()
 
 @PublishedApi
+@UsedFromCompilerGeneratedCode
 internal suspend fun getCoroutineContextImpl(): CoroutineContext =
     getContinuation<Any?>().context
 

--- a/libraries/stdlib/wasm/internal/kotlin/wasm/internal/Coroutines.kt
+++ b/libraries/stdlib/wasm/internal/kotlin/wasm/internal/Coroutines.kt
@@ -82,3 +82,12 @@ internal fun <T> interceptedIntrinsic(cont: Continuation<T>): Continuation<T> =
 @UsedFromCompilerGeneratedCode
 internal suspend inline fun <T> suspendCoroutineUninterceptedOrReturn(noinline block: (Continuation<T>) -> Any?): T =
     suspendCoroutineUninterceptedOrReturnIntrinsic(block)
+
+// Is replaced by State Machine or Stack Switching implementation
+@Suppress("UNUSED_PARAMETER")
+@PublishedApi
+@UsedFromCompilerGeneratedCode
+internal suspend fun <T> suspendCoroutineUninterceptedOrReturnIntrinsic(block: (Continuation<T>) -> Any?): T =
+    returnIfSuspended<T>(block(getContinuation<T>()))
+    // TODO: replace after bootstrap
+    //throw NotImplementedError("Implementation of suspendCoroutineUninterceptedOrReturnIntrinsic is intrinsic")

--- a/libraries/stdlib/wasm/internal/kotlin/wasm/internal/CoroutinesStackSwitching.kt
+++ b/libraries/stdlib/wasm/internal/kotlin/wasm/internal/CoroutinesStackSwitching.kt
@@ -73,7 +73,7 @@ internal fun <T> checkNotPendingSuspend(blockKotlinContinuation: CoroutineImplSt
 
 @UsedFromCompilerGeneratedCode
 @Suppress("UNCHECKED_CAST")
-internal suspend fun <T> suspendCoroutineUninterceptedOrReturnIntrinsicStackSwitching(block: (Continuation<T>) -> Any?): T {
+internal suspend inline fun <T> suspendCoroutineUninterceptedOrReturnIntrinsicStackSwitching(crossinline block: (Continuation<T>) -> Any?): T {
     val blockKotlinContinuation = getBlockKotlinContinuation<T>()
 
     val blockResult = block(blockKotlinContinuation)

--- a/libraries/stdlib/wasm/internal/kotlin/wasm/internal/CoroutinesStateMachine.kt
+++ b/libraries/stdlib/wasm/internal/kotlin/wasm/internal/CoroutinesStateMachine.kt
@@ -10,8 +10,6 @@ package kotlin.wasm.internal
 import kotlin.coroutines.Continuation
 import kotlin.internal.UsedFromCompilerGeneratedCode
 
-// Is replaced by Stack Switching intrinsic when -Xwasm-use-stack-switching-proposal passed
-@PublishedApi
 @UsedFromCompilerGeneratedCode
-internal suspend fun <T> suspendCoroutineUninterceptedOrReturnIntrinsic(block: (Continuation<T>) -> Any?): T =
+internal suspend inline fun <T> suspendCoroutineUninterceptedOrReturnIntrinsicStateMachine(crossinline block: (Continuation<T>) -> Any?): T =
     returnIfSuspended<T>(block(getContinuation<T>()))


### PR DESCRIPTION
In previous PR https://github.com/JetBrains/kotlin/pull/6603 we removed @DoNotInlineOnFirstStage annotation for `suspendCoroutineUninterceptedOrReturn` and introduced intermediate `suspendCoroutineUninterceptedOrReturnIntrinsic`, so that its internals will not leak into klibs. 

This degraded some coroutine benchmarks. So, here we adapt Wasm Inlining lowerings (2nd stage) to inline `suspendCoroutineUninterceptedOrReturnIntrinsic` calls and suspend blocks (passed to intrinsic). With https://github.com/JetBrains/kotlin/pull/7041 this PR restores K/Wasm coroutines performance.

Also, in this PR we inline `getCoroutineContextImpl` to reduce expected number of suspension points.

Fixes ^KT-88469



----
Regarding discussion of having / not having top-level `suspendCoroutineUninterceptedOrReturn` for K/Wasm non-inline.

Currently, we have typically chains of length 2 of IrGetValue for `block` argument of `suspendCoroutineUninterceptedOrReturn`. Even having only non-inline `suspendCoroutineUninterceptedOrReturn` (replaced with stack switching / state machine implementation), we would have chains of length 1 still needed to be eliminated - easier, but does not eliminate the problem completely.