### PR TITLE
KT-87990 Add consumer dependency overrides to Swift Export Xcode integration

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
+import org.jetbrains.kotlin.gradle.uklibs.include
 import org.jetbrains.kotlin.gradle.util.swiftExportEmbedAndSignEnvVariables
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.condition.OS
@@ -207,6 +208,64 @@ class ExportDslIT : KGPBaseTest() {
             buildAndFail(":compileKotlinIosArm64") {
                 assertHasDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
                 assertNoDiagnostic(KotlinToolingDiagnostics.DeprecatedSwiftExportDsl)
+            }
+        }
+    }
+
+    @DisplayName("An override colliding with the root module name fails the build with the diagnostic")
+    @GradleTest
+    fun testDuplicateModuleNameFailsTheBuild(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain {
+                        compileStubSourceWithSourceSetName()
+                        dependencies {
+                            api(project(":sub"))
+                        }
+                    }
+                }
+                export.swift {
+                    moduleName.set("Shared")
+                    xcodeIntegration {
+                        // Collides with the root module's own name, set above.
+                        configure(project.dependencies.project(mapOf("path" to ":sub"))) {
+                            moduleName.set("Shared")
+                        }
+                    }
+                }
+            }
+
+            val subproject = project("empty", gradleVersion) {
+                buildScriptInjection {
+                    project.applyMultiplatform {
+                        iosArm64()
+                        sourceSets.commonMain.get().compileStubSourceWithSourceSetName()
+                    }
+                }
+            }
+
+            include(subproject, "sub")
+
+            // The diagnostic is FATAL because it is reported after checkKotlinGradlePluginConfigurationErrors has
+            // run, so it has to fail the build on its own.
+            buildAndFail(
+                ":$EMBED_SWIFT_EXPORT_TASK_NAME",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
+            ) {
+                assertHasDiagnostic(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
+                // The build fails before the Swift Export tool is handed the modules.
+                assertTasksAreNotInTaskGraph(":iosArm64DebugSwiftExport")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.native
 
+import kotlinx.serialization.json.jsonPrimitive
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
@@ -13,11 +14,15 @@ import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.jetbrains.kotlin.gradle.uklibs.include
+import org.jetbrains.kotlin.gradle.util.getNestedList
+import org.jetbrains.kotlin.gradle.util.parseJsonToMap
 import org.jetbrains.kotlin.gradle.util.swiftExportEmbedAndSignEnvVariables
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertContains
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -266,6 +271,85 @@ class ExportDslIT : KGPBaseTest() {
                 assertHasDiagnostic(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
                 // The build fails before the Swift Export tool is handed the modules.
                 assertTasksAreNotInTaskGraph(":iosArm64DebugSwiftExport")
+            }
+        }
+    }
+
+    @DisplayName("A dependency override renames the module and flattens its package in the generated Swift")
+    @GradleTest
+    fun testDependencyOverrideIsAppliedEndToEnd(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain {
+                        compileSource(
+                            """
+                            fun makeOne(): com.example.sub.One = com.example.sub.One()
+                            """.trimIndent()
+                        )
+                        dependencies {
+                            api(project(":sub"))
+                        }
+                    }
+                }
+                export.swift {
+                    moduleName.set("Shared")
+                    xcodeIntegration {
+                        configure(project.dependencies.project(mapOf("path" to ":sub"))) {
+                            moduleName.set("Renamed")
+                            rootPackage.set("com.example.sub")
+                        }
+                    }
+                }
+            }
+
+            val subproject = project("empty", gradleVersion) {
+                buildScriptInjection {
+                    project.applyMultiplatform {
+                        iosArm64()
+                        sourceSets.commonMain.get().compileSource(
+                            """
+                            package com.example.sub
+                            class One
+                            """.trimIndent()
+                        )
+                    }
+                }
+            }
+
+            include(subproject, "sub")
+
+            build(
+                ":$EMBED_SWIFT_EXPORT_TASK_NAME",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
+            ) {
+                assertTasksExecuted(":iosArm64DebugSwiftExport")
+
+                val files = projectPath.resolve("build/SwiftExport/iosArm64/Debug/files")
+                // The derived name for `:sub` would have been `Sub`.
+                assertDirectoryDoesNotExist(files.resolve("Sub"))
+                val renamedSwift = files.resolve("Renamed/Renamed.swift")
+                assertFileExists(renamedSwift)
+
+                // Flattening the package exposes `com.example.sub.One` at the top level of the module.
+                assertContains(renamedSwift.readText(), "public typealias One = ExportedKotlinPackages.com.example.sub.One")
+
+                val modules = parseJsonToMap(projectPath.resolve("build/SwiftExport/iosArm64/Debug/modules/Shared.json"))
+                    .getNestedList("modules")
+                    .orEmpty()
+                    .map { it["name"]?.jsonPrimitive?.content }
+                assertContains(modules, "Renamed")
+                assertFalse(modules.contains("Sub"), modules.toString())
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -1909,21 +1909,25 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/compilati
 }
 
 public abstract class org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension {
-	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun swift (Lkotlin/jvm/functions/Function1;)V
 	public final fun swift (Lorg/gradle/api/Action;)V
 }
 
-public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationDsl {
-	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;
-	public abstract fun getRootPackage ()Lorg/gradle/api/provider/Property;
+public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationDsl : org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportModuleOptionsDsl {
 	public abstract fun xcodeIntegration ()V
 	public abstract fun xcodeIntegration (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun xcodeIntegration (Lorg/gradle/api/Action;)V
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportIntegration {
+	public abstract fun configure (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun configure (Ljava/lang/Object;Lorg/gradle/api/Action;)V
 	public abstract fun getSettings ()Lorg/gradle/api/provider/MapProperty;
+}
+
+public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportModuleOptionsDsl {
+	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;
+	public abstract fun getRootPackage ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportXcodeIntegration : org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportIntegration {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -1915,10 +1915,14 @@ internal object KotlinToolingDiagnostics {
     }
 
     object SwiftExportModuleResolutionError : ToolingDiagnosticFactory(ERROR, DiagnosticGroup.Kgp.Misconfiguration) {
-        operator fun invoke(modules: List<String>) = build {
+        /**
+         * @param modules the modules that were requested but not found, rendered for the user
+         * @param dsl the DSL snippet the request came from, so the message points at the right place
+         */
+        operator fun invoke(modules: List<String>, dsl: String = "swiftExport { export() }") = build {
             title("Swift Module Resolution Error")
                 .description {
-                    "The following modules specified in swiftExport { export() } were not found in the resolved components: ${
+                    "The following modules specified in $dsl were not found in the resolved components: ${
                         modules.joinToString(
                             ", "
                         )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -1934,6 +1934,31 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    /**
+     * FATAL because it is reported after `checkKotlinGradlePluginConfigurationErrors` has run, where an ERROR would
+     * only be logged.
+     */
+    object SwiftExportDuplicateModuleNames : ToolingDiagnosticFactory(FATAL, DiagnosticGroup.Kgp.Misconfiguration) {
+        /**
+         * @param duplicates final Swift module name to the components that produced it
+         */
+        operator fun invoke(duplicates: Map<String, List<String>>) = build {
+            title("Duplicate Swift Module Names")
+                .description {
+                    "The following Swift module names are produced by more than one module (compared ignoring case):\n" +
+                            duplicates.entries.joinToString("\n") { (moduleName, owners) ->
+                                "  '$moduleName': ${owners.joinToString(", ")}"
+                            }
+                }
+                .solution {
+                    "Give each module a distinct name with " +
+                            "export { swift { xcodeIntegration { configure(dependency) { moduleName = \"...\" } } } }. " +
+                            "If the collision is with the root module's own name, rename the root module instead with " +
+                            "export { swift { moduleName = \"...\" } }."
+                }
+        }
+    }
+
     object SwiftExportMinimumDeployTargetError : ToolingDiagnosticFactory(FATAL, DiagnosticGroup.Kgp.Misconfiguration) {
         operator fun invoke(
             deploymentTargetSettingName: String,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.registerEmbedSwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.initSwiftExportClasspathConfigurations
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.swiftExportDependencySelectorFactory
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration
 
 internal object SwiftExportDSLConstants {
@@ -34,7 +35,7 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
     )
 
     // TODO: Move to a more generic SetUpExportAction.
-    val exportExtension = objects.ExportExtension()
+    val exportExtension = objects.ExportExtension(swiftExportDependencySelectorFactory())
     multiplatformExtension.addExtension(EXPORT_EXTENSION_NAME, exportExtension)
 
     val appleTargets = project

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -75,6 +75,7 @@ internal fun Project.registerSwiftExportTask(
         mainCompilation = mainCompilation,
         swiftApiFlattenPackage = swiftExportConfiguration.rootPackage,
         exportedModules = swiftExportConfiguration.exportedModules,
+        swiftExportConfiguration = swiftExportConfiguration,
         customSetting = swiftExportConfiguration.settings
     )
 
@@ -166,6 +167,7 @@ private fun Project.registerSwiftExportRun(
     mainCompilation: KotlinNativeCompilation,
     swiftApiFlattenPackage: Provider<String>,
     exportedModules: Provider<Set<SwiftExportedDependency>>,
+    swiftExportConfiguration: SwiftExportConfigurationCompat,
     customSetting: Provider<Map<String, String>>,
 ): TaskProvider<SwiftExportTask> {
     val swiftExportTaskName = lowerCamelCaseName(
@@ -195,10 +197,14 @@ private fun Project.registerSwiftExportRun(
         task.parameters.bridgeModuleName.set("SharedBridge")
         task.parameters.swiftExportSettings.set(customSetting)
         task.parameters.swiftModules.set(
-            collectModules(
+            swiftExportConfiguration.adjustSwiftModules(
+                collectModules(
+                    exportConfigurationProvider,
+                    apiConfigurationProvider,
+                    exportedModules
+                ),
                 exportConfigurationProvider,
                 apiConfigurationProvider,
-                exportedModules
             )
         )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -205,6 +205,7 @@ private fun Project.registerSwiftExportRun(
                 ),
                 exportConfigurationProvider,
                 apiConfigurationProvider,
+                swiftApiModuleName,
             )
         )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
@@ -10,8 +10,14 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
+import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.dsl.KotlinGradlePluginDsl
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelectorFactory
+import org.jetbrains.kotlin.gradle.utils.newInstance
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
 import javax.inject.Inject
 
@@ -42,10 +48,16 @@ which cannot be suppressed.
 See Gradle issue https://github.com/gradle/gradle/issues/32019
  */
 @KotlinGradlePluginDsl
-abstract class ExportExtension @Inject constructor(
+abstract class ExportExtension @Inject internal constructor(
     objectFactory: ObjectFactory,
+    providerFactory: ProviderFactory,
+    dependencySelectorFactory: SwiftExportDependencySelectorFactory,
 ) {
-    private val defaultSwiftExportConfiguration = DefaultSwiftExportConfiguration(objectFactory)
+    private val defaultSwiftExportConfiguration = DefaultSwiftExportConfiguration(
+        objectFactory = objectFactory,
+        providerFactory = providerFactory,
+        dependencySelectorFactory = dependencySelectorFactory,
+    )
 
     internal val swiftExportConfiguration: SwiftExportConfiguration get() = defaultSwiftExportConfiguration
 
@@ -94,17 +106,7 @@ abstract class ExportExtension @Inject constructor(
  */
 @ExperimentalSwiftExportDsl
 @KotlinGradlePluginDsl
-interface SwiftExportConfigurationDsl {
-    /**
-     * Configure the name of this module that will be used in Swift Export.
-     */
-    val moduleName: Property<String>
-
-    /**
-     * Configure this module's root package. If provided, the root package will be used for package flattening in Swift Export.
-     */
-    val rootPackage: Property<String>
-
+interface SwiftExportConfigurationDsl : SwiftExportModuleOptionsDsl {
     /**
      * Activate the Xcode integration for this module.
      *
@@ -134,22 +136,40 @@ interface SwiftExportConfigurationDsl {
 }
 
 /**
+ * Swift Export options of a module: the exported module itself, or one of its dependencies.
+ *
+ * Shared by [SwiftExportConfigurationDsl] and [SwiftExportIntegration.configure].
+ *
+ * This API is experimental and may change in future versions.
+ *
+ * @since 2.5.0
+ */
+@ExperimentalSwiftExportDsl
+@KotlinGradlePluginDsl
+interface SwiftExportModuleOptionsDsl {
+    /**
+     * The Swift module name, used as is, so it must be a valid Swift module name.
+     *
+     * For a dependency, it takes precedence over the derived name and over the name the dependency publishes.
+     */
+    val moduleName: Property<String>
+
+    /**
+     * The root package to flatten.
+     *
+     * For a dependency, it takes precedence over the root package the dependency publishes. Ignored for
+     * transitively exported dependencies.
+     */
+    val rootPackage: Property<String>
+}
+
+/**
  * Represents Swift Export configuration for an exported module.
  *
  * This API is experimental and may change in future versions.
  */
 @ExperimentalSwiftExportDsl
-internal interface SwiftExportConfiguration {
-    /**
-     * The name of this module that will be used in Swift Export.
-     */
-    val moduleName: Property<String>
-
-    /**
-     * This module's root package.
-     */
-    val rootPackage: Property<String>
-
+internal interface SwiftExportConfiguration : SwiftExportModuleOptionsDsl {
     /**
      * The Xcode integration activated via [SwiftExportConfigurationDsl.xcodeIntegration],
      * or `null` if it was never activated for this module.
@@ -168,6 +188,12 @@ internal interface SwiftExportXcodeIntegrationConfiguration {
      * The settings passed to Swift Export for this module.
      */
     val settings: Provider<Map<String, String>>
+
+    /**
+     * Overrides from [SwiftExportIntegration.configure], keyed by the dependency they select. A later call wins,
+     * per property.
+     */
+    val dependencyOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>
 }
 
 /**
@@ -182,6 +208,35 @@ interface SwiftExportIntegration {
      * Configure the settings passed to Swift Export for this module.
      */
     val settings: MapProperty<String, String>
+
+    /**
+     * Override the Swift Export options of [dependency].
+     *
+     * [dependency] takes what Gradle's dependency handler takes: `"group:name:version"`, `project(":path")`,
+     * a [org.gradle.api.Project], a version catalog accessor like `libs.foo`, or a [Provider] of any of those.
+     * The version is ignored; the override is matched against the resolved component.
+     *
+     * The dependency must already be in the Swift Export graph, this function does not add it. An override
+     * that matches nothing is reported as an error.
+     *
+     * A notation that is not a valid dependency (coordinates without a group, for example) fails right here.
+     * A [Provider] is only realized when the graph is assembled, so an error inside one shows up then.
+     *
+     * Repeated calls follow normal Gradle property semantics: the last assignment wins, per property.
+     *
+     * Overrides are local to this consumer and are not published.
+     *
+     * @since 2.5.0
+     */
+    fun configure(dependency: Any, configure: SwiftExportModuleOptionsDsl.() -> Unit)
+
+    /**
+     * Override the Swift Export options of [dependency].
+     *
+     * @see configure
+     * @since 2.5.0
+     */
+    fun configure(dependency: Any, configure: Action<SwiftExportModuleOptionsDsl>)
 }
 
 /**
@@ -195,6 +250,8 @@ interface SwiftExportXcodeIntegration : SwiftExportIntegration
 
 private class DefaultSwiftExportConfiguration(
     private val objectFactory: ObjectFactory,
+    private val providerFactory: ProviderFactory,
+    private val dependencySelectorFactory: SwiftExportDependencySelectorFactory,
 ) : SwiftExportConfiguration, SwiftExportConfigurationDsl {
     override val moduleName: Property<String> = objectFactory.property(String::class.java)
     override val rootPackage: Property<String> = objectFactory.property(String::class.java)
@@ -208,7 +265,11 @@ private class DefaultSwiftExportConfiguration(
 
     override fun xcodeIntegration(configure: SwiftExportXcodeIntegration.() -> Unit) {
         val integration = xcodeIntegrationConfiguration
-            ?: DefaultSwiftExportXcodeIntegration(objectFactory).also { xcodeIntegrationConfiguration = it }
+            ?: DefaultSwiftExportXcodeIntegration(
+                objectFactory = objectFactory,
+                providerFactory = providerFactory,
+                dependencySelectorFactory = dependencySelectorFactory,
+            ).also { xcodeIntegrationConfiguration = it }
         integration.configure()
     }
 
@@ -218,9 +279,56 @@ private class DefaultSwiftExportConfiguration(
 }
 
 private class DefaultSwiftExportXcodeIntegration(
-    objectFactory: ObjectFactory,
+    private val objectFactory: ObjectFactory,
+    private val providerFactory: ProviderFactory,
+    private val dependencySelectorFactory: SwiftExportDependencySelectorFactory,
 ) : SwiftExportXcodeIntegration, SwiftExportXcodeIntegrationConfiguration {
+
     override val settings: MapProperty<String, String> = objectFactory.mapProperty(String::class.java, String::class.java)
+
+    /** One `configure(dependency) { }` call each, in declaration order, so that a later call wins. */
+    private val pendingOverrides = mutableListOf<Pair<Provider<SwiftExportDependencySelector>, SwiftExportModuleOptionsDsl>>()
+
+    override fun configure(dependency: Any, configure: SwiftExportModuleOptionsDsl.() -> Unit) {
+        val dsl = objectFactory.newInstance<SwiftExportModuleOptionsDsl>()
+        dsl.configure()
+        pendingOverrides += dependency.selectorProvider() to dsl
+    }
+
+    override fun configure(dependency: Any, configure: Action<SwiftExportModuleOptionsDsl>) =
+        configure(dependency) { configure.execute(this) }
+
+    override val dependencyOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>> =
+        providerFactory.provider {
+            val overrides = LinkedHashMap<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>()
+            for ((selectorProvider, dsl) in pendingOverrides) {
+                val selector = selectorProvider.get()
+                val previous = overrides[selector]
+                overrides[selector] = SwiftExportDeclaredModuleOptions(
+                    moduleName = dsl.moduleName.orNull ?: previous?.moduleName,
+                    rootPackage = dsl.rootPackage.orNull ?: previous?.rootPackage,
+                )
+            }
+            overrides
+        }
+
+    /**
+     * A [Provider] notation can't be turned into a selector until it is realized, and realizing it during
+     * configuration would break laziness. Other notations are converted right away so that a bad one fails at
+     * the call site.
+     */
+    private fun Any.selectorProvider(): Provider<SwiftExportDependencySelector> = when (this) {
+        is Provider<*> -> map { resolved -> dependencySelectorFactory.fromNotation(resolved) }
+        // A version catalog alias that has nested aliases (`libs.foo` next to `libs.foo.core`) is generated as a
+        // ProviderConvertible rather than a Provider.
+        is ProviderConvertible<*> -> asProvider().map { resolved -> dependencySelectorFactory.fromNotation(resolved) }
+        else -> {
+            val selector = dependencySelectorFactory.fromNotation(this)
+            providerFactory.provider { selector }
+        }
+    }
 }
 
-internal fun ObjectFactory.ExportExtension(): ExportExtension = newInstance(ExportExtension::class.java)
+internal fun ObjectFactory.ExportExtension(
+    dependencySelectorFactory: SwiftExportDependencySelectorFactory,
+): ExportExtension = newInstance(ExportExtension::class.java, dependencySelectorFactory)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -60,11 +60,14 @@ internal interface SwiftExportConfigurationCompat {
     /**
      * Applies what this DSL declares on top of the [modules] collected from the export graph. The legacy DSL
      * declares nothing and returns them as they are.
+     *
+     * @param rootModuleName the Swift module name of the module being exported
      */
     fun adjustSwiftModules(
         modules: Provider<List<SwiftExportedModule>>,
         exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
         apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+        rootModuleName: Provider<String>,
     ): Provider<List<SwiftExportedModule>>
 
     /**
@@ -107,6 +110,7 @@ internal interface SwiftExportConfigurationCompat {
                     modules: Provider<List<SwiftExportedModule>>,
                     exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
                     apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+                    rootModuleName: Provider<String>,
                 ): Provider<List<SwiftExportedModule>> = kotlinNativeCompilation.project.applySwiftExportConsumerOverrides(
                     modules = modules,
                     overrides = providers.provider {
@@ -114,6 +118,7 @@ internal interface SwiftExportConfigurationCompat {
                     },
                     exportConfiguration = exportConfiguration,
                     apiConfiguration = apiConfiguration,
+                    rootModuleName = rootModuleName,
                 )
 
                 override val settings: MapProperty<String, String>
@@ -153,6 +158,7 @@ internal interface SwiftExportConfigurationCompat {
                     modules: Provider<List<SwiftExportedModule>>,
                     exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
                     apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+                    rootModuleName: Provider<String>,
                 ): Provider<List<SwiftExportedModule>> = modules
 
                 override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -18,9 +18,12 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.exportedSwiftExportApiConfiguration
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.applySwiftExportConsumerOverrides
 import org.jetbrains.kotlin.gradle.plugin.mpp.internal
 import org.jetbrains.kotlin.gradle.targets.native.resolvableApiConfiguration
+import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 
 /**
  * A common interface for [SwiftExportConfiguration] and [org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension]
@@ -53,6 +56,16 @@ internal interface SwiftExportConfigurationCompat {
      * Returns a list of exported modules.
      */
     val exportedModules: Provider<Set<SwiftExportedDependency>>
+
+    /**
+     * Applies what this DSL declares on top of the [modules] collected from the export graph. The legacy DSL
+     * declares nothing and returns them as they are.
+     */
+    fun adjustSwiftModules(
+        modules: Provider<List<SwiftExportedModule>>,
+        exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
+        apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+    ): Provider<List<SwiftExportedModule>>
 
     /**
      * Configure SwiftExportConfig.settings parameters
@@ -89,6 +102,20 @@ internal interface SwiftExportConfigurationCompat {
 
                 override val exportedModules: Provider<Set<SwiftExportedDependency>>
                     get() = providers.provider { emptySet() } // TODO: KT-85687
+
+                override fun adjustSwiftModules(
+                    modules: Provider<List<SwiftExportedModule>>,
+                    exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
+                    apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+                ): Provider<List<SwiftExportedModule>> = kotlinNativeCompilation.project.applySwiftExportConsumerOverrides(
+                    modules = modules,
+                    overrides = providers.provider {
+                        configuration.activatedXcodeIntegration?.dependencyOverrides?.orNull ?: emptyMap()
+                    },
+                    exportConfiguration = exportConfiguration,
+                    apiConfiguration = apiConfiguration,
+                )
+
                 override val settings: MapProperty<String, String>
                     get() = objects.mapProperty(String::class.java, String::class.java) // TODO: KT-87890
                 override val freeCompilerArgs: ListProperty<String>
@@ -121,6 +148,12 @@ internal interface SwiftExportConfigurationCompat {
                             kotlinNativeCompilation.internal.configurations.compileDependencyConfiguration
                         )
                     }
+
+                override fun adjustSwiftModules(
+                    modules: Provider<List<SwiftExportedModule>>,
+                    exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
+                    apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+                ): Provider<List<SwiftExportedModule>> = modules
 
                 override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings
                 override val freeCompilerArgs: ListProperty<String> get() = extension.advancedConfiguration.freeCompilerArgs

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/ConsumerOverridesOptionsSource.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/ConsumerOverridesOptionsSource.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
+
+/**
+ * The highest precedence layer: overrides from `xcodeIntegration { configure(dependency) { } }`.
+ */
+internal class ConsumerOverridesOptionsSource(
+    private val overrides: Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>,
+) : SwiftExportModuleOptionsSource {
+    override fun optionsFor(component: SwiftExportResolvedComponent): SwiftExportDeclaredModuleOptions? =
+        overrides.entries.firstOrNull { (selector, _) -> selector.matches(component) }?.value
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -18,19 +18,22 @@ import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import java.io.File
 
 private const val XCODE_INTEGRATION_CONFIGURE_DSL = "export { swift { xcodeIntegration { configure() } } }"
+private const val EXPORTED_MODULE_ITSELF = "the module being exported"
 
 /**
- * Applies the overrides from `xcodeIntegration { configure(dependency) { } }` to the modules collected from the
- * export graph, then reports overrides that matched nothing.
+ * Applies the overrides from `xcodeIntegration { configure(dependency) { } }` to the collected modules, then
+ * reports overrides that matched nothing and module names shared by more than one module.
  *
- * Runs on the collected modules rather than inside the collector, so the legacy `swiftExport { }` flow is not
- * involved: the two DSLs cannot be combined, so an override can only ever come from the `export { }` DSL.
+ * Works on the collector's output, so the legacy `swiftExport { }` flow never runs through here.
+ *
+ * @param rootModuleName the Swift module name of the module being exported, for collision detection
  */
 internal fun Project.applySwiftExportConsumerOverrides(
     modules: Provider<List<SwiftExportedModule>>,
     overrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
     exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
     apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+    rootModuleName: Provider<String>,
 ): Provider<List<SwiftExportedModule>> = provider {
     val overridesMap = overrides.get()
     // Declared option layers, highest precedence first. KT-87987 adds the producer source here.
@@ -66,12 +69,23 @@ internal fun Project.applySwiftExportConsumerOverrides(
         )
     }
 
+    val owners = listOf(rootModuleName.get() to EXPORTED_MODULE_ITSELF) +
+            exported.map { (module, component) -> module.moduleName to (component?.displayName ?: module.artifact.name) }
+    // Ignoring case: the output directories are named after the modules, and the macOS file system is
+    // case-insensitive by default.
+    val duplicates = owners.groupBy { (name, _) -> name.lowercase() }
+        .values
+        .filter { it.size > 1 }
+        .associate { group -> group.map { (name, _) -> name }.distinct().joinToString("/") to group.map { (_, owner) -> owner } }
+    if (duplicates.isNotEmpty()) {
+        reportDiagnostic(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames(duplicates))
+    }
+
     exported.map { (module, _) -> module }
 }
 
 /**
- * The graph node each artifact came from. The first node reaching an artifact wins, which is also the order the
- * collector derives module names in.
+ * The graph node each artifact came from. First node wins, same as in the collector.
  */
 private fun componentByArtifact(
     exportConfiguration: LazyResolvedConfigurationWithArtifacts,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.validateSwiftExportModuleName
+import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
+import java.io.File
+
+/**
+ * Applies the overrides from `xcodeIntegration { configure(dependency) { } }` to the modules collected from the
+ * export graph.
+ *
+ * Runs on the collected modules rather than inside the collector, so the legacy `swiftExport { }` flow is not
+ * involved: the two DSLs cannot be combined, so an override can only ever come from the `export { }` DSL.
+ */
+internal fun Project.applySwiftExportConsumerOverrides(
+    modules: Provider<List<SwiftExportedModule>>,
+    overrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
+    exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
+    apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
+): Provider<List<SwiftExportedModule>> = provider {
+    val overridesMap = overrides.get()
+    // Declared option layers, highest precedence first. KT-87987 adds the producer source here.
+    val sources = listOf(ConsumerOverridesOptionsSource(overridesMap))
+
+    val componentByArtifact = componentByArtifact(exportConfiguration.get(), apiConfiguration.orNull)
+    val exported = modules.get().map { module ->
+        val component = componentByArtifact[module.artifact] ?: return@map module to null
+        val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it) }
+        val adjusted = when {
+            module.shouldBeFullyExported -> createFullyExportedSwiftExportedModule(
+                moduleName = declaredName ?: module.moduleName,
+                flattenPackage = sources.declaredRootPackage(component) ?: module.flattenPackage,
+                artifact = module.artifact,
+            )
+            // A transitively exported module has no root package, so a declared one has no effect here.
+            else -> createTransitiveSwiftExportedModule(
+                moduleName = declaredName ?: module.moduleName,
+                artifact = module.artifact,
+            )
+        }
+        adjusted to component
+    }
+
+    exported.map { (module, _) -> module }
+}
+
+/**
+ * The graph node each artifact came from. The first node reaching an artifact wins, which is also the order the
+ * collector derives module names in.
+ */
+private fun componentByArtifact(
+    exportConfiguration: LazyResolvedConfigurationWithArtifacts,
+    apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
+): Map<File, SwiftExportResolvedComponent> {
+    val result = LinkedHashMap<File, SwiftExportResolvedComponent>()
+    fun collect(configuration: LazyResolvedConfigurationWithArtifacts, dependencies: Iterable<ResolvedDependencyResult>) {
+        for (dependency in dependencies) {
+            for (artifact in configuration.getArtifacts(dependency.selected)) {
+                result.putIfAbsent(
+                    artifact.file,
+                    SwiftExportResolvedComponent(artifact.id.componentIdentifier, dependency.selected.moduleVersion),
+                )
+            }
+        }
+    }
+    collect(exportConfiguration, exportConfiguration.allResolvedDependencies)
+    if (apiConfiguration != null) {
+        collect(apiConfiguration, apiConfiguration.root.dependencies.filterIsInstance<ResolvedDependencyResult>())
+    }
+    return result
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
@@ -15,9 +17,11 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.validat
 import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import java.io.File
 
+private const val XCODE_INTEGRATION_CONFIGURE_DSL = "export { swift { xcodeIntegration { configure() } } }"
+
 /**
  * Applies the overrides from `xcodeIntegration { configure(dependency) { } }` to the modules collected from the
- * export graph.
+ * export graph, then reports overrides that matched nothing.
  *
  * Runs on the collected modules rather than inside the collector, so the legacy `swiftExport { }` flow is not
  * involved: the two DSLs cannot be combined, so an override can only ever come from the `export { }` DSL.
@@ -49,6 +53,17 @@ internal fun Project.applySwiftExportConsumerOverrides(
             )
         }
         adjusted to component
+    }
+
+    val components = exported.mapNotNull { (_, component) -> component }
+    val unmatched = overridesMap.keys.filterNot { selector -> components.any(selector::matches) }
+    if (unmatched.isNotEmpty()) {
+        reportDiagnostic(
+            KotlinToolingDiagnostics.SwiftExportModuleResolutionError(
+                unmatched.map { it.displayName },
+                XCODE_INTEGRATION_CONFIGURE_DSL,
+            )
+        )
     }
 
     exported.map { (module, _) -> module }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportDependencySelector.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportDependencySelector.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.internal.ProjectByPath
+import org.jetbrains.kotlin.gradle.plugin.internal.ProjectDependencyAccessor
+import org.jetbrains.kotlin.gradle.plugin.internal.compatAccessor
+import org.jetbrains.kotlin.gradle.plugin.variantImplementationFactoryProvider
+import org.jetbrains.kotlin.gradle.utils.projectPathOrNull
+
+/**
+ * Selects a dependency in the Swift Export graph for the overrides from
+ * `xcodeIntegration { configure(dependency) { } }`.
+ *
+ * Matched against the resolved [SwiftExportResolvedComponent], not the requested coordinates, so an override
+ * still applies when conflict resolution picks another version.
+ */
+internal sealed interface SwiftExportDependencySelector {
+
+    /** How this selector is rendered in diagnostics. */
+    val displayName: String
+
+    fun matches(component: SwiftExportResolvedComponent): Boolean
+
+    /**
+     * Matches a project by its Gradle path.
+     *
+     * Like the legacy `swiftExport { export(...) }` DSL, this can't tell apart projects with the same path in
+     * different included builds.
+     */
+    data class ProjectPath(val projectPath: String) : SwiftExportDependencySelector {
+        override val displayName: String get() = projectPath
+
+        override fun matches(component: SwiftExportResolvedComponent): Boolean =
+            component.id.projectPathOrNull == projectPath
+    }
+
+    /**
+     * Matches an external module by group and name. The version is ignored.
+     *
+     * A module substituted with a project (an included build, `dependencySubstitution`) selects a
+     * [ProjectComponentIdentifier] but keeps the module coordinates, so those are matched too.
+     */
+    data class Module(val group: String, val name: String) : SwiftExportDependencySelector {
+        override val displayName: String get() = "$group:$name"
+
+        override fun matches(component: SwiftExportResolvedComponent): Boolean {
+            val id = component.id
+            if (id is ModuleComponentIdentifier && id.group == group && id.module == name) return true
+            val moduleVersion = component.moduleVersion ?: return false
+            return moduleVersion.group == group && moduleVersion.name == name
+        }
+    }
+}
+
+/**
+ * Converts the dependency notations accepted by
+ * [org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportIntegration.configure] into selectors.
+ *
+ * Takes the same notations as the legacy `swiftExport { export(...) }` DSL except [Provider]s, which the caller
+ * unwraps to keep them lazy.
+ */
+internal class SwiftExportDependencySelectorFactory(
+    private val dependencyHandler: DependencyHandler,
+    private val projectDependencyAccessorFactory: Provider<ProjectDependencyAccessor.Factory>,
+    private val projectByPath: ProjectByPath,
+) {
+    fun fromNotation(dependency: Any): SwiftExportDependencySelector {
+        if (dependency is Project) return SwiftExportDependencySelector.ProjectPath(dependency.path)
+        val created = dependency as? Dependency ?: dependencyHandler.create(dependency)
+        return if (created is ProjectDependency) created.pathSelector() else created.moduleSelector()
+    }
+
+    private fun ProjectDependency.pathSelector() = SwiftExportDependencySelector.ProjectPath(
+        compatAccessor(projectDependencyAccessorFactory, projectByPath).dependencyProject().path
+    )
+
+    private fun Dependency.moduleSelector(): SwiftExportDependencySelector.Module {
+        val group = group ?: throw InvalidUserDataException(
+            "Cannot configure Swift Export for dependency '$name': it has no group, so it cannot be matched " +
+                    "against a resolved component. Use full 'group:name' coordinates or a project dependency."
+        )
+        return SwiftExportDependencySelector.Module(group = group, name = name)
+    }
+}
+
+internal fun Project.swiftExportDependencySelectorFactory() = SwiftExportDependencySelectorFactory(
+    dependencyHandler = dependencies,
+    projectDependencyAccessorFactory = variantImplementationFactoryProvider<ProjectDependencyAccessor.Factory>(),
+    projectByPath = ::project,
+)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportModuleOptionsSource.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportModuleOptionsSource.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
+
+/**
+ * A node of the resolved Swift Export graph.
+ *
+ * Holds both the selected [ComponentIdentifier] and the module coordinates it resolved to, because they can
+ * differ: a `group:name` dependency substituted with a project selects a project component that still resolves
+ * to `group:name`. Coordinates are matched through [moduleVersion], project paths through [id].
+ */
+internal data class SwiftExportResolvedComponent(
+    val id: ComponentIdentifier,
+    /** `null` when Gradle resolved the component without module coordinates. */
+    val moduleVersion: ModuleVersionIdentifier?,
+) {
+    val displayName: String get() = id.displayName
+}
+
+/**
+ * Options declared for a module, as opposed to derived from its coordinates or project path. A `null` property
+ * means this layer does not declare it.
+ */
+internal data class SwiftExportDeclaredModuleOptions(
+    val moduleName: String?,
+    val rootPackage: String?,
+)
+
+/**
+ * One layer of declared module options.
+ *
+ * Layers are consulted in order and the first non-null value wins, per property:
+ *
+ *  1. consumer overrides from `xcodeIntegration { configure(dependency) { } }` (KT-87990)
+ *  2. options published by the dependency itself (KT-87987)
+ *
+ * The derived default applies when no layer declares a value.
+ */
+internal fun interface SwiftExportModuleOptionsSource {
+    fun optionsFor(component: SwiftExportResolvedComponent): SwiftExportDeclaredModuleOptions?
+}
+
+/**
+ * The declared module name for [component], or `null` to use the derived default.
+ */
+internal fun List<SwiftExportModuleOptionsSource>.declaredModuleName(component: SwiftExportResolvedComponent): String? =
+    firstNotNullOfOrNull { it.optionsFor(component)?.moduleName }
+
+/**
+ * The declared root package for [component], or `null`.
+ */
+internal fun List<SwiftExportModuleOptionsSource>.declaredRootPackage(component: SwiftExportResolvedComponent): String? =
+    firstNotNullOfOrNull { it.optionsFor(component)?.rootPackage }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -7,6 +7,7 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.provider.ProviderConvertible
@@ -16,6 +17,8 @@ import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositori
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnosticFactory
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SwiftExportTask
@@ -42,7 +45,9 @@ import org.junit.jupiter.api.Assumptions
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -1360,10 +1365,127 @@ class ExportExtensionSwiftExportTests {
         project.assertNoDiagnostics(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
     }
 
+    @Test
+    fun `two overrides producing the same module name fail`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") { moduleName.set("Clash") }
+                    configure("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0") { moduleName.set("Clash") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.assertRealizingSwiftModulesFailsWith(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
+    }
+
+    @Test
+    fun `an override clashing with the exported module name fails`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                moduleName.set("Shared")
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") { moduleName.set("Shared") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.assertRealizingSwiftModulesFailsWith(
+            KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames(
+                mapOf("Shared" to listOf("the module being exported", "org.jetbrains.kotlinx:kotlinx-io-bytestring-iossimulatorarm64:0.7.0"))
+            )
+        )
+    }
+
+    @Test
+    fun `module names differing only in case are duplicates`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                moduleName.set("Shared")
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") { moduleName.set("shared") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.assertRealizingSwiftModulesFailsWith(
+            KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames(
+                mapOf("Shared/shared" to listOf("the module being exported", "org.jetbrains.kotlinx:kotlinx-io-bytestring-iossimulatorarm64:0.7.0"))
+            )
+        )
+    }
+
+    @Test
+    fun `distinct module names are not reported as duplicates`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                moduleName.set("Shared")
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") { moduleName.set("ByteString") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertEquals(listOf("ByteString"), actualModules.map { it.moduleName })
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
+    }
+
     /** The export graph diagnostics are reported when the `swiftModules` provider is realized, not during configuration. */
     private fun Project.realizeSwiftModules(): List<SwiftExportedModule> =
         tasks.withType(SwiftExportTask::class.java).single().parameters.swiftModules.get()
 
+    /**
+     * Outside a real build the diagnostics collector turns a FATAL diagnostic into an exception right away, and
+     * Gradle wraps it in a `PropertyQueryException`, hence the walk along the cause chain.
+     */
+    private fun Project.assertRealizingSwiftModulesFailsWith(diagnostic: ToolingDiagnosticFactory) =
+        assertRealizingSwiftModulesFails { assertContainsDiagnostic(diagnostic) }
+
+    private fun Project.assertRealizingSwiftModulesFailsWith(diagnostic: ToolingDiagnostic) =
+        assertRealizingSwiftModulesFails { assertContainsDiagnostic(diagnostic) }
+
+    private fun Project.assertRealizingSwiftModulesFails(assertDiagnostic: Project.() -> Unit) {
+        val thrown = assertFails { realizeSwiftModules() }
+        if (thrown.allCauses.none { it is InvalidUserCodeException }) {
+            fail("Expected an InvalidUserCodeException in the cause chain, but got:\n${thrown.stackTraceToString()}")
+        }
+        assertDiagnostic()
+    }
 }
 
 private fun swiftExportProject(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -1018,6 +1018,254 @@ class ExportExtensionSwiftExportTests {
         )
     }
 
+    @Test
+    fun `override renames a direct external api dependency`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        moduleName.set("ByteString")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "ByteString",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    shouldBeFullyExported = true,
+                ),
+            ),
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `override sets the root package of a direct external api dependency`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        rootPackage.set("kotlinx.io.bytestring")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    shouldBeFullyExported = true,
+                    flattenPackage = "kotlinx.io.bytestring",
+                ),
+            ),
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `override applies regardless of the version it names`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    // Not the version in the graph: matching ignores it.
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.1.0") {
+                        moduleName.set("ByteString")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "ByteString",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    shouldBeFullyExported = true,
+                ),
+            ),
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `override through a dependency provider renames the module`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            }
+        )
+        // Exercises the Provider branch, the one a version catalog accessor
+        // (Provider<MinimalExternalModuleDependency>) takes.
+        project.exportExtension.swift {
+            xcodeIntegration {
+                configure(project.provider { project.dependencies.create("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") }) {
+                    moduleName.set("ByteString")
+                }
+            }
+        }
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "ByteString",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    shouldBeFullyExported = true,
+                ),
+            ),
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `override renames a direct project api dependency`() {
+        val project = buildProject(
+            projectBuilder = { withName("shared") },
+            configureProject = { configureRepositoriesForTests() }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api(projectDependency)
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure(projectDependency) {
+                        moduleName.set("Renamed")
+                        rootPackage.set("org.example.subproject")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "Renamed",
+                    artifactName = "subproject",
+                    shouldBeFullyExported = true,
+                    flattenPackage = "org.example.subproject",
+                ),
+            ),
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `override renames a transitive dependency but its root package is ignored`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        moduleName.set("ByteString")
+                        rootPackage.set("kotlinx.io.bytestring")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "ByteString",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    shouldBeFullyExported = false,
+                    flattenPackage = null,
+                ),
+            ),
+            actualModules.toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `an override with an invalid module name is reported`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        moduleName.set("not-a-valid-swift-module")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.realizeSwiftModules()
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.SwiftExportInvalidModuleName)
+    }
+
+    /** The export graph diagnostics are reported when the `swiftModules` provider is realized, not during configuration. */
+    private fun Project.realizeSwiftModules(): List<SwiftExportedModule> =
+        tasks.withType(SwiftExportTask::class.java).single().parameters.swiftModules.get()
+
 }
 
 private fun swiftExportProject(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -1262,6 +1262,104 @@ class ExportExtensionSwiftExportTests {
         project.assertContainsDiagnostic(KotlinToolingDiagnostics.SwiftExportInvalidModuleName)
     }
 
+    @Test
+    fun `an override for a dependency absent from the graph is reported`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.example:not-in-the-graph:1.0") { moduleName.set("Absent") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.realizeSwiftModules()
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
+    }
+
+    @Test
+    fun `an override for a dependency that is never exported is reported`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                    // A JVM-only jar: it is in the graph but nothing is exported for it.
+                    api("org.glassfish:jakarta.json:2.0.1")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.glassfish:jakarta.json:2.0.1") { moduleName.set("Json") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.realizeSwiftModules()
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
+    }
+
+    @Test
+    fun `a matched override is not reported as unresolved`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") { moduleName.set("ByteString") }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertEquals(listOf("ByteString"), actualModules.map { it.moduleName })
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
+    }
+
+    @Test
+    fun `an override written against an available-at target variant is applied`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    // The klib is published under the target-suffixed module and the root module redirects to it,
+                    // so the override must apply through either name.
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring-iossimulatorarm64:0.7.0") {
+                        moduleName.set("ByteString")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        val actualModules = project.realizeSwiftModules()
+
+        assertEquals(listOf("ByteString"), actualModules.map { it.moduleName })
+        project.assertNoDiagnostics(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
+    }
+
     /** The export graph diagnostics are reported when the `swiftModules` provider is realized, not during configuration. */
     private fun Project.realizeSwiftModules(): List<SwiftExportedModule> =
         tasks.withType(SwiftExportTask::class.java).single().parameters.swiftModules.get()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -7,7 +7,9 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests
@@ -18,6 +20,11 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationDsl
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.SerializeSwiftExportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.tasks.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
 import org.jetbrains.kotlin.gradle.unitTests.utils.applyEmbedAndSignEnvironment
 import org.jetbrains.kotlin.gradle.util.*
@@ -35,6 +42,7 @@ import org.junit.jupiter.api.Assumptions
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -117,6 +125,174 @@ class ExportExtensionUnitTests {
 
         assertSame(integration, project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
         assertEquals(mapOf("first" to "1", "second" to "2"), integration.settings.get())
+    }
+
+    @Test
+    fun `dependency overrides are readable from the dsl`() {
+        val project = buildProjectWithMPP()
+        project.exportExtension.swift {
+            xcodeIntegration {
+                configure("org.example:foo:1.0") {
+                    moduleName.set("FooBar")
+                    rootPackage.set("org.example.foo")
+                }
+            }
+        }
+
+        val integration = assertNotNull(project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>(
+                SwiftExportDependencySelector.Module("org.example", "foo") to
+                        SwiftExportDeclaredModuleOptions(moduleName = "FooBar", rootPackage = "org.example.foo")
+            ),
+            integration.dependencyOverrides.get(),
+        )
+    }
+
+    @Test
+    fun `repeated configure calls follow normal gradle property semantics`() {
+        val project = buildProjectWithMPP()
+        project.exportExtension.swift {
+            xcodeIntegration {
+                configure("org.example:foo:1.0") {
+                    moduleName.set("First")
+                    rootPackage.set("org.example.first")
+                }
+                configure("org.example:foo:1.0") {
+                    moduleName.set("Second")
+                }
+            }
+        }
+
+        val integration = assertNotNull(project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>(
+                SwiftExportDependencySelector.Module("org.example", "foo") to
+                        SwiftExportDeclaredModuleOptions(moduleName = "Second", rootPackage = "org.example.first")
+            ),
+            integration.dependencyOverrides.get(),
+        )
+    }
+
+    @Test
+    fun `different notations for the same component collapse into one override`() {
+        val project = buildProjectWithMPP()
+        project.exportExtension.swift {
+            xcodeIntegration {
+                configure("org.example:foo:1.0") { moduleName.set("FromCoordinates") }
+                configure(project.provider { project.dependencies.create("org.example:foo:2.5") }) {
+                    rootPackage.set("org.example.foo")
+                }
+            }
+        }
+
+        val integration = assertNotNull(project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>(
+                SwiftExportDependencySelector.Module("org.example", "foo") to
+                        SwiftExportDeclaredModuleOptions(moduleName = "FromCoordinates", rootPackage = "org.example.foo")
+            ),
+            integration.dependencyOverrides.get(),
+        )
+    }
+
+    @Test
+    fun `a project dependency override is keyed by project path`() {
+        val root = buildProjectWithMPP()
+        buildProjectWithMPP(projectBuilder = { withParent(root); withName("sub") })
+        root.exportExtension.swift {
+            xcodeIntegration {
+                configure(root.dependencies.project(mapOf("path" to ":sub"))) { moduleName.set("Sub") }
+            }
+        }
+
+        val integration = assertNotNull(root.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>(
+                SwiftExportDependencySelector.ProjectPath(":sub") to
+                        SwiftExportDeclaredModuleOptions(moduleName = "Sub", rootPackage = null)
+            ),
+            integration.dependencyOverrides.get(),
+        )
+    }
+
+    @Test
+    fun `a notation that cannot be converted is rejected at the configure call site`() {
+        val project = buildProjectWithMPP()
+
+        assertFailsWith<InvalidUserDataException> {
+            project.exportExtension.swift {
+                xcodeIntegration {
+                    configure(":no-group") { moduleName.set("NoGroup") }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a provider notation is not realized while configuring`() {
+        val project = buildProjectWithMPP()
+        var realized = false
+        project.exportExtension.swift {
+            xcodeIntegration {
+                configure(project.provider { realized = true; "org.example:foo:1.0" }) { moduleName.set("Foo") }
+            }
+        }
+
+        assertFalse(realized)
+        val integration = assertNotNull(project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
+        assertEquals(
+            setOf(SwiftExportDependencySelector.Module("org.example", "foo")),
+            integration.dependencyOverrides.get().keys,
+        )
+        assertTrue(realized)
+    }
+
+    @Test
+    fun `a provider convertible notation is accepted and stays lazy`() {
+        val project = buildProjectWithMPP()
+        var realized = false
+        // A version catalog alias with nested aliases is generated as a ProviderConvertible, not a Provider.
+        val notation = ProviderConvertible {
+            project.provider { realized = true; project.dependencies.create("org.example:foo:1.0") }
+        }
+        project.exportExtension.swift {
+            xcodeIntegration {
+                configure(notation) { moduleName.set("Foo") }
+            }
+        }
+
+        assertFalse(realized)
+        val integration = assertNotNull(project.exportExtension.swiftExportConfiguration.activatedXcodeIntegration)
+        assertEquals(
+            setOf(SwiftExportDependencySelector.Module("org.example", "foo")),
+            integration.dependencyOverrides.get().keys,
+        )
+        assertTrue(realized)
+    }
+
+    @Test
+    fun `dependency overrides are not published`() {
+        val project = buildProjectWithMPP()
+        project.exportExtension.swift {
+            moduleName.set("Shared")
+            xcodeIntegration {
+                configure("org.example:foo:1.0") {
+                    moduleName.set("FooBar")
+                    rootPackage.set("org.example.foo")
+                }
+            }
+        }
+
+        project.locateOrRegisterSwiftExportMetadataTaskAndConsumableConfiguration(
+            project.exportExtension.swiftExportConfiguration
+        )
+
+        val serializeTask = project.tasks.withType(SerializeSwiftExportMetadata::class.java).single()
+        assertEquals(
+            SwiftExportMetadata(moduleName = "Shared", rootPackage = null),
+            serializeTask.swiftExportMetadata(),
+        )
     }
 }
 
@@ -841,6 +1017,7 @@ class ExportExtensionSwiftExportTests {
             actualModules.toModulesForAssertion(),
         )
     }
+
 }
 
 private fun swiftExportProject(
@@ -924,9 +1101,10 @@ private fun <T> assertSetsEqual(expected: Set<T>, actual: Set<T>, message: Strin
 
 private fun List<SwiftExportedModule>.toModulesForAssertion() = mapToSetOrEmpty { module ->
     ExportedSwiftModuleForAssertion(
-        module.moduleName,
-        module.artifact.name,
-        module.shouldBeFullyExported
+        moduleName = module.moduleName,
+        artifactName = module.artifact.name,
+        shouldBeFullyExported = module.shouldBeFullyExported,
+        flattenPackage = module.flattenPackage,
     )
 }
 
@@ -934,4 +1112,5 @@ private data class ExportedSwiftModuleForAssertion(
     val moduleName: String,
     val artifactName: String,
     val shouldBeFullyExported: Boolean,
+    val flattenPackage: String? = null,
 )

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportDependencySelectorTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportDependencySelectorTests.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.unitTests
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportResolvedComponent
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.swiftExportDependencySelectorFactory
+import org.jetbrains.kotlin.gradle.util.buildProject
+import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SwiftExportDependencySelectorTests {
+
+    private fun Project.selectorFor(dependency: Any): SwiftExportDependencySelector =
+        swiftExportDependencySelectorFactory().fromNotation(dependency)
+
+    private fun moduleVersion(group: String, name: String, version: String) = object : ModuleVersionIdentifier {
+        override fun getGroup() = group
+        override fun getName() = name
+        override fun getVersion() = version
+        override fun getModule() = object : ModuleIdentifier {
+            override fun getGroup() = group
+            override fun getName() = name
+        }
+    }
+
+    private fun moduleComponent(group: String, name: String, version: String = "1.0") = SwiftExportResolvedComponent(
+        id = object : ModuleComponentIdentifier {
+            override fun getGroup() = group
+            override fun getModule() = name
+            override fun getVersion() = version
+            override fun getModuleIdentifier() = moduleVersion(group, name, version).module
+            override fun getDisplayName() = "$group:$name:$version"
+        },
+        moduleVersion = moduleVersion(group, name, version),
+    )
+
+    /**
+     * A real [org.gradle.api.artifacts.component.ProjectComponentIdentifier] from resolving a project dependency:
+     * the interface gains methods across Gradle versions, so a hand-written double wouldn't compile everywhere.
+     */
+    private fun projectComponent(path: String, publishedAs: Pair<String, String>? = null): SwiftExportResolvedComponent {
+        val root = buildProject()
+        val name = path.substringAfterLast(':')
+        buildProject(projectBuilder = { withParent(root); withName(name) }) {
+            configurations.consumable("forTest")
+        }
+        val resolvable = root.configurations.detachedConfiguration(
+            root.dependencies.project(mapOf("path" to path, "configuration" to "forTest"))
+        )
+        val selected = resolvable.incoming.resolutionResult.root.dependencies
+            .filterIsInstance<ResolvedDependencyResult>()
+            .single()
+            .selected
+        return SwiftExportResolvedComponent(
+            id = selected.id,
+            moduleVersion = publishedAs?.let { (group, module) -> moduleVersion(group, module, "1.0") },
+        )
+    }
+
+    @Test
+    fun `string coordinates convert to a module selector without the version`() {
+        val project = buildProjectWithMPP()
+
+        assertEquals(
+            SwiftExportDependencySelector.Module(group = "org.example", name = "foo"),
+            project.selectorFor("org.example:foo:1.0"),
+        )
+    }
+
+    @Test
+    fun `the same module selector results from different requested versions`() {
+        val project = buildProjectWithMPP()
+
+        assertEquals(
+            project.selectorFor("org.example:foo:1.0"),
+            project.selectorFor("org.example:foo:2.5"),
+        )
+    }
+
+    @Test
+    fun `a created external dependency converts to a module selector`() {
+        val project = buildProjectWithMPP()
+        val dependency = project.dependencies.create("org.example:foo:1.0")
+
+        assertEquals(
+            SwiftExportDependencySelector.Module(group = "org.example", name = "foo"),
+            project.selectorFor(dependency),
+        )
+    }
+
+    @Test
+    fun `a project converts to a project path selector`() {
+        val root = buildProjectWithMPP()
+        val sub = buildProjectWithMPP(projectBuilder = { withParent(root); withName("sub") })
+
+        assertEquals(SwiftExportDependencySelector.ProjectPath(":sub"), root.selectorFor(sub))
+    }
+
+    @Test
+    fun `a project dependency converts to a project path selector`() {
+        val root = buildProjectWithMPP()
+        buildProjectWithMPP(projectBuilder = { withParent(root); withName("sub") })
+        val dependency = root.dependencies.project(mapOf("path" to ":sub"))
+
+        assertEquals(SwiftExportDependencySelector.ProjectPath(":sub"), root.selectorFor(dependency))
+    }
+
+    @Test
+    fun `selector display names are suitable for diagnostics`() {
+        assertEquals(
+            "org.example:foo",
+            SwiftExportDependencySelector.Module(group = "org.example", name = "foo").displayName,
+        )
+        assertEquals(
+            ":shared:core",
+            SwiftExportDependencySelector.ProjectPath(":shared:core").displayName,
+        )
+    }
+
+    @Test
+    fun `a dependency without a group is rejected at conversion`() {
+        val project = buildProjectWithMPP()
+
+        assertFailsWith<InvalidUserDataException> { project.selectorFor(":no-group") }
+    }
+
+    @Test
+    fun `a module selector matches an external component regardless of version`() {
+        val selector = SwiftExportDependencySelector.Module(group = "org.example", name = "foo")
+
+        assertTrue(selector.matches(moduleComponent("org.example", "foo", version = "2.5")))
+        assertFalse(selector.matches(moduleComponent("org.example", "bar")))
+    }
+
+    @Test
+    fun `a module selector matches a project the module was substituted with`() {
+        val selector = SwiftExportDependencySelector.Module(group = "org.example", name = "foo")
+
+        assertTrue(selector.matches(projectComponent(":foo", publishedAs = "org.example" to "foo")))
+        assertFalse(selector.matches(projectComponent(":foo", publishedAs = "org.example" to "bar")))
+        assertFalse(selector.matches(projectComponent(":foo")))
+    }
+
+    @Test
+    fun `a project path selector matches only project components`() {
+        val selector = SwiftExportDependencySelector.ProjectPath(":foo")
+
+        assertTrue(selector.matches(projectComponent(":foo")))
+        assertFalse(selector.matches(projectComponent(":bar")))
+        assertFalse(selector.matches(moduleComponent("org.example", "foo")))
+    }
+
+    @Test
+    fun `an unknown component identifier matches nothing`() {
+        val component = SwiftExportResolvedComponent(ComponentIdentifier { "opaque" }, moduleVersion = null)
+
+        assertFalse(SwiftExportDependencySelector.Module(group = "org.example", name = "foo").matches(component))
+        assertFalse(SwiftExportDependencySelector.ProjectPath(":foo").matches(component))
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportModuleOptionsSourceTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportModuleOptionsSourceTests.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.unitTests
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportModuleOptionsSource
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportResolvedComponent
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.declaredModuleName
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.declaredRootPackage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The seam only reads what a layer returns for a component, so opaque identifiers are enough. Matching real
+ * identifiers is covered in [ExportExtensionSwiftExportTests].
+ */
+class SwiftExportModuleOptionsSourceTests {
+
+    private val component = SwiftExportResolvedComponent(ComponentIdentifier { "test-component" }, moduleVersion = null)
+
+    private fun layer(moduleName: String?, rootPackage: String?) =
+        SwiftExportModuleOptionsSource { SwiftExportDeclaredModuleOptions(moduleName, rootPackage) }
+
+    @Test
+    fun `the highest precedence layer wins for module name`() {
+        val layers = listOf(
+            layer(moduleName = "Higher", rootPackage = null),
+            layer(moduleName = "Lower", rootPackage = null),
+        )
+
+        assertEquals("Higher", layers.declaredModuleName(component))
+    }
+
+    @Test
+    fun `properties resolve independently of each other`() {
+        val layers = listOf(
+            layer(moduleName = "Higher", rootPackage = null),
+            layer(moduleName = "Lower", rootPackage = "org.example.lower"),
+        )
+
+        assertEquals("Higher", layers.declaredModuleName(component))
+        assertEquals("org.example.lower", layers.declaredRootPackage(component))
+    }
+
+    @Test
+    fun `a layer with no metadata for the component is skipped`() {
+        val layers = listOf(
+            SwiftExportModuleOptionsSource { null },
+            layer(moduleName = "Lower", rootPackage = "org.example.lower"),
+        )
+
+        assertEquals("Lower", layers.declaredModuleName(component))
+        assertEquals("org.example.lower", layers.declaredRootPackage(component))
+    }
+
+    @Test
+    fun `nothing declared falls through to the derived default`() {
+        val layers = listOf(
+            layer(moduleName = null, rootPackage = null),
+            SwiftExportModuleOptionsSource { null },
+        )
+
+        assertNull(layers.declaredModuleName(component))
+        assertNull(layers.declaredRootPackage(component))
+    }
+
+    @Test
+    fun `no layers at all falls through to the derived default`() {
+        val layers = emptyList<SwiftExportModuleOptionsSource>()
+
+        assertNull(layers.declaredModuleName(component))
+        assertNull(layers.declaredRootPackage(component))
+    }
+}


### PR DESCRIPTION
This pull request introduces expanding the Swift Export DSL to allow per-dependency module metadata overrides, improved error handling for module name collisions, and internal refactoring to support these features.

**Swift Export DSL and API enhancements:**

* Introduced the `SwiftExportModuleMetadataDsl` interface, now shared by both root modules and dependencies, allowing configuration of `moduleName` and `rootPackage` for any module involved in Swift export. This interface is now exposed in the public API. [[1]](diffhunk://#diff-a7c45bd59e7c7d710d215a0d216f5bf39428cfcaa26f3798f59001e44d44e6faL137-R172) [[2]](diffhunk://#diff-82f89dcaaec969cbfd68dbcf4a8d014a29f7eb05f99786f739f17ac53edf0bc9L1914-R1934)
* Added new `configure(dependency, ...)` methods to `SwiftExportIntegration`, enabling users to override Swift module metadata for specific dependencies directly from the build script. This supports various Gradle dependency notations and is available in both Kotlin and Groovy DSLs. [[1]](diffhunk://#diff-a7c45bd59e7c7d710d215a0d216f5bf39428cfcaa26f3798f59001e44d44e6faR211-R239) [[2]](diffhunk://#diff-82f89dcaaec969cbfd68dbcf4a8d014a29f7eb05f99786f739f17ac53edf0bc9L1914-R1934)

**Error handling and diagnostics:**

* Added a new fatal diagnostic, `SwiftExportDuplicateModuleNames`, which detects and reports collisions of Swift module names (case-insensitive) across all exported modules, including dependencies. The error message provides actionable solutions.
* Improved `SwiftExportModuleResolutionError` to include the DSL snippet that caused the error, making diagnostics more precise and actionable.

**Test coverage and validation:**

* Added integration tests to validate the new behavior: one test ensures that duplicate module names cause a build failure with the correct diagnostic, and another verifies that dependency overrides are applied end-to-end, including package flattening and module renaming in generated Swift code.

**Internal refactoring and dependency injection:**

* Refactored `ExportExtension` and related initialization to inject a `SwiftExportDependencySelectorFactory`, supporting the new dependency override mechanism. [[1]](diffhunk://#diff-a7c45bd59e7c7d710d215a0d216f5bf39428cfcaa26f3798f59001e44d44e6faL45-R60) [[2]](diffhunk://#diff-3cd1bf4b086dbb3c29c9bb7c6ae2e3272adf68056c91b2222e368a0f56e22d9cL37-R38)
* Updated internal task registration and execution to use the new override-aware configuration, ensuring that dependency overrides are respected during the Swift export process. [[1]](diffhunk://#diff-d9a35c55ac1d41c4c11c8277d697e251674b31fb6f012ef726c37e9411697311R78) [[2]](diffhunk://#diff-d9a35c55ac1d41c4c11c8277d697e251674b31fb6f012ef726c37e9411697311R170) [[3]](diffhunk://#diff-d9a35c55ac1d41c4c11c8277d697e251674b31fb6f012ef726c37e9411697311R200-R208)
