### PR TITLE
[2.5.0-Beta1] [Native] after x64 deprecation def files have changed ^KT-84955

### DIFF
--- a/kotlin-native/platformLibs/src/platform/osx/Hypervisor.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Hypervisor.def
@@ -1,4 +1,4 @@
-depends = Kernel darwin osx posix
+depends = darwin osx posix
 language = Objective-C
 package = platform.Hypervisor
 modules = Hypervisor


### PR DESCRIPTION
Original pull request: https://github.com/JetBrains/kotlin/pull/8022 by @mMaxy