### PR TITLE
[ObjCExport] k2: Maintain ctors' stabilised ordering during translation

### DIFF
--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCConstructor.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCConstructor.kt
@@ -67,6 +67,7 @@ fun ObjCExportContext.translateToObjCConstructors(symbol: KaClassSymbol): List<O
     // Hide "unimplemented" super constructors:
     with(analysisSession) { this@translateToObjCConstructors.analysisSession.getSuperClassSymbolNotAny(symbol)?.memberScope }?.constructors.orEmpty()
         .filter { analysisSession.isVisibleInObjC(it) }
+        .sortedWith(analysisSession.getStableCallableOrder())
         .forEach { superConstructor ->
             val translatedSuperConstructor = buildObjCMethod(superConstructor, unavailable = true)
             if (result.none { it.name == translatedSuperConstructor.name }) {

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
@@ -166,11 +166,7 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
         doTest(headersTestDataDir.resolve("classWithHidesFromObjCAnnotation"))
     }
 
-    /**
-     * Disabled because of init constructors order KT-70626
-     */
     @Test
-    @TodoAnalysisApi
     fun `test - functionWithThrowsAnnotation`() {
         doTest(headersTestDataDir.resolve("functionWithThrowsAnnotation"))
     }
@@ -628,11 +624,7 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
         doTest(headersTestDataDir.resolve("varWithPrivateSetterTranslatedAsImmutableProperty"))
     }
 
-    /**
-     * Disabled because of init constructors order KT-70626
-     */
     @Test
-    @TodoAnalysisApi
     fun `test - mangle throws annotation`() {
         doTest(headersTestDataDir.resolve("mangleThrowsAnnotation"))
     }


### PR DESCRIPTION
When translating a class and generating constructors, k1 esures that the ordering is stabilised and maintained right from the beginning. While k2 attempts to do that in the beginning, later on, when building super constructors, this ordering gets lost. As a result, the ordering produced is no longer stabilised and inline with k1's.

This change fixes it and enables the corresponding tests.

^KT-70626 Fixed