### PR TITLE
JVM: Use linkedLabel() instead of Label()

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -993,7 +993,7 @@ class ExpressionCodegen(
         val isNonLocalReturn = methodSignatureMapper.mapFunctionName(owner) != methodSignatureMapper.mapFunctionName(irFunction)
 
         val [returnType, returnIrType] = owner.returnAsmAndIrTypes()
-        val afterReturnLabel = Label()
+        val afterReturnLabel = linkedLabel()
         expression.value.accept(this, data).materializeAt(returnType, returnIrType)
         generateFinallyBlocksIfNeeded(returnType, afterReturnLabel, data, null)
         expression.markLineNumber(startOffset = true)

--- a/compiler/testData/codegen/box/try/kt47891.kt
+++ b/compiler/testData/codegen/box/try/kt47891.kt
@@ -1,0 +1,15 @@
+// TARGET_BACKEND: JVM
+
+fun box(): String {
+    try {
+        try {
+            run {
+                return "NOT OK1"
+            }
+        } finally {
+            return "NOT OK2"
+        }
+    } finally {
+        return "OK"
+    }
+}


### PR DESCRIPTION
It's unsafe to use `Label()` here.

`mv.mark(afterReturnLabel)`  only builds a single way direction of connection from `Label` to `LabelNode`.

It causes trouble when we do something like `adapter.accept(MethodBodyVisitor(codegen.visitor))` later. 
The original `LabelNode` won't be found, but create a new one and add into instructions of `methodNode` of `codegen.visitor`.

Mean the while, the `Label` is used to fill `tryWithFinallyInfo.gaps`  and original `LabelNode` used to create `TCB`...

This is why a `LabelNode` of `TCB` can miss in instruction list.

^KT-47891 fixed