### PR TITLE
[K/JS] Add FIR checkers to prohibit casting to a suspend functional type in some cases

### DIFF
--- a/analysis/analysis-api-fir-diagnostics/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnostic.kt
+++ b/analysis/analysis-api-fir-diagnostics/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnostic.kt
@@ -9307,6 +9307,13 @@ public interface KaFirDiagnostic<PSI : PsiElement> : KaDiagnosticWithPsi<PSI> {
 
     @KaUnstableDiagnosticApi
     @SubclassOptInRequired(KaImplementationDetail::class)
+    public interface JsSuspendFunctionInterfaceCast : KaFirDiagnostic<KtElement> {
+        override val diagnosticClass: KClass<JsSuspendFunctionInterfaceCast>
+            get() = JsSuspendFunctionInterfaceCast::class
+    }
+
+    @KaUnstableDiagnosticApi
+    @SubclassOptInRequired(KaImplementationDetail::class)
     public interface OverridingExternalFunWithOptionalParams : KaFirDiagnostic<KtElement> {
         override val diagnosticClass: KClass<OverridingExternalFunWithOptionalParams>
             get() = OverridingExternalFunWithOptionalParams::class

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
@@ -7090,6 +7090,12 @@ private fun KaDiagnosticConverterBuilder.addConversions155() {
             token,
         )
     }
+    add(FirJsErrors.JS_SUSPEND_FUNCTION_INTERFACE_CAST) { firDiagnostic ->
+        JsSuspendFunctionInterfaceCastImpl(
+            firDiagnostic as KtDiagnosticWithSource,
+            token,
+        )
+    }
 }
 
 private fun KaDiagnosticConverterBuilder.addConversions156() {

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
@@ -6573,6 +6573,11 @@ internal class ImplementingFunctionInterfaceImpl(
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtClassOrObject>(firDiagnostic, token), KaFirDiagnostic.ImplementingFunctionInterface
 
+internal class JsSuspendFunctionInterfaceCastImpl(
+    firDiagnostic: KtDiagnosticWithSource,
+    token: KaLifetimeToken,
+) : KaAbstractFirDiagnostic<KtElement>(firDiagnostic, token), KaFirDiagnostic.JsSuspendFunctionInterfaceCast
+
 internal class OverridingExternalFunWithOptionalParamsImpl(
     firDiagnostic: KtDiagnosticWithSource,
     token: KaLifetimeToken,

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirJsDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirJsDiagnosticsList.kt
@@ -84,6 +84,9 @@ object JS_DIAGNOSTICS_LIST : DiagnosticList("FirJsErrors") {
 
     val FUN_INTERFACES by object : DiagnosticGroup("Fun Interfaces") {
         val IMPLEMENTING_FUNCTION_INTERFACE by error<KtClassOrObject>(PositioningStrategy.DECLARATION_SIGNATURE_OR_DEFAULT)
+        val JS_SUSPEND_FUNCTION_INTERFACE_CAST by error<KtElement>() {
+            isSuppressible = true
+        }
     }
 
     val EXTERNAL by object : DiagnosticGroup("External") {
@@ -153,7 +156,6 @@ object JS_DIAGNOSTICS_LIST : DiagnosticList("FirJsErrors") {
             LanguageFeature.ErrorAboutDataClassCopyVisibilityChange,
         )
     }
-
 
     val NO_RUNTIME by object : DiagnosticGroup("NoRuntime") {
         val JS_NO_RUNTIME_WRONG_TARGET by error<KtElement>(PositioningStrategy.DECLARATION_SIGNATURE_OR_DEFAULT)

--- a/compiler/fir/checkers/checkers.js/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/js/FirJsErrors.kt
+++ b/compiler/fir/checkers/checkers.js/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/js/FirJsErrors.kt
@@ -67,6 +67,7 @@ object FirJsErrors : KtDiagnosticsContainer() {
 
     // Fun Interfaces
     val IMPLEMENTING_FUNCTION_INTERFACE: KtDiagnosticFactory0 = KtDiagnosticFactory0("IMPLEMENTING_FUNCTION_INTERFACE", ERROR, SourceElementPositioningStrategies.DECLARATION_SIGNATURE_OR_DEFAULT, KtClassOrObject::class, getRendererFactory())
+    val JS_SUSPEND_FUNCTION_INTERFACE_CAST: KtDiagnosticFactory0 = KtDiagnosticFactory0("JS_SUSPEND_FUNCTION_INTERFACE_CAST", ERROR, SourceElementPositioningStrategies.DEFAULT, KtElement::class, getRendererFactory())
 
     // External
     val OVERRIDING_EXTERNAL_FUN_WITH_OPTIONAL_PARAMS: KtDiagnosticFactory0 = KtDiagnosticFactory0("OVERRIDING_EXTERNAL_FUN_WITH_OPTIONAL_PARAMS", ERROR, SourceElementPositioningStrategies.DECLARATION_SIGNATURE_OR_DEFAULT, KtElement::class, getRendererFactory())

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/diagnostics/js/FirJsErrorsDefaultMessages.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/diagnostics/js/FirJsErrorsDefaultMessages.kt
@@ -51,6 +51,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.NAMED_COMPAN
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.NAME_CONTAINS_ILLEGAL_CHARS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.JS_ACTUAL_EXTERNAL_INTERFACE_WHILE_EXPECT_WITHOUT_JS_NO_RUNTIME
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.JS_NO_RUNTIME_ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT
+import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.JS_SUSPEND_FUNCTION_INTERFACE_CAST
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.NATIVE_ANNOTATIONS_ALLOWED_ONLY_ON_MEMBER_OR_EXTENSION_FUN
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.NATIVE_GETTER_RETURN_TYPE_SHOULD_BE_NULLABLE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors.NATIVE_INDEXER_CAN_NOT_HAVE_DEFAULT_ARGUMENTS
@@ -101,6 +102,10 @@ object FirJsErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
         map.put(SPREAD_OPERATOR_IN_DYNAMIC_CALL, "Cannot apply spread operator in dynamic call.")
         map.put(WRONG_OPERATION_WITH_DYNAMIC, "Wrong operation with dynamic value: {0}.", CommonRenderers.STRING)
         map.put(IMPLEMENTING_FUNCTION_INTERFACE, "Implementing a function interface is prohibited in JavaScript.")
+        map.put(
+            JS_SUSPEND_FUNCTION_INTERFACE_CAST,
+            "Casting a type implementing a suspend function interface to a suspend function interface is not allowed."
+        )
         map.put(OVERRIDING_EXTERNAL_FUN_WITH_OPTIONAL_PARAMS, "Overriding 'external' function with optional parameters.")
         map.put(
             OVERRIDING_EXTERNAL_FUN_WITH_OPTIONAL_PARAMS_WITH_FAKE,

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsDeclarationCheckers.kt
@@ -62,7 +62,13 @@ object JsDeclarationCheckers : DeclarationCheckers() {
 
     override val propertyCheckers: Set<FirPropertyChecker>
         get() = setOf(
-            FirJsPropertyDelegationByDynamicChecker
+            FirJsPropertyDelegationByDynamicChecker,
+            FirJsSuspendLambdaAsObjectPropertyChecker,
+        )
+
+    override val valueParameterCheckers: Set<FirValueParameterChecker>
+        get() = setOf(
+            FirJsSuspendLambdaAsObjectValueParameterChecker,
         )
 
     override val fileCheckers: Set<FirFileChecker>

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsExpressionCheckers.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsExpressionCheckers.kt
@@ -33,7 +33,8 @@ object JsExpressionCheckers : ExpressionCheckers() {
 
     override val callCheckers: Set<FirCallChecker>
         get() = setOf(
-            FirJsExternalArgumentCallChecker
+            FirJsExternalArgumentCallChecker,
+            FirJsSuspendLambdaAsObjectCallChecker,
         )
 
     override val getClassCallCheckers: Set<FirGetClassCallChecker>
@@ -51,5 +52,10 @@ object JsExpressionCheckers : ExpressionCheckers() {
     override val typeOperatorCallCheckers: Set<FirTypeOperatorCallChecker>
         get() = setOf(
             FirJsNoRuntimeTypeOperatorChecker,
+        )
+
+    override val returnExpressionCheckers: Set<FirReturnExpressionChecker>
+        get() = setOf(
+            FirJsSuspendLambdaAsObjectReturnChecker,
         )
 }

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/declaration/FirJsSuspendLambdaAsObjectPropertyChecker.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/declaration/FirJsSuspendLambdaAsObjectPropertyChecker.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.js.checkers.declaration
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirPropertyChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.hasExplicitReturnType
+import org.jetbrains.kotlin.fir.analysis.js.checkers.expression.reportIfUnsafeSuspendFunctionalValue
+import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.types.coneType
+
+object FirJsSuspendLambdaAsObjectPropertyChecker : FirPropertyChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirProperty) {
+        // Only a *declared* type is a boundary crossing; an inferred one isn't.
+        if (!declaration.symbol.hasExplicitReturnType) return
+
+        val initializer = declaration.initializer ?: return
+        val propertyType = declaration.returnTypeRef.coneType
+        reportIfUnsafeSuspendFunctionalValue(initializer, forcedType = propertyType)
+    }
+}

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/declaration/FirJsSuspendLambdaAsObjectValueParameterChecker.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/declaration/FirJsSuspendLambdaAsObjectValueParameterChecker.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.js.checkers.declaration
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirValueParameterChecker
+import org.jetbrains.kotlin.fir.analysis.js.checkers.expression.reportIfUnsafeSuspendFunctionalValue
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.types.coneType
+
+object FirJsSuspendLambdaAsObjectValueParameterChecker : FirValueParameterChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirValueParameter) {
+        val defaultValue = declaration.defaultValue ?: return
+        val parameterType = declaration.returnTypeRef.coneType
+        reportIfUnsafeSuspendFunctionalValue(defaultValue, forcedType = parameterType)
+    }
+}

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/expression/FirJsSuspendLambdaAsObjectCallChecker.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/expression/FirJsSuspendLambdaAsObjectCallChecker.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.js.checkers.expression
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirCallChecker
+import org.jetbrains.kotlin.fir.expressions.FirCall
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirOperation
+import org.jetbrains.kotlin.fir.expressions.FirTypeOperatorCall
+import org.jetbrains.kotlin.fir.expressions.resolvedArgumentMapping
+import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.fir.types.varargElementType
+
+object FirJsSuspendLambdaAsObjectCallChecker : FirCallChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirCall) {
+        when (expression) {
+            is FirFunctionCall -> checkArguments(expression)
+            is FirTypeOperatorCall -> checkCast(expression)
+            else -> {}
+        }
+    }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    private fun checkArguments(call: FirFunctionCall) {
+        // Check against the declared parameter type, not the argument's own type, so generic substitution
+        // (e.g. a suspend-functional value passed as `K`) isn't flagged.
+        val argumentMapping = call.resolvedArgumentMapping ?: return
+        for (entry in argumentMapping) {
+            val argument = entry.key
+            val parameter = entry.value
+            var parameterType = parameter.returnTypeRef.coneType
+            if (parameter.isVararg) {
+                parameterType = parameterType.varargElementType()
+            }
+            reportIfUnsafeSuspendFunctionalValue(argument, forcedType = parameterType)
+        }
+    }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    private fun checkCast(call: FirTypeOperatorCall) {
+        if (call.operation != FirOperation.AS && call.operation != FirOperation.SAFE_AS) return
+        val targetType = call.conversionTypeRef.coneType
+        if (!targetType.isSuspendFunctionTypeOrSubtype(context.session)) return
+        val argument = call.argumentList.arguments.singleOrNull() ?: return
+        reportIfUnsafeSuspendFunctionalValue(argument, forcedType = targetType, reportSource = call.source)
+    }
+}

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/expression/FirJsSuspendLambdaAsObjectReturnChecker.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/expression/FirJsSuspendLambdaAsObjectReturnChecker.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.js.checkers.expression
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.hasExplicitReturnType
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirReturnExpressionChecker
+import org.jetbrains.kotlin.fir.declarations.FirConstructor
+import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
+import org.jetbrains.kotlin.fir.resolve.fullyExpandedType
+import org.jetbrains.kotlin.fir.types.coneType
+
+object FirJsSuspendLambdaAsObjectReturnChecker : FirReturnExpressionChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirReturnExpression) {
+        val targetElement = expression.target.labeledElement
+        if (targetElement is FirConstructor) return
+        // Only a *declared* return type is a boundary crossing; an inferred one isn't.
+        if (!targetElement.symbol.hasExplicitReturnType) return
+
+        val functionReturnType = targetElement.returnTypeRef.coneType.fullyExpandedType()
+        reportIfUnsafeSuspendFunctionalValue(expression.result, forcedType = functionReturnType)
+    }
+}

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/expression/FirJsSuspendLambdaAsObjectUtils.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/expression/FirJsSuspendLambdaAsObjectUtils.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.js.checkers.expression
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.hasExplicitReturnType
+import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors
+import org.jetbrains.kotlin.fir.expressions.FirAnonymousObjectExpression
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirFunctionTypeConversionExpression
+import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
+import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
+import org.jetbrains.kotlin.fir.expressions.unwrapArgument
+import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.references.toResolvedVariableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.isSuspendOrKSuspendFunctionType
+import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.fir.types.typeContext
+
+/**
+ * true if this type is a suspend function type (`suspend () -> Unit`, `KSuspendFunction0`, etc.) or a subtype of one,
+ * i.e. a class/object/interface that implements such a type as a supertype.
+ */
+internal fun ConeKotlinType.isSuspendFunctionTypeOrSubtype(session: FirSession): Boolean {
+    return with(session.typeContext) { isTypeOrSubtypeOf { it.isSuspendOrKSuspendFunctionType(session) } }
+}
+
+/**
+ * true if this expression is a value directly constructed right here: a constructor call, an object literal, or a
+ * reference to a named `object`. A `val` with no explicit type is unwrapped to its initializer, since its inferred
+ * type can't hide the real shape. Anything else reached indirectly (parameter, `var`, explicitly-typed property)
+ * is treated as safe, since telling it apart from a real callable would need data-flow analysis.
+ */
+context(context: CheckerContext)
+internal fun FirExpression.isDirectSuspendFunctionalObjectConstruction(): Boolean {
+    return when (val unwrapped = unwrapArgument()) {
+        is FirAnonymousObjectExpression -> true
+        is FirResolvedQualifier -> unwrapped.isNamedObjectReference()
+        is FirFunctionCall -> unwrapped.isConstructorCall()
+        is FirFunctionTypeConversionExpression -> unwrapped.expression.isDirectSuspendFunctionalObjectConstruction()
+        is FirPropertyAccessExpression -> unwrapped.unwrapImplicitlyTypedValInitializer()
+            ?.isDirectSuspendFunctionalObjectConstruction() ?: false
+        else -> false
+    }
+}
+
+private fun FirResolvedQualifier.isNamedObjectReference(): Boolean =
+    accessedObjectSymbol != null
+
+private fun FirFunctionCall.isConstructorCall(): Boolean =
+    calleeReference.toResolvedCallableSymbol() is FirConstructorSymbol
+
+/** Returns the initializer of the accessed `val`, but only when it has no explicit type (so nothing is hidden). */
+private fun FirPropertyAccessExpression.unwrapImplicitlyTypedValInitializer(): FirExpression? {
+    val property = calleeReference.toResolvedVariableSymbol() as? FirPropertySymbol ?: return null
+    if (property.isVar || property.hasExplicitReturnType) return null
+    return property.resolvedInitializer
+}
+
+/**
+ * Reports [FirJsErrors.JS_SUSPEND_FUNCTION_INTERFACE_CAST] on [reportSource] (or [rawExpression]'s source) if
+ * [rawExpression] is a direct construction of a suspend-functional object whose type is (a subtype of) [forcedType]
+ * (or its own resolved type).
+ */
+context(context: CheckerContext, reporter: DiagnosticReporter)
+internal fun reportIfUnsafeSuspendFunctionalValue(
+    rawExpression: FirExpression,
+    forcedType: ConeKotlinType? = null,
+    reportSource: KtSourceElement? = null,
+) {
+    val expression = rawExpression.unwrapArgument()
+    val type = forcedType ?: expression.resolvedType
+    if (!type.isSuspendFunctionTypeOrSubtype(context.session)) return
+    if (!expression.isDirectSuspendFunctionalObjectConstruction()) return
+    reporter.reportOn(reportSource ?: rawExpression.source, FirJsErrors.JS_SUSPEND_FUNCTION_INTERFACE_CAST)
+}

--- a/compiler/testData/diagnostics/testsWithJsStdLib/jsSuspendLambdaAsObject.kt
+++ b/compiler/testData/diagnostics/testsWithJsStdLib/jsSuspendLambdaAsObject.kt
@@ -1,0 +1,106 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// DIAGNOSTICS: -UNUSED_PARAMETER -USELESS_CAST -UNCHECKED_CAST -USELESS_IS_CHECK
+
+object Obj : suspend () -> Unit {
+    override suspend fun invoke() {}
+}
+
+class Cls : suspend () -> Unit {
+    override suspend fun invoke() {}
+}
+
+interface SubInt : suspend () -> Unit
+
+class SubCls : SubInt {
+    override suspend fun invoke() {}
+}
+
+fun takeSuspend(f: suspend () -> Unit) {}
+fun takeGeneric(f: Any) {}
+
+suspend fun foo() {}
+fun bar() {}
+
+fun testArguments() {
+    takeSuspend(<!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Obj<!>)
+    takeSuspend(<!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>)
+    takeSuspend(<!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>SubCls()<!>)
+
+    // Positive: no explicit type on the val, so its inferred type is the real object's type - safely unwrapped to the constructor call
+    val o = Obj
+    takeSuspend(<!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>o<!>)
+
+    val c = Cls()
+    takeSuspend(<!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>c<!>)
+
+    // Positive: chained implicitly-typed vals still unwrap transitively, each hop has exactly one initializer
+    val c2 = c
+    takeSuspend(<!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>c2<!>)
+
+    // Negative: `var` can be reassigned, so its single initializer can't be trusted without data-flow
+    var vc = Cls()
+    takeSuspend(vc)
+
+    // Negative: explicit type on the val hides the initializer's real shape, can't unwrap without data-flow
+    val sc: SubInt = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>SubCls()<!>
+    takeSuspend(sc)
+
+    // Safe / Negative cases
+    takeSuspend { }
+    takeSuspend(::foo)
+    takeSuspend(::bar)
+
+    val nonSuspendLambda = {}
+    takeSuspend(nonSuspendLambda)
+
+    val suspendLambda: suspend () -> Unit = {}
+    takeSuspend(suspendLambda)
+
+    // Negative: parameter's declared type isn't suspend-functional (just `Any`)
+    takeGeneric(Obj)
+    takeGeneric(Cls())
+}
+
+fun <T> takeGenericParam(value: T) {}
+fun <K, V> putEntry(map: MutableMap<K, V>, key: K, value: V) {}
+
+fun testGenericSubstitution() {
+    // Negative: type parameter only *substituted* to a suspend-functional type, not declared as one
+    takeGenericParam<suspend () -> Unit>(Obj)
+    takeGenericParam<suspend () -> Unit>(Cls())
+
+    val map = mutableMapOf<suspend () -> Unit, String>()
+    putEntry(map, Obj, "obj")
+    putEntry(map, Cls(), "cls")
+}
+
+fun testCasts() {
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Obj as (suspend () -> Unit)<!>
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Obj as? (suspend () -> Unit)<!>
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls() as (suspend () -> Unit)<!>
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls() as? (suspend () -> Unit)<!>
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Any() as (suspend () -> Unit)<!>
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Any() as? (suspend () -> Unit)<!>
+
+    // Safe / Negative cases
+    val suspendLambda: suspend () -> Unit = {}
+    suspendLambda as (suspend () -> Unit)
+    suspendLambda as? (suspend () -> Unit)
+
+    ({ }) as (suspend () -> Unit)
+    (::foo) as (suspend () -> Unit)
+
+    // Positive: no explicit type on the val, so its inferred type is the real object's type - safely unwrapped to the constructor call
+    val c = Cls()
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>c as (suspend () -> Unit)<!>
+    <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>c as? (suspend () -> Unit)<!>
+
+    // is-checks should remain untouched
+    if (Obj is (suspend () -> Unit)) {}
+    if (Obj !is (suspend () -> Unit)) {}
+}
+
+fun testSuppression() {
+    @Suppress("JS_SUSPEND_FUNCTION_INTERFACE_CAST")
+    val suppressed: suspend () -> Unit = Cls()
+}

--- a/compiler/testData/diagnostics/testsWithJsStdLib/jsSuspendLambdaAsObjectImplicit.kt
+++ b/compiler/testData/diagnostics/testsWithJsStdLib/jsSuspendLambdaAsObjectImplicit.kt
@@ -1,0 +1,66 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// LANGUAGE: +FunctionalTypeWithExtensionAsSupertype
+// DIAGNOSTICS: -UNUSED_PARAMETER -UNUSED_VARIABLE
+
+object Obj : suspend () -> Unit {
+    override suspend fun invoke() {}
+}
+
+class Cls : suspend () -> Unit {
+    override suspend fun invoke() {}
+}
+
+class RCls : suspend Int.() -> Unit {
+    override suspend fun invoke(p1: Int) {}
+}
+
+// Properties / local variables with an explicit suspend-functional type
+
+val topLevelProperty: suspend () -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>
+
+class Container {
+    val memberProperty: suspend () -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>
+    val memberPropertyWithReceiver: suspend Int.() -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>RCls()<!>
+
+    // Negative: no explicit type -> inferred type is the class itself, not a boundary crossing
+    val memberPropertyInferred = Cls()
+}
+
+fun testLocalProperties() {
+    val local: suspend () -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>
+    val localWithReceiver: suspend Int.() -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>RCls()<!>
+
+    // Negative: no explicit type
+    val localInferred = Cls()
+
+    // Negative: real lambda / callable reference
+    val localLambda: suspend () -> Unit = { }
+}
+
+// Default parameter values
+
+fun withDefault(f: suspend () -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>) {}
+fun withDefaultReceiver(f: suspend Int.() -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>RCls()<!>) {}
+
+// Negative: real lambda as default
+fun withSafeDefault(f: suspend () -> Unit = { }) {}
+
+// Return statements
+
+fun makeExplicit(): suspend () -> Unit {
+    return <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>
+}
+
+fun makeImplicit(): suspend () -> Unit = <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>Cls()<!>
+
+fun makeWithReceiver(): suspend Int.() -> Unit {
+    return <!JS_SUSPEND_FUNCTION_INTERFACE_CAST!>RCls()<!>
+}
+
+// Negative: return type is inferred, no declared contract crossed
+fun makeInferred() = Cls()
+
+// Negative: real lambda returned
+fun makeSafe(): suspend () -> Unit {
+    return { }
+}


### PR DESCRIPTION
While implementing `suspend` functional types is generally allowed and has been introduced by KT-46204, some of the places are not guarded enough against runtime errors related to using such class instances as casted to suspend functional types.

Unfortunately, properly handling _all_ cases is not possible here without introducing data-flow analysis, since simple safe re-assigning with casting involved makes shallow analysis to skip them.

This PR introduces a set of preventive checks in a reasonable enough deepness of analysis.   

<details>
  <summary>(Click) covered invalid, reported via diagnostics, casts in this change</summary>

1.  Object class implementing `suspend () -> Unit` (or any `SuspendFunctionN`/`KSuspendFunctionN`,
    including with a receiver like `suspend A.() -> B`), passed directly as an argument to a
    suspend-functional-typed parameter — positional, named, and vararg/spread.

2.  Object explicitly cast via `as (suspend () -> Unit)`.

3.  Object explicitly cast via `as? (suspend () -> Unit)`.

4.  Object assigned as the default value of a `FirValueParameter` whose declared type is a
    suspend-functional type.

5.  Object assigned to a `val`/`var` (member property or local variable) with an *explicit*
    suspend-functional type declared on it.

6.  Object returned via explicit `return` or implicit last-expression return from a function/lambda
    whose declared return type is a suspend-functional type.

7.  Same as 1-6, but where the object's type is inferred (no explicit type) via an intermediate
    `val` — e.g. `val o = Obj; takeSuspend(o)` or `val c = Cls(); c as (suspend () -> Unit)` — the
    checker unwraps one or more chained implicitly-typed `val`s back to the original construction.

8.  A bare reference to a named `object` declaration implementing a suspend function type
    (e.g. passing `Obj` itself), same treatment as a fresh constructor call.

Please see the test files for examples.

</details>

The added diagnostics is intentionally made suspendible, since there might be the false-positives, so users should be able to opt out.

<details>

<summary>(Click) Cases intentionally ignored, most of them are possible to optimize later using DFA</summary>

1. Value held in a `var` (reassignment means the single initializer can't be trusted without data-flow analysis).
   ```
   var v: suspend () -> Unit = Cls()
   ...
   v = { println("Lambda, not an object") }
   ...
   takeSuspend(v) // not flagged
   ```

2. Value held in a property/parameter/variable with an *explicit* suspend-functional type annotation
   (can't see through it to the real underlying value without data-flow analysis).
   ```
   fun use(p: suspend () -> Unit) {
      takeSuspend(p) // not flagged
   }
   ```

3. Value reached only through a generic type parameter substitution.
   ```
   fun <T> take(value: T) {}
   take<suspend () -> Unit>(Cls()) // not flagged
   ```

4. `when`/`if`/elvis branch common-supertype typing.
   ```
   val f: suspend () -> Unit = if (cond) Cls() else Cls() // not flagged
   ```

5. Delegation (`by someObjectImplementingSuspendFunctionType`).
   ```
   class Wrapper : suspend () -> Unit by Cls() // not flagged
   ```

</details>


^KT-64821 Fixed