### PR TITLE
[CLI, Language] Remove CLI argument for `StrictEquals` and set the feature to `testOnly`.

### DIFF
--- a/analysis/analysis-test-framework/testFixtures/org/jetbrains/kotlin/analysis/test/framework/services/libraries/CliTestModuleCompilers.kt
+++ b/analysis/analysis-test-framework/testFixtures/org/jetbrains/kotlin/analysis/test/framework/services/libraries/CliTestModuleCompilers.kt
@@ -52,6 +52,8 @@ abstract class CliTestModuleCompiler : TestModuleCompiler() {
         resourceFiles: List<TestFile>,
         testServices: TestServices,
     ): Path {
+        allowTestsOnlyLanguageFeatures()
+
         val allowedLibraryPlatforms = module.directives[Directives.LIBRARY_PLATFORMS].map { it.targetPlatform }
         val compilationErrorExpected = Directives.COMPILATION_ERRORS in module.directives
                 || (allowedLibraryPlatforms.isNotEmpty() && module.targetPlatform(testServices) !in allowedLibraryPlatforms)

--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -3957,51 +3957,6 @@
                         "deprecatedMessage": null
                     },
                     {
-                        "name": "Xequality-bounds",
-                        "shortName": null,
-                        "deprecatedName": null,
-                        "description": {
-                            "current": "Enable experimental support for `@EqualityBound` annotations in `equals` operators.",
-                            "valueInVersions": []
-                        },
-                        "delimiter": null,
-                        "affectsCompilationOutcome": true,
-                        "restrictedToCompilerPhase": null,
-                        "valueType": {
-                            "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
-                            "isNullable": {
-                                "current": false,
-                                "valueInVersions": []
-                            },
-                            "defaultValue": {
-                                "current": false,
-                                "valueInVersions": []
-                            }
-                        },
-                        "valueDescription": {
-                            "current": null,
-                            "valueInVersions": []
-                        },
-                        "releaseVersionsMetadata": {
-                            "introducedVersion": "2.5.0",
-                            "stabilizedVersion": null,
-                            "deprecatedVersion": null,
-                            "removedVersion": null
-                        },
-                        "argumentType": {
-                            "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
-                            "isNullable": {
-                                "current": false,
-                                "valueInVersions": []
-                            },
-                            "defaultValue": {
-                                "current": false,
-                                "valueInVersions": []
-                            }
-                        },
-                        "deprecatedMessage": null
-                    },
-                    {
                         "name": "Xescaping-functions",
                         "shortName": null,
                         "deprecatedName": null,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
@@ -1475,21 +1475,6 @@ Warning: this flag is not intended for production use. If you want to configure 
     }
 
     compilerArgument {
-        name = "Xequality-bounds"
-        description = """
-            Enable experimental support for `@EqualityBound` annotations in `equals` operators.
-        """.trimIndent().asReleaseDependent()
-        valueType = BooleanType.defaultFalse
-        additionalAnnotations(
-            Enables(LanguageFeature.StrictEquals),
-        )
-
-        lifecycle(
-            introducedVersion = KotlinReleaseVersion.v2_5_0
-        )
-    }
-
-    compilerArgument {
         name = "Xintrinsic-const-evaluation"
         description = """
             Enables `IntrinsicConstEvaluation` language feature.`

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -492,7 +492,6 @@ public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/Co
 	public static final field X_DUMP_PERF Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_EAGER_LAMBDA_ANALYSIS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_ENABLE_ADDITIONAL_IR_CHECKERS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
-	public static final field X_EQUALITY_BOUNDS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_ESCAPING_FUNCTIONS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_EXPECT_ACTUAL_CLASSES Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_EXPLICIT_API Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments.kt
@@ -405,16 +405,6 @@ public interface CommonCompilerArguments : CommonToolArguments {
         CommonCompilerArgument("X_ENABLE_ADDITIONAL_IR_CHECKERS", KotlinReleaseVersion(2, 4, 20))
 
     /**
-     * Enable experimental support for `@EqualityBound` annotations in `equals` operators.
-     *
-     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
-     */
-    @JvmField
-    @ExperimentalCompilerArgument
-    public val X_EQUALITY_BOUNDS: CommonCompilerArgument<Boolean> =
-        CommonCompilerArgument("X_EQUALITY_BOUNDS", KotlinReleaseVersion(2, 5, 0))
-
-    /**
      * Add (+) or remove (-) a callable whose functional arguments are analyzed for escaping mutable variables. Callables are specified by their fully qualified name.
      *
      * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonCompilerArgumentsImpl.kt
@@ -73,7 +73,6 @@ import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgume
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EAGER_LAMBDA_ANALYSIS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_ENABLE_ADDITIONAL_IR_CHECKERS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_ENABLE_INCREMENTAL_COMPILATION
-import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EQUALITY_BOUNDS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_ESCAPING_FUNCTIONS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EXPECT_ACTUAL_CLASSES
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EXPLICIT_API
@@ -248,7 +247,6 @@ internal abstract class CommonCompilerArgumentsImpl(
     if (X_EAGER_LAMBDA_ANALYSIS in this) { arguments.eagerLambdaAnalysis = get(X_EAGER_LAMBDA_ANALYSIS)}
     if (X_ENABLE_ADDITIONAL_IR_CHECKERS in this) { arguments.enableAdditionalIrCheckers = get(X_ENABLE_ADDITIONAL_IR_CHECKERS) ?: emptyArray()}
     if (X_ENABLE_INCREMENTAL_COMPILATION in this) { arguments.incrementalCompilation = get(X_ENABLE_INCREMENTAL_COMPILATION)}
-    if (X_EQUALITY_BOUNDS in this) { arguments.equalityBounds = get(X_EQUALITY_BOUNDS)}
     if (X_ESCAPING_FUNCTIONS in this) { arguments.escapingFunctions = get(X_ESCAPING_FUNCTIONS).toTypedArray()}
     if (X_EXPECT_ACTUAL_CLASSES in this) { arguments.expectActualClasses = get(X_EXPECT_ACTUAL_CLASSES)}
     if (X_EXPLICIT_API in this) { arguments.explicitApi = get(X_EXPLICIT_API).stringValue}
@@ -364,7 +362,6 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_EAGER_LAMBDA_ANALYSIS] = arguments.eagerLambdaAnalysis } catch (_: NoSuchMethodError) {  }
     try { this[X_ENABLE_ADDITIONAL_IR_CHECKERS] = arguments.enableAdditionalIrCheckers } catch (_: NoSuchMethodError) {  }
     try { this[X_ENABLE_INCREMENTAL_COMPILATION] = arguments.incrementalCompilation } catch (_: NoSuchMethodError) {  }
-    try { this[X_EQUALITY_BOUNDS] = arguments.equalityBounds } catch (_: NoSuchMethodError) {  }
     try { this[X_ESCAPING_FUNCTIONS] = arguments.escapingFunctions.toListOrEmpty() } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPECT_ACTUAL_CLASSES] = arguments.expectActualClasses } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPLICIT_API] = arguments.explicitApi.let { ExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::explicitApi, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xexplicit-api value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
@@ -475,7 +472,6 @@ internal abstract class CommonCompilerArgumentsImpl(
     if (X_EAGER_LAMBDA_ANALYSIS in this) { arguments.eagerLambdaAnalysis = get(X_EAGER_LAMBDA_ANALYSIS)}
     if (X_ENABLE_ADDITIONAL_IR_CHECKERS in this) { arguments.enableAdditionalIrCheckers = get(X_ENABLE_ADDITIONAL_IR_CHECKERS) ?: emptyArray()}
     if (X_ENABLE_INCREMENTAL_COMPILATION in this) { arguments.incrementalCompilation = get(X_ENABLE_INCREMENTAL_COMPILATION)}
-    if (X_EQUALITY_BOUNDS in this) { arguments.equalityBounds = get(X_EQUALITY_BOUNDS)}
     if (X_ESCAPING_FUNCTIONS in this) { arguments.escapingFunctions = get(X_ESCAPING_FUNCTIONS).toTypedArray()}
     if (X_EXPECT_ACTUAL_CLASSES in this) { arguments.expectActualClasses = get(X_EXPECT_ACTUAL_CLASSES)}
     if (X_EXPLICIT_API in this) { arguments.explicitApi = get(X_EXPLICIT_API).stringValue}
@@ -677,9 +673,6 @@ internal abstract class CommonCompilerArgumentsImpl(
 
     public val X_ENABLE_INCREMENTAL_COMPILATION: CommonCompilerArgument<Boolean?> =
         CommonCompilerArgument("X_ENABLE_INCREMENTAL_COMPILATION")
-
-    public val X_EQUALITY_BOUNDS: CommonCompilerArgument<Boolean> =
-        CommonCompilerArgument("X_EQUALITY_BOUNDS")
 
     public val X_ESCAPING_FUNCTIONS: CommonCompilerArgument<List<String>> =
         CommonCompilerArgument("X_ESCAPING_FUNCTIONS")

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
@@ -487,17 +487,6 @@ It may only be used with specific checkers that are not enabled by default, and 
         }
 
     @Argument(
-        value = "-Xequality-bounds",
-        description = "Enable experimental support for `@EqualityBound` annotations in `equals` operators.",
-    )
-    @Enables(LanguageFeature.StrictEquals)
-    var equalityBounds: Boolean = false
-        set(value) {
-            checkFrozen()
-            field = value
-        }
-
-    @Argument(
         value = "-Xescaping-functions",
         valueDescription = "<+|-><fq.name>",
         description = "Add (+) or remove (-) a callable whose functional arguments are analyzed for escaping mutable variables. Callables are specified by their fully qualified name.",

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
@@ -46,7 +46,6 @@ fun copyCommonCompilerArguments(from: CommonCompilerArguments, to: CommonCompile
     to.dumpPerf = from.dumpPerf
     to.eagerLambdaAnalysis = from.eagerLambdaAnalysis
     to.enableAdditionalIrCheckers = from.enableAdditionalIrCheckers.copyOf()
-    to.equalityBounds = from.equalityBounds
     to.escapingFunctions = from.escapingFunctions.copyOf()
     to.expectActualClasses = from.expectActualClasses
     to.explicitApi = from.explicitApi

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/ConfigureCommonLanguageFeatures.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/ConfigureCommonLanguageFeatures.kt
@@ -88,10 +88,6 @@ internal fun MutableMap<LanguageFeature, LanguageFeature.State>.configureCommonL
         put(LanguageFeature.CallCompletionRefinementsFor25, LanguageFeature.State.ENABLED)
     }
 
-    if (arguments.equalityBounds) {
-        put(LanguageFeature.StrictEquals, LanguageFeature.State.ENABLED)
-    }
-
     if (arguments.explicitBackingFields) {
         put(LanguageFeature.ExplicitBackingFields, LanguageFeature.State.ENABLED)
     }

--- a/compiler/frontend.common-psi/gen/org/jetbrains/kotlin/diagnostics/rendering/FeatureToFlagMapGenerated.kt
+++ b/compiler/frontend.common-psi/gen/org/jetbrains/kotlin/diagnostics/rendering/FeatureToFlagMapGenerated.kt
@@ -49,7 +49,6 @@ val featureToEnablingFlagMap: Map<LanguageFeature, String> = mapOf(
     LanguageFeature.NewInference to "-Xnew-inference",
     LanguageFeature.PropertyParamAnnotationDefaultTargetMode to "-Xannotation-default-target=param-property",
     LanguageFeature.SamConversionPerArgument to "-Xnew-inference",
-    LanguageFeature.StrictEquals to "-Xequality-bounds",
     LanguageFeature.UnrestrictedBuilderInference to "-Xunrestricted-builder-inference",
     LanguageFeature.WhenGuards to "-Xwhen-guards",
 )

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -177,7 +177,6 @@ where advanced options include:
                              It may only be used with specific checkers that are not enabled by default, and which are prepared to be enabled this way. Only has effect if '-Xverify-ir' is not 'none'.
   -Xenable-incremental-compilation
                              Enable incremental compilation.
-  -Xequality-bounds          Enable experimental support for `@EqualityBound` annotations in `equals` operators.
   -Xescaping-functions=<+|-><fq.name>
                              Add (+) or remove (-) a callable whose functional arguments are analyzed for escaping mutable variables. Callables are specified by their fully qualified name.
   -Xexpect-actual-classes    'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta.

--- a/compiler/testData/cli/jvm/extraHelp.out
+++ b/compiler/testData/cli/jvm/extraHelp.out
@@ -205,7 +205,6 @@ where advanced options include:
                              It may only be used with specific checkers that are not enabled by default, and which are prepared to be enabled this way. Only has effect if '-Xverify-ir' is not 'none'.
   -Xenable-incremental-compilation
                              Enable incremental compilation.
-  -Xequality-bounds          Enable experimental support for `@EqualityBound` annotations in `equals` operators.
   -Xescaping-functions=<+|-><fq.name>
                              Add (+) or remove (-) a callable whose functional arguments are analyzed for escaping mutable variables. Callables are specified by their fully qualified name.
   -Xexpect-actual-classes    'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta.

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -149,7 +149,6 @@ where advanced options include:
                              It may only be used with specific checkers that are not enabled by default, and which are prepared to be enabled this way. Only has effect if '-Xverify-ir' is not 'none'.
   -Xenable-incremental-compilation
                              Enable incremental compilation.
-  -Xequality-bounds          Enable experimental support for `@EqualityBound` annotations in `equals` operators.
   -Xescaping-functions=<+|-><fq.name>
                              Add (+) or remove (-) a callable whose functional arguments are analyzed for escaping mutable variables. Callables are specified by their fully qualified name.
   -Xexpect-actual-classes    'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta.

--- a/compiler/tests-common/testFixtures/org/jetbrains/kotlin/klib/KlibCompilerInvocationTestUtils.kt
+++ b/compiler/tests-common/testFixtures/org/jetbrains/kotlin/klib/KlibCompilerInvocationTestUtils.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.klib
 
+import org.jetbrains.kotlin.cli.common.arguments.allowTestsOnlyLanguageFeatures
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.klib.KlibCompilerInvocationTestUtils.TestStructure.ModuleUnderTest
 import org.jetbrains.kotlin.test.InTextDirectivesUtils
@@ -121,6 +122,8 @@ object KlibCompilerInvocationTestUtils {
         binaryRunner: BinaryRunner<BA>,
         compilerEditionChange: KlibCompilerChangeScenario,
     ) {
+        allowTestsOnlyLanguageFeatures()
+
         if (testConfiguration.isIgnoredTest(testStructure.projectInfo)) {
             return testConfiguration.onIgnoredTest() // Ignore muted tests.
         }

--- a/core/language.version-settings/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
+++ b/core/language.version-settings/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
@@ -626,7 +626,7 @@ enum class LanguageFeature(
     ProhibitAllMultipleDefaultsInheritedFromSupertypes(sinceVersion = null, enabledInProgressiveMode = false, issue = NO_ISSUE_SPECIFIED, enabledInLatestLVTests = false),
     FunctionalTypeWithExtensionAsSupertype(sinceVersion = null, "KT-73894", enabledInLatestLVTests = false),
     ContextReceivers(sinceVersion = null, NO_ISSUE_SPECIFIED, enabledInLatestLVTests = false),
-    StrictEquals(sinceVersion = null, sinceApiVersion = ApiVersion.KOTLIN_2_5, issue = "KT-83683", enabledInLatestLVTests = true),
+    StrictEquals(sinceVersion = null, sinceApiVersion = ApiVersion.KOTLIN_2_5, issue = "KT-83683", testOnly = true, enabledInLatestLVTests = true),
     CallableReferencesToContextual(sinceVersion = null, issue = "KT-54594", enabledInLatestLVTests = true),
     JavaSamConversionEqualsHashCode(sinceVersion = null, forcesPreReleaseBinaries = true, issue = "KT-19318", enabledInLatestLVTests = false),
     AllowAnyAsAnActualTypeForExpectInterface(sinceVersion = null, issue = "KT-79308", enabledInLatestLVTests = false),

--- a/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
+++ b/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
@@ -168,7 +168,6 @@ where advanced options include:
                              It may only be used with specific checkers that are not enabled by default, and which are prepared to be enabled this way. Only has effect if '-Xverify-ir' is not 'none'.
   -Xenable-incremental-compilation
                              Enable incremental compilation.
-  -Xequality-bounds          Enable experimental support for `@EqualityBound` annotations in `equals` operators.
   -Xescaping-functions=<+|-><fq.name>
                              Add (+) or remove (-) a callable whose functional arguments are analyzed for escaping mutable variables. Callables are specified by their fully qualified name.
   -Xexpect-actual-classes    'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta.


### PR DESCRIPTION
See internal discussion https://jetbrains.slack.com/archives/C0B85J454TZ/p1788432882195609