### PR TITLE
Klib Loading: Soft-deprecate loading Klibs with older ABI version than 1.8.0 (~ compiler version 1.9.20)

### DIFF
--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/KlibLoaderExtensions.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/KlibLoaderExtensions.kt
@@ -13,7 +13,10 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.DuplicatedUniqueNameStrategy
 import org.jetbrains.kotlin.config.duplicatedUniqueNameStrategy
 import org.jetbrains.kotlin.io.canonicalPathString
+import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.KotlinAbiVersion.Companion.FIRST_SUPPORTED_WITHOUT_DEPRECATION_COMPILER_VERSION
 import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.hasAbi
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult
 import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
@@ -72,6 +75,46 @@ fun KlibLoaderResult.eliminateLibrariesWithDuplicatedUniqueNames(configuration: 
     } else {
         this
     }
+}
+
+/**
+ * Checks for soft-deprecated ABI versions among successfully loaded Klibs in [KlibLoaderResult.librariesStdlibFirst]:
+ * If there is a library with the ABI version <= [KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION] then
+ * a warning diagnostic is reported.
+ *
+ * Note: It's assumed that all Klibs having ABI version < [KotlinAbiVersion.FIRST_SUPPORTED] are already filtered out
+ * and counted as problematic in [KlibLoaderResult.problematicLibraries].
+ */
+fun KlibLoaderResult.warnAboutSoftDeprecatedAbiVersions(configuration: CompilerConfiguration): KlibLoaderResult {
+    if (KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION == KotlinAbiVersion.FIRST_SUPPORTED) return this
+
+    val librariesToWarnAbout: List<Triple<Path, KotlinAbiVersion, String?>> = librariesStdlibFirst.mapNotNull { library ->
+        if (!library.hasAbi) return@mapNotNull null
+
+        val libraryAbiVersion = library.versions.abiVersion ?: return@mapNotNull null
+        if (libraryAbiVersion.isAtLeast(KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION)) return@mapNotNull null
+
+        Triple(library.path, libraryAbiVersion, library.versions.compilerVersion)
+    }
+
+    if (librariesToWarnAbout.isEmpty()) return this
+
+    val warningMessage = buildString {
+        appendLine("Legacy ABI version warning.")
+        appendLine()
+        appendLine("There are libraries with ABI versions that will no longer be supported by future compiler versions:")
+        librariesToWarnAbout.forEach { [path, libraryAbiVersion, compilerVersion] ->
+            append("- $path, ABI version $libraryAbiVersion")
+            if (compilerVersion != null) append(" (produced by compiler $compilerVersion)")
+            appendLine()
+        }
+        appendLine()
+        appendLine("We recommend updating your project settings to use newer library versions compatible with Kotlin compiler $FIRST_SUPPORTED_WITHOUT_DEPRECATION_COMPILER_VERSION or later (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION} or later).")
+    }
+
+    configuration.report(SerializationErrors.KLIB_LOADING_WARNING, warningMessage)
+
+    return this
 }
 
 /**

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.common.LoadedKlibs
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
 import org.jetbrains.kotlin.backend.common.selectLibrariesByPaths
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
+import org.jetbrains.kotlin.backend.common.warnAboutSoftDeprecatedAbiVersions
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.ir.backend.js.checkers.JsLibrarySpecialCompatibilityChecker
 import org.jetbrains.kotlin.ir.backend.js.checkers.WasmLibrarySpecialCompatibilityChecker
@@ -41,6 +42,7 @@ fun loadWebKlibs(
         .apply { reportLoadingProblemsIfAny(configuration) }
         // TODO (KT-76785): Handling of duplicated names is a workaround that needs to be removed in the future.
         .eliminateLibrariesWithDuplicatedUniqueNames(configuration)
+        .warnAboutSoftDeprecatedAbiVersions(configuration)
 
     return LoadedKlibs(
         all = result.librariesStdlibFirst,

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.diagnostics.SerializationErrors
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
 import org.jetbrains.kotlin.backend.common.selectLibrariesByPaths
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
+import org.jetbrains.kotlin.backend.common.warnAboutSoftDeprecatedAbiVersions
 import org.jetbrains.kotlin.cli.common.arguments.K2NativeCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.cliArgument
 import org.jetbrains.kotlin.cli.common.testEnvironment
@@ -75,6 +76,7 @@ fun loadNativeKlibs(
         .apply { reportLoadingProblemsIfAny(configuration) }
         // TODO (KT-76785): Handling of duplicated names is a workaround that needs to be removed in the future.
         .eliminateLibrariesWithDuplicatedUniqueNames(configuration)
+        .warnAboutSoftDeprecatedAbiVersions(configuration)
 
     if (!configuration.skipLibrarySpecialCompatibilityChecks) {
         KonanLibrarySpecialCompatibilityChecker.check(

--- a/compiler/tests/org/jetbrains/kotlin/klib/KlibSoftDeprecationWarningTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/klib/KlibSoftDeprecationWarningTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.klib
+
+import org.jetbrains.kotlin.backend.common.warnAboutSoftDeprecatedAbiVersions
+import org.jetbrains.kotlin.cli.common.diagnosticsCollector
+import org.jetbrains.kotlin.cli.common.fir.FirDiagnosticsCompilerResultsReporter
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollectorImpl
+import org.jetbrains.kotlin.cli.create
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.MessageCollectorAccess
+import org.jetbrains.kotlin.config.messageCollector
+import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
+import org.jetbrains.kotlin.library.KLIB_PROPERTY_IR_PROVIDER
+import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.KotlinLibraryVersioning
+import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.writer.KlibWriter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.collections.set
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.pathString
+
+@OptIn(MessageCollectorAccess::class)
+class KlibSoftDeprecationWarningTest {
+    @TempDir
+    private lateinit var tmpDir: Path
+
+    @Test
+    fun testSoftDeprecationWarning() {
+        val libraries = listOf(
+            generateNewKlib(
+                uniqueName = "ok1",
+                abiVersion = KotlinAbiVersion.CURRENT,
+                compilerVersion = null,
+            ),
+            generateNewKlib(
+                uniqueName = "ok2",
+                abiVersion = KotlinAbiVersion.CURRENT,
+                compilerVersion = KotlinAbiVersion.CURRENT.toCompilerVersion(),
+            ),
+            generateNewKlib(
+                uniqueName = "ok3",
+                abiVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION,
+                compilerVersion = null,
+            ),
+            generateNewKlib(
+                uniqueName = "ok4",
+                abiVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION,
+                compilerVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.toCompilerVersion(),
+            ),
+            generateNewKlib(
+                uniqueName = "deprecated1",
+                abiVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.prev(),
+                compilerVersion = null,
+            ),
+            generateNewKlib(
+                uniqueName = "deprecated2",
+                abiVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.prev(),
+                compilerVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.prev().toCompilerVersion(),
+            ),
+            generateNewKlib(
+                uniqueName = "deprecated3",
+                abiVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.prev().prev(),
+                compilerVersion = null,
+            ),
+            generateNewKlib(
+                uniqueName = "deprecated4",
+                abiVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.prev().prev(),
+                compilerVersion = KotlinAbiVersion.FIRST_SUPPORTED_WITHOUT_DEPRECATION.prev().prev().toCompilerVersion(),
+            ),
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val compilerConfiguration = CompilerConfiguration.create().apply {
+            this.messageCollector = messageCollector
+        }
+
+        val loadingResult = KlibLoader {
+            libraryPaths(libraries.map { it.pathString })
+        }.load()
+            .warnAboutSoftDeprecatedAbiVersions(compilerConfiguration)
+
+        FirDiagnosticsCompilerResultsReporter.reportToMessageCollector(compilerConfiguration.diagnosticsCollector, compilerConfiguration)
+
+        assertFalse(loadingResult.hasProblems)
+        assertEquals(libraries.size, loadingResult.librariesStdlibFirst.size)
+
+        assertEquals(1, messageCollector.messages.size)
+
+        val actualMessage = messageCollector.messages.single()
+        assertEquals(CompilerMessageSeverity.STRONG_WARNING, actualMessage.severity)
+        assertNull(actualMessage.location)
+
+        val actualMessageTextFiltered = actualMessage.message.lineSequence()
+            .map { it.replace(tmpDir.pathString, "<path_prefix>") }
+            .map { it.replace('\\', '/') }
+            .joinToString(separator = "\n")
+
+        assertEquals(
+            """
+                Legacy ABI version warning.
+
+                There are libraries with ABI versions that will no longer be supported by future compiler versions:
+                - <path_prefix>/deprecated1, ABI version 1.7.0
+                - <path_prefix>/deprecated2, ABI version 1.7.0 (produced by compiler 1.7.0)
+                - <path_prefix>/deprecated3, ABI version 1.6.0
+                - <path_prefix>/deprecated4, ABI version 1.6.0 (produced by compiler 1.6.0)
+                
+                We recommend updating your project settings to use newer library versions compatible with Kotlin compiler 1.9.20 or later (ABI version 1.8.0 or later).
+            """.trimIndent(),
+            actualMessageTextFiltered.trim(),
+        )
+    }
+
+    private fun KotlinAbiVersion.toCompilerVersion(): String = toString()
+
+    private fun KotlinAbiVersion.prev(): KotlinAbiVersion =
+        if (minor == 0) KotlinAbiVersion(major - 1, 255, 0) else KotlinAbiVersion(major, minor - 1, 0)
+
+    private fun generateNewKlib(uniqueName: String, abiVersion: KotlinAbiVersion, compilerVersion: String?): Path {
+        val klibDir = tmpDir.apply { createDirectories() }.resolve(uniqueName)
+
+        assertFalse(klibDir.exists()) { "KLIB should not exist before compilation: $klibDir" }
+
+        // Write a fake library with the required unique name.
+        KlibWriter {
+            manifest {
+                moduleName(uniqueName)
+                versions(
+                    KotlinLibraryVersioning(
+                        compilerVersion = compilerVersion,
+                        abiVersion = abiVersion,
+                        metadataVersion = null,
+                    )
+                )
+                platformAndTargets(BuiltInsPlatform.NATIVE) // Does not matter.
+                manifest {
+                    customProperties {
+                        // Emulate the presence of ABI.
+                        this[KLIB_PROPERTY_IR_PROVIDER] = KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
+                    }
+                }
+            }
+        }.writeTo(klibDir)
+
+        assertTrue(klibDir.isDirectory()) { "KLIB should exist after compilation: $klibDir" }
+
+        return klibDir
+    }
+}

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinAbiVersion.kt
@@ -94,15 +94,27 @@ data class KotlinAbiVersion(val major: Int, val minor: Int, val patch: Int) {
          * The oldest ABI version supported by  the compiler.
          *
          * Note: At the moment this is 1.6.0 (corresponds to the compiler versions 1.6.x). But we are going to raise this limit
-         * at least up to 1.8.0 (compiler 1.9.20) in the future releases.
+         * at least up to 1.8.0 (compiler 1.9.20) in the future releases. See also [FIRST_SUPPORTED_WITHOUT_DEPRECATION].
          */
         val FIRST_SUPPORTED = KotlinAbiVersion(1, 6, 0)
 
         /**
          * The oldest version of the compiler that can produce KLIBs consumable by the current compiler version.
-         * See [FIRST_SUPPORTED].
+         * See also [FIRST_SUPPORTED].
          */
         const val FIRST_SUPPORTED_COMPILER_VERSION = "1.6.0"
+
+        /**
+         * The ABI version that matches the Kotlin compiler version (1.9.20), since which we do support
+         * backward compatibility of Klibs.
+         */
+        val FIRST_SUPPORTED_WITHOUT_DEPRECATION = KotlinAbiVersion(1, 8, 0)
+
+        /**
+         * The oldest version of the compiler that can produce KLIBs consumable by the current compiler version without
+         * deprecation warning. See also [FIRST_SUPPORTED_WITHOUT_DEPRECATION].
+         */
+        const val FIRST_SUPPORTED_WITHOUT_DEPRECATION_COMPILER_VERSION = "1.9.20"
 
         /**
          * Versions before 1.4.1 were the active development phase.

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
@@ -168,7 +168,7 @@ private fun ProblematicLibrary.computeMessageText(): String {
 
             val abiVersionCheckExplanation: String = when {
                 isLowerBoundaryExceeded && minSupportedCompilerVersionHint != null ->
-                    "produced by at least $minSupportedCompilerVersionHint compiler"
+                    "produced by compiler >= $minSupportedCompilerVersionHint"
 
                 minPermittedAbiVersion != null && maxPermittedAbiVersion != null ->
                     "having ABI version in the range [$minPermittedAbiVersion, $maxPermittedAbiVersion]"
@@ -184,8 +184,8 @@ private fun ProblematicLibrary.computeMessageText(): String {
                 val actionText = when {
                     isLowerBoundaryExceeded -> buildString {
                         append("Please upgrade the library to a newer version ")
-                        if (minSupportedCompilerVersionHint != null) append("compatible with $minSupportedCompilerVersionHint compiler ")
-                        append("(ABI version $minPermittedAbiVersion or higher).")
+                        if (minSupportedCompilerVersionHint != null) append("compatible with compiler version $minSupportedCompilerVersionHint or later ")
+                        append("(ABI version $minPermittedAbiVersion or later).")
                     }
                     else -> "Please upgrade your Kotlin compiler version to consume this library."
                 }

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
@@ -572,7 +572,7 @@ abstract class AbstractKlibLoaderTest {
                 """
                     KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
                     The current Kotlin compiler can consume libraries having ABI version >= ${KotlinAbiVersion.FIRST_SUPPORTED}.
-                    Please upgrade the library to a newer version (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                    Please upgrade the library to a newer version (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or later).
                 """.trimIndent()
             )
 
@@ -587,7 +587,7 @@ abstract class AbstractKlibLoaderTest {
                 """
                     KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
                     The current Kotlin compiler can consume libraries having ABI version in the range [${KotlinAbiVersion.FIRST_SUPPORTED}, ${KotlinAbiVersion.CURRENT}].
-                    Please upgrade the library to a newer version (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                    Please upgrade the library to a newer version (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or later).
                 """.trimIndent()
             )
 
@@ -600,8 +600,8 @@ abstract class AbstractKlibLoaderTest {
             .assertInvalidAbiMessage(
                 """
                     KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
-                    The current Kotlin compiler can consume libraries produced by at least $FIRST_SUPPORTED_COMPILER_VERSION compiler.
-                    Please upgrade the library to a newer version compatible with $FIRST_SUPPORTED_COMPILER_VERSION compiler (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                    The current Kotlin compiler can consume libraries produced by compiler >= $FIRST_SUPPORTED_COMPILER_VERSION.
+                    Please upgrade the library to a newer version compatible with compiler version $FIRST_SUPPORTED_COMPILER_VERSION or later (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or later).
                 """.trimIndent()
             )
 
@@ -615,8 +615,8 @@ abstract class AbstractKlibLoaderTest {
             .assertInvalidAbiMessage(
                 """
                     KLIB loader: Incompatible ABI version $obsoleteAbiVersion in library: $libraryPath
-                    The current Kotlin compiler can consume libraries produced by at least $FIRST_SUPPORTED_COMPILER_VERSION compiler.
-                    Please upgrade the library to a newer version compatible with $FIRST_SUPPORTED_COMPILER_VERSION compiler (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or higher).
+                    The current Kotlin compiler can consume libraries produced by compiler >= $FIRST_SUPPORTED_COMPILER_VERSION.
+                    Please upgrade the library to a newer version compatible with compiler version $FIRST_SUPPORTED_COMPILER_VERSION or later (ABI version ${KotlinAbiVersion.FIRST_SUPPORTED} or later).
                 """.trimIndent()
             )
     }

--- a/native/commonizer/tests/org/jetbrains/kotlin/commonizer/utils/metadataCompilation.kt
+++ b/native/commonizer/tests/org/jetbrains/kotlin/commonizer/utils/metadataCompilation.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
 import org.jetbrains.kotlin.backend.common.phaser.then
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
+import org.jetbrains.kotlin.backend.common.warnAboutSoftDeprecatedAbiVersions
 import org.jetbrains.kotlin.cli.common.*
 import org.jetbrains.kotlin.cli.common.config.ContentRoot
 import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
@@ -72,6 +73,7 @@ fun loadStdlibMetadata(configuration: CompilerConfiguration): NamedMetadata {
         .apply { reportLoadingProblemsIfAny(configuration, allAsErrors = true) }
         // TODO (KT-76785): Handling of duplicated names is a workaround that needs to be removed in the future.
         .eliminateLibrariesWithDuplicatedUniqueNames(configuration)
+        .warnAboutSoftDeprecatedAbiVersions(configuration)
 
     val stdlib = kotlinLoaderResult.librariesStdlibFirst.firstOrNull() ?: error("No stdlib found")
     val dummyLogger = CliLoggerAdapter(CommonizerLogLevel.Quiet, 2)


### PR DESCRIPTION
Previous step: https://github.com/JetBrains/kotlin/pull/7922