### PR TITLE
[Wasm] Unmute some coroutines-related tests on the first stage

### DIFF
--- a/compiler/testData/codegen/box/coroutines/kt82803.kt
+++ b/compiler/testData/codegen/box/coroutines/kt82803.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ KT-82803, KT-83728 are fixed in 2.4.0-Beta1
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/coroutines/kt83728.kt
+++ b/compiler/testData/codegen/box/coroutines/kt83728.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ KT-82803, KT-83728 are fixed in 2.4.0-Beta1
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/coroutines/suspendDoWhileContinueInsideElvis.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendDoWhileContinueInsideElvis.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ K/Wasm backend has issues KT-82803 & KT-83728 with FIR2IR v.2.3.0, fixed only in 2.4.0-Beta1. So, a test 2.3.0 frontend + current backend expectedly fails
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/coroutines/suspendForLoopBreakContinueInsideElvis.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendForLoopBreakContinueInsideElvis.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ KT-82803, KT-83728 are fixed in 2.4.0-Beta1
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/coroutines/suspendTwoProblematicExpressionsInOneCoroutine.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendTwoProblematicExpressionsInOneCoroutine.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ KT-82803, KT-83728 are fixed in 2.4.0-Beta1
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/coroutines/suspendWhileBreakContinueInsideElvis.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendWhileBreakContinueInsideElvis.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ KT-82803, KT-83728 are fixed in 2.4.0-Beta1
 
 import helpers.*
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/coroutines/suspendWhileContinueInsideElvisWithFinally.kt
+++ b/compiler/testData/codegen/box/coroutines/suspendWhileContinueInsideElvisWithFinally.kt
@@ -1,7 +1,5 @@
 // WITH_STDLIB
 // WITH_COROUTINES
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: Wasm-JS,Wasm-WASI:2.0,2.1,2.2,2.3
-// ^^^ KT-82803, KT-83728 are fixed in 2.4.0-Beta1
 
 import helpers.*
 import kotlin.coroutines.*


### PR DESCRIPTION
They are fixed in the scope of KT-87125.

#KT-87125