### PR TITLE
Cleanup backend by removing usages of features that can't be disabled

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/AbstractClassBuilder.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/AbstractClassBuilder.java
@@ -137,11 +137,11 @@ public abstract class AbstractClassBuilder implements ClassBuilder {
     }
 
     @Override
-    public void visitSMAP(@NotNull SourceMapper smap, boolean backwardsCompatibleSyntax, boolean intoInline, boolean validate) {
+    public void visitSMAP(@NotNull SourceMapper smap, boolean intoInline, boolean validate) {
         // Generate trivial SMAPs for inline functions, since after inlining them they are no longer trivial
         if (GENERATE_SMAP && !(smap.isTrivial() && !intoInline) && !smap.getResultMappings().isEmpty()) {
             List<FileMapping> fileMappings = smap.getResultMappings();
-            visitSource(fileMappings.get(0).getName(), SMAPBuilder.INSTANCE.build(fileMappings, backwardsCompatibleSyntax, validate));
+            visitSource(fileMappings.get(0).getName(), SMAPBuilder.INSTANCE.build(fileMappings, validate));
         } else {
             SourceInfo sourceInfo = smap.getSourceInfo();
             if (sourceInfo == null) return;

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/ClassBuilder.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/ClassBuilder.java
@@ -69,7 +69,7 @@ public interface ClassBuilder {
 
     void visitSource(@NotNull String name, @Nullable String debug);
 
-    void visitSMAP(@NotNull SourceMapper smap, boolean backwardsCompatibleSyntax, boolean intoInline, boolean validate);
+    void visitSMAP(@NotNull SourceMapper smap, boolean intoInline, boolean validate);
 
     void visitOuterClass(@NotNull String owner, @Nullable String name, @Nullable String desc);
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/DelegatingClassBuilder.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/DelegatingClassBuilder.java
@@ -96,8 +96,8 @@ public abstract class DelegatingClassBuilder implements ClassBuilder {
     }
 
     @Override
-    public void visitSMAP(@NotNull SourceMapper smap, boolean backwardsCompatibleSyntax, boolean intoInline, boolean validate) {
-        getDelegate().visitSMAP(smap, backwardsCompatibleSyntax, intoInline, validate);
+    public void visitSMAP(@NotNull SourceMapper smap, boolean intoInline, boolean validate) {
+        getDelegate().visitSMAP(smap, intoInline, validate);
     }
 
     @Override

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.codegen.coroutines.DEBUG_METADATA_ANNOTATION_ASM_TYP
 import org.jetbrains.kotlin.codegen.coroutines.isCoroutineSuperClass
 import org.jetbrains.kotlin.codegen.inline.coroutines.CoroutineTransformer
 import org.jetbrains.kotlin.codegen.inline.coroutines.FOR_INLINE_SUFFIX
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.load.kotlin.FileBasedKotlinClass
 import org.jetbrains.kotlin.load.kotlin.header.KotlinClassHeader
@@ -197,7 +196,6 @@ class AnonymousObjectTransformer(
         if (GENERATE_SMAP && !inliningContext.isInliningLambda) {
             classBuilder.visitSMAP(
                 sourceMapper,
-                !state.config.languageVersionSettings.supportsFeature(LanguageFeature.CorrectSourceMappingSyntax),
                 true,
                 state.config.shouldValidateBytecode
             )

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InternalFinallyBlockInliner.java
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InternalFinallyBlockInliner.java
@@ -74,8 +74,7 @@ public class InternalFinallyBlockInliner extends CoveringTryCatchNodeProcessor {
     public static void processInlineFunFinallyBlocks(
             @NotNull MethodNode inlineFun,
             int lambdaTryCatchBlockNodes,
-            int finallyParamOffset,
-            boolean properFinallySplit
+            int finallyParamOffset
     ) {
         int index = 0;
         List<TryCatchBlockNodeInfo> inlineFunTryBlockInfo = new ArrayList<>();
@@ -89,14 +88,13 @@ public class InternalFinallyBlockInliner extends CoveringTryCatchNodeProcessor {
         }
 
         if (hasFinallyBlocks(inlineFunTryBlockInfo)) {
-            new InternalFinallyBlockInliner(inlineFun, inlineFunTryBlockInfo, localVars, finallyParamOffset, properFinallySplit)
+            new InternalFinallyBlockInliner(inlineFun, inlineFunTryBlockInfo, localVars, finallyParamOffset)
                     .processInlineFunFinallyBlocks();
         }
     }
 
     @NotNull
     private final MethodNode inlineFun;
-    private final boolean properFinallySplit;
 
 
     //lambdaTryCatchBlockNodes is number of TryCatchBlockNodes that was inlined with lambdas into function
@@ -105,12 +103,10 @@ public class InternalFinallyBlockInliner extends CoveringTryCatchNodeProcessor {
             @NotNull MethodNode inlineFun,
             @NotNull List<TryCatchBlockNodeInfo> inlineFunTryBlockInfo,
             @NotNull List<LocalVarNodeWrapper> localVariableInfo,
-            int finallyParamOffset,
-            boolean properFinallySplit
+            int finallyParamOffset
     ) {
         super(finallyParamOffset);
         this.inlineFun = inlineFun;
-        this.properFinallySplit = properFinallySplit;
         for (TryCatchBlockNodeInfo block : inlineFunTryBlockInfo) {
             getTryBlocksMetaInfo().addNewInterval(block);
         }
@@ -268,7 +264,7 @@ public class InternalFinallyBlockInliner extends CoveringTryCatchNodeProcessor {
                 nestedUnsplitBlocksWithoutFinally.addAll(clusterBlocks);
 
                 updateExceptionTable(
-                        properFinallySplit ? nestedUnsplitBlocksWithoutFinally : clusterBlocks, newFinallyStart, newFinallyEnd,
+                        nestedUnsplitBlocksWithoutFinally, newFinallyStart, newFinallyEnd,
                         tryCatchBlockInlinedInFinally, labelsInsideFinallyOldToNew, insertedBlockEnd
                 );
                 nestedUnsplitBlocksWithoutFinally.clear();

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.codegen.optimization.fixStack.*
 import org.jetbrains.kotlin.codegen.optimization.nullCheck.isCheckParameterIsNotNull
 import org.jetbrains.kotlin.codegen.optimization.temporaryVals.TemporaryVariablesEliminationTransformer
 import org.jetbrains.kotlin.codegen.pseudoInsns.PseudoInsn
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.kotlin.utils.SmartList
@@ -54,7 +53,6 @@ class MethodInliner(
     private val defaultMaskEnd: Int = -1,
     private val skipLineNumbers: Boolean = false,
 ) {
-    private val languageVersionSettings = inliningContext.state.config.languageVersionSettings
     private val invokeCalls = ArrayList<InvokeCall>()
     private val anonymousObjectCapturedFieldsByConstructorArgumentCache = hashMapOf<String, List<String?>>()
 
@@ -128,8 +126,7 @@ class MethodInliner(
         if (inliningContext.isRoot) {
             val remapValue = remapper.remap(parameters.argsSizeOnStack + 1).value
             InternalFinallyBlockInliner.processInlineFunFinallyBlocks(
-                resultNode, lambdasFinallyBlocks, (remapValue as StackValue.Local).index,
-                languageVersionSettings.supportsFeature(LanguageFeature.ProperFinally)
+                resultNode, lambdasFinallyBlocks, (remapValue as StackValue.Local).index
             )
         }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAPBuilder.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAPBuilder.kt
@@ -16,7 +16,7 @@ import java.util.*
 import kotlin.math.max
 
 object SMAPBuilder {
-    fun build(fileMappings: List<FileMapping>, backwardsCompatibleSyntax: Boolean, validate: Boolean): String? {
+    fun build(fileMappings: List<FileMapping>, validate: Boolean): String? {
         if (fileMappings.isEmpty()) {
             return null
         }
@@ -38,15 +38,8 @@ object SMAPBuilder {
             }
         }
 
-        // Old versions of kotlinc and the IDEA plugin have incorrect implementations of SMAPParser:
-        //   1. they require *E between strata, which is not correct syntax according to JSR-045;
-        //   2. in KotlinDebug, they use `1#2,3:4` to mean "map lines 4..6 to line 1 of #2", when in reality (and in
-        //      the non-debug stratum) this maps lines 4..6 to lines 1..3. The correct syntax is `1#2:4,3`.
         val defaultStrata = fileMappings.toSMAP(KOTLIN_STRATA_NAME, mapToFirstLine = false)
-        val debugStrata = debugMappings.values.toSMAP(KOTLIN_DEBUG_STRATA_NAME, mapToFirstLine = !backwardsCompatibleSyntax)
-        if (backwardsCompatibleSyntax && defaultStrata.isNotEmpty() && debugStrata.isNotEmpty()) {
-            return "SMAP\n${fileMappings[0].name}\n$KOTLIN_STRATA_NAME\n$defaultStrata${SMAP.END}\n$debugStrata${SMAP.END}\n"
-        }
+        val debugStrata = debugMappings.values.toSMAP(KOTLIN_DEBUG_STRATA_NAME, mapToFirstLine = true)
         return "SMAP\n${fileMappings[0].name}\n$KOTLIN_STRATA_NAME\n$defaultStrata$debugStrata${SMAP.END}\n"
     }
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
@@ -62,9 +62,6 @@ class JvmBackendConfig(configuration: CompilerConfiguration) {
 
     val generateSmapCopyToAnnotation: Boolean = !configuration.getBoolean(JVMConfigurationKeys.NO_SOURCE_DEBUG_EXTENSION)
 
-    val functionsWithInlineClassReturnTypesMangled: Boolean =
-        languageVersionSettings.supportsFeature(LanguageFeature.MangleClassMembersReturningInlineClasses)
-
     val shouldValidateBytecode: Boolean = configuration.getBoolean(JVMConfigurationKeys.VALIDATE_BYTECODE)
 
     val classFileVersion: Int = run {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
@@ -53,11 +53,9 @@ class JvmBackendConfig(configuration: CompilerConfiguration) {
         languageVersionSettings.apiVersion >= ApiVersion.KOTLIN_1_4 &&
                 !configuration.getBoolean(JVMConfigurationKeys.NO_UNIFIED_NULL_CHECKS)
 
-    val noSourceCodeInNotNullAssertionExceptions: Boolean =
-        (languageVersionSettings.supportsFeature(LanguageFeature.NoSourceCodeInNotNullAssertionExceptions)
-                // This check is needed because we generate calls to `Intrinsics.checkNotNull` which is only available since 1.4
-                // (when unified null checks were introduced).
-                && unifiedNullChecks)
+    val noSourceCodeInNotNullAssertionExceptions =
+        // We generate `Intrinsics.checkNotNull` calls which are only available since 1.4 (when unified null checks were introduced)
+        unifiedNullChecks
                 // Never generate source code in assertion exceptions in K2 to make behavior of FIR PSI & FIR light-tree equivalent
                 // (obtaining source code is not supported in light tree).
                 || languageVersionSettings.languageVersion.usesK2

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
@@ -25,11 +25,7 @@ class JvmBackendConfig(configuration: CompilerConfiguration) {
         else JvmStringConcat.INLINE
 
     val samConversionsScheme: JvmClosureGenerationScheme =
-        configuration.get(JVMConfigurationKeys.SAM_CONVERSIONS)
-            ?: if (languageVersionSettings.supportsFeature(LanguageFeature.SamWrapperClassesAreSynthetic))
-                JvmClosureGenerationScheme.INDY
-            else
-                JvmClosureGenerationScheme.CLASS
+        configuration.get(JVMConfigurationKeys.SAM_CONVERSIONS) ?: JvmClosureGenerationScheme.INDY
 
     val lambdasScheme: JvmClosureGenerationScheme =
         configuration.get(JVMConfigurationKeys.LAMBDAS)

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
@@ -74,8 +74,6 @@ class JvmBackendConfig(configuration: CompilerConfiguration) {
 
     val generateParametersMetadata: Boolean = configuration.getBoolean(JVMConfigurationKeys.PARAMETERS_METADATA)
 
-    val shouldInlineConstVals: Boolean = languageVersionSettings.supportsFeature(LanguageFeature.InlineConstVals)
-
     val jvmDefaultMode: JvmDefaultMode = languageVersionSettings.jvmDefaultMode
 
     val disableOptimization: Boolean = configuration.getBoolean(JVMConfigurationKeys.DISABLE_OPTIMIZATION)

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/JvmBackendConfig.kt
@@ -42,8 +42,7 @@ class JvmBackendConfig(configuration: CompilerConfiguration) {
 
     val isCallAssertionsDisabled: Boolean = configuration.getBoolean(JVMConfigurationKeys.DISABLE_CALL_ASSERTIONS)
     val isReceiverAssertionsDisabled: Boolean =
-        configuration.getBoolean(JVMConfigurationKeys.DISABLE_RECEIVER_ASSERTIONS) ||
-                !languageVersionSettings.supportsFeature(LanguageFeature.NullabilityAssertionOnExtensionReceiver)
+        configuration.getBoolean(JVMConfigurationKeys.DISABLE_RECEIVER_ASSERTIONS)
     val isParamAssertionsDisabled: Boolean = configuration.getBoolean(JVMConfigurationKeys.DISABLE_PARAM_ASSERTIONS)
 
     val assertionsMode: JVMAssertionsMode = configuration.get(JVMConfigurationKeys.ASSERTIONS_MODE, JVMAssertionsMode.DEFAULT)

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -689,12 +689,11 @@ private fun IrField.computeFieldFlags(context: JvmBackendContext, languageVersio
             (if (hasAnnotation(VOLATILE_ANNOTATION_FQ_NAME)) Opcodes.ACC_VOLATILE else 0) or
             (if (hasAnnotation(TRANSIENT_ANNOTATION_FQ_NAME)) Opcodes.ACC_TRANSIENT else 0) or
             (if (hasAnnotation(JVM_SYNTHETIC_ANNOTATION_FQ_NAME) ||
-                isPrivateCompanionFieldInInterface(languageVersionSettings)
+                isPrivateCompanionFieldInInterface()
             ) Opcodes.ACC_SYNTHETIC else 0)
 
-private fun IrField.isPrivateCompanionFieldInInterface(languageVersionSettings: LanguageVersionSettings): Boolean =
+private fun IrField.isPrivateCompanionFieldInInterface(): Boolean =
     origin == IrDeclarationOrigin.FIELD_FOR_OBJECT_INSTANCE &&
-            languageVersionSettings.supportsFeature(LanguageFeature.ProperVisibilityForCompanionObjectInstanceField) &&
             parentAsClass.isJvmInterface &&
             DescriptorVisibilities.isPrivate(parentAsClass.companionObject()!!.visibility)
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -655,7 +655,7 @@ private fun IrClass.getFlags(languageVersionSettings: LanguageVersionSettings): 
     origin.flags or
             getVisibilityAccessFlagForClass() or
             (if (isAnnotatedWithDeprecated) Opcodes.ACC_DEPRECATED else 0) or
-            getSynthAccessFlag(languageVersionSettings) or
+            getSynthAccessFlag() or
             when {
                 isAnnotationClass -> Opcodes.ACC_ANNOTATION or Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT
                 isInterface -> Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT
@@ -664,12 +664,10 @@ private fun IrClass.getFlags(languageVersionSettings: LanguageVersionSettings): 
                 else -> Opcodes.ACC_SUPER or modality.flags
             }.let { if (isKotlinValhallaValueClass(languageVersionSettings)) it and ACC_IDENTITY.inv() else it }
 
-private fun IrClass.getSynthAccessFlag(languageVersionSettings: LanguageVersionSettings): Int {
+private fun IrClass.getSynthAccessFlag(): Int {
     if (hasAnnotation(JVM_SYNTHETIC_ANNOTATION_FQ_NAME))
         return Opcodes.ACC_SYNTHETIC
-    if (origin == IrDeclarationOrigin.GENERATED_SAM_IMPLEMENTATION &&
-        languageVersionSettings.supportsFeature(LanguageFeature.SamWrapperClassesAreSynthetic)
-    )
+    if (origin == IrDeclarationOrigin.GENERATED_SAM_IMPLEMENTATION)
         return Opcodes.ACC_SYNTHETIC
     return 0
 }

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -187,7 +187,6 @@ class ClassCodegen private constructor(
 
         visitor.visitSMAP(
             smap,
-            !config.languageVersionSettings.supportsFeature(LanguageFeature.CorrectSourceMappingSyntax),
             parentFunction != null && parentFunction.isInline,
             config.shouldValidateBytecode
         )

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -152,10 +152,7 @@ class ClassCodegen private constructor(
         if (shouldSkipCodeGenerationAccordingToGenerationFilter()) return
 
         // Generate PermittedSubclasses attribute for sealed class.
-        if (config.languageVersionSettings.supportsFeature(LanguageFeature.JvmPermittedSubclassesAttributeForSealed) &&
-            irClass.modality == Modality.SEALED &&
-            config.target >= JvmTarget.JVM_17
-        ) {
+        if (irClass.modality == Modality.SEALED && config.target >= JvmTarget.JVM_17) {
             generatePermittedSubclasses()
         }
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/CoroutineCodegen.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.backend.jvm.ir.isInlineClass
 import org.jetbrains.kotlin.backend.jvm.unboxInlineClass
 import org.jetbrains.kotlin.codegen.ClassBuilder
 import org.jetbrains.kotlin.codegen.coroutines.CoroutineTransformerMethodVisitor
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.at
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
@@ -36,9 +35,6 @@ internal fun MethodNode.acceptWithStateMachine(
     obtainContinuationClassBuilder: () -> ClassBuilder,
 ) {
     val context = classCodegen.context
-    val languageVersionSettings = context.config.languageVersionSettings
-    assert(languageVersionSettings.supportsFeature(LanguageFeature.ReleaseCoroutines)) { "Experimental coroutines are unsupported in JVM_IR backend" }
-
     val lineNumber = if (irFunction.startOffset >= 0) {
         // if it suspend function like `suspend fun foo(...)`
         irFunction.file.fileEntry.getLineNumber(irFunction.startOffset) + 1

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -1427,10 +1427,8 @@ class ExpressionCodegen(
 
         val gapEnd = afterJumpLabel ?: endOfFinallyCode
         tryWithFinallyInfo.gaps.add(gapStart to gapEnd)
-        if (config.languageVersionSettings.supportsFeature(LanguageFeature.ProperFinally)) {
-            for (it in nestedTryWithoutFinally) {
-                it.gaps.add(gapStart to gapEnd)
-            }
+        for (it in nestedTryWithoutFinally) {
+            it.gaps.add(gapStart to gapEnd)
         }
     }
 

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -393,7 +393,7 @@ class ExpressionCodegen(
         // If the parameter is an extension receiver parameter or a captured extension receiver from enclosing,
         // then generate name accordingly.
         val name = if (param.origin == BOUND_RECEIVER_PARAMETER || param.origin == IrDeclarationOrigin.LAMBDA_EXTENSION_RECEIVER || isReceiver) {
-            getNameForReceiverParameter(irFunction, context.config.languageVersionSettings)
+            getNameForReceiverParameter(irFunction)
         } else {
             param.name.asString()
         }
@@ -405,11 +405,7 @@ class ExpressionCodegen(
         )
     }
 
-    private fun getNameForReceiverParameter(function: IrFunction, languageVersionSettings: LanguageVersionSettings): String {
-        if (!languageVersionSettings.supportsFeature(LanguageFeature.NewCapturedReceiverFieldNamingConvention)) {
-            return RECEIVER_PARAMETER_NAME
-        }
-
+    private fun getNameForReceiverParameter(function: IrFunction): String {
         val callableName = function.propertyIfAccessor.name
         if (callableName.isSpecial) {
             return RECEIVER_PARAMETER_NAME

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -804,10 +804,8 @@ class ExpressionCodegen(
 
     override fun visitFieldAccess(expression: IrFieldAccessExpression, data: BlockInfo): PromisedValue {
         val callee = expression.symbol.owner
-        if (context.config.shouldInlineConstVals) {
-            // Const fields should only have reads, and those should have been transformed by ConstLowering.
-            assert(callee.constantValue() == null) { "access of const val: ${expression.dump()}" }
-        }
+        // Const fields should only have reads, and those should have been transformed by ConstLowering.
+        assert(callee.constantValue() == null) { "access of const val: ${expression.dump()}" }
 
         val isStatic = expression.receiver == null
         expression.markLineNumber(startOffset = true)

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -402,7 +402,7 @@ private fun generateParameterNames(irFunction: IrFunction, mv: MethodVisitor, co
         val name = when (parameter.kind) {
             IrParameterKind.DispatchReceiver -> continue
             IrParameterKind.Regular, IrParameterKind.Context -> parameter.name.asString()
-            IrParameterKind.ExtensionReceiver -> irFunction.extensionReceiverName(config)
+            IrParameterKind.ExtensionReceiver -> irFunction.extensionReceiverName()
         }
         val origin = parameter.origin
         // A construct emitted by a Java compiler must be marked as synthetic if it does not correspond to a construct declared

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -274,9 +274,7 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
     }
 
     private fun getThrownExceptions(function: IrFunction): List<String>? {
-        if (context.config.languageVersionSettings.supportsFeature(LanguageFeature.DoNotGenerateThrowsForDelegatedKotlinMembers) &&
-            function.origin == IrDeclarationOrigin.DELEGATED_MEMBER
-        ) return null
+        if (function.origin == IrDeclarationOrigin.DELEGATED_MEMBER) return null
 
         // @Throws(vararg exceptionClasses: KClass<out Throwable>)
         val exceptionClasses = function.getAnnotation(JVM_THROWS_ANNOTATION_FQ_NAME)?.argumentMapping[Name.identifier("exceptionClasses")] ?: return null

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/CompareTo.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/CompareTo.kt
@@ -19,12 +19,10 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 import com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.backend.jvm.JvmSymbols
 import org.jetbrains.kotlin.backend.jvm.codegen.*
-import org.jetbrains.kotlin.backend.jvm.ir.isSmartcastFromHigherThanNullable
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.AsmUtil.comparisonOperandType
 import org.jetbrains.kotlin.codegen.NumberComparisonUtils
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.util.receiverAndArgs
@@ -226,15 +224,6 @@ class PrimitiveComparison(
         val a = left.accept(codegen, data).materializedAt(parameterType, left.type)
         val b = right.accept(codegen, data).materializedAt(parameterType, right.type)
 
-        val useNonIEEE754Comparison =
-            !codegen.context.config.languageVersionSettings.supportsFeature(LanguageFeature.ProperIeee754Comparisons)
-                    && (parameterType == Type.FLOAT_TYPE || parameterType == Type.DOUBLE_TYPE)
-                    && (left.isSmartcastFromHigherThanNullable(codegen.context) || right.isSmartcastFromHigherThanNullable(codegen.context))
-
-        return if (useNonIEEE754Comparison) {
-            NonIEEE754FloatComparison(expression, operatorToken, a, b)
-        } else {
-            BooleanComparison(expression, operatorToken, a, b)
-        }
+        return BooleanComparison(expression, operatorToken, a, b)
     }
 }

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/Equals.kt
@@ -8,14 +8,12 @@ package org.jetbrains.kotlin.backend.jvm.intrinsics
 import com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.backend.jvm.codegen.*
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClass
-import org.jetbrains.kotlin.backend.jvm.ir.isSmartcastFromHigherThanNullable
 import org.jetbrains.kotlin.backend.jvm.mapping.mapTypeAsDeclaration
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.AsmUtil.isPrimitive
 import org.jetbrains.kotlin.codegen.NumberComparisonUtils
 import org.jetbrains.kotlin.codegen.intrinsics.IntrinsicMethods
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.IrType
@@ -213,14 +211,7 @@ class Ieee754Equals(val operandType: Type) : CallBasedIntrinsicMethod() {
         val arg0isNullable = arg0.type.isNullable()
         val arg1isNullable = arg1.type.isNullable()
 
-        val useNonIEEE754Comparison =
-            !classCodegen.context.config.languageVersionSettings.supportsFeature(LanguageFeature.ProperIeee754Comparisons)
-                    && (arg0.isSmartcastFromHigherThanNullable(classCodegen.context) || arg1.isSmartcastFromHigherThanNullable(classCodegen.context))
-
         return when {
-            useNonIEEE754Comparison ->
-                Ieee754AreEqual(AsmTypes.OBJECT_TYPE, AsmTypes.OBJECT_TYPE)
-
             !arg0isNullable && !arg1isNullable ->
                 Ieee754Primitives()
 

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/EnumClassLowering.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
 import org.jetbrains.kotlin.backend.jvm.ir.irArray
 import org.jetbrains.kotlin.backend.jvm.ir.javaClassReference
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
@@ -78,11 +77,10 @@ internal class EnumClassLowering(private val context: JvmBackendContext) : Class
 
     override fun lower(irClass: IrClass) {
         if (!irClass.isEnumClass) return
-        // Also protected by API version check as it relies on EnumEntries in standard library
-        EnumClassTransformer(irClass, context.config.languageVersionSettings.supportsFeature(LanguageFeature.EnumEntries)).run()
+        EnumClassTransformer(irClass).run()
     }
 
-    private inner class EnumClassTransformer(private val irClass: IrClass, private val supportsEnumEntries: Boolean) {
+    private inner class EnumClassTransformer(private val irClass: IrClass) {
         private val loweredEnumConstructors = hashMapOf<IrConstructorSymbol, IrConstructor>()
         private val loweredEnumConstructorParameters = hashMapOf<IrValueParameterSymbol, IrValueParameter>()
         private val enumEntryOrdinals = hashMapOf<IrEnumEntry, Int>()
@@ -106,18 +104,8 @@ internal class EnumClassLowering(private val context: JvmBackendContext) : Class
             // Construct the synthetic $VALUES field, which contains an array of all enum entries by calling $values()
             val valuesField = buildValuesField(valuesHelperFunction)
 
-            val entriesField = when {
-                !irClass.hasGetEntriesFunction -> {
-                    null
-                }
-                !supportsEnumEntries -> {
-                    error("The frontend must have checked if the feature is supported while emitting the IR")
-                }
-                else -> {
-                    // Add synthetic $ENTRIES field and bind its initializer to `EnumEntries($VALUES)`.
-                    buildEntriesField(valuesField)
-                }
-            }
+            // Add synthetic $ENTRIES field and bind its initializer to `EnumEntries($VALUES)`.
+            val entriesField = if (irClass.hasGetEntriesFunction) buildEntriesField(valuesField) else null
 
             // Add synthetic parameters to enum constructors and implement the values and valueOf functions
             irClass.transformChildrenVoid(EnumClassDeclarationsTransformer(valuesField, entriesField))

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/EnumExternalEntriesLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/EnumExternalEntriesLowering.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.findEnumValuesFunction
 import org.jetbrains.kotlin.backend.jvm.ir.isEnumClassWhichRequiresExternalEntries
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.declarations.addField
 import org.jetbrains.kotlin.ir.builders.declarations.buildClass
@@ -62,9 +61,6 @@ import org.jetbrains.kotlin.name.SpecialNames
 internal class EnumExternalEntriesLowering(private val context: JvmBackendContext) :
     FileLoweringPass, IrElementTransformerVoidWithContext() {
     override fun lower(irFile: IrFile) {
-        if (!context.config.languageVersionSettings.supportsFeature(LanguageFeature.EnumEntries)) {
-            return
-        }
         irFile.transformChildrenVoid(this)
     }
 

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
@@ -829,8 +829,8 @@ internal class JvmInlineClassLowering(private val context: JvmBackendContext) : 
 
     private fun IrFunction.hashSuffix(): String? = InlineClassAbi.hashSuffix(
         this,
-        context.config.functionsWithInlineClassReturnTypesMangled,
-        context.config.useOldManglingSchemeForFunctionsWithInlineClassesInSignatures
+        mangleReturnTypes = true,
+        useOldMangleRules = context.config.useOldManglingSchemeForFunctionsWithInlineClassesInSignatures
     )
 
     private fun transformSimpleFunctionFlat(function: IrSimpleFunction, replacement: IrSimpleFunction): List<IrDeclaration> {
@@ -959,9 +959,7 @@ internal class JvmInlineClassLowering(private val context: JvmBackendContext) : 
 
     private fun IrSimpleFunction.signatureRequiresMangling(): Boolean {
         if (shouldBeExposedByAnnotationOrFlag(context)) return false
-        return nonDispatchParameters.any { it.type.getRequiresMangling() } ||
-                context.config.functionsWithInlineClassReturnTypesMangled &&
-                returnType.getRequiresMangling()
+        return nonDispatchParameters.any { it.type.getRequiresMangling() } || returnType.getRequiresMangling()
     }
 
     // forbid other overrides without modifying dispatcher file JvmValueClassLoweringDispatcher.kt

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOverloadsAnnotationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmOverloadsAnnotationLowering.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.declarations.buildConstructor
@@ -127,9 +126,7 @@ internal class JvmOverloadsAnnotationLowering(val context: JvmBackendContext) : 
                 origin = JvmLoweredDeclarationOrigin.JVM_OVERLOADS_WRAPPER
                 name = oldFunction.name
                 visibility = oldFunction.visibility
-                modality =
-                    if (context.config.languageVersionSettings.supportsFeature(LanguageFeature.GenerateJvmOverloadsAsFinal)) Modality.FINAL
-                    else oldFunction.modality
+                modality = Modality.FINAL
                 returnType = oldFunction.returnType
                 isInline = false
                 isSuspend = oldFunction.isSuspend

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmPropertiesLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmPropertiesLowering.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.getRequiresMangling
 import org.jetbrains.kotlin.backend.jvm.hasMangledReturnType
 import org.jetbrains.kotlin.backend.jvm.ir.needsAccessor
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility
@@ -218,19 +217,14 @@ internal class JvmPropertiesLowering(
             )
 
         private fun JvmBackendContext.computeSyntheticMethodName(property: IrProperty, suffix: String): String {
-            val baseName =
-                if (config.languageVersionSettings.supportsFeature(LanguageFeature.UseGetterNameForPropertyAnnotationsMethodOnJvm)) {
-                    val getter = property.getter
-                    if (getter != null) {
-                        val needsMangling =
-                            getter.nonDispatchParameters.any { it.type.getRequiresMangling() } ||
-                                    (config.functionsWithInlineClassReturnTypesMangled && getter.hasMangledReturnType)
-                        val mangled = if (needsMangling) inlineClassReplacements.getReplacementFunction(getter) else null
-                        defaultMethodSignatureMapper.mapFunctionName(mangled ?: getter)
-                    } else JvmAbi.getterName(property.name.asString())
-                } else {
-                    property.name.asString()
-                }
+            val getter = property.getter
+            val baseName = if (getter != null) {
+                val needsMangling =
+                    getter.nonDispatchParameters.any { it.type.getRequiresMangling() } ||
+                            (config.functionsWithInlineClassReturnTypesMangled && getter.hasMangledReturnType)
+                val mangled = if (needsMangling) inlineClassReplacements.getReplacementFunction(getter) else null
+                defaultMethodSignatureMapper.mapFunctionName(mangled ?: getter)
+            } else JvmAbi.getterName(property.name.asString())
             return baseName + suffix
         }
     }

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmPropertiesLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmPropertiesLowering.kt
@@ -220,8 +220,7 @@ internal class JvmPropertiesLowering(
             val getter = property.getter
             val baseName = if (getter != null) {
                 val needsMangling =
-                    getter.nonDispatchParameters.any { it.type.getRequiresMangling() } ||
-                            (config.functionsWithInlineClassReturnTypesMangled && getter.hasMangledReturnType)
+                    getter.nonDispatchParameters.any { it.type.getRequiresMangling() } || getter.hasMangledReturnType
                 val mangled = if (needsMangling) inlineClassReplacements.getReplacementFunction(getter) else null
                 defaultMethodSignatureMapper.mapFunctionName(mangled ?: getter)
             } else JvmAbi.getterName(property.name.asString())

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmTailrecLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmTailrecLowering.kt
@@ -8,16 +8,12 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.lower.TailrecLowering
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.ir.defaultValue
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrRichFunctionReference
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.types.IrType
 
 internal class JvmTailrecLowering(context: JvmBackendContext) : TailrecLowering(context) {
-    override val useProperComputationOrderOfTailrecDefaultParameters: Boolean =
-        context.config.languageVersionSettings.supportsFeature(LanguageFeature.ProperComputationOrderOfTailrecDefaultParameters)
-
     override fun followRichFunctionReference(reference: IrRichFunctionReference): Boolean =
         reference.origin == IrStatementOrigin.INLINE_LAMBDA
 

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/MainMethodGenerationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/MainMethodGenerationLowering.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.getJvmNameFromAnnotation
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
@@ -61,7 +60,6 @@ import org.jetbrains.kotlin.types.Variance
 @PhasePrerequisites(JvmOverloadsAnnotationLowering::class)
 internal class MainMethodGenerationLowering(private val context: JvmBackendContext) : ClassLoweringPass {
     override fun lower(irClass: IrClass) {
-        if (!context.config.languageVersionSettings.supportsFeature(LanguageFeature.ExtendedMainConvention)) return
         if (!irClass.isFileClass) return
 
         irClass.functions.find { it.isMainMethod() }?.let { mainMethod ->

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ObjectClassLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ObjectClassLowering.kt
@@ -8,10 +8,6 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.ir.addJavaLangDeprecatedAnnotation
-import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
-import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irExprBody
 import org.jetbrains.kotlin.ir.builders.irGetField
@@ -53,16 +49,6 @@ internal class ObjectClassLowering(val context: JvmBackendContext) : ClassLoweri
         } else {
             with(context.createIrBuilder(publicInstanceField.symbol)) {
                 publicInstanceField.initializer = irExprBody(irCall(constructor.symbol))
-            }
-        }
-
-        // Mark object instance field as deprecated if the object visibility is private or protected,
-        // and ProperVisibilityForCompanionObjectInstanceField language feature is not enabled.
-        if (!context.config.languageVersionSettings.supportsFeature(LanguageFeature.ProperVisibilityForCompanionObjectInstanceField) &&
-            (irClass.visibility == DescriptorVisibilities.PRIVATE || irClass.visibility == DescriptorVisibilities.PROTECTED)
-        ) {
-            with(context.createJvmIrBuilder(irClass.symbol)) {
-                publicInstanceField.addJavaLangDeprecatedAnnotation()
             }
         }
 

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PolymorphicSignatureLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PolymorphicSignatureLowering.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
@@ -52,8 +51,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.assignFrom
 internal class PolymorphicSignatureLowering(val context: JvmBackendContext) : IrTransformer<PolymorphicSignatureLowering.Data>(),
     FileLoweringPass {
     override fun lower(irFile: IrFile) {
-        if (context.config.languageVersionSettings.supportsFeature(LanguageFeature.PolymorphicSignature))
-            irFile.transformChildren(this, Data(null))
+        irFile.transformChildren(this, Data(null))
     }
 
     class Data(val coerceToType: IrType?) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -89,7 +89,7 @@ class JvmBackendContext(
 
     override val configuration get() = state.configuration
 
-    val inlineClassReplacements = MemoizedInlineClassReplacements(config.functionsWithInlineClassReturnTypesMangled, irFactory, this)
+    val inlineClassReplacements = MemoizedInlineClassReplacements(irFactory = irFactory, context = this)
 
     val inlineMethodGenerationLock = Any()
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
@@ -41,7 +41,6 @@ private var IrProperty.replacementForValueClasses: IrProperty? by irAttribute(co
  * Keeps track of replacement functions and inline class box/unbox functions.
  */
 class MemoizedInlineClassReplacements(
-    private val mangleReturnTypes: Boolean,
     private val irFactory: IrFactory,
     private val context: JvmBackendContext,
 ) {
@@ -186,7 +185,7 @@ class MemoizedInlineClassReplacements(
 
     private val IrSimpleFunction.needsReplacement: Boolean
         get() = when {
-            !(shouldBeExposedByAnnotationOrFlag(context) || hasMangledParameters() || mangleReturnTypes && hasMangledReturnType) -> false
+            !(shouldBeExposedByAnnotationOrFlag(context) || hasMangledParameters() || hasMangledReturnType) -> false
             isFromJava() -> mangleCallsToJavaMethodsWithValueClasses && !overridesOnlyMethodsFromJava()
             else -> true
         }
@@ -355,7 +354,7 @@ class MemoizedInlineClassReplacements(
             else ->
                 replacementOrigin
         }
-        name = InlineClassAbi.mangledNameFor(function, mangleReturnTypes, useOldManglingScheme)
+        name = InlineClassAbi.mangledNameFor(function, mangleReturnTypes = true, useOldMangleRules = useOldManglingScheme)
     }
 }
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
@@ -264,7 +264,7 @@ class MemoizedInlineClassReplacements(
                     defaultValue = null,
                     name = if (parameter.kind == IrParameterKind.ExtensionReceiver) {
                         // The function's name will be mangled, so preserve the old receiver name.
-                        Name.identifier(function.extensionReceiverName(context.config))
+                        Name.identifier(function.extensionReceiverName())
                     } else parameter.name
                 ).also {
                     // Assuming that constructors and non-override functions are always replaced with the unboxed
@@ -300,7 +300,7 @@ class MemoizedInlineClassReplacements(
                     IrParameterKind.ExtensionReceiver -> {
                         parameter.copyTo(
                             this,
-                            name = Name.identifier(function.extensionReceiverName(context.config)),
+                            name = Name.identifier(function.extensionReceiverName()),
                             origin = IrDeclarationOrigin.MOVED_EXTENSION_RECEIVER,
                             kind = IrParameterKind.Regular,
                         )

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
@@ -35,12 +35,10 @@ import org.jetbrains.kotlin.ir.overrides.isEffectivelyPrivate
 import org.jetbrains.kotlin.ir.symbols.IrEnumEntrySymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
-import org.jetbrains.kotlin.ir.symbols.IrVariableSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.getArrayElementType
 import org.jetbrains.kotlin.ir.util.isBoxedArray
-import org.jetbrains.kotlin.ir.util.isSubtypeOf
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
@@ -94,24 +92,6 @@ fun IrFunction.getJvmVisibilityOfDefaultArgumentStub() =
 
 fun IrDeclaration.isInCurrentModule(): Boolean =
     getPackageFragment() is IrFile
-
-// Determine if the IrExpression is smartcast, and if so, if it is cast from higher than nullable target types.
-// This is needed to pinpoint exceptional treatment of IEEE754 floating point comparisons, where proper IEEE
-// comparisons are used "if values are statically known to be of primitive numeric types", taken to mean as
-// "not learned through smartcasting".
-fun IrExpression.isSmartcastFromHigherThanNullable(context: JvmBackendContext): Boolean {
-    return when (this) {
-        is IrTypeOperatorCall ->
-            operator == IrTypeOperator.IMPLICIT_CAST && !argument.type.isSubtypeOf(type.makeNullable(), context.typeSystem)
-        is IrGetValue -> {
-            // Check if the variable initializer is smartcast. In FIR, if the subject of a `when` is smartcast,
-            // the IMPLICIT_CAST is in the initializer of the variable for the subject.
-            val variable = (symbol as? IrVariableSymbol)?.owner ?: return false
-            !variable.isVar && variable.initializer?.isSmartcastFromHigherThanNullable(context) == true
-        }
-        else -> false
-    }
-}
 
 fun IrElement.replaceThisByStaticReference(
     cachedFields: CachedFieldsForObjectInstances,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
@@ -14,9 +14,7 @@ import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.codegen.inline.classFileContainsMethod
 import org.jetbrains.kotlin.codegen.inline.coroutines.FOR_INLINE_SUFFIX
 import org.jetbrains.kotlin.codegen.mangleNameIfNeeded
-import org.jetbrains.kotlin.codegen.state.JvmBackendConfig
 import org.jetbrains.kotlin.config.JvmDefaultMode
-import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.ValhallaSupportMode.*
 import org.jetbrains.kotlin.config.isKotlinValhallaValueClass
@@ -474,11 +472,7 @@ fun classFileContainsMethod(classId: ClassId, function: IrFunction, context: Jvm
     return classFileContainsMethod(classId, context.state, Method(originalSignature.name, descriptor))
 }
 
-fun IrFunction.extensionReceiverName(config: JvmBackendConfig): String {
-    if (!config.languageVersionSettings.supportsFeature(LanguageFeature.NewCapturedReceiverFieldNamingConvention)) {
-        return AsmUtil.RECEIVER_PARAMETER_NAME
-    }
-
+fun IrFunction.extensionReceiverName(): String {
     parameters.singleOrNull { it.kind == IrParameterKind.ExtensionReceiver }?.let {
         if (it.name.asString().startsWith(AsmUtil.LABELED_THIS_PARAMETER)) {
             return it.name.asString()

--- a/compiler/testData/codegen/box/ieee754/comparableToTWithT_properIeeeComparisons.kt
+++ b/compiler/testData/codegen/box/ieee754/comparableToTWithT_properIeeeComparisons.kt
@@ -1,5 +1,3 @@
-// LANGUAGE: +ProperIeee754Comparisons
-
 fun less(x: Comparable<Float>, y: Float) = x is Float && x < y
 fun less(x: Comparable<Double>, y: Double) = x is Double && x < y
 

--- a/compiler/testData/codegen/boxModernJdk/testsWithJava17/fullValueClasses/javaExhaustiveWhenOnKotlinSealedValueClass.kt
+++ b/compiler/testData/codegen/boxModernJdk/testsWithJava17/fullValueClasses/javaExhaustiveWhenOnKotlinSealedValueClass.kt
@@ -1,4 +1,4 @@
-// LANGUAGE: +JvmPermittedSubclassesAttributeForSealed, +FullValueClasses
+// LANGUAGE: +FullValueClasses
 // ENABLE_JVM_PREVIEW
 
 // FILE: javaExhaustiveWhenOnKotlinSealedClass.kt

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiOutputExtension.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiOutputExtension.kt
@@ -187,7 +187,7 @@ class JvmAbiOutputExtension(
                                 }
 
                                 val sourceMapText = sourceMap?.parent?.takeIf { !it.isTrivial }
-                                    ?.let { SMAPBuilder.build(it.resultMappings, backwardsCompatibleSyntax = false, validate = false) }
+                                    ?.let { SMAPBuilder.build(it.resultMappings, validate = false) }
                                 // This is technically not the right way to use `ClassVisitor` (`visitSource` should be called before
                                 // `visitMethod` and such), but `ClassWriter` doesn't care, and we're a bit constrained here (see above).
                                 cv.visitSource(sourceFile, sourceMapText)

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/K1JvmIrCodegenFactory.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/K1JvmIrCodegenFactory.kt
@@ -342,7 +342,6 @@ private class JvmSerializerExtension(
     private val languageVersionSettings = state.config.languageVersionSettings
     private val isParamAssertionsDisabled = state.config.isParamAssertionsDisabled
     private val unifiedNullChecks = state.config.unifiedNullChecks
-    private val functionsWithInlineClassReturnTypesMangled = state.config.functionsWithInlineClassReturnTypesMangled
     override val metadataVersion = state.config.metadataVersion
     private val jvmDefaultMode = state.config.jvmDefaultMode
     private val useOldManglingScheme = state.config.useOldManglingSchemeForFunctionsWithInlineClassesInSignatures
@@ -507,13 +506,11 @@ private class JvmSerializerExtension(
     }
 
     private fun MutableVersionRequirementTable.writeFunctionNameManglingForReturnTypeRequirement(add: (Int) -> Unit) {
-        if (functionsWithInlineClassReturnTypesMangled) {
-            add(
-                VersionRequirementUtils.writeVersionRequirement(
-                    1, 4, 0, ProtoBuf.VersionRequirement.VersionKind.LANGUAGE_VERSION, this
-                )
+        add(
+            VersionRequirementUtils.writeVersionRequirement(
+                1, 4, 0, ProtoBuf.VersionRequirement.VersionKind.LANGUAGE_VERSION, this
             )
-        }
+        )
     }
 
     private fun MutableVersionRequirementTable.writeNewFunctionNameManglingRequirement(add: (Int) -> Unit) {


### PR DESCRIPTION
We have some effectively dead code: `!languageVersionSettings.supportsFeature(feature) { ... }` for such `feature` that `behaviorAfterSinceVersion == CannotBeDisabled` and `sinceVersion.isUnsupported == true`