### PR TITLE
JVM: Reuse $default parameter slots only if the types match

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -53,6 +53,9 @@ class MethodInliner(
     private val defaultMaskStart: Int = -1,
     private val defaultMaskEnd: Int = -1,
     private val skipLineNumbers: Boolean = false,
+    // Whether this is the call to the underlying function in a `$default` stub, which
+    // could not be handled because the two disagree on the JVM parameter layout. See KT-89206.
+    private val skipParameterLocalVariables: Boolean = false,
 ) {
     private val languageVersionSettings = inliningContext.state.config.languageVersionSettings
     private val invokeCalls = ArrayList<InvokeCall>()
@@ -506,6 +509,9 @@ class MethodInliner(
 
         inliningContext.inlineScopesGenerator?.addInlineScopesInfo(node, isRegeneratingAnonymousObject())
 
+        val skippedParameterLocalVariablesEnd =
+            if (skipParameterLocalVariables) argumentsSize(node.desc, node.access and Opcodes.ACC_STATIC != 0) else 0
+
         val transformationVisitor = object : InlineMethodInstructionAdapter(transformedNode) {
             private val GENERATE_DEBUG_INFO = GENERATE_SMAP && !isInlineOnlyMethod
 
@@ -573,6 +579,7 @@ class MethodInliner(
 
             override fun visitLocalVariable(name: String, desc: String, signature: String?, start: Label, end: Label, index: Int) {
                 if (!isInliningLambda && !GENERATE_DEBUG_INFO) return
+                if (index < skippedParameterLocalVariablesEnd) return
 
                 val isInlineFunctionMarker = name.startsWith(JvmAbi.LOCAL_VARIABLE_NAME_PREFIX_INLINE_FUNCTION)
                 val newName = when {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -1553,7 +1553,8 @@ class ExpressionCodegen(
             return IrCallGenerator.DefaultCallGenerator
         }
 
-        if (element.origin == JvmLoweredStatementOrigin.DEFAULT_STUB_CALL_TO_IMPLEMENTATION) {
+        val isDefaultStubCallToImplementation = element.origin == JvmLoweredStatementOrigin.DEFAULT_STUB_CALL_TO_IMPLEMENTATION
+        if (isDefaultStubCallToImplementation && sharesParameterLayoutWithEnclosingDefaultStub(element.symbol.owner)) {
             return IrInlineDefaultCodegen
         }
 
@@ -1590,9 +1591,21 @@ class ExpressionCodegen(
             mappings,
             sourceCompiler,
             reifiedTypeInliner,
-            markInlinedSuspensionPointAsUnitReturning
+            markInlinedSuspensionPointAsUnitReturning,
+            isDefaultStubCallToImplementation,
         )
     }
+
+    /**
+     * Whether [callee] and the enclosing `$default` stub use the same JVM parameter layout.
+     * [IrInlineDefaultCodegen] can reuse local slots only in this case; otherwise the general inliner has to coerce
+     * arguments, e.g. for nullable default-stub parameters of primitive-mapped type parameters. See KT-89206.
+     */
+    private fun sharesParameterLayoutWithEnclosingDefaultStub(callee: IrFunction): Boolean =
+        callee.parameters.size <= irFunction.parameters.size &&
+                callee.parameters.indices.all { index ->
+                    typeMapper.mapType(callee.parameters[index].type) == typeMapper.mapType(irFunction.parameters[index].type)
+                }
 
     private fun consumeReifiedOperationMarker(typeParameter: TypeParameterMarker) {
         require(typeParameter is IrTypeParameterSymbol)

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/IrInlineCodegen.kt
@@ -46,6 +46,9 @@ class IrInlineCodegen(
     private val sourceCompiler: SourceCompilerForInline,
     private val reifiedTypeInliner: ReifiedTypeInliner,
     private val markInlinedSuspensionPointAsUnitReturning: Boolean,
+    // Whether this is the call to the underlying function in a `$default` stub, which
+    // could not be handled because the two disagree on the JVM parameter layout. See KT-89206.
+    private val isDefaultStubCallToImplementation: Boolean,
 ) : IrInlineCallGenerator {
 
     private val inlineArgumentsInPlace = canInlineArgumentsInPlace()
@@ -160,10 +163,12 @@ class IrInlineCodegen(
                     //         .let {}
                     //   * Inline parameters.
                     //   * Continuation argument.
+                    //   * An unchanged `$default` stub parameter whose slot already has a local variable table entry.
                     val argValue = if (
                         (irValueParameter.parent as IrDeclaration).isInlineOnly() && irValueParameter.kind != IrParameterKind.ExtensionReceiver ||
                         irValueParameter.isInlineParameter() ||
-                        irValueParameter.origin == JvmLoweredDeclarationOrigin.CONTINUATION_CLASS
+                        irValueParameter.origin == JvmLoweredDeclarationOrigin.CONTINUATION_CLASS ||
+                        isDefaultStubCallToImplementation
                     ) {
                         codegen.genOrGetLocal(argumentExpression, parameterType, irValueParameter.type, blockInfo, eraseType = true)
                     } else {
@@ -334,6 +339,7 @@ class IrInlineCodegen(
             maskStartIndex,
             maskStartIndex + maskValues.size,
             skipLineNumbers = codegen.isNoLineNumberScope,
+            skipParameterLocalVariables = isDefaultStubCallToImplementation,
         ) //with captured
 
         val remapper = LocalVarRemapper(parameters, initialFrameSize)

--- a/compiler/testData/codegen/asmLike/defaultArgumentStubParameterSlots.asm.txt
+++ b/compiler/testData/codegen/asmLike/defaultArgumentStubParameterSlots.asm.txt
@@ -1,0 +1,68 @@
+public final class DefaultArgumentStubParameterSlotsKt : java/lang/Object {
+    public final static long partiallyMatchingStub(java.lang.String fixed, long value, java.lang.String p2) {
+        LABEL (L0)
+          ALOAD (0)
+          LDC (fixed)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          ALOAD (3)
+          LDC (other)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          ICONST_0
+          ISTORE (4)
+        LABEL (L1)
+        LINENUMBER (9)
+          LLOAD (1)
+          ALOAD (0)
+          INVOKEVIRTUAL (java/lang/String, length, ()I)
+          I2L
+          LADD
+          ALOAD (3)
+          INVOKEVIRTUAL (java/lang/String, length, ()I)
+          I2L
+          LADD
+          LRETURN
+        LABEL (L2)
+    }
+
+    public static long partiallyMatchingStub$default(java.lang.String fixed, java.lang.Long value, java.lang.String other, int p3, java.lang.Object p4) {
+        LABEL (L0)
+        LINENUMBER (8)
+          ILOAD (3)
+          ICONST_2
+          IAND
+          IFEQ (L1)
+          LDC (42)
+          INVOKESTATIC (java/lang/Long, valueOf, (J)Ljava/lang/Long;)
+          ASTORE (1)
+        LABEL (L1)
+          ILOAD (3)
+          ICONST_4
+          IAND
+          IFEQ (L2)
+          LDC (a)
+          ASTORE (2)
+        LABEL (L2)
+          ALOAD (1)
+          INVOKEVIRTUAL (java/lang/Long, longValue, ()J)
+          LSTORE (5)
+          ALOAD (2)
+          ASTORE (7)
+          ICONST_0
+          ISTORE (8)
+        LABEL (L3)
+        LINENUMBER (11)
+          LLOAD (5)
+          ALOAD (0)
+          INVOKEVIRTUAL (java/lang/String, length, ()I)
+          I2L
+          LADD
+          ALOAD (7)
+          INVOKEVIRTUAL (java/lang/String, length, ()I)
+          I2L
+          LADD
+        LABEL (L4)
+        LINENUMBER (8)
+          LRETURN
+        LABEL (L5)
+    }
+}

--- a/compiler/testData/codegen/asmLike/defaultArgumentStubParameterSlots.kt
+++ b/compiler/testData/codegen/asmLike/defaultArgumentStubParameterSlots.kt
@@ -1,0 +1,9 @@
+// CURIOUS_ABOUT: partiallyMatchingStub, partiallyMatchingStub$default
+// ISSUE: KT-89206
+
+// `value` is boxed in the stub and copied to a local; `fixed` can reuse the stub's slot.
+// The defaulted `other` argument is not a plain parameter read, so it is still copied.
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> partiallyMatchingStub(fixed: String, value: T = 42L as T, other: String = "a"): Long =
+    value + fixed.length + other.length

--- a/compiler/testData/codegen/box/inline/defaultArgumentWithPrimitiveTypeParameterUpperBound.kt
+++ b/compiler/testData/codegen/box/inline/defaultArgumentWithPrimitiveTypeParameterUpperBound.kt
@@ -1,0 +1,70 @@
+// ISSUE: KT-89206
+// WORKS_WHEN_VALUE_CLASS
+// WITH_STDLIB
+
+// A primitive upper-bound type parameter is boxed in a `$default` stub but unboxed in the function body.
+
+OPTIONAL_JVM_INLINE_ANNOTATION
+value class IntWrapper(val value: Int)
+
+OPTIONAL_JVM_INLINE_ANNOTATION
+value class StringWrapper(val value: String)
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> longBound(value: T = 42L as T): Long = value
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Int> intBound(value: T = 42 as T): Int = value
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : IntWrapper> valueClassBound(value: T = IntWrapper(42) as T): Int = value.value
+
+// A reference-backed value class still has the same JVM type in the stub and body.
+@Suppress("UNCHECKED_CAST")
+inline fun <T : StringWrapper> referenceValueClassBound(value: T = StringWrapper("42") as T): String = value.value
+
+inline fun referenceValueClassBoundThroughStub(): String = referenceValueClassBound<StringWrapper>()
+
+// Only `value` is boxed in the stub; `other` can still reuse the stub's slot.
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> partiallyMatchingStub(value: T = 42L as T, other: String = "a"): String = "$value$other"
+
+inline fun partiallyMatchingStubThroughStub(): String = partiallyMatchingStub<Long>()
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> nullableLongBound(value: T? = 42L as T): Long? = value
+
+// The exact shape reported in KT-89206: a `Nothing`-typed default. Declaring it used to be enough to crash codegen.
+inline fun <T : Long> todoDefault(value: T = TODO()): Long = value
+
+// Same, never called: the `$default` stub is generated for the declaration alone.
+inline fun <T : Long> todoDefaultNeverCalled(value: T = TODO()) {
+    value
+}
+
+fun box(): String {
+    if (longBound<Long>() != 42L) return "Fail 1: ${longBound<Long>()}"
+    if (longBound(1L) != 1L) return "Fail 2: ${longBound(1L)}"
+
+    if (intBound<Int>() != 42) return "Fail 3: ${intBound<Int>()}"
+    if (intBound(1) != 1) return "Fail 4: ${intBound(1)}"
+
+    if (valueClassBound<IntWrapper>() != 42) return "Fail 5: ${valueClassBound<IntWrapper>()}"
+    if (valueClassBound(IntWrapper(1)) != 1) return "Fail 6: ${valueClassBound(IntWrapper(1))}"
+
+    if (referenceValueClassBound<StringWrapper>() != "42") return "Fail 7: ${referenceValueClassBound<StringWrapper>()}"
+    if (referenceValueClassBound(StringWrapper("1")) != "1") return "Fail 8: ${referenceValueClassBound(StringWrapper("1"))}"
+    if (referenceValueClassBoundThroughStub() != "42") return "Fail 9: ${referenceValueClassBoundThroughStub()}"
+
+    if (partiallyMatchingStub<Long>() != "42a") return "Fail 10: ${partiallyMatchingStub<Long>()}"
+    if (partiallyMatchingStub(1L) != "1a") return "Fail 11: ${partiallyMatchingStub(1L)}"
+    if (partiallyMatchingStub(1L, "b") != "1b") return "Fail 12: ${partiallyMatchingStub(1L, "b")}"
+    if (partiallyMatchingStubThroughStub() != "42a") return "Fail 13: ${partiallyMatchingStubThroughStub()}"
+
+    if (nullableLongBound<Long>() != 42L) return "Fail 14: ${nullableLongBound<Long>()}"
+    if (nullableLongBound(1L) != 1L) return "Fail 15: ${nullableLongBound(1L)}"
+
+    if (todoDefault(7L) != 7L) return "Fail 16: ${todoDefault(7L)}"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeListing/defaultArguments/primitiveTypeParameterUpperBound.kt
+++ b/compiler/testData/codegen/bytecodeListing/defaultArguments/primitiveTypeParameterUpperBound.kt
@@ -1,0 +1,34 @@
+// ISSUE: KT-89206
+// WITH_STDLIB
+
+// Pins `$default` descriptors for primitive upper-bound type parameters.
+
+package test
+
+@JvmInline
+value class IntWrapper(val value: Int)
+
+@JvmInline
+value class StringWrapper(val value: String)
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> inlineLongBound(value: T = 42L as T): Long = value
+
+@Suppress("UNCHECKED_CAST")
+fun <T : Long> longBound(value: T = 42L as T): Long = value
+
+@Suppress("UNCHECKED_CAST")
+fun <T : IntWrapper> valueClassBound(value: T = IntWrapper(42) as T): Int = value.value
+
+// A reference-backed value class keeps the same JVM type in the stub and body.
+@Suppress("UNCHECKED_CAST")
+fun <T : StringWrapper> referenceValueClassBound(value: T = StringWrapper("42") as T): String = value.value
+
+// Only `value` differs between the stub and body; `other` is a `String` in both.
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> partiallyMatchingStub(value: T = 42L as T, other: String = "a"): String = "$value$other"
+
+@Suppress("UNCHECKED_CAST")
+fun <T : Long> nullableLongBound(value: T? = 42L as T): Long? = value
+
+fun <T : CharSequence> referenceBound(value: T? = null): T? = value

--- a/compiler/testData/codegen/bytecodeListing/defaultArguments/primitiveTypeParameterUpperBound.txt
+++ b/compiler/testData/codegen/bytecodeListing/defaultArguments/primitiveTypeParameterUpperBound.txt
@@ -1,0 +1,56 @@
+@kotlin.jvm.JvmInline
+@kotlin.Metadata
+public final class test/IntWrapper {
+    // source: 'primitiveTypeParameterUpperBound.kt'
+    private final field value: int
+    private synthetic method <init>(p0: int): void
+    public synthetic final static method box-impl(p0: int): test.IntWrapper
+    public static method constructor-impl(p0: int): int
+    public method equals(p0: java.lang.Object): boolean
+    public static method equals-impl(p0: int, p1: java.lang.Object): boolean
+    public final static method equals-impl0(p0: int, p1: int): boolean
+    public final method getValue(): int
+    public method hashCode(): int
+    public static method hashCode-impl(p0: int): int
+    public method toString(): java.lang.String
+    public static method toString-impl(p0: int): java.lang.String
+    public synthetic final method unbox-impl(): int
+}
+
+@kotlin.Metadata
+public final class test/PrimitiveTypeParameterUpperBoundKt {
+    // source: 'primitiveTypeParameterUpperBound.kt'
+    public synthetic static method inlineLongBound$default(p0: java.lang.Long, p1: int, p2: java.lang.Object): long
+    public final static method inlineLongBound(p0: long): long
+    public synthetic static method longBound$default(p0: java.lang.Long, p1: int, p2: java.lang.Object): long
+    public final static method longBound(p0: long): long
+    public synthetic static method nullableLongBound$default(p0: java.lang.Long, p1: int, p2: java.lang.Object): java.lang.Long
+    public final static @org.jetbrains.annotations.Nullable method nullableLongBound(@org.jetbrains.annotations.Nullable p0: java.lang.Long): java.lang.Long
+    public synthetic static method partiallyMatchingStub$default(p0: java.lang.Long, p1: java.lang.String, p2: int, p3: java.lang.Object): java.lang.String
+    public final static @org.jetbrains.annotations.NotNull method partiallyMatchingStub(p0: long, @org.jetbrains.annotations.NotNull p1: java.lang.String): java.lang.String
+    public synthetic static method referenceBound$default(p0: java.lang.CharSequence, p1: int, p2: java.lang.Object): java.lang.CharSequence
+    public final static @org.jetbrains.annotations.Nullable method referenceBound(@org.jetbrains.annotations.Nullable p0: java.lang.CharSequence): java.lang.CharSequence
+    public synthetic static method referenceValueClassBound-oQxV8iw$default(p0: java.lang.String, p1: int, p2: java.lang.Object): java.lang.String
+    public final static @org.jetbrains.annotations.NotNull method referenceValueClassBound-oQxV8iw(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public synthetic static method valueClassBound-Npg_7MQ$default(p0: test.IntWrapper, p1: int, p2: java.lang.Object): int
+    public final static method valueClassBound-Npg_7MQ(p0: int): int
+}
+
+@kotlin.jvm.JvmInline
+@kotlin.Metadata
+public final class test/StringWrapper {
+    // source: 'primitiveTypeParameterUpperBound.kt'
+    private final @org.jetbrains.annotations.NotNull field value: java.lang.String
+    private synthetic method <init>(p0: java.lang.String): void
+    public synthetic final static method box-impl(p0: java.lang.String): test.StringWrapper
+    public static @org.jetbrains.annotations.NotNull method constructor-impl(@org.jetbrains.annotations.NotNull p0: java.lang.String): java.lang.String
+    public method equals(p0: java.lang.Object): boolean
+    public static method equals-impl(p0: java.lang.String, p1: java.lang.Object): boolean
+    public final static method equals-impl0(p0: java.lang.String, p1: java.lang.String): boolean
+    public final @org.jetbrains.annotations.NotNull method getValue(): java.lang.String
+    public method hashCode(): int
+    public static method hashCode-impl(p0: java.lang.String): int
+    public method toString(): java.lang.String
+    public static method toString-impl(p0: java.lang.String): java.lang.String
+    public synthetic final method unbox-impl(): java.lang.String
+}

--- a/compiler/testData/debug/localVariables/inlineScopes/defaultArgumentsWithBoxedStubParameter.kt
+++ b/compiler/testData/debug/localVariables/inlineScopes/defaultArgumentsWithBoxedStubParameter.kt
@@ -1,0 +1,27 @@
+// TARGET_BACKEND: JVM
+// USE_INLINE_SCOPES_NUMBERS
+// FILE: test.kt
+// KT-89206: a type parameter whose upper bound is mapped to a JVM primitive is mapped to that primitive as well,
+// while its nullable counterpart is mapped to the boxed type. The parameter of a `$default` stub is made nullable,
+// so `f(J)J` gets `f$default(Ljava/lang/Long;ILjava/lang/Object;)J` and the stub cannot reuse its own parameter
+// slot for the body of `f`. The inlined `f` therefore stores `value` in a slot of its own, but only the stub's
+// own `value` is named in the local variable table, so a single `value` per inline scope stays visible here.
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> f(value: T = 42L as T): Long {
+    return value
+}
+
+fun box() {
+    f<Long>()
+    f(1L)
+}
+
+// EXPECTATIONS JVM_IR
+// test.kt:16 box:
+// test.kt:11 box:
+// test.kt:12 box: value\1:long=42:long, $i$f$f\1\16:int=0:int
+// test.kt:11 box: value\1:long=42:long
+// test.kt:17 box:
+// test.kt:12 box: value\2:long=1:long, $i$f$f\2\17:int=0:int
+// test.kt:18 box:

--- a/compiler/testData/debug/localVariables/inlineScopes/defaultArgumentsWithBoxedStubParameterAndLambda.kt
+++ b/compiler/testData/debug/localVariables/inlineScopes/defaultArgumentsWithBoxedStubParameterAndLambda.kt
@@ -1,0 +1,35 @@
+// TARGET_BACKEND: JVM
+// USE_INLINE_SCOPES_NUMBERS
+// FILE: test.kt
+// KT-89206: the same layout mismatch as in defaultArgumentsWithBoxedStubParameter.kt, but the function also takes
+// an inline lambda, so this also pins the scope and surrounding scope numbers of a lambda passed to a `$default`
+// stub that inlines its implementation the general way.
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> f(value: T = 42L as T, block: (Long) -> Long): Long {
+    return block(value)
+}
+
+inline fun g(): Long {
+    return f<Long> { it + 1 }
+}
+
+fun box() {
+    g()
+    f(1L) { it + 2 }
+}
+
+// EXPECTATIONS JVM_IR
+// test.kt:18 box:
+// test.kt:14 box: $i$f$g\1\18:int=0:int
+// test.kt:9 box: $i$f$g\1\18:int=0:int
+// test.kt:10 box: $i$f$g\1\18:int=0:int, value\2:long=42:long, $i$f$f\2\40:int=0:int
+// test.kt:14 box: $i$f$g\1\18:int=0:int, value\2:long=42:long, $i$f$f\2\40:int=0:int, it\3:long=42:long, $i$a$-f$default-TestKt$g$1\3\42\1:int=0:int
+// test.kt:10 box: $i$f$g\1\18:int=0:int, value\2:long=42:long, $i$f$f\2\40:int=0:int
+// test.kt:9 box: $i$f$g\1\18:int=0:int, value\2:long=42:long
+// test.kt:14 box: $i$f$g\1\18:int=0:int
+// test.kt:19 box:
+// test.kt:10 box: value\4:long=1:long, $i$f$f\4\19:int=0:int
+// test.kt:19 box: value\4:long=1:long, $i$f$f\4\19:int=0:int, it\5:long=1:long, $i$a$-f-TestKt$box$1\5\43\0:int=0:int
+// test.kt:10 box: value\4:long=1:long, $i$f$f\4\19:int=0:int
+// test.kt:20 box:

--- a/compiler/testData/debug/localVariables/inlineScopes/defaultArgumentsWithPartiallyMatchingStubParameters.kt
+++ b/compiler/testData/debug/localVariables/inlineScopes/defaultArgumentsWithPartiallyMatchingStubParameters.kt
@@ -1,0 +1,29 @@
+// TARGET_BACKEND: JVM
+// USE_INLINE_SCOPES_NUMBERS
+// FILE: test.kt
+// KT-89206: `value` is boxed in the stub and copied to a local; `other` reuses the stub's slot.
+
+@Suppress("UNCHECKED_CAST")
+inline fun <T : Long> f(value: T = 42L as T, other: String = "a"): String {
+    return "$value$other"
+}
+
+inline fun g(): String {
+    return f<Long>()
+}
+
+fun box() {
+    g()
+    f(1L, "b")
+}
+
+// EXPECTATIONS JVM_IR
+// test.kt:16 box:
+// test.kt:12 box: $i$f$g\1\16:int=0:int
+// test.kt:7 box: $i$f$g\1\16:int=0:int
+// test.kt:8 box: $i$f$g\1\16:int=0:int, value\2:long=42:long, other\2:java.lang.String="a":java.lang.String, $i$f$f\2\34:int=0:int
+// test.kt:7 box: $i$f$g\1\16:int=0:int, value\2:long=42:long, other\2:java.lang.String="a":java.lang.String
+// test.kt:12 box: $i$f$g\1\16:int=0:int
+// test.kt:17 box:
+// test.kt:8 box: value\3:long=1:long, other\3:java.lang.String="b":java.lang.String, $i$f$f\3\17:int=0:int
+// test.kt:18 box:


### PR DESCRIPTION
 #KT-89206 Fixed