### PR TITLE
[Gradle] Consume Swift Export metadata for project dependencies

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
@@ -272,8 +272,6 @@ class ExportDslIT : KGPBaseTest() {
                 environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
             ) {
                 assertHasDiagnostic(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
-                // The build fails before the Swift Export tool is handed the modules.
-                assertTasksAreNotInTaskGraph(":iosArm64DebugSwiftExport")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
@@ -198,6 +198,92 @@ class SwiftExportDslIT : KGPBaseTest() {
         }
     }
 
+    @DisplayName("Changing an exported module name override invalidates the Swift Export task")
+    @GradleTest
+    @Suppress("DEPRECATION") // Tests the deprecated legacy Swift Export DSL on purpose.
+    fun testExportedModuleNameOverrideIsTrackedAsTaskInput(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        val exportedLibrary = publishMultiplatformLibrary(gradleVersion) {
+            iosArm64()
+            sourceSets.commonMain.get().compileSource(
+                """
+                package org.foo
+                class One
+                """.trimIndent()
+            )
+        }
+
+        val moduleNameProperty = "exportedModuleNameOverride"
+        val initialModuleName = "InitialExportedModule"
+        val renamedModuleName = "RenamedExportedModule"
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            addPublishedProjectToRepositories(exportedLibrary)
+
+            // Only Serializable values may be captured inside the build script injection below.
+            val exportedLibraryCoordinate = exportedLibrary.rootCoordinate
+
+            buildScriptInjection {
+                // The exported module name is read from a Gradle property so that it can be changed between builds.
+                // Crucially, none of the task's tracked file inputs (the sources, the resolved klib, or the resolved
+                // export configuration) change when only this property changes.
+                val moduleNameOverride = project.providers.gradleProperty(moduleNameProperty).orElse(initialModuleName)
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+
+                    with(swiftExport) {
+                        export(exportedLibraryCoordinate) {
+                            moduleName.set(moduleNameOverride)
+                        }
+                    }
+                }
+            }
+
+            val initialModuleDir = "build/SwiftExport/iosArm64/Debug/files/$initialModuleName"
+            val renamedModuleDir = "build/SwiftExport/iosArm64/Debug/files/$renamedModuleName"
+
+            // 1) First run with the initial override: the task executes and emits the exported module under its name.
+            build(
+                ":iosArm64DebugSwiftExport",
+                "-P$moduleNameProperty=$initialModuleName",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir),
+            ) {
+                assertTasksExecuted(":iosArm64DebugSwiftExport")
+                assertDirectoryInProjectExists(initialModuleDir)
+            }
+
+            // 2) Re-running with the same override keeps the task UP-TO-DATE, as expected.
+            build(
+                ":iosArm64DebugSwiftExport",
+                "-P$moduleNameProperty=$initialModuleName",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir),
+            ) {
+                assertTasksUpToDate(":iosArm64DebugSwiftExport")
+            }
+
+            // 3) Change ONLY the exported module name override. The override drives the task's output and is tracked
+            // via the `exportedModulesInputs` task input, so up-to-date checking sees the change: the task re-executes
+            // and emits the exported module under its new name, while the stale directory is gone.
+            build(
+                ":iosArm64DebugSwiftExport",
+                "-P$moduleNameProperty=$renamedModuleName",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir),
+            ) {
+                assertTasksExecuted(":iosArm64DebugSwiftExport")
+                assertDirectoryInProjectExists(renamedModuleDir)
+                assertDirectoryInProjectDoesNotExist(initialModuleDir)
+            }
+        }
+    }
+
     @DisplayName("embedSwiftExport executes normally when package flatten rule is defined in Swift Export DSL")
     @GradleTest
     fun testSwiftExportDSLWithPackageFlatteringRuleEnabled(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
@@ -125,6 +125,110 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
         )
     }
 
+    @DisplayName(
+        "Swift Export metadata consumed from a direct unpublished dependency with moduleName override"
+    )
+    @GradleTest
+    fun directUnpublishedDependencyWithModuleNameOverride(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = false,
+            moduleNameOverride = "Foo",
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct unpublished dependency with rootPackage override"
+    )
+    @GradleTest
+    fun directUnpublishedDependencyWithRootPackageOverride(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = false,
+            rootPackageOverride = "com.foo.bar",
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct unpublished dependency with no overrides"
+    )
+    @GradleTest
+    fun directUnpublishedDependencyWithNoOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = false,
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct unpublished dependency with moduleName and rootPackage overrides"
+    )
+    @GradleTest
+    fun directUnpublishedDependencyWithModuleNameAndRootPackageOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = false,
+            moduleNameOverride = "Bar",
+            rootPackageOverride = "com.bar.baz",
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a transitive unpublished dependency with moduleName and rootPackage overrides"
+    )
+    @GradleTest
+    fun transitiveUnpublishedDependencyWithModuleNameAndRootPackageOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = false,
+            moduleNameOverride = "Bar",
+            rootPackageOverride = "com.bar.baz",
+            transitiveModuleNameOverride = "Baz",
+            transitiveRootPackageOverride = "com.foo.bar.baz",
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a transitive published dependency with moduleName and rootPackage overrides, " +
+                "via a direct unpublished dependency"
+    )
+    @GradleTest
+    fun directUnpublishedDependencyWithTransitivePublishedDependencyWithModuleNameAndRootPackageOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = false,
+            moduleNameOverride = "Bar",
+            rootPackageOverride = "com.bar.baz",
+            transitivePublished = true,
+            transitiveModuleNameOverride = "Baz",
+            transitiveRootPackageOverride = "com.foo.bar.baz",
+        )
+    }
+
     private fun testSwiftExportMetadataConsumption(
         gradleVersion: GradleVersion,
         testBuildDir: Path,
@@ -253,16 +357,10 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
                     applyMultiplatform {
                         iosArm64()
 
-                        val subprojectDependency = if (publishedSubproject != null) {
-                            publishedSubproject.rootCoordinate
-                        } else {
-                            project(":subproject")
-                        }
-
                         export.swift {
                             xcodeIntegration {
                                 if (configModuleNameOverride != null) {
-                                    configure(subprojectDependency) {
+                                    configure(publishedSubproject?.rootCoordinate ?: project(":subproject")) {
                                         moduleName.set(configModuleNameOverride)
                                     }
                                 }
@@ -273,7 +371,7 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
                             compileStubSourceWithSourceSetName()
 
                             dependencies {
-                                api(subprojectDependency)
+                                api(publishedSubproject?.rootCoordinate ?: project(":subproject"))
                             }
                         }
                     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -18,6 +18,8 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.registerEmbedSwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.initSwiftExportClasspathConfigurations
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.shareSwiftExportMetadata
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.swiftExportDependencySelectorFactory
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration
 
@@ -52,6 +54,23 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
     val swiftExportConfiguration = exportExtension.swiftExportConfiguration
     if (swiftExportConfiguration.moduleName.isPresent || swiftExportConfiguration.rootPackage.isPresent) {
         locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(swiftExportConfiguration)
+
+        // Published dependencies expose their metadata through the `swiftExportMetadataElements` variant registered
+        // above. Same-build subprojects additionally share it as a secondary variant on each apple target's
+        // `apiElements`, so that a consuming project in the same build can read it at execution time without relying on
+        // the module cache (which a not-yet-published subproject has no entry in).
+        val metadata = project.provider {
+            SwiftExportMetadata(
+                moduleName = swiftExportConfiguration.moduleName.orNull,
+                rootPackage = swiftExportConfiguration.rootPackage.orNull,
+            )
+        }
+        appleTargets.all { target ->
+            project.shareSwiftExportMetadata(
+                project.configurations.getByName(target.apiElementsConfigurationName),
+                metadata,
+            )
+        }
     }
 
     // The targets are awaited above, so the DSL is finalised by now and the activation is order-independent.

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -189,23 +189,18 @@ private fun Project.registerSwiftExportRun(
     val files = outputs.map { it.dir("files") }
     val serializedModules = outputs.map { it.dir("modules").file("${swiftApiModuleName.get()}.json") }
     val exportConfigurationProvider = provider { LazyResolvedConfigurationWithArtifacts(exportConfiguration) }
-    val apiConfigurationProvider = provider { apiConfiguration?.let(::LazyResolvedConfigurationWithArtifacts) }
     val metadataConfigurationProvider = provider {
-        if (shouldResolvePublishedMetadata) {
-            LazyResolvedConfigurationWithArtifacts(
-                exportConfiguration,
-                configureArtifactView = {
-                    withVariantReselection()
-                    componentFilter { it is ModuleComponentIdentifier }
-                },
-                configureArtifactViewAttributes = { attributes ->
-                    attributes.attribute(Usage.USAGE_ATTRIBUTE, usageByName(SWIFT_EXPORT_METADATA_USAGE))
-                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, categoryByName(Category.LIBRARY))
-                }
-            )
-        } else {
-            null
-        }
+        LazyResolvedConfigurationWithArtifacts(
+            exportConfiguration,
+            configureArtifactView = {
+                withVariantReselection()
+                componentFilter { it is ModuleComponentIdentifier }
+            },
+            configureArtifactViewAttributes = { attributes ->
+                attributes.attribute(Usage.USAGE_ATTRIBUTE, usageByName(SWIFT_EXPORT_METADATA_USAGE))
+                attributes.attribute(Category.CATEGORY_ATTRIBUTE, categoryByName(Category.LIBRARY))
+            }
+        )
     }
 
     return locateOrRegisterTask<SwiftExportTask>(swiftExportTaskName) { task ->
@@ -223,16 +218,19 @@ private fun Project.registerSwiftExportRun(
         task.parameters.konanTarget.set(target.konanTarget)
         task.parameters.bridgeModuleName.set("SharedBridge")
         task.parameters.swiftExportSettings.set(customSetting)
-        task.parameters.swiftModules.set(
-            collectModules(
-                exportConfigurationProvider = exportConfigurationProvider,
-                apiConfigurationProvider = apiConfigurationProvider,
-                exportedModulesProvider = exportedModules,
-                metadataConfigurationProvider = metadataConfigurationProvider,
-                dependencyOptionsOverridesProvider = dependencyOptionsOverrides,
-                rootModuleNameProvider = swiftApiModuleName,
-            )
-        )
+
+        // The exported modules are resolved from these Configuration-Cache-safe holders at execution time (see
+        // SwiftExportTask.run), not here. Up-to-date checking is provided by the raw configurations wired as task
+        // inputs above.
+        task.exportConfiguration.set(exportConfigurationProvider)
+        if (apiConfiguration != null) {
+            task.apiConfiguration.set(provider { LazyResolvedConfigurationWithArtifacts(apiConfiguration) })
+        }
+        if (shouldResolvePublishedMetadata) {
+            task.metadataConfiguration.set(metadataConfigurationProvider)
+        }
+        task.exportedModules.set(exportedModules)
+        task.dependencyOptionsOverrides.set(dependencyOptionsOverrides)
 
         task.ignoreExperimentalDiagnostic.set(kotlinPropertiesProvider.swiftExportIgnoreExperimental)
         task.mainModuleInput.moduleName.set(swiftApiModuleName)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -15,7 +15,9 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.categoryByName
+import org.jetbrains.kotlin.gradle.plugin.internal.kotlinSecondaryVariantsDataSharing
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_USAGE
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.consumeSwiftExportMetadata
 import org.jetbrains.kotlin.gradle.plugin.usageByName
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractNativeLibrary
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
@@ -228,6 +230,9 @@ private fun Project.registerSwiftExportRun(
         }
         if (shouldResolvePublishedMetadata) {
             task.metadataConfiguration.set(metadataConfigurationProvider)
+            task.sharedMetadata.set(
+                provider { kotlinSecondaryVariantsDataSharing.consumeSwiftExportMetadata(exportConfiguration) }
+            )
         }
         task.exportedModules.set(exportedModules)
         task.dependencyOptionsOverrides.set(dependencyOptionsOverrides)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportAction.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal
 
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
@@ -22,6 +23,7 @@ import java.util.logging.Logger
 internal abstract class SwiftExportAction : WorkAction<SwiftExportAction.SwiftExportWorkParameters> {
     internal interface SwiftExportWorkParameters : SwiftExportTaskParameters, WorkParameters {
         val konanDistribution: Property<Distribution>
+        val swiftModules: ListProperty<SwiftExportedModule>
     }
 
     private val swiftExportLogger = object : SwiftExportLogger {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportInit.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportInit.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.gradle.plugin.attributes.KlibPackaging
 import org.jetbrains.kotlin.gradle.plugin.categoryByName
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnosticsCollector
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.kotlinToolingDiagnosticsCollector
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.toolingDiagnosticsContext
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
@@ -102,6 +103,12 @@ internal val String.normalizedSwiftExportModuleName: String
 
 internal fun Project.validateSwiftExportModuleName(moduleName: String) =
     kotlinToolingDiagnosticsCollector.validateSwiftExportModuleName(this, moduleName)
+
+internal fun validateSwiftExportModuleName(moduleName: String, reportDiagnostic: (ToolingDiagnostic) -> Unit) {
+    if (!moduleName.matches(Regex(SWIFT_EXPORT_MODULE_NAME_VALIDATION_PATTERN))) {
+        reportDiagnostic(KotlinToolingDiagnostics.SwiftExportInvalidModuleName(moduleName))
+    }
+}
 
 internal fun KotlinToolingDiagnosticsCollector.validateSwiftExportModuleName(project: Project, moduleName: String) {
     if (!moduleName.matches(Regex(SWIFT_EXPORT_MODULE_NAME_VALIDATION_PATTERN))) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportWorkParameters.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportWorkParameters.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal
 
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -25,9 +24,6 @@ internal interface SwiftExportTaskParameters {
     @get:Input
     @get:Optional
     val swiftExportSettings: MapProperty<String, String>
-
-    @get:Input
-    val swiftModules: ListProperty<SwiftExportedModule>
 
     @get:Input
     val konanTarget: Property<KonanTarget>

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -5,17 +5,14 @@
 
 package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal
 
-import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
-import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
-import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_SCHEMA_VERSION
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
@@ -96,32 +93,28 @@ internal fun createHiddenSwiftExportedModule(
     )
 }
 
-internal fun Project.collectModules(
-    exportConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts>,
-    apiConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
-    metadataConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
-    exportedModulesProvider: Provider<Set<SwiftExportedDependency>>,
-    dependencyOptionsOverridesProvider: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
-    rootModuleNameProvider: Provider<String>,
-): Provider<List<SwiftExportedModule>> = provider {
-    val exportConfiguration = exportConfigurationProvider.get()
-    val apiConfiguration = apiConfigurationProvider.orNull
-    val metadataConfiguration = metadataConfigurationProvider.orNull
-    val exportedModules = exportedModulesProvider.get()
-    val dependencyOptionsOverrides = dependencyOptionsOverridesProvider.get()
-    val rootModuleName = rootModuleNameProvider.get()
-
-    project.applySwiftExportConsumerOverrides(
-        modules = project.swiftExportedModules(
+internal fun collectModules(
+    exportConfiguration: LazyResolvedConfigurationWithArtifacts,
+    apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
+    metadataConfiguration: LazyResolvedConfigurationWithArtifacts?,
+    exportedModules: Set<SwiftExportedDependency>,
+    dependencyOptionsOverrides: Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>,
+    rootModuleName: String,
+    reportDiagnostic: (ToolingDiagnostic) -> Unit,
+): List<SwiftExportedModule> {
+    return applySwiftExportConsumerOverrides(
+        modules = swiftExportedModules(
             exportConfiguration = exportConfiguration,
             apiConfiguration = apiConfiguration,
             exportedModules = exportedModules,
+            reportDiagnostic = reportDiagnostic,
         ),
         overrides = dependencyOptionsOverrides,
-        metadataByComponent = metadataConfiguration?.metadataByComponent(project::reportDiagnostic) ?: emptyMap(),
+        metadataByComponent = metadataConfiguration?.metadataByComponent(reportDiagnostic) ?: emptyMap(),
         exportConfiguration = exportConfiguration,
         apiConfiguration = apiConfiguration,
         rootModuleName = rootModuleName,
+        reportDiagnostic = reportDiagnostic,
     )
 }
 
@@ -163,10 +156,11 @@ internal fun defaultSwiftExportModuleName(id: ComponentIdentifier, moduleVersion
         else -> null
     }
 
-private fun Project.swiftExportedModules(
+internal fun swiftExportedModules(
     exportConfiguration: LazyResolvedConfigurationWithArtifacts,
     apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
     exportedModules: Set<SwiftExportedDependency>,
+    reportDiagnostic: (ToolingDiagnostic) -> Unit,
 ) = findAndCreateSwiftExportedModules(
     exportedModules = exportedModules,
     resolvedExportArtifacts = exportConfiguration.filteredArtifacts { allResolvedDependencies },
@@ -177,6 +171,7 @@ private fun Project.swiftExportedModules(
                 .filterNot { it.isConstraint }
         }
         ?: emptySet(),
+    reportDiagnostic = reportDiagnostic,
 )
 
 /**
@@ -240,10 +235,11 @@ private fun LazyResolvedConfigurationWithArtifacts.filteredArtifacts(
 private val File.isCinteropKlib get() = name.contains("-cinterop-") || name.contains("Cinterop-")
 private val File.isJavaJar get() = extension == "jar"
 
-private fun Project.findAndCreateSwiftExportedModules(
+private fun findAndCreateSwiftExportedModules(
     exportedModules: Set<SwiftExportedDependency>,
     resolvedExportArtifacts: Set<ResolvedArtifactWithVersionIdentifier>,
     resolvedDirectApiArtifacts: Set<ResolvedArtifactWithVersionIdentifier>,
+    reportDiagnostic: (ToolingDiagnostic) -> Unit,
 ): List<SwiftExportedModule> {
     val result = mutableListOf<SwiftExportedModule>()
     val processedComponents = mutableSetOf<ResolvedArtifactWithVersionIdentifier>()
@@ -277,7 +273,7 @@ private fun Project.findAndCreateSwiftExportedModules(
             result.add(
                 createFullyExportedSwiftExportedModule(
                     explicitModule.moduleName.orElse(
-                        normalizedAndValidatedModuleName(explicitModule.inheritedName)
+                        normalizedAndValidatedModuleName(explicitModule.inheritedName, reportDiagnostic)
                     ).get(),
                     explicitModule.flattenPackage.orNull,
                     matchingArtifact.artifact.file
@@ -333,5 +329,5 @@ private data class SwiftExportedModuleImp(
     override val exportMode: SwiftExportedModuleMode,
 ) : SwiftExportedModule
 
-private fun Project.normalizedAndValidatedModuleName(moduleName: String) =
-    moduleName.normalizedSwiftExportModuleName.also { validateSwiftExportModuleName(it) }
+private fun normalizedAndValidatedModuleName(moduleName: String, reportDiagnostic: (ToolingDiagnostic) -> Unit) =
+    moduleName.normalizedSwiftExportModuleName.also { validateSwiftExportModuleName(it, reportDiagnostic) }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -13,6 +13,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.internal.KotlinProjectSharedDataProvider
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_SCHEMA_VERSION
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
@@ -97,6 +98,7 @@ internal fun collectModules(
     exportConfiguration: LazyResolvedConfigurationWithArtifacts,
     apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
     metadataConfiguration: LazyResolvedConfigurationWithArtifacts?,
+    sharedMetadata: KotlinProjectSharedDataProvider<SwiftExportMetadata>?,
     exportedModules: Set<SwiftExportedDependency>,
     dependencyOptionsOverrides: Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>,
     rootModuleName: String,
@@ -110,7 +112,14 @@ internal fun collectModules(
             reportDiagnostic = reportDiagnostic,
         ),
         overrides = dependencyOptionsOverrides,
-        metadataByComponent = metadataConfiguration?.metadataByComponent(reportDiagnostic) ?: emptyMap(),
+        metadataByComponent = buildMap {
+            if (metadataConfiguration != null) {
+                putAll(metadataConfiguration.metadataByComponent(reportDiagnostic))
+            }
+            if (sharedMetadata != null) {
+                putAll(sharedMetadata.metadataByComponent())
+            }
+        },
         exportConfiguration = exportConfiguration,
         apiConfiguration = apiConfiguration,
         rootModuleName = rootModuleName,
@@ -212,6 +221,22 @@ internal fun LazyResolvedConfigurationWithArtifacts.metadataByComponent(
         }
         artifact.id.componentIdentifier to metadata
     }.toMap()
+}
+
+/**
+ * Reads the Swift Export metadata shared by same-build subproject dependencies as a secondary variant, keyed by the
+ * owning [ProjectComponentIdentifier] so it can be correlated with the klib artifacts the same way the published
+ * metadata is (both use [ResolvedArtifactWithVersionIdentifier.rootComponentId], i.e. `resolvedVariant.owner`).
+ * Entries with an incompatible [SwiftExportMetadata.schemaVersion] are skipped.
+ */
+private fun KotlinProjectSharedDataProvider<SwiftExportMetadata>.metadataByComponent(): Map<ComponentIdentifier, SwiftExportMetadata> {
+    return buildMap {
+        for (dependency in allResolvedDependencies) {
+            val metadata = getProjectDataFromDependencyOrNull(dependency) ?: continue
+            if (metadata.schemaVersion != SWIFT_EXPORT_METADATA_SCHEMA_VERSION) continue
+            put(dependency.resolvedVariant.owner, metadata)
+        }
+    }
 }
 
 private fun LazyResolvedConfigurationWithArtifacts.filteredArtifacts(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
@@ -19,6 +20,7 @@ import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.UsesKotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.internal.KotlinProjectSharedDataProvider
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportAction
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportTaskParameters
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
@@ -28,6 +30,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createF
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
 import org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeProvider
 import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import org.jetbrains.kotlin.gradle.utils.getFile
@@ -89,6 +92,23 @@ internal abstract class SwiftExportTask @Inject constructor(
 
     @get:Internal
     abstract val metadataConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
+
+    /**
+     * Swift Export metadata shared by same-build subproject dependencies as a secondary variant. Held as a
+     * Configuration-Cache-safe [KotlinProjectSharedDataProvider] and read at execution time (see [run]); the producer's
+     * JSON is a task output, so it only exists once [sharedMetadataFiles] has forced the producing task to run.
+     */
+    @get:Internal
+    abstract val sharedMetadata: Property<KotlinProjectSharedDataProvider<SwiftExportMetadata>>
+
+    /**
+     * Gradle `InputFiles` view of [sharedMetadata]. Declaring it as a task input provides the `builtBy` edge that makes
+     * the subproject metadata producers run before this task executes, so their JSON exists when [run] reads it.
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val sharedMetadataFiles: List<FileCollection>
+        get() = sharedMetadata.orNull?.let { listOf(it.files) } ?: emptyList()
 
     @get:Internal
     abstract val exportedModules: SetProperty<SwiftExportedDependency>
@@ -176,6 +196,7 @@ internal abstract class SwiftExportTask @Inject constructor(
         exportConfiguration = exportConfiguration.get(),
         apiConfiguration = apiConfiguration.orNull,
         metadataConfiguration = metadataConfiguration.orNull,
+        sharedMetadata = sharedMetadata.orNull,
         exportedModules = exportedModules.get(),
         dependencyOptionsOverrides = dependencyOptionsOverrides.get(),
         rootModuleName = mainModuleInput.moduleName.get(),

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
@@ -110,8 +110,25 @@ internal abstract class SwiftExportTask @Inject constructor(
     val sharedMetadataFiles: List<FileCollection>
         get() = sharedMetadata.orNull?.let { listOf(it.files) } ?: emptyList()
 
+    /**
+     * The explicitly-exported dependencies declared via the `export("…") { moduleName.set(…); flattenPackage.set(…) }`
+     * DSL. Held as `@Internal` because [SwiftExportedDependency] wraps live Gradle `Property` values and a dependency
+     * selector, which is not a valid task input on its own. Read at execution time by [resolveSwiftExportedModules].
+     * Up-to-date tracking of its output-affecting content is provided by [exportedModulesInputs].
+     */
     @get:Internal
     abstract val exportedModules: SetProperty<SwiftExportedDependency>
+
+    /**
+     * Up-to-date tracking projection of [exportedModules]. It exposes the plain, output-affecting values of every
+     * exported dependency - its identity (external coordinates or project path) and the explicit `moduleName` /
+     * `flattenPackage` overrides - as a stable list of strings.
+     */
+    @get:Input
+    internal val exportedModulesInputs: List<String>
+        get() = exportedModules.get()
+            .map { "${it.name}|${it.moduleName.orNull}|${it.flattenPackage.orNull}" }
+            .sorted()
 
     @get:Internal
     abstract val dependencyOptionsOverrides: MapProperty<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
@@ -9,18 +9,27 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.UsesKotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportAction
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportTaskParameters
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.collectModules
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
 import org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeProvider
+import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.konan.target.Distribution
 import javax.inject.Inject
@@ -66,6 +75,39 @@ internal abstract class SwiftExportTask @Inject constructor(
     @get:Nested
     abstract val parameters: SwiftExportTaskParameters
 
+    /**
+     * The dependency graph the exported modules are resolved from. Held as Configuration-Cache-safe
+     * [LazyResolvedConfigurationWithArtifacts] rather than a precomputed module list so that the resolution happens at
+     * execution time (see [run]); up-to-date checking is provided by the raw configurations wired as task inputs in
+     * `registerSwiftExportRun`.
+     */
+    @get:Internal
+    abstract val exportConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
+
+    @get:Internal
+    abstract val apiConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
+
+    @get:Internal
+    abstract val metadataConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
+
+    @get:Internal
+    abstract val exportedModules: SetProperty<SwiftExportedDependency>
+
+    @get:Internal
+    abstract val dependencyOptionsOverrides: MapProperty<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>
+
+    @get:Input
+    internal val overridesInputs: List<String>
+        get() = dependencyOptionsOverrides.get()
+            .map { (selector, options) ->
+                val selectorKey = when (selector) {
+                    is SwiftExportDependencySelector.ProjectPath -> "project|${selector.projectPath}"
+                    is SwiftExportDependencySelector.Module -> "module|${selector.group}|${selector.name}"
+                }
+                "$selectorKey|${options.moduleName}|${options.rootPackage}"
+            }
+            .sorted()
+
     @get:Internal
     abstract val ignoreExperimentalDiagnostic: Property<Boolean>
 
@@ -85,23 +127,25 @@ internal abstract class SwiftExportTask @Inject constructor(
             workerSpec.forkOptions.systemProperties.put("ide.can.use.coroutines.fork", "false")
         }
 
-        val swiftModules = parameters.swiftModules.map {
-            it.toMutableList().apply {
+        // The exported-module list is resolved here, at execution time, rather than during configuration: the resolved
+        // configurations only need to be readable when the task runs, which keeps the resolution off the
+        // configuration-cache store phase.
+        val swiftModules = buildList {
+            addAll(resolveSwiftExportedModules())
+            add(
+                createFullyExportedSwiftExportedModule(
+                    mainModuleInput.moduleName.get(),
+                    mainModuleInput.flattenPackage.orNull,
+                    mainModuleInput.artifact.getFile()
+                )
+            )
+            if (cinteropModuleName.isPresent) {
                 add(
-                    createFullyExportedSwiftExportedModule(
-                        mainModuleInput.moduleName.get(),
-                        mainModuleInput.flattenPackage.orNull,
-                        mainModuleInput.artifact.getFile()
+                    createTransitiveSwiftExportedModule(
+                        moduleName = cinteropModuleName.get(),
+                        artifact = cinteropModuleArtifact.getFile()
                     )
                 )
-                if (cinteropModuleName.isPresent) {
-                    add(
-                        createTransitiveSwiftExportedModule(
-                            moduleName = cinteropModuleName.get(),
-                            artifact = cinteropModuleArtifact.getFile()
-                        )
-                    )
-                }
             }
         }
 
@@ -116,6 +160,27 @@ internal abstract class SwiftExportTask @Inject constructor(
             workParameters.konanTarget.set(parameters.konanTarget)
         }
     }
+
+    /**
+     * Resolves the transitive and explicitly-exported Swift modules from the dependency graph. This is done at
+     * execution time (called from [run]), reading the Configuration-Cache-safe holders resolved during configuration.
+     * The main module and the optional cinterop module are appended by [run]; they are not part of this result.
+     *
+     * Exposed as `internal` so functional tests can assert the resolved module set without executing the whole task.
+     * [reportDiagnostic] defaults to this task's execution-time reporter; tests may pass a project-scoped reporter to
+     * observe resolution diagnostics through the regular collector.
+     */
+    internal fun resolveSwiftExportedModules(
+        reportDiagnostic: (ToolingDiagnostic) -> Unit = { this.reportDiagnostic(it) },
+    ): List<SwiftExportedModule> = collectModules(
+        exportConfiguration = exportConfiguration.get(),
+        apiConfiguration = apiConfiguration.orNull,
+        metadataConfiguration = metadataConfiguration.orNull,
+        exportedModules = exportedModules.get(),
+        dependencyOptionsOverrides = dependencyOptionsOverrides.get(),
+        rootModuleName = mainModuleInput.moduleName.get(),
+        reportDiagnostic = reportDiagnostic,
+    )
 
     private fun cleanup() {
         fileSystem.delete {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
@@ -79,24 +79,41 @@ internal abstract class SwiftExportTask @Inject constructor(
     abstract val parameters: SwiftExportTaskParameters
 
     /**
-     * The dependency graph the exported modules are resolved from. Held as Configuration-Cache-safe
-     * [LazyResolvedConfigurationWithArtifacts] rather than a precomputed module list so that the resolution happens at
-     * execution time (see [run]); up-to-date checking is provided by the raw configurations wired as task inputs in
-     * `registerSwiftExportRun`.
+     * The complete compilation dependency graph the exported modules are resolved from.
+     *
+     * Held as Configuration-Cache-safe [LazyResolvedConfigurationWithArtifacts] rather than a precomputed module list
+     * so that the resolution happens at execution time (see [run]); up-to-date checking is provided by the raw
+     * configurations wired as task inputs in `registerSwiftExportRun`.
      */
     @get:Internal
     abstract val exportConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
 
+    /**
+     * A version of the compilation dependency graph (represented by [exportConfiguration]) that only includes api
+     * dependencies. Used for identifying direct api dependencies of an exported module.
+     *
+     * Held as Configuration-Cache-safe [LazyResolvedConfigurationWithArtifacts] rather than a precomputed module list
+     * so that the resolution happens at execution time (see [run]); up-to-date checking is provided by the raw
+     * configurations wired as task inputs in `registerSwiftExportRun`.
+     */
     @get:Internal
     abstract val apiConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
 
+    /**
+     * Mirrors [exportConfiguration] but contains Swift Export metadata of dependencies inside [exportConfiguration].
+     *
+     * Held as Configuration-Cache-safe [LazyResolvedConfigurationWithArtifacts] rather than a precomputed module list
+     * so that the resolution happens at execution time (see [run]); up-to-date checking is provided by the raw
+     * configurations wired as task inputs in `registerSwiftExportRun`.
+     */
     @get:Internal
     abstract val metadataConfiguration: Property<LazyResolvedConfigurationWithArtifacts>
 
     /**
-     * Swift Export metadata shared by same-build subproject dependencies as a secondary variant. Held as a
-     * Configuration-Cache-safe [KotlinProjectSharedDataProvider] and read at execution time (see [run]); the producer's
-     * JSON is a task output, so it only exists once [sharedMetadataFiles] has forced the producing task to run.
+     * Swift Export metadata shared by same-build subproject dependencies as a secondary variant.
+     *
+     * Held as a Configuration-Cache-safe [KotlinProjectSharedDataProvider] and read at execution time (see [run]);
+     * the producer's JSON is a task output, so it only exists once [sharedMetadataFiles] has forced the producing task to run.
      */
     @get:Internal
     abstract val sharedMetadata: Property<KotlinProjectSharedDataProvider<SwiftExportMetadata>>
@@ -111,10 +128,12 @@ internal abstract class SwiftExportTask @Inject constructor(
         get() = sharedMetadata.orNull?.let { listOf(it.files) } ?: emptyList()
 
     /**
-     * The explicitly-exported dependencies declared via the `export("…") { moduleName.set(…); flattenPackage.set(…) }`
-     * DSL. Held as `@Internal` because [SwiftExportedDependency] wraps live Gradle `Property` values and a dependency
-     * selector, which is not a valid task input on its own. Read at execution time by [resolveSwiftExportedModules].
-     * Up-to-date tracking of its output-affecting content is provided by [exportedModulesInputs].
+     * The explicitly-exported dependencies declared via the legacy `swiftExport { export(…) }` DSL. Is expected
+     * to be empty when the new `export { swift { … } }` DSL is used.
+     *
+     * Held as `@Internal` because [SwiftExportedDependency] wraps live Gradle `Property` values and a dependency
+     * selector, which is not a valid task input on its own. Up-to-date tracking of its output-affecting content
+     * is provided by [exportedModulesInputs].
      */
     @get:Internal
     abstract val exportedModules: SetProperty<SwiftExportedDependency>
@@ -130,11 +149,24 @@ internal abstract class SwiftExportTask @Inject constructor(
             .map { "${it.name}|${it.moduleName.orNull}|${it.flattenPackage.orNull}" }
             .sorted()
 
+    /**
+     * The consumer-side module option overrides declared via the `export { swift { xcodeIntegration { configure(…) } } }` DSL,
+     * keyed by the dependency they apply to (external `group:name` coordinates or a project path).
+     *
+     * Held as `@Internal` because [SwiftExportDependencySelector] and [SwiftExportDeclaredModuleOptions] wrap plain
+     * values that are not a valid task input on their own. Read at execution time by [resolveSwiftExportedModules].
+     * Up-to-date tracking of its output-affecting content is provided by [dependencyOptionsOverridesInputs].
+     */
     @get:Internal
     abstract val dependencyOptionsOverrides: MapProperty<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>
 
+    /**
+     * Up-to-date tracking projection of [dependencyOptionsOverrides]. It exposes the plain, output-affecting values of
+     * every override - the selector identity (external `group:name` coordinates or a project path) and the declared
+     * `moduleName` / `rootPackage` options - as a stable list of strings.
+     */
     @get:Input
-    internal val overridesInputs: List<String>
+    internal val dependencyOptionsOverridesInputs: List<String>
         get() = dependencyOptionsOverrides.get()
             .map { (selector, options) ->
                 val selectorKey = when (selector) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -5,11 +5,10 @@
 
 package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
 
-import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
-import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
@@ -33,13 +32,14 @@ private const val EXPORTED_MODULE_ITSELF = "the module being exported"
  *
  * @param rootModuleName the Swift module name of the module being exported, for collision detection
  */
-internal fun Project.applySwiftExportConsumerOverrides(
+internal fun applySwiftExportConsumerOverrides(
     modules: List<SwiftExportedModule>,
     overrides: Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>,
     metadataByComponent: Map<ComponentIdentifier, SwiftExportMetadata>,
     exportConfiguration: LazyResolvedConfigurationWithArtifacts,
     apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
     rootModuleName: String,
+    reportDiagnostic: (ToolingDiagnostic) -> Unit,
 ): List<SwiftExportedModule> {
     if (overrides.isEmpty() && metadataByComponent.isEmpty()) return modules
 
@@ -52,7 +52,7 @@ internal fun Project.applySwiftExportConsumerOverrides(
     val componentByArtifact = componentByArtifact(exportConfiguration, apiConfiguration)
     val exported = modules.map { module ->
         val component = componentByArtifact[module.artifact] ?: return@map module to null
-        val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it) }
+        val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it, reportDiagnostic) }
         val visibility = sources.declaredVisibility(component)
         val mode = when (visibility) {
             SwiftExportVisibility.EXPOSED -> SwiftExportedModuleMode.FULL

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportMetadata.kt
@@ -12,11 +12,17 @@ import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.internal.json.KgpJson
 import org.jetbrains.kotlin.gradle.plugin.categoryByName
+import org.jetbrains.kotlin.gradle.plugin.internal.KotlinProjectSharedDataProvider
+import org.jetbrains.kotlin.gradle.plugin.internal.KotlinSecondaryVariantsDataSharing
+import org.jetbrains.kotlin.gradle.plugin.internal.KotlinShareableDataAsSecondaryVariant
+import org.jetbrains.kotlin.gradle.plugin.internal.kotlinSecondaryVariantsDataSharing
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.SerializeSwiftExportMetadata
 import org.jetbrains.kotlin.gradle.plugin.usageByName
 import org.jetbrains.kotlin.gradle.utils.createConsumable
@@ -40,10 +46,48 @@ internal data class SwiftExportMetadata(
     val schemaVersion: Int = SWIFT_EXPORT_METADATA_SCHEMA_VERSION,
     val moduleName: String?,
     val rootPackage: String?,
-) : Serializable
+) : Serializable, KotlinShareableDataAsSecondaryVariant
 
 internal fun deserializeSwiftExportMetadata(inputStream: InputStream) =
     KgpJson.default.decodeFromStream<SwiftExportMetadata>(inputStream)
+
+/**
+ * Key under which the Swift Export metadata is shared as a Configuration secondary variant between projects of the same
+ * build via [KotlinSecondaryVariantsDataSharing]. Published dependencies expose the same information through the
+ * `swiftExportMetadataElements` variant instead; same-build subprojects use secondary-variant sharing so the metadata
+ * can be read at task execution time (Configuration-Cache/Isolated-Projects safe).
+ */
+private const val SWIFT_EXPORT_METADATA_SHARING_KEY = "swiftExportMetadata"
+
+/**
+ * Producer side: attaches [metadata] as a secondary variant on [outgoingConfiguration] so consuming projects in the
+ * same build can read it at execution time.
+ */
+internal fun Project.shareSwiftExportMetadata(
+    outgoingConfiguration: Configuration,
+    metadata: Provider<SwiftExportMetadata>,
+) {
+    kotlinSecondaryVariantsDataSharing.shareDataFromProvider(
+        key = SWIFT_EXPORT_METADATA_SHARING_KEY,
+        outgoingConfiguration = outgoingConfiguration,
+        dataProvider = metadata,
+        serializer = SwiftExportMetadata.serializer(),
+    )
+}
+
+/**
+ * Consumer side: reads the Swift Export metadata shared by same-build subproject dependencies of [from]. Restricted to
+ * [ProjectComponentIdentifier]s so it never overlaps with the published-metadata path, which only handles external
+ * modules.
+ */
+internal fun KotlinSecondaryVariantsDataSharing.consumeSwiftExportMetadata(
+    from: Configuration,
+): KotlinProjectSharedDataProvider<SwiftExportMetadata> = consume(
+    key = SWIFT_EXPORT_METADATA_SHARING_KEY,
+    incomingConfiguration = from,
+    serializer = SwiftExportMetadata.serializer(),
+    componentFilter = { it is ProjectComponentIdentifier },
+)
 
 internal fun SwiftExportMetadata.serializeSwiftExportMetadata(outputStream: OutputStream) =
     KgpJson.default.encodeToStream(this, outputStream)

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnosticFactory
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
@@ -703,8 +704,7 @@ class ExportExtensionSwiftExportTests {
 
         project.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -734,8 +734,7 @@ class ExportExtensionSwiftExportTests {
 
         project.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -776,8 +775,7 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
         projectDependency.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -818,8 +816,7 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
         projectDependency.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -864,8 +861,7 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
         projectDependency.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -917,8 +913,7 @@ class ExportExtensionSwiftExportTests {
 
         project.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         assertTrue(actualModules.isEmpty(), "No modules should be exported for JVM dependencies")
     }
@@ -952,8 +947,7 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
         projectDependency.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -1008,8 +1002,7 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
         projectDependency.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -1058,8 +1051,7 @@ class ExportExtensionSwiftExportTests {
 
         project.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -1123,8 +1115,7 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
         projectDependency.evaluate()
 
-        val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = project.realizeSwiftModules()
 
         val expectedModules = setOf(
             ExportedSwiftModuleForAssertion(
@@ -1953,7 +1944,7 @@ class ExportExtensionSwiftExportTests {
 
     /** The export graph diagnostics are reported when the `swiftModules` provider is realized, not during configuration. */
     private fun Project.realizeSwiftModules(): List<SwiftExportedModule> =
-        tasks.withType(SwiftExportTask::class.java).single().parameters.swiftModules.get()
+        tasks.withType(SwiftExportTask::class.java).single().resolveSwiftExportedModules(project::reportDiagnostic)
 
     /**
      * Outside a real build the diagnostics collector turns a FATAL diagnostic into an exception right away, and

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.AppleTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.appleTarget
@@ -323,7 +324,7 @@ class SwiftExportUnitTests {
         val project = projects.first()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -374,7 +375,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -406,7 +407,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
+        val actualModules = swiftExportTask.resolveSwiftExportedModules().filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(SwiftExportModuleForAssertion("OrgJetbrainsKotlinxKotlinxDatetime", "kotlinx-datetime.klib", true))
@@ -439,7 +440,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
+        val actualModules = swiftExportTask.resolveSwiftExportedModules().filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -479,7 +480,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
+        val actualModules = swiftExportTask.resolveSwiftExportedModules().filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -519,7 +520,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
+        val actualModules = swiftExportTask.resolveSwiftExportedModules().filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -553,7 +554,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -694,7 +695,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -733,7 +734,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         assertTrue(actualModules.isEmpty(), "No modules should be exported for JVM dependencies")
     }
@@ -753,7 +754,9 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        // Module resolution now happens at task execution. Route its diagnostics into the project collector so the
+        // resolution error stays observable here (the task's own reporter renders immediately without storing it).
+        val actualModules = swiftExportTask.resolveSwiftExportedModules { project.reportDiagnostic(it) }
 
         project.assertContainsDiagnostic(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
         assertTrue(actualModules.isEmpty(), "No modules should be exported for invalid dependencies")
@@ -779,7 +782,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -824,7 +827,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -885,7 +888,7 @@ class SwiftExportUnitTests {
         projectDependency.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -949,7 +952,7 @@ class SwiftExportUnitTests {
         projectDependency.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -1013,7 +1016,7 @@ class SwiftExportUnitTests {
         projectDependency.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -1077,7 +1080,7 @@ class SwiftExportUnitTests {
         projectDependency.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -1143,7 +1146,7 @@ class SwiftExportUnitTests {
         projectDependency_1.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -1206,7 +1209,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList())
+        val actualModules = swiftExportTask.resolveSwiftExportedModules()
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(


### PR DESCRIPTION
Implements retrieving Swift Export configuration for project dependencies. 

The mechanisms used to resolve the metadata for these two types of dependencies are different: for external dependencies, the metadata is resolved from the swiftExportMetadataElements configuration, whereas for project dependencies, the KotlinSecondaryVariantsDataSharing service is used. The latter works by registering a task that serializes dependency metadata to disk where it can be picked up and resolved by the dependent project; since this approach is task-based, it was necessary to move exported module processing logic from the build's configuration phase to the execution phase to be able to establish task dependencies.

The validation relies on integration tests to be able to test metadata publishing and consumption end to end.

^KT-89323 Verification Pending