### PR TITLE
[stdlib] Add text-specific samples for windowed and windowedSequence

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -2424,7 +2424,7 @@ public inline fun String.partition(predicate: (Char) -> Boolean): Pair<String, S
  * @param partialWindows controls whether or not to keep partial windows in the end if any,
  * by default `false` which means partial windows won't be preserved
  * 
- * @sample samples.collections.Sequences.Transformations.takeWindows
+ * @sample samples.text.Strings.windowed
  */
 @SinceKotlin("1.2")
 public fun CharSequence.windowed(size: Int, step: Int = 1, partialWindows: Boolean = false): List<String> {
@@ -2446,7 +2446,7 @@ public fun CharSequence.windowed(size: Int, step: Int = 1, partialWindows: Boole
  * @param partialWindows controls whether or not to keep partial windows in the end if any,
  * by default `false` which means partial windows won't be preserved
  * 
- * @sample samples.collections.Sequences.Transformations.averageWindows
+ * @sample samples.text.Strings.windowedTransform
  */
 @SinceKotlin("1.2")
 public fun <R> CharSequence.windowed(size: Int, step: Int = 1, partialWindows: Boolean = false, transform: (CharSequence) -> R): List<R> {
@@ -2477,7 +2477,7 @@ public fun <R> CharSequence.windowed(size: Int, step: Int = 1, partialWindows: B
  * @param partialWindows controls whether or not to keep partial windows in the end if any,
  * by default `false` which means partial windows won't be preserved
  * 
- * @sample samples.collections.Sequences.Transformations.takeWindows
+ * @sample samples.text.Strings.windowedSequence
  */
 @SinceKotlin("1.2")
 public fun CharSequence.windowedSequence(size: Int, step: Int = 1, partialWindows: Boolean = false): Sequence<String> {
@@ -2499,7 +2499,7 @@ public fun CharSequence.windowedSequence(size: Int, step: Int = 1, partialWindow
  * @param partialWindows controls whether or not to keep partial windows in the end if any,
  * by default `false` which means partial windows won't be preserved
  * 
- * @sample samples.collections.Sequences.Transformations.averageWindows
+ * @sample samples.text.Strings.windowedTransformToSequence
  */
 @SinceKotlin("1.2")
 public fun <R> CharSequence.windowedSequence(size: Int, step: Int = 1, partialWindows: Boolean = false, transform: (CharSequence) -> R): Sequence<R> {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -101,6 +101,67 @@ class Strings {
     }
 
     @Sample
+    fun windowed() {
+        val word = "kotlin"
+
+        // each window is a string of the given size, and the window moves one character forward at a time
+        val trigrams = word.windowed(3)
+        assertPrints(trigrams, "[kot, otl, tli, lin]")
+
+        // a larger step moves the window several characters forward at a time
+        assertPrints(word.windowed(size = 3, step = 2), "[kot, tli]")
+
+        // by default, a trailing window shorter than the given size is dropped
+        assertPrints(word.windowed(size = 4, step = 2), "[kotl, tlin]")
+        // but it can be kept with partialWindows = true
+        assertPrints(word.windowed(size = 4, step = 2, partialWindows = true), "[kotl, tlin, in]")
+
+        // a window larger than the whole string is dropped as well
+        assertPrints("abc".windowed(5), "[]")
+        // when partial windows are kept, every position of the string starts a window, even if it does not fit
+        assertPrints("abc".windowed(5, partialWindows = true), "[abc, bc, c]")
+
+        // an empty string has no windows
+        assertPrints("".windowed(2), "[]")
+    }
+
+    @Sample
+    fun windowedSequence() {
+        val word = "kotlin"
+        val windows = word.windowedSequence(3)
+
+        // windows are produced lazily, one by one, as the sequence is iterated
+        assertPrints(windows.first { it.startsWith('t') }, "tli")
+        assertPrints(windows.toList(), "[kot, otl, tli, lin]")
+
+        // step and partialWindows work in the same way as for windowed
+        assertPrints(word.windowedSequence(size = 4, step = 2, partialWindows = true).toList(), "[kotl, tlin, in]")
+    }
+
+    @Sample
+    fun windowedTransform() {
+        val digits = "31415"
+
+        // each window is passed to the transform function as a CharSequence
+        val numbers = digits.windowed(size = 3) { window -> window.toString().toInt() }
+        assertPrints(numbers, "[314, 141, 415]")
+
+        // a trailing partial window is passed to the transform function as well when partial windows are kept
+        val sparseNumbers = digits.windowed(size = 3, step = 2, partialWindows = true) { window -> window.toString().toInt() }
+        assertPrints(sparseNumbers, "[314, 415, 5]")
+    }
+
+    @Sample
+    fun windowedTransformToSequence() {
+        val digits = "31415926"
+        val digitSums = digits.windowedSequence(size = 3) { window -> window.sumOf { it.digitToInt() } }
+
+        // the sequence is evaluated lazily, so windows after the first match are not processed
+        assertPrints(digitSums.first { it > 10 }, "15")
+        assertPrints(digitSums.toList(), "[8, 6, 10, 15, 16, 17]")
+    }
+
+    @Sample
     fun elementAt() {
         val string = "kotlin"
         assertPrints(string.elementAt(0), "k")

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Generators.kt
@@ -667,6 +667,7 @@ object Generators : TemplateGroupBase() {
 
         specialFor(CharSequences) {
             signature("windowed(size: Int, step: Int = 1, partialWindows: Boolean = false, transform: (CharSequence) -> R)")
+            sample("samples.text.Strings.windowedTransform")
         }
         body(CharSequences) {
             """
@@ -717,6 +718,7 @@ object Generators : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Sequences.Transformations.takeWindows")
+        specialFor(CharSequences) { sample("samples.text.Strings.windowed") }
 
         body {
             """
@@ -770,7 +772,7 @@ object Generators : TemplateGroupBase() {
             by default `false` which means partial windows won't be preserved
             """
         }
-        sample("samples.collections.Sequences.Transformations.averageWindows")
+        sample("samples.text.Strings.windowedTransformToSequence")
         typeParam("R")
         returns("Sequence<R>")
 
@@ -806,7 +808,7 @@ object Generators : TemplateGroupBase() {
             by default `false` which means partial windows won't be preserved
             """
         }
-        sample("samples.collections.Sequences.Transformations.takeWindows")
+        sample("samples.text.Strings.windowedSequence")
         returns("Sequence<String>")
 
         body(CharSequences) { "return windowedSequence(size, step, partialWindows) { it.toString() }" }


### PR DESCRIPTION
Replaces the generic `kotlin.collections` samples with string-focused examples for the four `CharSequence` overloads of `windowed` and `windowedSequence` (plain and `transform` variants). They currently point to `Sequences.Transformations.takeWindows` / `averageWindows`, so the `kotlin.text` docs show windows over a sequence of integers instead of strings.

The samples show character n-grams, the effect of `step` and `partialWindows` (including the case where partial windows are kept for a window larger than the string), lazy evaluation of `windowedSequence`, and the `transform` overloads receiving each window as a `CharSequence`. The sample references are added to the `CharSequences` specializations in the generator template and `_Strings.kt` is regenerated.

Related issue: [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867/kotlin.text-extension-function-samples-should-be-specialized-for-strings). Scoped to the `windowed` family only; the remaining functions from the issue are left for follow-up PRs, as previous contributors did.

Verified locally with `./gradlew :tools:kotlin-stdlib-gen:run` and `./gradlew :kotlin-stdlib:samples:test --tests "samples.text.Strings"`.

The samples were drafted with Claude Code and reviewed and tested by me.
