### PR TITLE
[KDF] Fix invalid name rendering when dataschema is nested in a class

### DIFF
--- a/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/ExpressionAnalysisAdditionalChecker.kt
+++ b/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/ExpressionAnalysisAdditionalChecker.kt
@@ -51,6 +51,7 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.render
 import org.jetbrains.kotlinx.dataframe.impl.toCamelCaseByDelimiters
 import org.jetbrains.kotlinx.dataframe.plugin.DataFramePlugin
 import org.jetbrains.kotlinx.dataframe.plugin.extensions.FirDataFrameErrors.CAST_ERROR
@@ -219,7 +220,7 @@ private class Checker(
         reporter.reportOn(
             expression,
             MATERIALIZED_SCHEMA_ON_CAST,
-            source.toMaterializedSchema(targetType.renderReadable(), asDataClass),
+            source.toMaterializedSchema(targetType.classId.shortClassName.render(), asDataClass),
             context
         )
     }

--- a/plugins/kotlin-dataframe/testData/diagnostics/materializedNestedSchemaOnCast.fir.txt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/materializedNestedSchemaOnCast.fir.txt
@@ -1,0 +1,49 @@
+FILE: materializedNestedSchemaOnCast.kt
+    public final fun box(): R|kotlin/String| {
+        lval cities: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/DataFrameOf_29>| = R|kotlin/run|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/DataFrameOf_29>|>(<L> = fun <anonymous>(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/DataFrameOf_29>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class DataFrameOf_29I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public constructor(): R|<local>/DataFrameOf_29I|
+
+            }
+
+            local final class DataFramePropertiesScope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/DataFrameOf_29I>|.city: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/DataFrameOf_29I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public constructor(): R|<local>/DataFramePropertiesScope0|
+
+            }
+
+            local abstract class DataFrameOf_29 : R|<local>/DataFrameOf_29I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val dataFramePropertiesScope0: R|<local>/DataFramePropertiesScope0|
+                    public get(): R|<local>/DataFramePropertiesScope0|
+
+                public constructor(): R|<local>/DataFrameOf_29|
+
+            }
+
+            ^ R|org/jetbrains/kotlinx/dataframe/api/dataFrameOf|(vararg(String(city).R|kotlin/to|<R|kotlin/String|, R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|>(R|org/jetbrains/kotlinx/dataframe/api/columnOf|<R|kotlin/String|>(vararg(String(London), String(Seoul))))))
+        }
+        )
+        R|<local>/cities|.R|org/jetbrains/kotlinx/dataframe/api/cast|<R|Context.MySchema|>()
+        ^box String(OK)
+    }
+    public final class Context : R|kotlin/Any| {
+        public constructor(): R|Context| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|org/jetbrains/kotlinx/dataframe/annotations/DataSchema|() public final class MySchema : R|kotlin/Any|, R|org/jetbrains/kotlinx/dataframe/api/DataRowSchema| {
+            public constructor(): R|Context.MySchema| {
+                super<R|kotlin/Any|>()
+            }
+
+        }
+
+    }

--- a/plugins/kotlin-dataframe/testData/diagnostics/materializedNestedSchemaOnCast.kt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/materializedNestedSchemaOnCast.kt
@@ -1,0 +1,21 @@
+// RENDER_DIAGNOSTIC_ARGUMENTS
+
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val cities = dataFrameOf(
+        "city" to columnOf("London", "Seoul"),
+    )
+
+    cities.<!MATERIALIZED_SCHEMA_ON_CAST("@DataSchemadata class MySchema(    val city: String,)")!>cast<!><Context.MySchema>()
+
+    return "OK"
+}
+
+class Context {
+    @DataSchema
+    class MySchema
+}

--- a/plugins/kotlin-dataframe/testData/diagnostics/materializedSchemaWithBackticksOnCast.fir.txt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/materializedSchemaWithBackticksOnCast.fir.txt
@@ -1,0 +1,42 @@
+FILE: materializedSchemaWithBackticksOnCast.kt
+    public final fun box(): R|kotlin/String| {
+        lval cities: R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/DataFrameOf_29>| = R|kotlin/run|<R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/DataFrameOf_29>|>(<L> = fun <anonymous>(): R|org/jetbrains/kotlinx/dataframe/DataFrame<<local>/DataFrameOf_29>| <inline=Inline, kind=EXACTLY_ONCE>  {
+            local abstract class DataFrameOf_29I : R|kotlin/Any| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/Order|(order = Int(0)) public abstract val city: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public constructor(): R|<local>/DataFrameOf_29I|
+
+            }
+
+            local final class DataFramePropertiesScope0 : R|kotlin/Any| {
+                public final val R|org/jetbrains/kotlinx/dataframe/DataRow<<local>/DataFrameOf_29I>|.city: R|kotlin/String|
+                    public get(): R|kotlin/String|
+
+                public final val R|org/jetbrains/kotlinx/dataframe/ColumnsScope<<local>/DataFrameOf_29I>|.city: R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+                    public get(): R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|
+
+                public constructor(): R|<local>/DataFramePropertiesScope0|
+
+            }
+
+            local abstract class DataFrameOf_29 : R|<local>/DataFrameOf_29I| {
+                @R|org/jetbrains/kotlinx/dataframe/annotations/ScopeProperty|() public abstract val dataFramePropertiesScope0: R|<local>/DataFramePropertiesScope0|
+                    public get(): R|<local>/DataFramePropertiesScope0|
+
+                public constructor(): R|<local>/DataFrameOf_29|
+
+            }
+
+            ^ R|org/jetbrains/kotlinx/dataframe/api/dataFrameOf|(vararg(String(city).R|kotlin/to|<R|kotlin/String|, R|org/jetbrains/kotlinx/dataframe/DataColumn<kotlin/String>|>(R|org/jetbrains/kotlinx/dataframe/api/columnOf|<R|kotlin/String|>(vararg(String(London), String(Seoul))))))
+        }
+        )
+        R|<local>/cities|.R|org/jetbrains/kotlinx/dataframe/api/cast|<R|My Unusual name|>()
+        ^box String(OK)
+    }
+    @R|org/jetbrains/kotlinx/dataframe/annotations/DataSchema|() public final class My Unusual name : R|kotlin/Any|, R|org/jetbrains/kotlinx/dataframe/api/DataRowSchema| {
+        public constructor(): R|My Unusual name| {
+            super<R|kotlin/Any|>()
+        }
+
+    }

--- a/plugins/kotlin-dataframe/testData/diagnostics/materializedSchemaWithBackticksOnCast.kt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/materializedSchemaWithBackticksOnCast.kt
@@ -1,0 +1,19 @@
+// RENDER_DIAGNOSTIC_ARGUMENTS
+
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val cities = dataFrameOf(
+        "city" to columnOf("London", "Seoul"),
+    )
+
+    cities.<!MATERIALIZED_SCHEMA_ON_CAST("@DataSchemadata class `My Unusual name`(    val city: String,)")!>cast<!><`My Unusual name`>()
+
+    return "OK"
+}
+
+@DataSchema
+class `My Unusual name`


### PR DESCRIPTION
Before the fix, materialized schema would have invalid name. It's a red code
```
@DataSchema
class Context.MySchema(...)
```