### PR TITLE
[Daemon] Deduplicate client registrations in client set

### DIFF
--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.utils.KotlinPaths
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
@@ -872,6 +873,38 @@ class CompilerDaemonTest : KotlinIntegrationTestBase() {
                 logFile.assertLogContainsSequence("Idle timeout exceeded 1s",
                                                   "Shutdown started")
             }
+        }
+    }
+
+    @Test
+    @DisplayName("Daemon correctly deduplicates client registrations in client set")
+    fun testDaemonKeepsOnlyOneClientRegistered() {
+        val daemonOptions = DaemonOptions(
+            autoshutdownIdleSeconds = 1000,
+            shutdownDelayMilliseconds = 1,
+            runFilesPath = File(testTempDir, getTestName(testInfo)).absolutePath
+        )
+        val clientFlag = FileUtil.createTempFile(getTestName(testInfo), "-client.alive").also { it.deleteOnExit() }
+        val sessionFlag = FileUtil.createTempFile(getTestName(testInfo), "-session.alive").also { it.deleteOnExit() }
+        try {
+            val daemonJVMOptions = makeTestDaemonJvmOptions()
+            val daemon = KotlinCompilerClient.connectToCompileService(
+                compilerId,
+                clientFlag,
+                daemonJVMOptions,
+                daemonOptions,
+                DaemonReportingTargets(out = System.err),
+                autostart = true
+            )
+            assertNotNull(daemon) { "failed to connect daemon" }
+            assertEquals(1, daemon.getClients().get().size)
+            daemon.registerClient(clientFlag.absolutePath)
+            daemon.registerClient(clientFlag.absolutePath)
+            daemon.registerClient(clientFlag.absolutePath)
+            assertEquals(1, daemon.getClients().get().size)
+        } finally {
+            sessionFlag.delete()
+            clientFlag.delete()
         }
     }
 

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -64,6 +64,7 @@ import java.util.concurrent.ConcurrentSkipListSet
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -112,20 +113,30 @@ abstract class CompileServiceImplBase(
         CompilerSystemProperties.KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY.value = "true"
     }
 
+    protected class OneShotDisposable(disposable: Disposable?) {
+        val disposableReference = AtomicReference<Disposable?>(disposable)
+
+        fun dispose() {
+            val disposable = disposableReference.getAndSet(null)
+            disposable?.let {
+                Disposer.dispose(it)
+            }
+        }
+    }
+
+    protected fun Disposable.asOneShot(): OneShotDisposable = OneShotDisposable(this)
+
     // wrapped in a class to encapsulate alive check logic
-    protected class ClientOrSessionProxy<out T : Any>(
+    protected data class ClientOrSessionProxy<out T : Any>(
         val aliveFlagPath: String?,
         val data: T? = null,
-        private var disposable: Disposable? = null,
+        private val disposable: OneShotDisposable? = null,
     ) {
         val isAlive: Boolean
             get() = aliveFlagPath?.let { File(it).exists() } ?: true // assuming that if no file was given, the client is alive
 
         fun dispose() {
-            disposable?.let {
-                Disposer.dispose(it)
-                disposable = null
-            }
+            disposable?.dispose()
         }
     }
 
@@ -884,7 +895,7 @@ class CompileServiceImpl(
                     override fun dispose() {
                         runningCompilations.cancelAll()
                     }
-                })
+                }.asOneShot())
             }).apply {
                 log.info("leased a new session $this, session alive file: $aliveFlagPath")
             })
@@ -1021,7 +1032,7 @@ class CompileServiceImpl(
                 disposable, port, compilerId, templateClasspath, templateClassName,
                 messageCollector, null
             )
-            val sessionId = state.sessions.leaseSession(ClientOrSessionProxy(aliveFlagPath, repl, disposable))
+            val sessionId = state.sessions.leaseSession(ClientOrSessionProxy(aliveFlagPath, repl, disposable.asOneShot()))
 
             CompileService.CallResult.Good(sessionId)
         }


### PR DESCRIPTION
To prevent the set growing indefinitely, make the client registrations use equals/hashcode to deduplicate identical clients saved in the client hashset.

^KT-89056 Verficiation Pending