### PR TITLE
[stdlib] Fix incorrect exception type in *Range.random() docs KT-89174

### DIFF
--- a/libraries/stdlib/common/src/generated/_Ranges.kt
+++ b/libraries/stdlib/common/src/generated/_Ranges.kt
@@ -152,7 +152,7 @@ public fun CharProgression.lastOrNull(): Char? {
 /**
  * Returns a random element from this range.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.3")
 @kotlin.internal.InlineOnly
@@ -163,7 +163,7 @@ public inline fun IntRange.random(): Int {
 /**
  * Returns a random element from this range.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.3")
 @kotlin.internal.InlineOnly
@@ -174,7 +174,7 @@ public inline fun LongRange.random(): Long {
 /**
  * Returns a random element from this range.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.3")
 @kotlin.internal.InlineOnly
@@ -185,7 +185,7 @@ public inline fun CharRange.random(): Char {
 /**
  * Returns a random element from this range using the specified source of randomness.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.3")
 public fun IntRange.random(random: Random): Int {
@@ -199,7 +199,7 @@ public fun IntRange.random(random: Random): Int {
 /**
  * Returns a random element from this range using the specified source of randomness.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.3")
 public fun LongRange.random(random: Random): Long {
@@ -213,7 +213,7 @@ public fun LongRange.random(random: Random): Long {
 /**
  * Returns a random element from this range using the specified source of randomness.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.3")
 public fun CharRange.random(random: Random): Char {

--- a/libraries/stdlib/common/src/generated/_URanges.kt
+++ b/libraries/stdlib/common/src/generated/_URanges.kt
@@ -108,7 +108,7 @@ public fun ULongProgression.lastOrNull(): ULong? {
 /**
  * Returns a random element from this range.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -119,7 +119,7 @@ public inline fun UIntRange.random(): UInt {
 /**
  * Returns a random element from this range.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -130,7 +130,7 @@ public inline fun ULongRange.random(): ULong {
 /**
  * Returns a random element from this range using the specified source of randomness.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.5")
 public fun UIntRange.random(random: Random): UInt {
@@ -144,7 +144,7 @@ public fun UIntRange.random(random: Random): UInt {
 /**
  * Returns a random element from this range using the specified source of randomness.
  * 
- * @throws IllegalArgumentException if this range is empty.
+ * @throws NoSuchElementException if this range is empty.
  */
 @SinceKotlin("1.5")
 public fun ULongRange.random(random: Random): ULong {

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
@@ -1031,7 +1031,7 @@ object Elements : TemplateGroupBase() {
             """
             Returns a random ${f.element} from this ${f.collection}.
 
-            @throws ${if (f == RangesOfPrimitives) "IllegalArgumentException" else "NoSuchElementException"} if this ${f.collection} is empty.
+            @throws NoSuchElementException if this ${f.collection} is empty.
             """
         }
         body {
@@ -1064,7 +1064,7 @@ object Elements : TemplateGroupBase() {
             """
             Returns a random ${f.element} from this ${f.collection} using the specified source of randomness.
 
-            @throws ${if (f == RangesOfPrimitives) "IllegalArgumentException" else "NoSuchElementException"} if this ${f.collection} is empty.
+            @throws NoSuchElementException if this ${f.collection} is empty.
             """
         }
         body {


### PR DESCRIPTION
[KT-89174](https://youtrack.jetbrains.com/issue/KT-89174) Incorrect exception type documented in random function for ranges