### PR TITLE
[Gradle IT] Update outdated library versions used as dependencies

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt
@@ -1517,7 +1517,7 @@ class Kotlin2JsIrGradlePluginIT : KGPBaseTest() {
 
                 val publishedPom = moduleDir.resolve("kotlin-js-plugin-js-1.0.pom")
                 val pomText = publishedPom.readText().replace(Regex("\\s+"), "")
-                assertTrue { "kotlinx-html-js</artifactId><version>0.7.5</version><scope>compile</scope>" in pomText }
+                assertTrue { "kotlinx-html-js</artifactId><version>0.12.0</version><scope>compile</scope>" in pomText }
                 assertTrue { "kotlin-stdlib-js</artifactId><scope>runtime</scope>" in pomText }
 
                 assertFileExists(moduleDir.resolve("kotlin-js-plugin-js-1.0-sources.jar"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-coroutines/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-coroutines/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     sourceSets {
         val jsMain = getByName("jsMain") {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-plugin-project/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-plugin-project/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         jsMain {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-html-js:0.7.5")
+                api("org.jetbrains.kotlinx:kotlinx-html-js:0.12.0")
                 implementation(kotlin("stdlib-js"))
             }
         }


### PR DESCRIPTION
This is needed because we raise the bar for the minimal KLIB ABI version up to 1.8.0, and KLIBs with older ABI versions won't be accepted anymore:
- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 -> 1.9.0
- org.jetbrains.kotlinx:kotlinx-html-js:0.7.5 -> 0.12.0

^KT-73115