### PR TITLE
[Build] Don't register KGP IT coverage task if `kotlin.test.gradle.it…

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -563,9 +563,11 @@ tasks.withType<Test>().configureEach {
 
 excludeGradleEmbeddedStdlibFromTestTasksRuntimeClasspath()
 
-registerKgpTestCoverageDataVariant(
-    configurationName = "integrationTestCoverageDataElements",
-    suiteName = "integrationTest",
-    execFile = layout.buildDirectory.file("jacoco/coverage.exec"),
-    testTask = tasks.named("kgpAllParallelTests"),
-)
+if (!project.kotlinBuildProperties.hideExtraTestTasksInGradleIntegrationTests.get()) {
+    registerKgpTestCoverageDataVariant(
+        configurationName = "integrationTestCoverageDataElements",
+        suiteName = "integrationTest",
+        execFile = layout.buildDirectory.file("jacoco/coverage.exec"),
+        testTask = tasks.named("kgpAllParallelTests"),
+    )
+}


### PR DESCRIPTION
….hide.extra.tasks=true`

The mentioned property disables registration of `kgpAllParallelTests`, which is required for the coverage task.