### PR TITLE
[K/JS] Fix non-deterministic order of super types after DCE lowering

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UselessDeclarationsRemover.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/dce/UselessDeclarationsRemover.kt
@@ -87,6 +87,12 @@ class UselessDeclarationsRemover(
         }
     }
 
+    /**
+     * Collects the transitive supertypes of this class that survive DCE.
+     *
+     * @return an insertion-ordered set of the surviving supertypes. The insertion order is needed to keep the order of types
+     * deterministic, so that it doesn't change between compilations.
+     */
     private fun IrClassSymbol.collectUsedSuperTypes(): Set<IrClassSymbol> {
         return savedTypesCache.getOrPut(this) {
             if (owner in usefulDeclarations || context.keeper.shouldKeep(owner)) {
@@ -94,7 +100,7 @@ class UselessDeclarationsRemover(
             } else {
                 owner.superTypes
                     .flatMap { it.takeIf { !it.isAny() }?.classOrNull?.collectUsedSuperTypes() ?: emptyList() }
-                    .toHashSet()
+                    .toCollection(LinkedHashSet())
             }
         }
     }


### PR DESCRIPTION
Because of the usage of non-order-preserving `HashSet`, the `UselessDeclarationsRemover` reassigned the `superTypes` property of the `IrClass` in an random order, causing code changes during recompilations of the exact same code across `initMetadataFor*` calls.

^KT-68281 Fixed