### PR TITLE
[Gradle] Don't reinstall the K/N bundle over an existing installation

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/NativeDownloadAndPlatformLibsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/NativeDownloadAndPlatformLibsIT.kt
@@ -10,6 +10,7 @@ import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.testbase.BuildOptions.ConfigurationCacheValue
+import org.jetbrains.kotlin.gradle.targets.native.toolchain.NativeVersionValueSource
 import org.jetbrains.kotlin.gradle.utils.NativeCompilerDownloader
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
@@ -47,6 +48,7 @@ class NativeDownloadAndPlatformLibsIT : KGPBaseTest() {
 
     private val platformName: String = HostManager.platformName()
     private val currentCompilerVersion = NativeCompilerDownloader.DEFAULT_KONAN_VERSION
+    private val prebuiltDistributionDirName = "kotlin-native-prebuilt-$platformName-$currentCompilerVersion"
 
     private val generateRegexTemplate = "Generate (?:and precompile )?platform libraries for "
     private val generateRegex = generateRegexTemplate.toRegex()
@@ -108,7 +110,7 @@ class NativeDownloadAndPlatformLibsIT : KGPBaseTest() {
 
                 // checking that konan was downloaded and native dependencies were not downloaded into ~/.konan dir
                 assertDirectoryExists(workingDir.resolve(".konan/dependencies"))
-                assertDirectoryExists(workingDir.resolve(".konan/kotlin-native-prebuilt-$platformName-$currentCompilerVersion"))
+                assertDirectoryExists(workingDir.resolve(".konan/$prebuiltDistributionDirName"))
             }
         }
     }
@@ -120,6 +122,30 @@ class NativeDownloadAndPlatformLibsIT : KGPBaseTest() {
             build("assemble") {
                 assertOutputContains("Kotlin/Native distribution: .*kotlin-native-prebuilt-$platformName".toRegex())
                 assertOutputDoesNotContain(generateRegex)
+            }
+        }
+    }
+
+    @DisplayName("Toolchain leaves a distribution installed by the legacy downloader alone (KT-86251)")
+    @GradleTest
+    fun testToolchainDoesNotReinstallOverLegacyInstallation(gradleVersion: GradleVersion) {
+        platformLibrariesProject("linuxX64", gradleVersion = gradleVersion) {
+            // the legacy downloader has to leave behind the marker the toolchain looks for
+            build("tasks") {
+                assertOutputContains("Unpack Kotlin/Native compiler to ")
+
+                val distributionDir = buildOptions.konanDataDir!!.resolve(prebuiltDistributionDirName)
+                assertFileExists(distributionDir.resolve(NativeVersionValueSource.MARKER_FILE))
+            }
+
+            // the toolchain has to leave that installation alone. Unpacking on top of it happens in place, so
+            // anything reading the distribution at the same time sees half-written files.
+            build(
+                "downloadKotlinNativeDistribution",
+                buildOptions = buildOptions.copy(freeArgs = listOf("-Pkotlin.native.toolchain.enabled=true")),
+            ) {
+                assertTasksExecuted(":downloadKotlinNativeDistribution")
+                assertOutputDoesNotContain("Moving Kotlin/Native bundle from")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/NativeCompilerDownloader.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/NativeCompilerDownloader.kt
@@ -24,13 +24,16 @@ import org.jetbrains.kotlin.gradle.report.GradleBuildMetricsReporter
 import org.jetbrains.kotlin.gradle.targets.native.internal.NativeDistributionTypeProvider
 import org.jetbrains.kotlin.gradle.targets.native.internal.PlatformLibrariesGenerator
 import org.jetbrains.kotlin.gradle.targets.native.konanPropertiesBuildService
+import org.jetbrains.kotlin.gradle.targets.native.toolchain.NativeVersionValueSource
 import org.jetbrains.kotlin.internal.compilerRunner.native.nativeCompilerClasspath
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.DependencyDirectories
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import java.io.File
+import java.nio.file.DirectoryNotEmptyException
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 class NativeCompilerDownloader(
     val project: Project,
@@ -202,13 +205,22 @@ class NativeCompilerDownloader(
                     it.into(tmpDir)
                 }
                 val compilerTmp = tmpDir.resolve(dependencyNameWithOsAndVersion)
-                if (!compilerTmp.renameTo(compilerDirectory)) {
-                    project.copy {
-                        it.from(compilerTmp)
-                        it.into(compilerDirectory)
-                    }
+                // the toolchain unpacks the archive over any distribution without this marker (KT-86251), so mark
+                // the tmp tree and let the move below publish the marker together with the distribution
+                NativeVersionValueSource.markAsProvisioned(compilerTmp)
+
+                try {
+                    // 'tmpDir' sits next to 'compilerDirectory', so this is a rename: the whole distribution, marker
+                    // included, appears in one step. REPLACE_EXISTING only ever clears an empty leftover directory.
+                    Files.move(compilerTmp.toPath(), compilerDirectory.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                    logger.debug("Moved Kotlin/Native compiler from $tmpDir to $compilerDirectory")
+                } catch (e: DirectoryNotEmptyException) {
+                    // the same exception also reports 'the move needed copying', which installs nothing, so only
+                    // read it as 'another build got here first' when there really is a distribution in place
+                    if (!compilerDirectory.exists()) throw e
+                    // writing on top of that one would corrupt what the other build is reading (KT-86251)
+                    logger.debug("Kotlin/Native compiler is already installed in $compilerDirectory")
                 }
-                logger.debug("Moved Kotlin/Native compiler from $tmpDir to $compilerDirectory")
             } finally {
                 tmpDir.deleteRecursively()
             }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/toolchain/NativeVersionValueSource.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/toolchain/NativeVersionValueSource.kt
@@ -76,7 +76,7 @@ internal abstract class NativeVersionValueSource :
 
             removeBundleIfNeeded(reinstallFlag || needToReinstall, bundleDir)
 
-            if (!bundleDir.resolve(MARKER_FILE).exists()) {
+            if (!provisionedMarkerFile(bundleDir).exists()) {
                 val gradleCachesKotlinNativeDir =
                     resolveKotlinNativeConfiguration(kotlinNativeVersion, kotlinNativeBundleConfiguration)
 
@@ -128,7 +128,7 @@ internal abstract class NativeVersionValueSource :
 
             checkKotlinNativeVersionWasDownloaded(toDirectory)
 
-            createSuccessfulInstallationFile(toDirectory)
+            markAsProvisioned(toDirectory)
 
             logger.info("Moved Kotlin/Native bundle from $fromDirectory to ${toDirectory.absolutePath}")
         }
@@ -153,8 +153,11 @@ internal abstract class NativeVersionValueSource :
             }
         }
 
-        private fun createSuccessfulInstallationFile(bundleDir: File) {
-            bundleDir.resolve(MARKER_FILE).createNewFile()
+        private fun provisionedMarkerFile(bundleDir: File): File = bundleDir.resolve(MARKER_FILE)
+
+        // both provisioners have to agree on what a finished installation looks like, see KT-86251
+        internal fun markAsProvisioned(bundleDir: File) {
+            provisionedMarkerFile(bundleDir).createNewFile()
         }
     }
 }


### PR DESCRIPTION
The Kotlin/Native toolchain treats a bundle directory as installed only when it holds the 'provisioned.ok' marker, and only the toolchain itself ever wrote that marker. A distribution installed by 'NativeCompilerDownloader' -- the configuration-phase path, used whenever 'kotlin.native.distribution.downloadFromMaven' is off -- has no marker, so the toolchain declares it unprovisioned and unpacks the archive on top of it.

That re-extraction is neither necessary nor safe. Extraction shells out to tar, which unlinks each existing file before recreating it, so every shipped file in the distribution briefly does not exist. A build reading the distribution at that moment gets a NoSuchFileException, which is what AndroidX has been hitting on files such as
klib/cache/<target>-gSTATIC-system/stdlib-per-file-cache/.../ir. They share one konan data dir between an outer build installing through 'NativeCompilerDownloader' and Gradle TestKit sub-builds installing through the toolchain, so the two paths meet routinely.

Write the marker from 'NativeCompilerDownloader' as well, so that both installers agree on what a complete installation looks like and the toolchain leaves such a directory alone.

The configuration-phase path had a second way to rewrite a live distribution. When its atomic rename failed because the directory was already there, it fell back to copying on top of it, which rewrites files another build may be reading. Skip that copy and, since this build then installed nothing, leave the marker to whoever did.

^KT-86251

 🍒 from https://github.com/JetBrains/kotlin/pull/7636