### PR TITLE
Enable INDY for SAM conversion with contravariant projections

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -197,7 +197,13 @@ open class UpgradeCallableReferences(
         override fun visitTypeOperator(expression: IrTypeOperatorCall, data: IrDeclarationParent): IrExpression {
             if (upgradeSamConversions && expression.operator == IrTypeOperator.SAM_CONVERSION) {
                 expression.transformChildren(this, data)
-                val argument = expression.argument
+                val argument = expression.argument.let {
+                    if (it is IrTypeOperatorCall && it.operator == IrTypeOperator.IMPLICIT_CAST) {
+                        it.argument
+                    } else {
+                        it
+                    }
+                }
                 if (argument !is IrRichFunctionReference) return expression
                 return argument.apply {
                     startOffset = expression.startOffset

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -42,6 +42,8 @@ open class UpgradeCallableReferences(
         irFunction.transform(UpgradeTransformer(), irFunction)
     }
 
+    protected open fun getSamConversionArgument(argument: IrExpression): IrExpression = argument
+
     private data class AdaptedBlock(
         val function: IrSimpleFunction,
         val reference: IrFunctionReference,
@@ -197,13 +199,7 @@ open class UpgradeCallableReferences(
         override fun visitTypeOperator(expression: IrTypeOperatorCall, data: IrDeclarationParent): IrExpression {
             if (upgradeSamConversions && expression.operator == IrTypeOperator.SAM_CONVERSION) {
                 expression.transformChildren(this, data)
-                val argument = expression.argument.let {
-                    if (it is IrTypeOperatorCall && it.operator == IrTypeOperator.IMPLICIT_CAST) {
-                        it.argument
-                    } else {
-                        it
-                    }
-                }
+                val argument = getSamConversionArgument(expression.argument)
                 if (argument !is IrRichFunctionReference) return expression
                 return argument.apply {
                     startOffset = expression.startOffset

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -339,9 +339,11 @@ class ExpressionCodegen(
 
     // * Operator functions require non-null assertions on parameters even if they are private.
     // * Local function for lambda survives at this stage if it was used in 'invokedynamic'-based code.
+    // * Anonymous indy functions keep the LOCAL_FUNCTION origin and are marked by their lowering.
     // * Hidden constructors with mangled parameters require non-null assertions (see KT-53492)
     private fun shouldGenerateNonNullAssertionsForPrivateFun(irFunction: IrFunction): Boolean {
         if (irFunction is IrSimpleFunction && irFunction.isOperator || irFunction.origin == IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA) return true
+        if (irFunction.isIndyImplementationMethod) return true
         if (irFunction is IrConstructor && irFunction.hiddenConstructorMangledParams != null) return true
         return false
     }

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/IndyLambdaMetafactoryLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/IndyLambdaMetafactoryLowering.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.JvmSymbols
 import org.jetbrains.kotlin.backend.jvm.ir.*
+import org.jetbrains.kotlin.backend.jvm.isIndyImplementationMethod
 import org.jetbrains.kotlin.backend.jvm.lower.indy.*
 import org.jetbrains.kotlin.backend.jvm.unboxInlineClass
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -321,6 +322,11 @@ class IndyLambdaMetafactoryLowering(val backendContext: JvmBackendContext) : Fil
         val samType = call.type as? IrSimpleType ?: fail("'samType' is expected to be a simple type")
 
         val implFunSymbol = call.invokeFunction.symbol
+
+        // Anonymous functions keep LOCAL_FUNCTION, so mark indy implementations for parameter assertions.
+        if (call.invokeFunction.origin == IrDeclarationOrigin.LOCAL_FUNCTION) {
+            call.invokeFunction.isIndyImplementationMethod = true
+        }
 
         val generatedParameters = LambdaMetafactoryArgumentsBuilder(backendContext, emptySet())
             .getLambdaMetafactoryArguments(

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
@@ -7,8 +7,24 @@ package org.jetbrains.kotlin.backend.jvm.lower
 
 import org.jetbrains.kotlin.backend.common.lower.UpgradeCallableReferences
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.util.isFunction
+import org.jetbrains.kotlin.ir.util.isSuspendFunction
 
 internal class JvmUpgradeCallableReferences(context: JvmBackendContext) : UpgradeCallableReferences(
     context = context,
     upgradeSamConversions = true,
-)
+) {
+    // FIR2IR casts function references to approximated function types for projected SAM types (KT-51868).
+    // Unwrap only those casts; LambdaMetafactoryArgumentsBuilder handles the resulting mismatch (KT-57995).
+    override fun getSamConversionArgument(argument: IrExpression): IrExpression =
+        if (argument is IrTypeOperatorCall &&
+            argument.operator == IrTypeOperator.IMPLICIT_CAST &&
+            argument.argument is IrRichFunctionReference &&
+            (argument.typeOperand.isFunction() || argument.typeOperand.isSuspendFunction())
+        ) {
+            argument.argument
+        } else {
+            argument
+        }
+}

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.jvm.ir.getInlineClassUnderlyingType
 import org.jetbrains.kotlin.backend.jvm.ir.getJvmAnnotationRetention
 import org.jetbrains.kotlin.backend.jvm.ir.isCompiledToJvmDefault
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClass
+import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
 import org.jetbrains.kotlin.builtins.functions.BuiltInFunctionArity
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.Modality
@@ -19,16 +20,22 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrRichFunctionReference
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.overrides.buildFakeOverrideMember
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_SERIALIZABLE_LAMBDA_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.Variance
 import java.lang.annotation.RetentionPolicy
 
@@ -307,6 +314,8 @@ internal class LambdaMetafactoryArgumentsBuilder(
             val constraint = constraints.parameters[methodParameter]
             if (!checkTypeCompliesWithConstraint(implParameter.type, constraint))
                 return false
+            if (!isReferenceParameterAdaptable(implParameter.type, methodParameter.type))
+                return false
         }
         if (!checkTypeCompliesWithConstraint(implFun.returnType, constraints.returnType))
             return false
@@ -352,6 +361,7 @@ internal class LambdaMetafactoryArgumentsBuilder(
             if (parameterConstraint.requiresImplLambdaBoxing()) {
                 makeLambdaParameterNullable(implFun, implParameter)
             }
+            adaptReferenceLambdaParameter(implFun, implParameter, methodParameter.type)
         }
         if (constraints.returnType.requiresImplLambdaBoxing() ||
             implFun.returnType.isUnit() && !fakeInstanceMethod.returnType.isUnit()
@@ -374,6 +384,41 @@ internal class LambdaMetafactoryArgumentsBuilder(
                 super.visitGetValue(expression)
             }
         }, null)
+    }
+
+    private fun isReferenceParameterAdaptable(implType: IrType, methodType: IrType): Boolean {
+        if (implType == methodType) return true
+        if (implType.isPrimitiveType() || methodType.isPrimitiveType()) return false
+        if (implType.isInlineClassType() || methodType.isInlineClassType()) return false
+        return isSubtypeOf(implType, methodType) || isSubtypeOf(methodType, implType)
+    }
+
+    private fun isSubtypeOf(subType: IrType, superType: IrType): Boolean =
+        AbstractTypeChecker.isSubtypeOf(createIrTypeCheckerState(context.typeSystem), subType, superType)
+
+    private fun adaptReferenceLambdaParameter(function: IrFunction, parameter: IrValueParameter, methodType: IrType) {
+        val implementationType = parameter.type
+        if (implementationType == methodType || !isReferenceParameterAdaptable(implementationType, methodType)) return
+        if (!isSubtypeOf(implementationType, methodType)) return
+
+        // LambdaMetafactory passes the erased SAM parameter type to the implementation method.
+        // Keep the lambda's original Kotlin type at each use site and insert the required JVM cast.
+        parameter.type = methodType
+        function.body?.transformChildrenVoid(object : IrElementTransformerVoid() {
+            override fun visitGetValue(expression: IrGetValue): IrExpression {
+                if (expression.symbol != parameter.symbol) return super.visitGetValue(expression)
+                val transformed = super.visitGetValue(expression) as IrGetValue
+                transformed.type = methodType
+                return IrTypeOperatorCallImpl(
+                    expression.startOffset,
+                    expression.endOffset,
+                    implementationType,
+                    IrTypeOperator.IMPLICIT_CAST,
+                    implementationType,
+                    transformed,
+                )
+            }
+        })
     }
 
     private fun validateMethodParameters(

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
@@ -383,7 +383,10 @@ internal class LambdaMetafactoryArgumentsBuilder(
                 makeLambdaParameterNullable(implFun, implParameter)
             }
             if (!isJdkAdaptableParameter(instantiatedType = methodParameter.type, implType = implParameter.type)) {
-                widenLambdaParameterType(implFun, implParameter, methodParameter.type)
+                // Preserve nullability so codegen retains the implementation parameter's null assertion.
+                val widenedType = if (implParameter.type.isNullable()) methodParameter.type.makeNullable()
+                else methodParameter.type.makeNotNull()
+                widenLambdaParameterType(implFun, implParameter, widenedType)
             }
         }
         if (constraints.returnType.requiresImplLambdaBoxing() ||

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
@@ -469,9 +469,9 @@ internal class LambdaMetafactoryArgumentsBuilder(
             // Two different JVM primitives: don't rely on implicit primitive widening conversions.
             instantiatedIsPrimitive && implIsPrimitive -> false
             // Boxing: the primitive value is boxed to its wrapper class, which must then widen to the impl type.
-            instantiatedIsPrimitive ->
-                implAsmType.sort == Type.OBJECT &&
-                        (implAsmType.internalName == "java/lang/Object" || implAsmType == AsmUtil.boxType(instantiatedAsmType))
+            // Making the type nullable is how the wrapper class is spelled in Kotlin: 'Int' maps to 'I', 'Int?' to
+            // 'Ljava/lang/Integer;'.
+            instantiatedIsPrimitive -> isErasedReferenceWidening(instantiatedType.makeNullable(), implType)
             // Unboxing: only possible from the exact wrapper type.
             implIsPrimitive -> instantiatedAsmType == AsmUtil.boxType(implAsmType)
             // Reference widening: the impl parameter type must be a supertype of the instantiated parameter type.

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
@@ -34,7 +34,6 @@ import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_SERIALIZABLE_LAMBDA_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.org.objectweb.asm.Type
 import java.lang.annotation.RetentionPolicy
@@ -408,7 +407,7 @@ internal class LambdaMetafactoryArgumentsBuilder(
         // The widened parameter still holds values of the original type at run time, and every use site casts it
         // back to the original type. That is only correct if the original type is (possibly after boxing) a plain
         // reference-widening away from the instantiated method parameter type.
-        return isSubtypeOf(implType, methodType.makeNullable())
+        return isErasedReferenceWidening(subType = implType, superType = methodType)
     }
 
     private fun collectParametersWithWrites(function: IrFunction): Set<IrValueParameterSymbol> {
@@ -473,14 +472,22 @@ internal class LambdaMetafactoryArgumentsBuilder(
             // Unboxing: only possible from the exact wrapper type.
             implIsPrimitive -> instantiatedAsmType == AsmUtil.boxType(implAsmType)
             // Reference widening: the impl parameter type must be a supertype of the instantiated parameter type.
-            else -> isSubtypeOf(instantiatedType, implType.makeNullable())
+            else -> isErasedReferenceWidening(subType = instantiatedType, superType = implType)
         }
     }
 
-    private val irTypeCheckerState by lazy(LazyThreadSafetyMode.NONE) { createIrTypeCheckerState(context.typeSystem) }
-
-    private fun isSubtypeOf(subType: IrType, superType: IrType): Boolean =
-        AbstractTypeChecker.isSubtypeOf(irTypeCheckerState, subType, superType)
+    // Check reference widening on erased classes, as LambdaMetafactory does at run time.
+    private fun isErasedReferenceWidening(subType: IrType, superType: IrType): Boolean {
+        val subAsmType = context.defaultTypeMapper.mapType(subType)
+        val superAsmType = context.defaultTypeMapper.mapType(superType)
+        if (subAsmType == superAsmType) return true
+        // Different array types share an erased class; conservatively allow only widening to Object.
+        if (subAsmType.sort == Type.ARRAY || superAsmType.sort == Type.ARRAY)
+            return superAsmType.internalName == "java/lang/Object"
+        if (subType.isInlineClassType() || superType.isInlineClassType()) return false
+        if (subType !is IrSimpleType || superType !is IrSimpleType) return false
+        return getErasedClassForSignatureAdaptation(subType).isSubclassOf(getErasedClassForSignatureAdaptation(superType))
+    }
 
     private fun widenLambdaParameterType(function: IrFunction, parameter: IrValueParameter, methodType: IrType) {
         val originalType = parameter.type

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/indy/LambdaMetafactoryArguments.kt
@@ -13,17 +13,16 @@ import org.jetbrains.kotlin.backend.jvm.ir.isCompiledToJvmDefault
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClass
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
 import org.jetbrains.kotlin.builtins.functions.BuiltInFunctionArity
+import org.jetbrains.kotlin.codegen.AsmUtil
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrGetValue
-import org.jetbrains.kotlin.ir.expressions.IrRichFunctionReference
-import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.overrides.buildFakeOverrideMember
+import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
@@ -37,6 +36,7 @@ import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_SERIALIZABLE_LAMBDA_ANN
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.org.objectweb.asm.Type
 import java.lang.annotation.RetentionPolicy
 
 internal sealed class MetafactoryArgumentsResult {
@@ -278,7 +278,8 @@ internal class LambdaMetafactoryArgumentsBuilder(
 
         adaptFakeInstanceMethodSignature(fakeInstanceMethod, signatureAdaptationConstraints)
         if (implFun.isAdaptable()) {
-            adaptLambdaSignature(implFun, fakeInstanceMethod, signatureAdaptationConstraints, reference.boundValues.size)
+            if (!adaptLambdaSignature(implFun, fakeInstanceMethod, signatureAdaptationConstraints, reference.boundValues.size))
+                return null
         } else if (
             !checkMethodSignatureCompliance(implFun, fakeInstanceMethod, signatureAdaptationConstraints, reference)
         ) {
@@ -314,7 +315,9 @@ internal class LambdaMetafactoryArgumentsBuilder(
             val constraint = constraints.parameters[methodParameter]
             if (!checkTypeCompliesWithConstraint(implParameter.type, constraint))
                 return false
-            if (!isReferenceParameterAdaptable(implParameter.type, methodParameter.type))
+            // A non-adaptable function's signature cannot be changed, so the instantiated method parameter must
+            // already be adaptable to it by LambdaMetafactory's own rules.
+            if (!isJdkAdaptableParameter(instantiatedType = methodParameter.type, implType = implParameter.type))
                 return false
         }
         if (!checkTypeCompliesWithConstraint(implFun.returnType, constraints.returnType))
@@ -343,31 +346,87 @@ internal class LambdaMetafactoryArgumentsBuilder(
             else -> false
         }
 
+    /**
+     * Adapt an implementation function's signature to the instantiated method type derived from [fakeInstanceMethod].
+     * Returns false without mutating the function if no correct adaptation exists.
+     *
+     * Since the SAM conversion argument selection no longer requires the invoke function's signature to match the
+     * SAM's function type exactly (an implicit cast to the approximated SAM function type is dropped for SAM types
+     * with `in` projections, see JvmUpgradeCallableReferences.getSamConversionArgument and KT-57995), the
+     * implementation function's parameter types can now be strictly narrower than the instantiated method's ones
+     * (e.g. a `(String) -> Unit` lambda converted to `Consumer<in String>`, approximated to `Consumer<Any?>`).
+     * LambdaMetafactory rejects such an implementation method, so its parameters are widened to the instantiated
+     * types, keeping the original type at each use site with a cast.
+     */
     private fun adaptLambdaSignature(
         implFun: IrSimpleFunction,
         fakeInstanceMethod: IrSimpleFunction,
         constraints: SignatureAdaptationConstraints,
         capturedParametersCount: Int,
-    ) {
-        if (!implFun.isAdaptable()) {
-            throw AssertionError("Function origin should be adaptable: ${implFun.dump()}")
-        }
-
+    ): Boolean {
         val implParameters = implFun.nonDispatchParameters.drop(capturedParametersCount)
         val methodParameters = fakeInstanceMethod.nonDispatchParameters
         validateMethodParameters(implParameters, methodParameters, implFun, fakeInstanceMethod)
+        val parametersWithWrites by lazy(LazyThreadSafetyMode.NONE) { collectParametersWithWrites(implFun) }
+
+        // Validate every parameter before changing any of them. This method is called once as a feasibility probe
+        // and again when the invokedynamic call is emitted, so failed adaptation must not leave partial changes.
         for ([implParameter, methodParameter] in implParameters.zip(methodParameters)) {
-            val parameterConstraint = constraints.parameters[methodParameter]
-            if (parameterConstraint.requiresImplLambdaBoxing()) {
+            val makeNullable = constraints.parameters[methodParameter].requiresImplLambdaBoxing()
+            val implType = if (makeNullable) implParameter.type.makeNullable() else implParameter.type
+            if (!isJdkAdaptableParameter(instantiatedType = methodParameter.type, implType = implType) &&
+                !canWidenLambdaParameter(implParameter, implType, methodParameter.type, parametersWithWrites)
+            ) return false
+        }
+
+        for ([implParameter, methodParameter] in implParameters.zip(methodParameters)) {
+            if (constraints.parameters[methodParameter].requiresImplLambdaBoxing()) {
                 makeLambdaParameterNullable(implFun, implParameter)
             }
-            adaptReferenceLambdaParameter(implFun, implParameter, methodParameter.type)
+            if (!isJdkAdaptableParameter(instantiatedType = methodParameter.type, implType = implParameter.type)) {
+                widenLambdaParameterType(implFun, implParameter, methodParameter.type)
+            }
         }
         if (constraints.returnType.requiresImplLambdaBoxing() ||
             implFun.returnType.isUnit() && !fakeInstanceMethod.returnType.isUnit()
         ) {
             implFun.returnType = implFun.returnType.makeNullable()
         }
+        return true
+    }
+
+    private fun canWidenLambdaParameter(
+        parameter: IrValueParameter,
+        implType: IrType,
+        methodType: IrType,
+        parametersWithWrites: Set<IrValueParameterSymbol>,
+    ): Boolean {
+        if (parameter.varargElementType != null) return false
+        if (parameter.symbol in parametersWithWrites) return false
+        if (implType.isNothing() || implType.isNullableNothing()) return false
+        if (implType.isInlineClassType() || methodType.isInlineClassType()) return false
+        // The widened parameter still holds values of the original type at run time, and every use site casts it
+        // back to the original type. That is only correct if the original type is (possibly after boxing) a plain
+        // reference-widening away from the instantiated method parameter type.
+        return isSubtypeOf(implType, methodType.makeNullable())
+    }
+
+    private fun collectParametersWithWrites(function: IrFunction): Set<IrValueParameterSymbol> {
+        val result = HashSet<IrValueParameterSymbol>()
+        function.body?.accept(object : IrVisitorVoid() {
+            override fun visitElement(element: IrElement) {
+                element.acceptChildren(this, null)
+            }
+
+            override fun visitSetValue(expression: IrSetValue) {
+                val symbol = expression.symbol
+                if (symbol is IrValueParameterSymbol) {
+                    result.add(symbol)
+                }
+                super.visitSetValue(expression)
+            }
+        }, null)
+        return result
     }
 
     private fun makeLambdaParameterNullable(function: IrFunction, parameter: IrValueParameter) {
@@ -386,36 +445,61 @@ internal class LambdaMetafactoryArgumentsBuilder(
         }, null)
     }
 
-    private fun isReferenceParameterAdaptable(implType: IrType, methodType: IrType): Boolean {
-        if (implType == methodType) return true
-        if (implType.isPrimitiveType() || methodType.isPrimitiveType()) return false
-        if (implType.isInlineClassType() || methodType.isInlineClassType()) return false
-        return isSubtypeOf(implType, methodType) || isSubtypeOf(methodType, implType)
+    /**
+     * Mirror of the strict parameter adaptation check performed at run time by
+     * `java.lang.invoke.AbstractValidatingLambdaMetafactory.isAdaptableTo` (with `strict = true`): a parameter of
+     * the instantiated method type is adaptable to the corresponding implementation method parameter only via
+     * reference widening, boxing to the exact wrapper type (or a wider reference type), or unboxing from the exact
+     * wrapper type. JDK 1.8 does not enforce every one of these cases, but JDK 9+ and D8 do, so emitting an
+     * adaptation this check rejects produces a LambdaConversionException at run time on modern JDKs.
+     *
+     * The comparison is done on mapped JVM types because those are what LambdaMetafactory validates. This also
+     * keeps the decision stable when the same reference is processed again after local declarations lowering has
+     * replaced type parameters with copies: the mapped erasures do not change, while IrType equality would.
+     */
+    private fun isJdkAdaptableParameter(instantiatedType: IrType, implType: IrType): Boolean {
+        val instantiatedAsmType = context.defaultTypeMapper.mapType(instantiatedType)
+        val implAsmType = context.defaultTypeMapper.mapType(implType)
+        if (instantiatedAsmType == implAsmType) return true
+        val instantiatedIsPrimitive = AsmUtil.isPrimitive(instantiatedAsmType)
+        val implIsPrimitive = AsmUtil.isPrimitive(implAsmType)
+        return when {
+            // Two different JVM primitives: don't rely on implicit primitive widening conversions.
+            instantiatedIsPrimitive && implIsPrimitive -> false
+            // Boxing: the primitive value is boxed to its wrapper class, which must then widen to the impl type.
+            instantiatedIsPrimitive ->
+                implAsmType.sort == Type.OBJECT &&
+                        (implAsmType.internalName == "java/lang/Object" || implAsmType == AsmUtil.boxType(instantiatedAsmType))
+            // Unboxing: only possible from the exact wrapper type.
+            implIsPrimitive -> instantiatedAsmType == AsmUtil.boxType(implAsmType)
+            // Reference widening: the impl parameter type must be a supertype of the instantiated parameter type.
+            else -> isSubtypeOf(instantiatedType, implType.makeNullable())
+        }
     }
 
+    private val irTypeCheckerState by lazy(LazyThreadSafetyMode.NONE) { createIrTypeCheckerState(context.typeSystem) }
+
     private fun isSubtypeOf(subType: IrType, superType: IrType): Boolean =
-        AbstractTypeChecker.isSubtypeOf(createIrTypeCheckerState(context.typeSystem), subType, superType)
+        AbstractTypeChecker.isSubtypeOf(irTypeCheckerState, subType, superType)
 
-    private fun adaptReferenceLambdaParameter(function: IrFunction, parameter: IrValueParameter, methodType: IrType) {
-        val implementationType = parameter.type
-        if (implementationType == methodType || !isReferenceParameterAdaptable(implementationType, methodType)) return
-        if (!isSubtypeOf(implementationType, methodType)) return
-
-        // LambdaMetafactory passes the erased SAM parameter type to the implementation method.
-        // Keep the lambda's original Kotlin type at each use site and insert the required JVM cast.
+    private fun widenLambdaParameterType(function: IrFunction, parameter: IrValueParameter, methodType: IrType) {
+        val originalType = parameter.type
         parameter.type = methodType
+        // LambdaMetafactory passes a value of the instantiated method parameter type to the implementation method,
+        // so the implementation method must declare exactly that type in its signature. The passed value still has
+        // the lambda's original (narrower) type at run time; retain that type at every use site with an implicit
+        // cast, which materializes as the required checkcast/unboxing during codegen.
         function.body?.transformChildrenVoid(object : IrElementTransformerVoid() {
             override fun visitGetValue(expression: IrGetValue): IrExpression {
                 if (expression.symbol != parameter.symbol) return super.visitGetValue(expression)
-                val transformed = super.visitGetValue(expression) as IrGetValue
-                transformed.type = methodType
+                expression.type = methodType
                 return IrTypeOperatorCallImpl(
-                    expression.startOffset,
-                    expression.endOffset,
-                    implementationType,
-                    IrTypeOperator.IMPLICIT_CAST,
-                    implementationType,
-                    transformed,
+                    startOffset = expression.startOffset,
+                    endOffset = expression.endOffset,
+                    type = originalType,
+                    operator = IrTypeOperator.IMPLICIT_CAST,
+                    typeOperand = originalType,
+                    argument = expression,
                 )
             }
         })

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrAttributes.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrAttributes.kt
@@ -67,3 +67,6 @@ var IrVariable.originalSnippetValueSymbol: IrSymbol? by irAttribute(copyByDefaul
 var IrCall.originalForReflectiveCall: IrCall? by irAttribute(copyByDefault = false)
 
 var IrMutableAnnotationContainer.isJavaLangDeprecatedOnlyAddedByCompiler: Boolean by irFlag(copyByDefault = true)
+
+// Marks an anonymous function used as an indy implementation method so codegen emits parameter assertions.
+var IrFunction.isIndyImplementationMethod: Boolean by irFlag(copyByDefault = false)

--- a/compiler/testData/codegen/boxJvm/fir/inaccessibleLambdaParameter.kt
+++ b/compiler/testData/codegen/boxJvm/fir/inaccessibleLambdaParameter.kt
@@ -1,6 +1,4 @@
 // TARGET_BACKEND: JVM_IR
-// IGNORE_BACKEND: JVM_IR
-// Reason: java.lang.ClassNotFoundException: error.NonExistentClass (shouldn't work anyway due to MISSING_DEPENDENCY_CLASS)
 // ISSUE: KT-62525
 
 // MODULE: start

--- a/compiler/testData/codegen/boxJvm/fir/inaccessibleLambdaReceiver.kt
+++ b/compiler/testData/codegen/boxJvm/fir/inaccessibleLambdaReceiver.kt
@@ -1,6 +1,4 @@
 // TARGET_BACKEND: JVM_IR
-// IGNORE_BACKEND: JVM_IR
-// Reason: java.lang.ClassNotFoundException: error.NonExistentClass (shouldn't work anyway due to MISSING_DEPENDENCY_CLASS)
 // ISSUE: KT-66743
 
 // MODULE: start

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995.kt
@@ -1,0 +1,22 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// 1 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+
+import java.util.function.Consumer
+
+var result = "Fail"
+
+fun <T> foo(c: Consumer<in T>, value: T) {
+    c.accept(value)
+}
+
+fun box(): String {
+    foo<String>({ result = it }, "OK")
+    return result
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_anonymousFunctionNullabilityAssertion.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_anonymousFunctionNullabilityAssertion.kt
@@ -1,0 +1,50 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+// LAMBDAS: CLASS
+
+// CHECK_BYTECODE_TEXT
+// 3 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+
+// Anonymous functions keep LOCAL_FUNCTION, so codegen cannot recognize indy use by origin. Check parameter
+// assertions for both widened and direct SAM conversions.
+
+// FILE: J.java
+import java.util.function.Consumer;
+
+public final class J {
+    public static boolean bodyRanWithNull(Consumer<? super String> consumer) {
+        try {
+            consumer.accept(null);
+        } catch (NullPointerException expected) {
+            return false;
+        }
+        return true;
+    }
+}
+
+// FILE: box.kt
+import java.util.function.Consumer
+
+val events = StringBuilder()
+
+fun <T> exposeForJava(consumer: Consumer<in T>): Consumer<in T> = consumer
+
+fun box(): String {
+    val projected = exposeForJava<String>(fun(_: String) { events.append("projected") })
+    if (J.bodyRanWithNull(projected)) return "Fail: null reached the non-null anonymous-function body: $events"
+
+    val plain = Consumer(fun(_: String) { events.append("plain") })
+    if (J.bodyRanWithNull(plain)) return "Fail: null reached the plain anonymous-function body: $events"
+
+    if (events.isNotEmpty()) return "Fail: a body ran before the null check: $events"
+
+    val nullable = exposeForJava<String?>(fun(value: String?) { events.append(if (value == null) "nullable" else "notNull") })
+    if (!J.bodyRanWithNull(nullable)) return "Fail: null rejected by an anonymous function with a nullable parameter"
+    if (events.toString() != "nullable") return "Fail: $events"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_boundedUpperBound.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_boundedUpperBound.kt
@@ -1,0 +1,24 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// 0 java/lang/invoke/LambdaMetafactory
+
+// The SAM type parameter has a non-trivial upper bound, so the careful
+// approximation of the 'in' projection gives up (see KT-51868) and the SAM
+// conversion must stay class-based: with an erased-to-Any? instantiated
+// signature LambdaMetafactory would reject the call site on JDK 9+.
+
+fun interface Cmp<T : CharSequence> {
+    fun compare(a: T, b: T): Int
+}
+
+fun <T : CharSequence> foo(comparator: Cmp<in T>, a: T, b: T) = comparator.compare(a, b)
+
+fun box(): String {
+    val t = foo<String>({ a, b -> a.length - b.length }, "a", "bb")
+    if (t >= 0) return "Fail: t=$t"
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_boxingThenWidening.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_boxingThenWidening.kt
@@ -1,0 +1,26 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+// LAMBDAS: CLASS
+
+// CHECK_BYTECODE_TEXT
+// 1 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+
+// LambdaMetafactory boxes an 'int' argument to 'Integer' and then widens it to any supertype of 'Integer', so
+// converting a '(Number) -> Unit' reference to 'IntConsumer' is a valid adaptation and must use invokedynamic.
+
+import java.util.function.IntConsumer
+
+var result = 0
+
+fun takeNumber(value: Number) {
+    result = value.toInt()
+}
+
+fun box(): String {
+    IntConsumer(::takeNumber).accept(42)
+    return if (result == 42) "OK" else "Fail: $result"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_classLambdas.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_classLambdas.kt
@@ -1,0 +1,24 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+// LAMBDAS: CLASS
+
+// CHECK_BYTECODE_TEXT
+// 1 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+// 0 Kt57995_classLambdasKt\$box\$
+
+import java.util.function.Consumer
+
+var result = "Fail"
+
+fun <T> foo(c: Consumer<in T>, value: T) {
+    c.accept(value)
+}
+
+fun box(): String {
+    foo<String>({ result = it }, "OK")
+    return result
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_classSamConversions.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_classSamConversions.kt
@@ -1,0 +1,28 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: CLASS
+
+import java.util.Comparator
+import java.util.function.Consumer
+
+var result = "Fail"
+
+fun <T> foo(c: Consumer<in T>, value: T) {
+    c.accept(value)
+}
+
+fun box(): String {
+    foo<String>({ result = it }, "OK")
+    if (result != "OK") return "Fail consumer: $result"
+
+    val map = HashMap<Int, String>()
+    val computed = map.computeIfAbsent(41) { (it + 1).toString() }
+    if (computed != "42") return "Fail computeIfAbsent: $computed"
+
+    val comparator = Comparator.comparingInt<String> { it.length }
+    if (comparator.compare("a", "bb") >= 0) return "Fail comparingInt"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_functionReferences.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_functionReferences.kt
@@ -1,0 +1,32 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// 2 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+// 0 kotlin/jvm/internal/FunctionReference
+
+import java.util.function.Consumer
+
+var result = "Fail"
+
+fun takeString(s: String) {
+    result = s
+}
+
+fun <T> consume(c: Consumer<in T>, value: T) {
+    c.accept(value)
+}
+
+fun box(): String {
+    val map = HashMap<String, Int>()
+    map["a"] = 1
+    map.merge("a", 2, Int::plus)
+    if (map["a"] != 3) return "Fail merge: ${map["a"]}"
+
+    consume(::takeString, "OK")
+    return result
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_groundSamType.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_groundSamType.kt
@@ -1,0 +1,43 @@
+// TARGET_BACKEND: JVM
+// FULL_JDK
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// JVM_IR_TEMPLATES
+// 4 java/lang/invoke/LambdaMetafactory
+
+import java.util.Comparator
+import java.util.HashMap
+import java.util.function.Consumer
+
+fun <T> consume(block: Consumer<in T>) {}
+
+fun use() {
+    consume<String> { }
+}
+
+fun useComparingInt(): Boolean {
+    val comparator = Comparator.comparingInt<String> { it.length }
+    return comparator.compare("a", "bb") < 0
+}
+
+fun useMapCompute(): Boolean {
+    val map = HashMap<String, Int>()
+    map["value"] = 2
+    return map.compute("value") { key, value -> key.length + (value ?: 0) } == 7
+}
+
+fun useMapComputeIfAbsent(): Boolean {
+    val map = HashMap<String, Int>()
+    return map.computeIfAbsent("value") { it.length } == 5
+}
+
+fun box(): String {
+    use()
+    if (!useComparingInt()) return "Fail comparingInt"
+    if (!useMapCompute()) return "Fail compute"
+    if (!useMapComputeIfAbsent()) return "Fail computeIfAbsent"
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_intersectionBounds.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_intersectionBounds.kt
@@ -1,0 +1,32 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// SAM_CONVERSIONS: INDY
+// LAMBDAS: CLASS
+
+// CHECK_BYTECODE_TEXT
+// 0 java/lang/invoke/LambdaMetafactory
+
+// The SAM method parameter is a type parameter with two interface upper bounds, so it is erased to the
+// first one ('A'), while the lambda parameter is 'B'. LambdaMetafactory can't adapt an instantiated
+// method type '(LA;)V' to an implementation method '(LB;)V', so this SAM conversion must stay
+// class-based instead of failing with a LambdaConversionException on JDK 9+.
+
+interface A
+interface B
+
+class AB : A, B
+
+fun interface Sink<T> {
+    fun accept(value: T)
+}
+
+var result = "Fail"
+
+fun <T> makeSink(): Sink<T> where T : A, T : B =
+    Sink { _: B -> result = "OK" }
+
+fun box(): String {
+    makeSink<AB>().accept(AB())
+    return result
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_nullabilityAssertion.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_nullabilityAssertion.kt
@@ -1,0 +1,49 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+// LAMBDAS: CLASS
+
+// CHECK_BYTECODE_TEXT
+// 2 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+
+// A SAM type with an 'in' projection is converted to a single invokedynamic, which requires widening the
+// implementation lambda's parameter to the instantiated method parameter type. That must not drop the
+// non-null assertion on the lambda parameter (KT-44278), including when the parameter is unused.
+
+// FILE: J.java
+import java.util.function.Consumer;
+
+public final class J {
+    public static boolean bodyRanWithNull(Consumer<? super String> consumer) {
+        try {
+            consumer.accept(null);
+        } catch (NullPointerException expected) {
+            return false;
+        }
+        return true;
+    }
+}
+
+// FILE: box.kt
+import java.util.function.Consumer
+
+val events = StringBuilder()
+
+fun <T> exposeForJava(consumer: Consumer<in T>): Consumer<in T> = consumer
+
+fun box(): String {
+    // 'it' is non-null and unused: the null check still has to run, before the body.
+    val nonNull = exposeForJava<String>({ events.append("nonNull") })
+    if (J.bodyRanWithNull(nonNull)) return "Fail: null reached the non-null lambda body: $events"
+    if (events.isNotEmpty()) return "Fail: body ran before the null check: $events"
+
+    // 'it' is nullable: null must reach the body as before.
+    val nullable = exposeForJava<String?>({ events.append(if (it == null) "nullable" else "notNull") })
+    if (!J.bodyRanWithNull(nullable)) return "Fail: null rejected by a lambda with a nullable parameter"
+    if (events.toString() != "nullable") return "Fail: $events"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_primitiveParams.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_primitiveParams.kt
@@ -1,0 +1,27 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// 3 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+
+import java.util.Comparator
+
+fun box(): String {
+    val map = HashMap<Int, String>()
+    val computed = map.computeIfAbsent(41) { (it + 1).toString() }
+    if (computed != "42") return "Fail computeIfAbsent: $computed"
+
+    val comparator = Comparator.comparingInt<String> { it.length }
+    if (comparator.compare("a", "bb") >= 0) return "Fail comparingInt"
+
+    val counters = HashMap<String, Int>()
+    counters["a"] = 1
+    val merged = counters.merge("a", 2) { old, new -> old + new }
+    if (merged != 3) return "Fail merge: $merged"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_serializable.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/kt57995_serializable.kt
@@ -1,0 +1,35 @@
+// TARGET_BACKEND: JVM
+// JVM_TARGET: 1.8
+// WITH_STDLIB
+// FULL_JDK
+// SAM_CONVERSIONS: INDY
+
+// CHECK_BYTECODE_TEXT
+// 1 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
+
+// FILE: SerFunction.java
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+public interface SerFunction<T, R> extends Function<T, R>, Serializable {
+}
+
+// FILE: box.kt
+
+import java.io.*
+
+fun roundTrip(x: Any?): Any? {
+    val bos = ByteArrayOutputStream()
+    ObjectOutputStream(bos).use { it.writeObject(x) }
+    return ObjectInputStream(ByteArrayInputStream(bos.toByteArray())).readObject()
+}
+
+fun <T> useAfterRoundTrip(f: SerFunction<in T, String>, value: T): String {
+    @Suppress("UNCHECKED_CAST")
+    val g = roundTrip(f) as SerFunction<in T, String>
+    return g.apply(value)
+}
+
+fun box(): String = useAfterRoundTrip<String>({ it + "K" }, "O")

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/specializedGenerics/genericWithInProjection.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/specializedGenerics/genericWithInProjection.kt
@@ -4,8 +4,8 @@
 // LAMBDAS: CLASS
 
 // CHECK_BYTECODE_TEXT
-// 0 java/lang/invoke/LambdaMetafactory
-// TODO: restore indy for SAM types with contravariant projections. See KT-52428 for more info.
+// 1 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
 
 fun interface Cmp<T> {
     fun compare(a: T, b: T): Int

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/specializedGenerics/genericWithInProjectionWithIndyLambdas.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/specializedGenerics/genericWithInProjectionWithIndyLambdas.kt
@@ -5,10 +5,10 @@
 
 // CHECK_BYTECODE_TEXT
 // 1 java/lang/invoke/LambdaMetafactory
+// 0 \$sam\$
 
-// ^ Since indy for SAM types with contravariant projections is disabled (see genericWithInProjection.kt), the bytecode in this test is
-//   suboptimal. The lambda is generated via invokedynamic LambdaMetafactory and then wrapped into an instance of Cmp.
-//   The optimal way would be to generate the Cmp instance via invokedynamic LambdaMetafactory directly.
+// ^ The Cmp instance is generated via invokedynamic LambdaMetafactory directly, without an intermediate
+//   function object and a SAM wrapper class over it (KT-57995).
 
 fun interface Cmp<T> {
     fun compare(a: T, b: T): Int

--- a/compiler/testData/codegen/boxJvm/invokedynamic/sam/streamApi1.kt
+++ b/compiler/testData/codegen/boxJvm/invokedynamic/sam/streamApi1.kt
@@ -6,7 +6,7 @@
 // FULL_JDK
 
 // CHECK_BYTECODE_TEXT
-// 2 java/lang/invoke/LambdaMetafactory
+// 1 java/lang/invoke/LambdaMetafactory
 
 import java.util.stream.Collectors
 

--- a/compiler/testData/codegen/bytecodeListing/sam/samWithContravariantProjection.txt
+++ b/compiler/testData/codegen/bytecodeListing/sam/samWithContravariantProjection.txt
@@ -6,22 +6,9 @@ public final class A {
 }
 
 @kotlin.Metadata
-synthetic final class TestKt$example$1 {
-    // source: 'test.kt'
-    enclosing method TestKt.example()V
-    public final static field INSTANCE: TestKt$example$1
-    inner (anonymous) class TestKt$example$1
-    static method <clinit>(): void
-    method <init>(): void
-    public synthetic bridge method invoke(p0: java.lang.Object): java.lang.Object
-    public final method invoke(p0: java.lang.Object): void
-}
-
-@kotlin.Metadata
 public final class TestKt {
     // source: 'test.kt'
-    inner (anonymous) class TestKt$example$1
-    private final static method example$lambda$0(p0: kotlin.jvm.functions.Function1, p1: java.lang.Object): void
+    private final static method example$foo(p0: java.lang.Object): void
     public final static method example(): void
     public final static method foo(@org.jetbrains.annotations.NotNull p0: java.lang.Object): void
 }


### PR DESCRIPTION
This is achieved by removing implicit cast, inserted by Fir2Ir. The change is local to JVM, since removing the cast for other backends, when it is beneficial only on JVM, is too broad of a change.