### PR TITLE
Clear frontend protobuf caches in Native tests

### DIFF
--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCache.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCache.kt
@@ -81,6 +81,11 @@ internal class FirThreadSafeCache<K : Any, V, CONTEXT>(
             else -> withEntry("value", unwrapped.toString())
         }
     }
+
+    @FirCacheInternals
+    override fun clear() {
+        map.clear()
+    }
 }
 
 private val LOG = Logger.getInstance(FirThreadSafeCache::class.java)

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCacheWithPostCompute.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCacheWithPostCompute.kt
@@ -30,4 +30,9 @@ internal class FirThreadSafeCacheWithPostCompute<K : Any, V, CONTEXT, DATA>(
     @FirCacheInternals
     override val cachedValues: Collection<V>
         get() = map.values.mapNotNull { it.getValueIfComputed() }
+
+    @FirCacheInternals
+    override fun clear() {
+        map.clear()
+    }
 }

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCachesFactory.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCachesFactory.kt
@@ -107,4 +107,9 @@ private class FirCaffeineCache<K : Any, V, CONTEXT>(
     @FirCacheInternals
     override val cachedValues: Collection<V>
         get() = cache.asMap().values.mapNotNull { it.nullValueToNull() }
+
+    @FirCacheInternals
+    override fun clear() {
+        cache.invalidateAll()
+    }
 }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/KlibBasedSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/KlibBasedSymbolProvider.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProvider
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.components.metadata
 import org.jetbrains.kotlin.library.metadata.KlibDeserializedContainerSource
+import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
 import org.jetbrains.kotlin.library.metadata.getIncompatibility
 import org.jetbrains.kotlin.library.metadata.parseModuleHeader
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
@@ -48,7 +49,7 @@ class KlibBasedSymbolProvider(
         }
 
 
-    private val moduleHeaders by lazy {
+    private val moduleHeaders: Map<KotlinLibrary, KlibMetadataProtoBuf.Header> by lazy {
         resolvedLibraries.associateWith {
             parseModuleHeader(metadataProvider(it).moduleHeaderData)
         }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataSymbolProvider.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.fir.session
 
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.ThreadSafeMutableState
+import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.createCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.caches.getValue
@@ -41,7 +42,7 @@ class MetadataSymbolProvider(
 
     private val constDeserializer = FirConstDeserializer(BuiltInSerializerProtocol)
 
-    private val metadataTopLevelClassesInPackageCache = session.firCachesFactory.createCache(::findMetadataTopLevelClassesInPackage)
+    private val metadataTopLevelClassesInPackageCache: FirCache<FqName, Set<String>?, Nothing?> = session.firCachesFactory.createCache(::findMetadataTopLevelClassesInPackage)
 
     override fun computePackagePartsInfos(packageFqName: FqName): List<PackagePartsCacheData> {
         return packageAndMetadataPartProvider.findMetadataPackageParts(packageFqName.asString()).mapNotNull { partName ->

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.fir.deserialization
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.caches.FirCache
+import org.jetbrains.kotlin.fir.caches.FirCacheInternals
 import org.jetbrains.kotlin.fir.caches.createCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.caches.getValue
@@ -171,7 +172,7 @@ abstract class AbstractFirDeserializedSymbolProvider(
             getPackageParts(fqName).flatMapTo(mutableSetOf()) { it.typeAliasNameIndex.keys }
         }
 
-    private val packagePartsCache = session.firCachesFactory.createCache(::tryComputePackagePartInfos)
+    private val packagePartsCache: FirCache<FqName, List<PackagePartsCacheData>, Nothing?> = session.firCachesFactory.createCache(::tryComputePackagePartInfos)
 
     private val typeAliasCache: FirCache<ClassId, FirTypeAliasSymbol?, FirNestedTypeAliasDeserializationContext?> =
         session.firCachesFactory.createCacheWithPostCompute(
@@ -193,8 +194,8 @@ abstract class AbstractFirDeserializedSymbolProvider(
             }
         )
 
-    private val functionCache = session.firCachesFactory.createCache(::loadFunctionsByCallableId)
-    private val propertyCache = session.firCachesFactory.createCache(::loadPropertiesByCallableId)
+    private val functionCache: FirCache<CallableId, List<FirNamedFunctionSymbol>, Nothing?> = session.firCachesFactory.createCache(::loadFunctionsByCallableId)
+    private val propertyCache: FirCache<CallableId, List<FirPropertySymbol>, Nothing?> = session.firCachesFactory.createCache(::loadPropertiesByCallableId)
 
     // ------------------------ Abstract members ------------------------
 
@@ -465,5 +466,11 @@ abstract class AbstractFirDeserializedSymbolProvider(
             return clazz
         }
         return getTypeAlias(classId, nestedTypeAliasContext = null) ?: clazz
+    }
+
+    @FirSymbolProviderInternals
+    override fun clearInsignificantCaches() {
+        @OptIn(FirCacheInternals::class)
+        packagePartsCache.clear()
     }
 }

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/deserialization/OptionalAnnotationClassesProvider.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/deserialization/OptionalAnnotationClassesProvider.kt
@@ -46,7 +46,7 @@ class OptionalAnnotationClassesProvider(
         }
     }
 
-    private val optionalAnnotationClassesAndPackages by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    private val optionalAnnotationClassesAndPackages: Pair<MutableMap<ClassId, ClassData>, MutableSet<String>> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val optionalAnnotationClasses = mutableMapOf<ClassId, ClassData>()
         val optionalAnnotationPackages = mutableSetOf<String>()
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/extensions/FirSwitchableExtensionDeclarationsSymbolProvider.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/extensions/FirSwitchableExtensionDeclarationsSymbolProvider.kt
@@ -105,6 +105,11 @@ open class FirSwitchableExtensionDeclarationsSymbolProvider protected constructo
 
     @FirSymbolProviderInternals
     internal fun isDisabled(): Boolean = disabled
+
+    @FirSymbolProviderInternals
+    override fun clearInsignificantCaches() {
+        delegate.clearInsignificantCaches()
+    }
 }
 
 val FirSession.generatedDeclarationsSymbolProvider: FirSwitchableExtensionDeclarationsSymbolProvider? by FirSession.nullableSessionComponentAccessor()

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/FirSymbolProvider.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/FirSymbolProvider.kt
@@ -64,6 +64,14 @@ abstract class FirSymbolProvider(val session: FirSession) : FirSessionComponent 
     abstract fun getTopLevelPropertySymbolsTo(destination: MutableList<FirPropertySymbol>, packageFqName: FqName, name: Name)
 
     abstract fun hasPackage(fqName: FqName): Boolean
+
+    /**
+     * Clears caches which are needed only for performance and not required for proper resolution.
+     * This method should be used only in tests to reduce the memory footprint of providers after
+     * frontend phase is over.
+     */
+    @FirSymbolProviderInternals
+    open fun clearInsignificantCaches() {}
 }
 
 private fun FirSession.getClassDeclaredMemberScope(classId: ClassId): FirScope? {

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirCachingCompositeSymbolProvider.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirCachingCompositeSymbolProvider.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.fir.resolve.providers.impl
 
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.NoMutableState
+import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.createCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.caches.getValue
@@ -33,11 +34,11 @@ class FirCachingCompositeSymbolProvider(
     private val expectedCachesToBeCleanedOnce: Boolean = false,
 ) : FirSymbolProvider(session) {
 
-    private val classLikeCache = session.firCachesFactory.createCache(::computeClass)
-    private val topLevelCallableCache = session.firCachesFactory.createCache(::computeTopLevelCallables)
-    private val topLevelFunctionCache = session.firCachesFactory.createCache(::computeTopLevelFunctions)
-    private val topLevelPropertyCache = session.firCachesFactory.createCache(::computeTopLevelProperties)
-    private val packageCache = session.firCachesFactory.createCache(::computePackage)
+    private val classLikeCache: FirCache<ClassId, FirClassLikeSymbol<*>?, Nothing?> =session.firCachesFactory.createCache(::computeClass)
+    private val topLevelCallableCache: FirCache<CallableId, List<FirCallableSymbol<*>>, Nothing?> = session.firCachesFactory.createCache(::computeTopLevelCallables)
+    private val topLevelFunctionCache: FirCache<CallableId, List<FirNamedFunctionSymbol>, Nothing?> = session.firCachesFactory.createCache(::computeTopLevelFunctions)
+    private val topLevelPropertyCache: FirCache<CallableId, List<FirPropertySymbol>, Nothing?> = session.firCachesFactory.createCache(::computeTopLevelProperties)
+    private val packageCache: FirCache<FqName, Boolean, Nothing?> = session.firCachesFactory.createCache(::computePackage)
 
     override val symbolNamesProvider: FirSymbolNamesProvider = object : FirCompositeCachedSymbolNamesProvider(
         session,
@@ -89,6 +90,7 @@ class FirCachingCompositeSymbolProvider(
 
     // Unfortunately, this is a part of a hack for overcoming the problem of plugin's generated entities
     // (for more details see its usage at org.jetbrains.kotlin.fir.resolve.transformers.plugin.FirCompilerRequiredAnnotationsResolveProcessor.afterPhase)
+    @FirSymbolProviderInternals
     fun createCopyWithCleanCaches(): FirCachingCompositeSymbolProvider {
         require(expectedCachesToBeCleanedOnce) { "Unexpected caches clearing" }
         return FirCachingCompositeSymbolProvider(session, providers, expectedCachesToBeCleanedOnce = false)
@@ -145,4 +147,9 @@ class FirCachingCompositeSymbolProvider(
 
     private fun computeClass(classId: ClassId): FirClassLikeSymbol<*>? =
         providers.firstNotNullOfOrNull { provider -> provider.getClassLikeSymbolByClassId(classId) }
+
+    @FirSymbolProviderInternals
+    override fun clearInsignificantCaches() {
+        providers.forEach { it.clearInsignificantCaches() }
+    }
 }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirCompositeSymbolProvider.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirCompositeSymbolProvider.kt
@@ -53,4 +53,9 @@ class FirCompositeSymbolProvider(session: FirSession, val providers: List<FirSym
     override fun getClassLikeSymbolByClassId(classId: ClassId): FirClassLikeSymbol<*>? {
         return providers.firstNotNullOfOrNull { it.getClassLikeSymbolByClassId(classId) }
     }
+
+    @FirSymbolProviderInternals
+    override fun clearInsignificantCaches() {
+        providers.forEach { it.clearInsignificantCaches() }
+    }
 }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirDelegatingSymbolProvider.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirDelegatingSymbolProvider.kt
@@ -39,4 +39,9 @@ abstract class FirDelegatingSymbolProvider(private val delegate: FirSymbolProvid
     }
 
     override fun hasPackage(fqName: FqName): Boolean = delegate.hasPackage(fqName)
+
+    @FirSymbolProviderInternals
+    override fun clearInsignificantCaches() {
+        delegate.clearInsignificantCaches()
+    }
 }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirCommonDeclarationsMappingCollectingSymbolProvider.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/providers/impl/FirCommonDeclarationsMappingCollectingSymbolProvider.kt
@@ -128,4 +128,10 @@ class FirCommonDeclarationsMappingCollectingSymbolProvider(
             argumentMappingIsEqual = null
         )
     }
+
+    @FirSymbolProviderInternals
+    override fun clearInsignificantCaches() {
+        commonSymbolProvider.clearInsignificantCaches()
+        platformSymbolProvider.clearInsignificantCaches()
+    }
 }

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirCacheWithPostCompute.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirCacheWithPostCompute.kt
@@ -32,6 +32,9 @@ abstract class FirCache<in K : Any, out V, in CONTEXT> {
      */
     @FirCacheInternals
     abstract val cachedValues: Collection<V>
+
+    @FirCacheInternals
+    abstract fun clear()
 }
 
 @Suppress("NOTHING_TO_INLINE")

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirThreadUnsafeCachesFactory.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirThreadUnsafeCachesFactory.kt
@@ -64,6 +64,11 @@ private class FirThreadUnsafeCache<K : Any, V, CONTEXT>(
     @FirCacheInternals
     override val cachedValues: Collection<V>
         get() = map.valuesSnapshot.toList()
+
+    @FirCacheInternals
+    override fun clear() {
+        map.clear()
+    }
 }
 
 private class FirThreadUnsafeCacheWithPostCompute<K : Any, V, CONTEXT, DATA>(
@@ -87,6 +92,11 @@ private class FirThreadUnsafeCacheWithPostCompute<K : Any, V, CONTEXT, DATA>(
     @FirCacheInternals
     override val cachedValues: Collection<V>
         get() = map.valuesSnapshot.toList()
+
+    @FirCacheInternals
+    override fun clear() {
+        map.clear()
+    }
 }
 
 private class FirThreadUnsafeValue<V>(createValue: () -> V) : FirLazyValue<V>() {

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/NullableMap.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/NullableMap.kt
@@ -49,6 +49,10 @@ value class NullableMap<K, V>(
 
     @PrivateForInline
     object NullValue
+
+    fun clear() {
+        map.clear()
+    }
 }
 
 inline fun <K, V> NullableMap<K, V>.getOrPut(key: K, defaultValue: () -> V): V {

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/utils.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/utils.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.test.klib
 
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.LanguageVersion
+import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProviderInternals
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.test.TestInfrastructureInternals
 import org.jetbrains.kotlin.test.builders.RegisteredDirectivesBuilder
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.ALLOW_DANGEROUS_LANGUAGE_VERSION_TESTING
@@ -15,7 +17,10 @@ import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.API_VERSI
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.LANGUAGE
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.LANGUAGE_VERSION
 import org.jetbrains.kotlin.test.directives.model.StringDirective
+import org.jetbrains.kotlin.test.model.FrontendKinds
+import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.test.services.artifactsProvider
 import org.jetbrains.kotlin.test.services.defaultsProvider
 import org.jetbrains.kotlin.test.services.moduleStructure
 import org.junit.jupiter.api.Assumptions
@@ -115,5 +120,18 @@ fun RegisteredDirectivesBuilder.setupCustomLVForKlibForwardCompatibilityTest(sec
                 - 2nd stage compiler default LV: $secondStageCompilerDefaultLanguageVersion
             """.trimIndent()
         )
+    }
+}
+
+/**
+ * Use this function to clear protobuf caches in frontend providers to reduce the
+ * memory footprint of frontend artifacts.
+ */
+fun TestServices.clearFrontendProviderCaches(module: TestModule) {
+    artifactsProvider.getArtifactSafe(module, FrontendKinds.FIR)?.let { output ->
+        output.partsForDependsOnModules.forEach {
+            @OptIn(FirSymbolProviderInternals::class)
+            it.session.symbolProvider.clearInsignificantCaches()
+        }
     }
 }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
@@ -31,12 +31,9 @@ import org.jetbrains.kotlin.test.services.configuration.CommonEnvironmentConfigu
 import org.jetbrains.kotlin.test.services.configuration.NativeFirstStageEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.NativeSecondStageEnvironmentConfigurator
 import org.jetbrains.kotlin.utils.bind
-import org.junit.jupiter.api.Assumptions
 
 abstract class AbstractNativeCodegenBoxCoreTest : AbstractTwoStageNativeCoreTest() {
     override fun configure(builder: TwoStageTestConfigurationBuilder): Unit = with(builder) {
-        Assumptions.abort<Nothing>("temporarily muted because of OOM") // @Disabled annotation does not work on such tests somewhy!!!
-
         super.configure(builder)
         commonConfiguration {
             defaultDirectives {

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/NativeCliBasedFacades.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/NativeCliBasedFacades.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.test.directives.KlibBasedCompilerTestDirectives.SKIP
 import org.jetbrains.kotlin.test.frontend.fir.Fir2IrCliBasedOutputArtifact
 import org.jetbrains.kotlin.test.frontend.fir.Fir2IrCliFacade
 import org.jetbrains.kotlin.test.frontend.fir.FirCliFacade
+import org.jetbrains.kotlin.test.klib.clearFrontendProviderCaches
 import org.jetbrains.kotlin.test.model.*
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.defaultsProvider
@@ -60,6 +61,8 @@ class KlibSerializerNativeCliFacade(
         val input = cliArtifact.withNewDiagnosticCollector(diagnosticsCollector)
         val serializedOutput = NativeIrSerializationPipelinePhase.executePhase(input) ?: return null
         val output = NativeKlibWritingPipelinePhase.executePhase(serializedOutput)
+
+        testServices.clearFrontendProviderCaches(module)
 
         return BinaryArtifacts.KLib(File(output.outputKlibPath), input.configuration.diagnosticsCollector)
     }


### PR DESCRIPTION
I've tested how it affects the memory on a bunch of reasonable size (`org.jetbrains.kotlin.konan.test.blackbox.NativeCodegenBoxTestGenerated.Box.Annotations.Instances`), here are the results:

Before changes:
- used=699.73 MB, committed=1460.00 MB, max=3641.00 MB
- 13956 `PackagePartsCacheData` in 39 providers

After changes:
-  used=680.55 MB, committed=1473.50 MB, max=3641.00 MB
- 274 `PackagePartsCacheData` in 1 provider