### PR TITLE
[test] Revert a part of fef631e6 to fix JS test artifact placement

### DIFF
--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt
@@ -149,6 +149,9 @@ fun main(args: Array<String>) {
 
             testClass<AbstractJsCodegenBoxTest> {
                 model("box", excludeDirs = jvmOnlyBoxTests + k1BoxTestDir)
+            }
+
+            testClass<AbstractJsCodegenBoxInlineTest> {
                 model("boxInline")
             }
 

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsTest.kt
@@ -119,8 +119,18 @@ abstract class AbstractJsCodegenBoxTestBase(
 }
 
 abstract class AbstractJsCodegenBoxTest : AbstractJsCodegenBoxTestBase(
-    pathToTestDir = "compiler/testData/codegen/",
+    pathToTestDir = "compiler/testData/codegen/box",
     testGroupOutputDirPrefix = "codegen/box/"
+) {
+    override fun configure(builder: TestConfigurationBuilder) {
+        super.configure(builder)
+        builder.configureLoweredIrDumpHandlers()
+    }
+}
+
+abstract class AbstractJsCodegenBoxInlineTest : AbstractJsCodegenBoxTestBase(
+    pathToTestDir = "compiler/testData/codegen/boxInline",
+    testGroupOutputDirPrefix = "codegen/boxInline/"
 ) {
     override fun configure(builder: TestConfigurationBuilder) {
         super.configure(builder)


### PR DESCRIPTION
In https://github.com/JetBrains/kotlin/commit/fef631e6270e9ea9bc230cb7209d8000a86bafff, a `pathToTestDir` argument was added in the `AbstractJsCodegenBoxTest` constructor.

Because of this, generated JS files in tests started appearing in the wrong location: `js/js.tests/build/node/out/codegen/box/box` instead of `js/js.tests/build/node/out/codegen/box`.

This broke the Kotlin Compiler DevKit plugin, which allows to quickly jump to generated artifacts from the test source file.