### PR TITLE
[tests] Update macOS target from macosX64 to macosArm64 in KMP IT

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-multi-modules/mpp-additional/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-multi-modules/mpp-additional/build.gradle
@@ -16,7 +16,7 @@ kotlin {
         nodejs()
     }
     linuxX64("linux")
-    macosX64("macos")
+    macosArm64("macos")
     iosX64()
     jvm()
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-multi-modules/top-mpp/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-multi-modules/top-mpp/build.gradle
@@ -44,7 +44,7 @@ kotlin {
         }
     }
 
-    macosX64('macos') {
+    macosArm64('macos') {
         // Binary configuration
         binaries {
             // Creating static library with a custom name.


### PR DESCRIPTION
The macosX64 target was deprecated

The goal is to fix these two failing tests
* `org.jetbrains.kotlin.gradle.HierarchicalMppIT.testMultiModulesHmppKt48370(Gradle 8.14.5: KT-48370: Multiplatform Gradle build fails for Native targets with "we cannot choose between the following variants of project")`
* `org.jetbrains.kotlin.gradle.UnnamedTaskInputsIT.inputsMpp(Gradle 8.14.5: MPP)`