### PR TITLE
[KDF] Avoid CAST_TARGET_WARNING diagnostic when intention of cast is to "erase" schema to Any

### DIFF
--- a/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/ExpressionAnalysisAdditionalChecker.kt
+++ b/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/ExpressionAnalysisAdditionalChecker.kt
@@ -202,7 +202,10 @@ private class Checker(
         val targetType = targetProjection.typeRef.coneType as? ConeClassLikeType ?: return null
         val targetSymbol = targetType.toSymbol()
         if (targetSymbol != null && !sessionHolder.session.predicateBasedProvider.matches(VALID_CAST_TARGET_PREDICATE, targetSymbol)) {
-            reporter.reportOn(source, CAST_TARGET_WARNING, targetType.renderReadable(), context)
+            // Avoiding diagnostic when intention of cast is to "erase" schema
+            if (!targetType.isAnyOrNullableAny) {
+                reporter.reportOn(source, CAST_TARGET_WARNING, targetType.renderReadable(), context)
+            }
         }
         return targetType
     }

--- a/plugins/kotlin-dataframe/testData/diagnostics/targetOfCastIsAny.fir.txt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/targetOfCastIsAny.fir.txt
@@ -1,0 +1,6 @@
+FILE: targetOfCastIsAny.kt
+    public final fun box(): R|kotlin/String| {
+        lval df: R|{org/jetbrains/kotlinx/dataframe/AnyFrame=} org/jetbrains/kotlinx/dataframe/DataFrame<*>| = Q|org/jetbrains/kotlinx/dataframe/DataFrame|.R|org/jetbrains/kotlinx/dataframe/DataFrame.Companion.Empty|
+        R|<local>/df|.R|org/jetbrains/kotlinx/dataframe/api/cast|<R|kotlin/Any|>()
+        ^box String(OK)
+    }

--- a/plugins/kotlin-dataframe/testData/diagnostics/targetOfCastIsAny.kt
+++ b/plugins/kotlin-dataframe/testData/diagnostics/targetOfCastIsAny.kt
@@ -1,0 +1,10 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+fun box(): String {
+    val df = DataFrame.Empty
+    df.cast<Any>()
+    return "OK"
+}


### PR DESCRIPTION
Diagnostic creates a bit of noise when i cast to raw dataframe type intentionally.
<img width="1934" height="140" alt="image" src="https://github.com/user-attachments/assets/bb9ff828-adaf-4e36-ad16-26f9634b4c16" />

With this PR, casting to Any no longer triggers a warning