### PR TITLE
[Build] Move JVM backend modules from `fe10-for-ide` to `fir-for-ide`…

### DIFF
--- a/prepare/ide-plugin-dependencies/kotlin-compiler-fe10-for-ide/build.gradle.kts
+++ b/prepare/ide-plugin-dependencies/kotlin-compiler-fe10-for-ide/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 val fe10CompilerModules: Array<String> = CompilerModules.fe10CompilerModules
-val jvmCompilerModules: Array<String> = CompilerModules.jvmCompilerModules
 
 val excludedCompilerModules = listOf(
     ":compiler:incremental-compilation-impl",
@@ -16,6 +15,6 @@ val extraCompilerModules = listOf(
     ":compiler:frontend.java",
 )
 
-val projects = fe10CompilerModules.asList() - excludedCompilerModules + jvmCompilerModules + extraCompilerModules
+val projects = fe10CompilerModules.asList() - excludedCompilerModules + extraCompilerModules
 
 publishJarsForIde(projects)

--- a/prepare/ide-plugin-dependencies/kotlin-compiler-fir-for-ide/build.gradle.kts
+++ b/prepare/ide-plugin-dependencies/kotlin-compiler-fir-for-ide/build.gradle.kts
@@ -5,11 +5,12 @@ plugins {
 }
 
 val firCompilerModules: Array<String> = CompilerModules.firCompilerModules
+val jvmCompilerModules: Array<String> = CompilerModules.jvmCompilerModules
 
 val excludedFirModules = listOf(
     ":compiler:fir:raw-fir:light-tree2fir",
 )
 
-val projects = firCompilerModules.asList() - excludedFirModules
+val projects = firCompilerModules.asList() + jvmCompilerModules - excludedFirModules
 
 publishJarsForIde(projects)


### PR DESCRIPTION
… artifact

There is a number of JVM backend classes used from `KaFirCompilerFacility`. So it makes sense to bundle them together with the rest compiler part of the FIR implementation of Analysis API.