### PR TITLE
[Native][tests] Update outdated library versions used as dependencies

### DIFF
--- a/kotlin-native/backend.native/tests/samples/csvparser/build.gradle.kts
+++ b/kotlin-native/backend.native/tests/samples/csvparser/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.6")
             }
         }
     }

--- a/kotlin-native/backend.native/tests/samples/videoplayer/build.gradle.kts
+++ b/kotlin-native/backend.native/tests/samples/videoplayer/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.6")
             }
         }
     }

--- a/kotlin-native/performance/benchmarksAnalyzer/build.gradle.kts
+++ b/kotlin-native/performance/benchmarksAnalyzer/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.6")
                 implementation(project(":benchmarksReports"))
             }
         }

--- a/kotlin-native/performance/benchmarksLauncher/build.gradle.kts
+++ b/kotlin-native/performance/benchmarksLauncher/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
                 api(project(":benchmarksReports"))
 
                 implementation(kotlin("stdlib"))
-                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.6")
             }
             kotlin.srcDir("src/main/kotlin")
         }

--- a/kotlin-native/performance/benchmarksReports/build.gradle.kts
+++ b/kotlin-native/performance/benchmarksReports/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
         }
         jvmMain {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.6")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
             }
         }


### PR DESCRIPTION
This is needed because we raise the bar for the minimal KLIB ABI version up to 1.8.0, and KLIBs with older ABI versions won't be accepted anymore:
- org.jetbrains.kotlinx:kotlinx-cli:0.3.5 -> 0.3.6

^KT-73115