### PR TITLE
Klib loading: Relax minimal KLib ABI version to 1.6.0

### DIFF
--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
@@ -91,10 +91,10 @@ data class KotlinAbiVersion(val major: Int, val minor: Int, val patch: Int) {
         val CURRENT = KotlinAbiVersion(2, 5, 0)
 
         /**
-         * The ABI version that matches the Kotlin compiler version (1.9.20), since which we do support
-         * backward compatibility of Klibs.
+         * A preparatory restriction to v1.6.0 before the upcoming restriction to 1.8.0 (The ABI version that matches the Kotlin compiler version 1.9.20),
+         * since which we do support backward compatibility of Klibs.
          */
-        val FIRST_SUPPORTED = KotlinAbiVersion(1, 8, 0)
+        val FIRST_SUPPORTED = KotlinAbiVersion(1, 6, 0)
 
         /**
          * Versions before 1.4.1 were the active development phase.

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
@@ -542,8 +542,6 @@ abstract class AbstractKlibLoaderTest {
             KotlinAbiVersion(1, 4, 1),
             KotlinAbiVersion(1, 4, 2),
             KotlinAbiVersion(1, 5, 0),
-            KotlinAbiVersion(1, 6, 0),
-            KotlinAbiVersion(1, 7, 0),
         )
 
         // Sanity: Make sure that all are unique.
@@ -560,6 +558,8 @@ abstract class AbstractKlibLoaderTest {
 
     private fun findAllKnownSupportedAbiVersions(): List<KotlinAbiVersion> {
         val knownSupportedAbiVersions = buildList {
+            this += KotlinAbiVersion(1, 6, 0)
+            this += KotlinAbiVersion(1, 7, 0)
             this += KotlinAbiVersion(1, 8, 0)
             this += KotlinAbiVersion(1, 201, 0)
 


### PR DESCRIPTION
^KT-73115