### PR TITLE
[Lombok] Generate canEqual for @EqualsAndHashCode

### DIFF
--- a/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/EqualsAndHashCodeGenerator.kt
+++ b/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/EqualsAndHashCodeGenerator.kt
@@ -13,14 +13,18 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
+import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.processAllDeclaredCallables
 import org.jetbrains.kotlin.fir.declarations.utils.isStatic
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicate.DeclarationPredicate
+import org.jetbrains.kotlin.fir.resolve.getSuperClassSymbolOrAny
 import org.jetbrains.kotlin.fir.scopes.impl.FirClassDeclaredMemberScope
 import org.jetbrains.kotlin.fir.scopes.processAllFunctions
 import org.jetbrains.kotlin.fir.scopes.processAllProperties
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -32,6 +36,8 @@ import org.jetbrains.kotlin.lombok.config.lombokService
 import org.jetbrains.kotlin.lombok.generators.kotlin.findAnnotationOnPropertyOrField
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.StandardClassIds
+import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
 
 /**
@@ -47,25 +53,30 @@ data class EqualsAndHashCodePropertyInfo(
 )
 
 /**
- * Declaration key shared by the generated `equals` and `hashCode` for the same class so that the IR body
- * filler builds both bodies from the same property snapshot.
+ * Declaration key shared by the generated `equals`, `hashCode` and (optional) `canEqual` for the same class so
+ * that the IR body filler builds all bodies from the same property snapshot.
+ *
+ * @param hasCanEqual whether this class also generates `canEqual`, so the `equals` body filler knows whether to
+ *   call it
  */
 class EqualsAndHashCodeGeneratorKey(
     val propertyInfos: List<EqualsAndHashCodePropertyInfo>,
     val callSuper: Boolean,
+    val hasCanEqual: Boolean,
 ) : LombokDeclarationKey()
 
 val FirDeclarationOrigin.isEqualsAndHashCode
     get() = this is FirDeclarationOrigin.Plugin && key is EqualsAndHashCodeGeneratorKey
 
 /**
- * Holder for the (optional) `equals`/`hashCode` symbols generated for a single class.
- * Both share the same [EqualsAndHashCodeGeneratorKey] instance so that the IR body filler
- * sees a consistent property selection across the two functions.
+ * Holder for the (optional) `equals`/`hashCode`/`canEqual` symbols generated for a single class.
+ * All three share the same [EqualsAndHashCodeGeneratorKey] instance so that the IR body filler
+ * sees a consistent property selection across the functions.
  */
 private class EqualsAndHashCodeMembers(
     val equals: FirNamedFunctionSymbol,
     val hashCode: FirNamedFunctionSymbol,
+    val canEqual: FirNamedFunctionSymbol?,
 )
 
 /**
@@ -95,7 +106,8 @@ class EqualsAndHashCodeGenerator(session: FirSession) : FirDeclarationGeneration
         session.firCachesFactory.createCache(::initializeMembersIfNeeded)
 
     override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext): Set<Name> {
-        return if (cache.getValue(classSymbol, context) != null) callableNames else emptySet()
+        val members = cache.getValue(classSymbol, context) ?: return emptySet()
+        return if (members.canEqual != null) callableNames + AccessorGenerator.CAN_EQUAL else callableNames
     }
 
     override fun generateFunctions(callableId: CallableId, context: MemberGenerationContext?): List<FirNamedFunctionSymbol> {
@@ -105,6 +117,7 @@ class EqualsAndHashCodeGenerator(session: FirSession) : FirDeclarationGeneration
             when (callableId.callableName) {
                 EQUALS_NAME -> members.equals
                 HASHCODE_NAME -> members.hashCode
+                AccessorGenerator.CAN_EQUAL -> members.canEqual ?: return emptyList()
                 else -> shouldNotBeCalled()
             }
         )
@@ -126,6 +139,16 @@ class EqualsAndHashCodeGenerator(session: FirSession) : FirDeclarationGeneration
         // The checker reports the partial-override error or the "both already exist" warning.
         if (hasUserDeclaredEqualsOrHashCode(declaredScope)) return null
 
+        // Lombok's own rule: skip `canEqual` only for a class that can have no subclass worth rejecting anyway -
+        // final and with nothing but `Any` to chain to. Note that a non-trivial superclass alone already forces
+        // generation, finality notwithstanding.
+        val generatesCanEqual = !(classSymbol.looksFinal && !classSymbol.hasNonTrivialSuperclass(session))
+
+        // The whole ancestor chain matters, not just the immediate superclass: Kotlin's override check considers
+        // every ancestor, so a generated `canEqual` two or more levels below the one that first declared it still
+        // needs `override`, or it fails to compile with "hides member of supertype".
+        val canEqualIsOverride = generatesCanEqual && classSymbol.hasCanEqualInHierarchy(session)
+
         val key by lazy(LazyThreadSafetyMode.NONE) {
             val propertyInfos = computePropertiesToInclude(annotation, declaredScope)
 
@@ -136,6 +159,7 @@ class EqualsAndHashCodeGenerator(session: FirSession) : FirDeclarationGeneration
                     classSymbol,
                     session,
                 ),
+                hasCanEqual = generatesCanEqual,
             )
         }
 
@@ -159,8 +183,63 @@ class EqualsAndHashCodeGenerator(session: FirSession) : FirDeclarationGeneration
             isOverride = true,
             createKey = { key },
         )
+        val canEqualSymbol = runIf(generatesCanEqual) {
+            createJavaOrKotlinMemberFunction(
+                owner = classSymbol,
+                name = AccessorGenerator.CAN_EQUAL,
+                valueParameters = listOf(ConeLombokValueParameter(OTHER, session.builtinTypes.nullableAnyType)),
+                returnTypeRef = session.builtinTypes.booleanType,
+                visibility = Visibilities.Protected,
+                modality = Modality.OPEN,
+                isOverride = canEqualIsOverride,
+                createKey = { key },
+            )
+        }
 
-        return EqualsAndHashCodeMembers(equalsSymbol, hashCodeSymbol)
+        return EqualsAndHashCodeMembers(equalsSymbol, hashCodeSymbol, canEqualSymbol)
+    }
+
+    /**
+     * Whether [this] is final, without resolving [FirRegularClassSymbol.resolvedStatus]: this can be called from
+     * `getCallableNamesForClass`, itself callable as early as the SUPERTYPES stage, at which point requesting a
+     * lazy resolve to STATUS - even for this class's own declaration - is a phase contract violation.
+     *
+     * A `null` raw modality is safe to read as final here because a *class* (as opposed to a member) has no
+     * context-dependent default: unlike a member, which can inherit openness, a class with no explicit modality
+     * modifier is always final, so nothing about this needs the class's status to actually be resolved.
+     */
+    @OptIn(SymbolInternals::class)
+    private val FirRegularClassSymbol.looksFinal: Boolean
+        get() = fir.status.modality.let { it == null || it == Modality.FINAL }
+
+    /**
+     * Whether [this] (or any of its ancestors, up to but excluding [Any]) already declares a `canEqual(other:
+     * Any?): Boolean`, hand-written or itself Lombok-generated.
+     */
+    private tailrec fun FirClassSymbol<*>.hasCanEqualInHierarchy(session: FirSession): Boolean {
+        val superClassSymbol = getSuperClassSymbolOrAny(session) ?: return false
+        if (superClassSymbol.classId == StandardClassIds.Any) return false
+        if (superClassSymbol.declaresCanEqual(session)) return true
+        return superClassSymbol.hasCanEqualInHierarchy(session)
+    }
+
+    private fun FirClassSymbol<*>.declaresCanEqual(session: FirSession): Boolean {
+        var found = false
+        // TYPES, not the default STATUS: this runs from within this very class's own STATUS-phase status
+        // computation, and a phase cannot request a lazy resolve into itself for another declaration - only into
+        // a strictly earlier one. Matching a `canEqual(other: Any?)` shape only needs value parameter types,
+        // which TYPES already resolves.
+        processAllDeclaredCallables(session, memberRequiredPhase = FirResolvePhase.TYPES) { callable ->
+            if (!found &&
+                callable is FirNamedFunctionSymbol &&
+                callable.name == AccessorGenerator.CAN_EQUAL &&
+                !callable.hasReceiverOrContextParameters &&
+                callable.valueParameterSymbols.singleOrNull()?.resolvedReturnType?.isNullableAny == true
+            ) {
+                found = true
+            }
+        }
+        return found
     }
 
     private fun hasUserDeclaredEqualsOrHashCode(declaredScope: FirClassDeclaredMemberScope?): Boolean {

--- a/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/kotlin/ir/EqualsAndHashCodeIrGenerator.kt
+++ b/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/kotlin/ir/EqualsAndHashCodeIrGenerator.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.ir.util.findDeclaration
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.isInterface
 import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.lombok.generators.AccessorGenerator
 import org.jetbrains.kotlin.lombok.generators.EqualsAndHashCodeGeneratorKey
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.util.OperatorNameConventions
@@ -65,6 +66,10 @@ object EqualsAndHashCodeIrBodyBuilder : IrBodyBuilder<EqualsAndHashCodeGenerator
             HASHCODE_NAME -> {
                 buildHashCodeBody(irClass, key, thisParam)
             }
+            AccessorGenerator.CAN_EQUAL -> {
+                val otherParam = declaration.parameters.single { it.kind == IrParameterKind.Regular }
+                buildCanEqualBody(irClass, otherParam)
+            }
         }
     }
 
@@ -77,6 +82,23 @@ object EqualsAndHashCodeIrBodyBuilder : IrBodyBuilder<EqualsAndHashCodeGenerator
         +irIfThenReturnTrue(irEqeqeq(irGetThis(thisParam), irGetOther(otherParam)))
         +irIfThenReturnFalse(irNotIs(irGetOther(otherParam), irClass.defaultTypeForLombok()))
 
+        val included: List<IrProperty> = extractIncludedProperties(key, irClass)
+
+        // The cast is shared by the `canEqual` call and the property comparisons below - create it once, and
+        // only when at least one of them needs it, mirroring the old no-op shortcut for a property-less class.
+        val otherCast = runIf(key.hasCanEqual || included.isNotEmpty()) {
+            irTemporary(
+                irImplicitCast(irGetOther(otherParam), irClass.defaultTypeForLombok()),
+                nameHint = "other_with_cast",
+            )
+        }
+
+        // Right after the instanceof-check-and-cast, and before `super.equals()`: the same position real Lombok
+        // generates its own `canEqual` call in, so a stricter subtype can reject a looser supertype (KT-89189).
+        if (key.hasCanEqual) {
+            +irIfThenReturnFalse(primitiveBooleanNot(buildCanEqualCall(irClass, irGet(otherCast!!), irGetThis(thisParam))))
+        }
+
         val superEquals = runIf(key.callSuper) { buildSuperEqualsCall(irClass, thisParam, otherParam) }
         if (superEquals != null) {
             +irIfThenReturnFalse(
@@ -84,17 +106,10 @@ object EqualsAndHashCodeIrBodyBuilder : IrBodyBuilder<EqualsAndHashCodeGenerator
             )
         }
 
-        val included: List<IrProperty> = extractIncludedProperties(key, irClass)
-
-        if (included.isEmpty()) {
+        if (otherCast == null) {
             +irReturnTrue()
             return
         }
-
-        val otherCast = irTemporary(
-            irImplicitCast(irGetOther(otherParam), irClass.defaultTypeForLombok()),
-            nameHint = "other_with_cast",
-        )
 
         for (property in included) {
             val thisProp = irGetPropertyValue(irGetThis(thisParam), property)
@@ -293,6 +308,23 @@ object EqualsAndHashCodeIrBodyBuilder : IrBodyBuilder<EqualsAndHashCodeGenerator
             superQualifierSymbol = superClass.symbol,
         ).apply {
             arguments[0] = IrGetValueImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, thisParam.type, thisParam.symbol)
+        }
+    }
+
+    private fun IrBlockBodyBuilder.buildCanEqualBody(irClass: IrClass, otherParam: IrValueParameter) {
+        +irReturn(irIs(irGetOther(otherParam), irClass.defaultTypeForLombok()))
+    }
+
+    /**
+     * `receiver.canEqual(argument)`, virtually dispatched: [receiver] is statically typed as [irClass] but may be
+     * an instance of a stricter subtype whose own generated `canEqual` overrides this one.
+     */
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    private fun IrBlockBodyBuilder.buildCanEqualCall(irClass: IrClass, receiver: IrExpression, argument: IrExpression): IrExpression {
+        val canEqualFunction = irClass.findDeclaration<IrSimpleFunction> { it.name == AccessorGenerator.CAN_EQUAL }!!
+        return irCall(canEqualFunction.symbol).apply {
+            arguments[0] = receiver
+            arguments[1] = argument
         }
     }
 

--- a/plugins/lombok/testData/box/kotlin/callSuperConfig.kt.txt
+++ b/plugins/lombok/testData/box/kotlin/callSuperConfig.kt.txt
@@ -39,6 +39,10 @@ class DerivedExplicitFalse : Base {
 
   }
 
+  protected open fun canEqual(other: Any?): Boolean {
+    return other is DerivedExplicitFalse
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -47,6 +51,9 @@ class DerivedExplicitFalse : Base {
       other !is DerivedExplicitFalse -> return false
     }
     val tmp_0: DerivedExplicitFalse = other /*as DerivedExplicitFalse */
+    when {
+      tmp_0.canEqual(other = <this>).not() -> return false
+    }
     when {
       EQEQ(arg0 = <this>.<get-ownProp>(), arg1 = tmp_0.<get-ownProp>()).not() -> return false
     }
@@ -78,6 +85,10 @@ class DerivedExplicitTrue : Base {
 
   }
 
+  protected open fun canEqual(other: Any?): Boolean {
+    return other is DerivedExplicitTrue
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -85,10 +96,13 @@ class DerivedExplicitTrue : Base {
     when {
       other !is DerivedExplicitTrue -> return false
     }
+    val tmp_2: DerivedExplicitTrue = other /*as DerivedExplicitTrue */
+    when {
+      tmp_2.canEqual(other = <this>).not() -> return false
+    }
     when {
       super<Base>.equals(other = other).not() -> return false
     }
-    val tmp_2: DerivedExplicitTrue = other /*as DerivedExplicitTrue */
     when {
       EQEQ(arg0 = <this>.<get-ownProp>(), arg1 = tmp_2.<get-ownProp>()).not() -> return false
     }
@@ -120,6 +134,10 @@ class DerivedImplicit : Base {
 
   }
 
+  protected open fun canEqual(other: Any?): Boolean {
+    return other is DerivedImplicit
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -127,10 +145,13 @@ class DerivedImplicit : Base {
     when {
       other !is DerivedImplicit -> return false
     }
+    val tmp_4: DerivedImplicit = other /*as DerivedImplicit */
+    when {
+      tmp_4.canEqual(other = <this>).not() -> return false
+    }
     when {
       super<Base>.equals(other = other).not() -> return false
     }
-    val tmp_4: DerivedImplicit = other /*as DerivedImplicit */
     when {
       EQEQ(arg0 = <this>.<get-ownProp>(), arg1 = tmp_4.<get-ownProp>()).not() -> return false
     }
@@ -238,3 +259,4 @@ fun box(): String {
   }
   return "OK"
 }
+

--- a/plugins/lombok/testData/box/kotlin/equalsAndHashCode.kt
+++ b/plugins/lombok/testData/box/kotlin/equalsAndHashCode.kt
@@ -83,6 +83,17 @@ open class CallSuperBase(val baseProp: Int)
 @EqualsAndHashCode(callSuper = true)
 class CallSuperDerived(val ownProp: String) : CallSuperBase(10)
 
+// KT-89189: `canEqual` must make `equals` symmetric across a hierarchy - a subtype with more state must not
+// compare equal to an instance of its looser supertype, in either direction.
+@EqualsAndHashCode
+open class CanEqualGrandparent(val a: Int)
+
+@EqualsAndHashCode(callSuper = true)
+open class CanEqualParent(a: Int, val b: Int) : CanEqualGrandparent(a)
+
+@EqualsAndHashCode(callSuper = true)
+class CanEqualChild(a: Int, b: Int, val c: Int) : CanEqualParent(a, b)
+
 @EqualsAndHashCode
 class WithComputedProperties(val real: String) {
     val computedProp: String get() = "computed"
@@ -191,6 +202,29 @@ fun box(): String {
     val cd2 = CallSuperDerived("x")
     assertEquals(true, cd1 == cd2)
     assertEquals(true, cd1.hashCode() == cd2.hashCode())
+
+    // KT-89189: a `CallSuperBase` and a `CallSuperDerived` sharing the same `baseProp` must not compare equal
+    // in either direction, unlike the bug where the looser supertype's `equals` accepted the stricter subtype.
+    assertEquals(true, CallSuperBase(10) == CallSuperBase(10))
+    val callSuperBase = CallSuperBase(10)
+    val callSuperDerived = CallSuperDerived("x")
+    assertEquals(false, callSuperBase == callSuperDerived)
+    assertEquals(false, callSuperDerived == callSuperBase)
+
+    // Same asymmetry check, one level deeper: the override lookup must walk the whole ancestor chain, not just
+    // the immediate superclass, or one of the three classes below fails to even compile.
+    val grandparent = CanEqualGrandparent(1)
+    val parent = CanEqualParent(1, 2)
+    val child = CanEqualChild(1, 2, 3)
+    assertEquals(true, CanEqualGrandparent(1) == CanEqualGrandparent(1))
+    assertEquals(true, CanEqualParent(1, 2) == CanEqualParent(1, 2))
+    assertEquals(true, CanEqualChild(1, 2, 3) == CanEqualChild(1, 2, 3))
+    assertEquals(false, grandparent == parent)
+    assertEquals(false, parent == grandparent)
+    assertEquals(false, parent == child)
+    assertEquals(false, child == parent)
+    assertEquals(false, grandparent == child)
+    assertEquals(false, child == grandparent)
 
     assertEquals(true, WithComputedProperties("X") == WithComputedProperties("X"))
 

--- a/plugins/lombok/testData/box/kotlin/equalsAndHashCode.kt.txt
+++ b/plugins/lombok/testData/box/kotlin/equalsAndHashCode.kt.txt
@@ -69,6 +69,114 @@ class CallSuperDerived : CallSuperBase {
 
 }
 
+@EqualsAndHashCode(callSuper = true)
+class CanEqualChild : CanEqualParent {
+  val c: Int
+    field = c
+    get
+
+  constructor(a: Int, b: Int, c: Int) /* primary */ {
+    super/*CanEqualParent*/(a = a, b = b)
+    /* <init>() */
+
+  }
+
+  override fun equals(other: Any?): Boolean {
+    when {
+      EQEQEQ(arg0 = <this>, arg1 = other) -> return true
+    }
+    when {
+      other !is CanEqualChild -> return false
+    }
+    when {
+      super<CanEqualParent>.equals(other = other).not() -> return false
+    }
+    val tmp_4: CanEqualChild = other /*as CanEqualChild */
+    when {
+      EQEQ(arg0 = <this>.<get-c>(), arg1 = tmp_4.<get-c>()).not() -> return false
+    }
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var tmp_5: Int = super<CanEqualParent>.hashCode()
+    tmp_5 = tmp_5.times(other = 59).plus(other = <this>.<get-c>().hashCode())
+    return tmp_5
+  }
+
+}
+
+@EqualsAndHashCode
+open class CanEqualGrandparent {
+  val a: Int
+    field = a
+    get
+
+  constructor(a: Int) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  override fun equals(other: Any?): Boolean {
+    when {
+      EQEQEQ(arg0 = <this>, arg1 = other) -> return true
+    }
+    when {
+      other !is CanEqualGrandparent -> return false
+    }
+    val tmp_6: CanEqualGrandparent = other /*as CanEqualGrandparent */
+    when {
+      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_6.<get-a>()).not() -> return false
+    }
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var tmp_7: Int = 1
+    tmp_7 = tmp_7.times(other = 59).plus(other = <this>.<get-a>().hashCode())
+    return tmp_7
+  }
+
+}
+
+@EqualsAndHashCode(callSuper = true)
+open class CanEqualParent : CanEqualGrandparent {
+  val b: Int
+    field = b
+    get
+
+  constructor(a: Int, b: Int) /* primary */ {
+    super/*CanEqualGrandparent*/(a = a)
+    /* <init>() */
+
+  }
+
+  override fun equals(other: Any?): Boolean {
+    when {
+      EQEQEQ(arg0 = <this>, arg1 = other) -> return true
+    }
+    when {
+      other !is CanEqualParent -> return false
+    }
+    when {
+      super<CanEqualGrandparent>.equals(other = other).not() -> return false
+    }
+    val tmp_8: CanEqualParent = other /*as CanEqualParent */
+    when {
+      EQEQ(arg0 = <this>.<get-b>(), arg1 = tmp_8.<get-b>()).not() -> return false
+    }
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var tmp_9: Int = super<CanEqualGrandparent>.hashCode()
+    tmp_9 = tmp_9.times(other = 59).plus(other = <this>.<get-b>().hashCode())
+    return tmp_9
+  }
+
+}
+
 @EqualsAndHashCode
 data class DataClassWithExclude {
   val name: String
@@ -96,21 +204,21 @@ data class DataClassWithExclude {
     when {
       other !is DataClassWithExclude -> return false
     }
-    val tmp_4: DataClassWithExclude = other /*as DataClassWithExclude */
+    val tmp_10: DataClassWithExclude = other /*as DataClassWithExclude */
     when {
-      EQEQ(arg0 = <this>.<get-name>(), arg1 = tmp_4.<get-name>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-name>(), arg1 = tmp_10.<get-name>()).not() -> return false
     }
     when {
-      EQEQ(arg0 = <this>.<get-age>(), arg1 = tmp_4.<get-age>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-age>(), arg1 = tmp_10.<get-age>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_5: Int = 1
-    tmp_5 = tmp_5.times(other = 59).plus(other = <this>.<get-name>().hashCode())
-    tmp_5 = tmp_5.times(other = 59).plus(other = <this>.<get-age>().hashCode())
-    return tmp_5
+    var tmp_11: Int = 1
+    tmp_11 = tmp_11.times(other = 59).plus(other = <this>.<get-name>().hashCode())
+    tmp_11 = tmp_11.times(other = 59).plus(other = <this>.<get-age>().hashCode())
+    return tmp_11
   }
 
   operator fun component1(): String {
@@ -154,8 +262,8 @@ class Empty {
   }
 
   override fun hashCode(): Int {
-    var tmp_6: Int = 1
-    return tmp_6
+    var tmp_12: Int = 1
+    return tmp_12
   }
 
 }
@@ -183,17 +291,17 @@ class OnlyIncluded {
     when {
       other !is OnlyIncluded -> return false
     }
-    val tmp_7: OnlyIncluded = other /*as OnlyIncluded */
+    val tmp_13: OnlyIncluded = other /*as OnlyIncluded */
     when {
-      EQEQ(arg0 = <this>.<get-included>(), arg1 = tmp_7.<get-included>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-included>(), arg1 = tmp_13.<get-included>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_8: Int = 1
-    tmp_8 = tmp_8.times(other = 59).plus(other = <this>.<get-included>().hashCode())
-    return tmp_8
+    var tmp_14: Int = 1
+    tmp_14 = tmp_14.times(other = 59).plus(other = <this>.<get-included>().hashCode())
+    return tmp_14
   }
 
 }
@@ -221,21 +329,21 @@ data class PlainDataClass {
     when {
       other !is PlainDataClass -> return false
     }
-    val tmp_9: PlainDataClass = other /*as PlainDataClass */
+    val tmp_15: PlainDataClass = other /*as PlainDataClass */
     when {
-      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_9.<get-a>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_15.<get-a>()).not() -> return false
     }
     when {
-      EQEQ(arg0 = <this>.<get-b>(), arg1 = tmp_9.<get-b>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-b>(), arg1 = tmp_15.<get-b>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_10: Int = 1
-    tmp_10 = tmp_10.times(other = 59).plus(other = <this>.<get-a>().hashCode())
-    tmp_10 = tmp_10.times(other = 59).plus(other = <this>.<get-b>().hashCode())
-    return tmp_10
+    var tmp_16: Int = 1
+    tmp_16 = tmp_16.times(other = 59).plus(other = <this>.<get-a>().hashCode())
+    tmp_16 = tmp_16.times(other = 59).plus(other = <this>.<get-b>().hashCode())
+    return tmp_16
   }
 
   operator fun component1(): String {
@@ -283,21 +391,21 @@ class Simple {
     when {
       other !is Simple -> return false
     }
-    val tmp_11: Simple = other /*as Simple */
+    val tmp_17: Simple = other /*as Simple */
     when {
-      EQEQ(arg0 = <this>.<get-name>(), arg1 = tmp_11.<get-name>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-name>(), arg1 = tmp_17.<get-name>()).not() -> return false
     }
     when {
-      EQEQ(arg0 = <this>.<get-age>(), arg1 = tmp_11.<get-age>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-age>(), arg1 = tmp_17.<get-age>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_12: Int = 1
-    tmp_12 = tmp_12.times(other = 59).plus(other = <this>.<get-name>().hashCode())
-    tmp_12 = tmp_12.times(other = 59).plus(other = <this>.<get-age>().hashCode())
-    return tmp_12
+    var tmp_18: Int = 1
+    tmp_18 = tmp_18.times(other = 59).plus(other = <this>.<get-name>().hashCode())
+    tmp_18 = tmp_18.times(other = 59).plus(other = <this>.<get-age>().hashCode())
+    return tmp_18
   }
 
 }
@@ -321,20 +429,20 @@ class SingleNullableInt {
     when {
       other !is SingleNullableInt -> return false
     }
-    val tmp_13: SingleNullableInt = other /*as SingleNullableInt */
+    val tmp_19: SingleNullableInt = other /*as SingleNullableInt */
     when {
-      EQEQ(arg0 = <this>.<get-optionalId>(), arg1 = tmp_13.<get-optionalId>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-optionalId>(), arg1 = tmp_19.<get-optionalId>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_14: Int = 1
-    tmp_14 = tmp_14.times(other = 59).plus(other = when {
+    var tmp_20: Int = 1
+    tmp_20 = tmp_20.times(other = 59).plus(other = when {
       EQEQ(arg0 = <this>.<get-optionalId>(), arg1 = null) -> 43
       else -> <this>.<get-optionalId>().hashCode()
     })
-    return tmp_14
+    return tmp_20
   }
 
 }
@@ -358,20 +466,20 @@ class SingleNullableString {
     when {
       other !is SingleNullableString -> return false
     }
-    val tmp_15: SingleNullableString = other /*as SingleNullableString */
+    val tmp_21: SingleNullableString = other /*as SingleNullableString */
     when {
-      EQEQ(arg0 = <this>.<get-optional>(), arg1 = tmp_15.<get-optional>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-optional>(), arg1 = tmp_21.<get-optional>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_16: Int = 1
-    tmp_16 = tmp_16.times(other = 59).plus(other = when {
+    var tmp_22: Int = 1
+    tmp_22 = tmp_22.times(other = 59).plus(other = when {
       EQEQ(arg0 = <this>.<get-optional>(), arg1 = null) -> 43
       else -> <this>.<get-optional>().hashCode()
     })
-    return tmp_16
+    return tmp_22
   }
 
 }
@@ -399,27 +507,27 @@ class TwoNullableInts {
     when {
       other !is TwoNullableInts -> return false
     }
-    val tmp_17: TwoNullableInts = other /*as TwoNullableInts */
+    val tmp_23: TwoNullableInts = other /*as TwoNullableInts */
     when {
-      EQEQ(arg0 = <this>.<get-first>(), arg1 = tmp_17.<get-first>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-first>(), arg1 = tmp_23.<get-first>()).not() -> return false
     }
     when {
-      EQEQ(arg0 = <this>.<get-second>(), arg1 = tmp_17.<get-second>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-second>(), arg1 = tmp_23.<get-second>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_18: Int = 1
-    tmp_18 = tmp_18.times(other = 59).plus(other = when {
+    var tmp_24: Int = 1
+    tmp_24 = tmp_24.times(other = 59).plus(other = when {
       EQEQ(arg0 = <this>.<get-first>(), arg1 = null) -> 43
       else -> <this>.<get-first>().hashCode()
     })
-    tmp_18 = tmp_18.times(other = 59).plus(other = when {
+    tmp_24 = tmp_24.times(other = 59).plus(other = when {
       EQEQ(arg0 = <this>.<get-second>(), arg1 = null) -> 43
       else -> <this>.<get-second>().hashCode()
     })
-    return tmp_18
+    return tmp_24
   }
 
 }
@@ -443,17 +551,17 @@ class WithComputedProperties {
     when {
       other !is WithComputedProperties -> return false
     }
-    val tmp_19: WithComputedProperties = other /*as WithComputedProperties */
+    val tmp_25: WithComputedProperties = other /*as WithComputedProperties */
     when {
-      EQEQ(arg0 = <this>.<get-real>(), arg1 = tmp_19.<get-real>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-real>(), arg1 = tmp_25.<get-real>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_20: Int = 1
-    tmp_20 = tmp_20.times(other = 59).plus(other = <this>.<get-real>().hashCode())
-    return tmp_20
+    var tmp_26: Int = 1
+    tmp_26 = tmp_26.times(other = 59).plus(other = <this>.<get-real>().hashCode())
+    return tmp_26
   }
 
   val computedProp: String
@@ -490,21 +598,21 @@ class WithDollarPrefixedProperties {
     when {
       other !is WithDollarPrefixedProperties -> return false
     }
-    val tmp_21: WithDollarPrefixedProperties = other /*as WithDollarPrefixedProperties */
+    val tmp_27: WithDollarPrefixedProperties = other /*as WithDollarPrefixedProperties */
     when {
-      EQEQ(arg0 = <this>.<get-regular>(), arg1 = tmp_21.<get-regular>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-regular>(), arg1 = tmp_27.<get-regular>()).not() -> return false
     }
     when {
-      EQEQ(arg0 = <this>.<get-$explicitlyIncluded>(), arg1 = tmp_21.<get-$explicitlyIncluded>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-$explicitlyIncluded>(), arg1 = tmp_27.<get-$explicitlyIncluded>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_22: Int = 1
-    tmp_22 = tmp_22.times(other = 59).plus(other = <this>.<get-regular>().hashCode())
-    tmp_22 = tmp_22.times(other = 59).plus(other = <this>.<get-$explicitlyIncluded>().hashCode())
-    return tmp_22
+    var tmp_28: Int = 1
+    tmp_28 = tmp_28.times(other = 59).plus(other = <this>.<get-regular>().hashCode())
+    tmp_28 = tmp_28.times(other = 59).plus(other = <this>.<get-$explicitlyIncluded>().hashCode())
+    return tmp_28
   }
 
 }
@@ -532,17 +640,17 @@ class WithExclude {
     when {
       other !is WithExclude -> return false
     }
-    val tmp_23: WithExclude = other /*as WithExclude */
+    val tmp_29: WithExclude = other /*as WithExclude */
     when {
-      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_23.<get-a>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_29.<get-a>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_24: Int = 1
-    tmp_24 = tmp_24.times(other = 59).plus(other = <this>.<get-a>().hashCode())
-    return tmp_24
+    var tmp_30: Int = 1
+    tmp_30 = tmp_30.times(other = 59).plus(other = <this>.<get-a>().hashCode())
+    return tmp_30
   }
 
 }
@@ -566,17 +674,17 @@ class WithNestedArray {
     when {
       other !is WithNestedArray -> return false
     }
-    val tmp_25: WithNestedArray = other /*as WithNestedArray */
+    val tmp_31: WithNestedArray = other /*as WithNestedArray */
     when {
-      deepEquals(p0 = <this>.<get-array>(), p1 = tmp_25.<get-array>()).not() -> return false
+      deepEquals(p0 = <this>.<get-array>(), p1 = tmp_31.<get-array>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_26: Int = 1
-    tmp_26 = tmp_26.times(other = 59).plus(other = deepHashCode(p0 = <this>.<get-array>()))
-    return tmp_26
+    var tmp_32: Int = 1
+    tmp_32 = tmp_32.times(other = 59).plus(other = deepHashCode(p0 = <this>.<get-array>()))
+    return tmp_32
   }
 
 }
@@ -604,24 +712,24 @@ class WithNullable {
     when {
       other !is WithNullable -> return false
     }
-    val tmp_27: WithNullable = other /*as WithNullable */
+    val tmp_33: WithNullable = other /*as WithNullable */
     when {
-      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_27.<get-a>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_33.<get-a>()).not() -> return false
     }
     when {
-      EQEQ(arg0 = <this>.<get-b>(), arg1 = tmp_27.<get-b>()).not() -> return false
+      EQEQ(arg0 = <this>.<get-b>(), arg1 = tmp_33.<get-b>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_28: Int = 1
-    tmp_28 = tmp_28.times(other = 59).plus(other = when {
+    var tmp_34: Int = 1
+    tmp_34 = tmp_34.times(other = 59).plus(other = when {
       EQEQ(arg0 = <this>.<get-a>(), arg1 = null) -> 43
       else -> <this>.<get-a>().hashCode()
     })
-    tmp_28 = tmp_28.times(other = 59).plus(other = <this>.<get-b>().hashCode())
-    return tmp_28
+    tmp_34 = tmp_34.times(other = 59).plus(other = <this>.<get-b>().hashCode())
+    return tmp_34
   }
 
 }
@@ -645,17 +753,17 @@ class WithNullableArray {
     when {
       other !is WithNullableArray -> return false
     }
-    val tmp_29: WithNullableArray = other /*as WithNullableArray */
+    val tmp_35: WithNullableArray = other /*as WithNullableArray */
     when {
-      deepEquals(p0 = <this>.<get-array>(), p1 = tmp_29.<get-array>()).not() -> return false
+      deepEquals(p0 = <this>.<get-array>(), p1 = tmp_35.<get-array>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_30: Int = 1
-    tmp_30 = tmp_30.times(other = 59).plus(other = deepHashCode(p0 = <this>.<get-array>()))
-    return tmp_30
+    var tmp_36: Int = 1
+    tmp_36 = tmp_36.times(other = 59).plus(other = deepHashCode(p0 = <this>.<get-array>()))
+    return tmp_36
   }
 
 }
@@ -679,17 +787,17 @@ class WithObjectArray {
     when {
       other !is WithObjectArray -> return false
     }
-    val tmp_31: WithObjectArray = other /*as WithObjectArray */
+    val tmp_37: WithObjectArray = other /*as WithObjectArray */
     when {
-      deepEquals(p0 = <this>.<get-array>(), p1 = tmp_31.<get-array>()).not() -> return false
+      deepEquals(p0 = <this>.<get-array>(), p1 = tmp_37.<get-array>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_32: Int = 1
-    tmp_32 = tmp_32.times(other = 59).plus(other = deepHashCode(p0 = <this>.<get-array>()))
-    return tmp_32
+    var tmp_38: Int = 1
+    tmp_38 = tmp_38.times(other = 59).plus(other = deepHashCode(p0 = <this>.<get-array>()))
+    return tmp_38
   }
 
 }
@@ -713,17 +821,17 @@ class WithPrimitiveArray {
     when {
       other !is WithPrimitiveArray -> return false
     }
-    val tmp_33: WithPrimitiveArray = other /*as WithPrimitiveArray */
+    val tmp_39: WithPrimitiveArray = other /*as WithPrimitiveArray */
     when {
-      equals(p0 = <this>.<get-array>(), p1 = tmp_33.<get-array>()).not() -> return false
+      equals(p0 = <this>.<get-array>(), p1 = tmp_39.<get-array>()).not() -> return false
     }
     return true
   }
 
   override fun hashCode(): Int {
-    var tmp_34: Int = 1
-    tmp_34 = tmp_34.times(other = 59).plus(other = hashCode(p0 = <this>.<get-array>()))
-    return tmp_34
+    var tmp_40: Int = 1
+    tmp_40 = tmp_40.times(other = 59).plus(other = hashCode(p0 = <this>.<get-array>()))
+    return tmp_40
   }
 
 }
@@ -843,6 +951,23 @@ fun box(): String {
   val cd2: CallSuperDerived = CallSuperDerived(ownProp = "x")
   assertEquals<Boolean>(a = true, b = EQEQ(arg0 = cd1, arg1 = cd2))
   assertEquals<Boolean>(a = true, b = EQEQ(arg0 = cd1.hashCode(), arg1 = cd2.hashCode()))
+  assertEquals<Boolean>(a = true, b = EQEQ(arg0 = CallSuperBase(baseProp = 10), arg1 = CallSuperBase(baseProp = 10)))
+  val callSuperBase: CallSuperBase = CallSuperBase(baseProp = 10)
+  val callSuperDerived: CallSuperDerived = CallSuperDerived(ownProp = "x")
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = callSuperBase, arg1 = callSuperDerived))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = callSuperDerived, arg1 = callSuperBase))
+  val grandparent: CanEqualGrandparent = CanEqualGrandparent(a = 1)
+  val parent: CanEqualParent = CanEqualParent(a = 1, b = 2)
+  val child: CanEqualChild = CanEqualChild(a = 1, b = 2, c = 3)
+  assertEquals<Boolean>(a = true, b = EQEQ(arg0 = CanEqualGrandparent(a = 1), arg1 = CanEqualGrandparent(a = 1)))
+  assertEquals<Boolean>(a = true, b = EQEQ(arg0 = CanEqualParent(a = 1, b = 2), arg1 = CanEqualParent(a = 1, b = 2)))
+  assertEquals<Boolean>(a = true, b = EQEQ(arg0 = CanEqualChild(a = 1, b = 2, c = 3), arg1 = CanEqualChild(a = 1, b = 2, c = 3)))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = grandparent, arg1 = parent))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = parent, arg1 = grandparent))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = parent, arg1 = child))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = child, arg1 = parent))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = grandparent, arg1 = child))
+  assertEquals<Boolean>(a = false, b = EQEQ(arg0 = child, arg1 = grandparent))
   assertEquals<Boolean>(a = true, b = EQEQ(arg0 = WithComputedProperties(real = "X"), arg1 = WithComputedProperties(real = "X")))
   @EqualsAndHashCode
   local class LocalClass {
@@ -863,17 +988,17 @@ fun box(): String {
       when {
         other !is LocalClass -> return false
       }
-      val tmp_35: LocalClass = other /*as LocalClass */
+      val tmp_41: LocalClass = other /*as LocalClass */
       when {
-        EQEQ(arg0 = <this>.<get-x>(), arg1 = tmp_35.<get-x>()).not() -> return false
+        EQEQ(arg0 = <this>.<get-x>(), arg1 = tmp_41.<get-x>()).not() -> return false
       }
       return true
     }
 
     override fun hashCode(): Int {
-      var tmp_36: Int = 1
-      tmp_36 = tmp_36.times(other = 59).plus(other = <this>.<get-x>().hashCode())
-      return tmp_36
+      var tmp_42: Int = 1
+      tmp_42 = tmp_42.times(other = 59).plus(other = <this>.<get-x>().hashCode())
+      return tmp_42
     }
 
   }

--- a/plugins/lombok/testData/box/kotlin/equalsAndHashCode.kt.txt
+++ b/plugins/lombok/testData/box/kotlin/equalsAndHashCode.kt.txt
@@ -10,6 +10,10 @@ open class CallSuperBase {
 
   }
 
+  protected open fun canEqual(other: Any?): Boolean {
+    return other is CallSuperBase
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -18,6 +22,9 @@ open class CallSuperBase {
       other !is CallSuperBase -> return false
     }
     val tmp_0: CallSuperBase = other /*as CallSuperBase */
+    when {
+      tmp_0.canEqual(other = <this>).not() -> return false
+    }
     when {
       EQEQ(arg0 = <this>.<get-baseProp>(), arg1 = tmp_0.<get-baseProp>()).not() -> return false
     }
@@ -44,6 +51,10 @@ class CallSuperDerived : CallSuperBase {
 
   }
 
+  protected override fun canEqual(other: Any?): Boolean {
+    return other is CallSuperDerived
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -51,10 +62,13 @@ class CallSuperDerived : CallSuperBase {
     when {
       other !is CallSuperDerived -> return false
     }
+    val tmp_2: CallSuperDerived = other /*as CallSuperDerived */
+    when {
+      tmp_2.canEqual(other = <this>).not() -> return false
+    }
     when {
       super<CallSuperBase>.equals(other = other).not() -> return false
     }
-    val tmp_2: CallSuperDerived = other /*as CallSuperDerived */
     when {
       EQEQ(arg0 = <this>.<get-ownProp>(), arg1 = tmp_2.<get-ownProp>()).not() -> return false
     }
@@ -81,6 +95,10 @@ class CanEqualChild : CanEqualParent {
 
   }
 
+  protected override fun canEqual(other: Any?): Boolean {
+    return other is CanEqualChild
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -88,10 +106,13 @@ class CanEqualChild : CanEqualParent {
     when {
       other !is CanEqualChild -> return false
     }
+    val tmp_4: CanEqualChild = other /*as CanEqualChild */
+    when {
+      tmp_4.canEqual(other = <this>).not() -> return false
+    }
     when {
       super<CanEqualParent>.equals(other = other).not() -> return false
     }
-    val tmp_4: CanEqualChild = other /*as CanEqualChild */
     when {
       EQEQ(arg0 = <this>.<get-c>(), arg1 = tmp_4.<get-c>()).not() -> return false
     }
@@ -118,6 +139,10 @@ open class CanEqualGrandparent {
 
   }
 
+  protected open fun canEqual(other: Any?): Boolean {
+    return other is CanEqualGrandparent
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -126,6 +151,9 @@ open class CanEqualGrandparent {
       other !is CanEqualGrandparent -> return false
     }
     val tmp_6: CanEqualGrandparent = other /*as CanEqualGrandparent */
+    when {
+      tmp_6.canEqual(other = <this>).not() -> return false
+    }
     when {
       EQEQ(arg0 = <this>.<get-a>(), arg1 = tmp_6.<get-a>()).not() -> return false
     }
@@ -152,6 +180,10 @@ open class CanEqualParent : CanEqualGrandparent {
 
   }
 
+  protected override fun canEqual(other: Any?): Boolean {
+    return other is CanEqualParent
+  }
+
   override fun equals(other: Any?): Boolean {
     when {
       EQEQEQ(arg0 = <this>, arg1 = other) -> return true
@@ -159,10 +191,13 @@ open class CanEqualParent : CanEqualGrandparent {
     when {
       other !is CanEqualParent -> return false
     }
+    val tmp_8: CanEqualParent = other /*as CanEqualParent */
+    when {
+      tmp_8.canEqual(other = <this>).not() -> return false
+    }
     when {
       super<CanEqualGrandparent>.equals(other = other).not() -> return false
     }
-    val tmp_8: CanEqualParent = other /*as CanEqualParent */
     when {
       EQEQ(arg0 = <this>.<get-b>(), arg1 = tmp_8.<get-b>()).not() -> return false
     }


### PR DESCRIPTION
This generates canEqual using the same rule real Lombok uses (skipped only for a final class with no non-trivial superclass), calls it from equals() right after the instanceof check, and marks it override when an ancestor in the hierarchy already declares one.
Ran the Lombok plugin's box tests locally (testEqualsAndHashCode, testCallSuperConfig) and both pass.                                                                                                                                             

Fixes KT-89189: https://youtrack.jetbrains.com/issue/KT-8918