### PR TITLE
Release KLIB file handles on standalone session disposal

### DIFF
--- a/analysis/analysis-api-standalone/analysis-api-standalone-fir/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/StandaloneProjectFactory.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-fir/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/StandaloneProjectFactory.kt
@@ -15,9 +15,11 @@ import com.intellij.mock.MockProject
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.PackageIndex
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.impl.ZipHandler
 import com.intellij.psi.*
 import com.intellij.psi.impl.PsiJavaModuleModificationTracker
 import com.intellij.psi.impl.file.impl.JavaFileManager
@@ -84,6 +86,14 @@ object StandaloneProjectFactory {
             compilerConfiguration,
             applicationEnvironmentMode,
         )
+
+        // JAR/klib files used in the Standalone Analysis API session remain open because of a global ZIP cache in IntelliJ.
+        // Unless the cache releases all file descriptors, concurrent sessions may fail to delete archives (esp. on Windows).
+        // Alive sessions aren't affected as the cache opens archives again when needed.
+        Disposer.register(projectDisposable) {
+            @Suppress("UnstableApiUsage")
+            ZipHandler.clearFileAccessorCache()
+        }
 
         registerApplicationExtensionPoints(applicationEnvironment)
 


### PR DESCRIPTION
The files of all JARs and KLIBs opened through CoreJarFileSystem are kept open in a global ZipHandler cache. It is only cleared when the shared application environment is disposed, which never happens while other sessions or in-process compilations are alive. So a disposed standalone session kept its libraries open, and on Windows they could not be deleted or overwritten afterwards.

The cache is now cleared when the session's disposable is disposed. Alive sessions are not affected: the cached accessors are refcounted and re-opened on demand.

^KT-89242 Fixed