### PR TITLE
Java Direct: resolve a Kotlin class's supertypes on air where needed

### DIFF
--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/declarations/FirJavaClass.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/declarations/FirJavaClass.kt
@@ -149,16 +149,13 @@ class FirJavaClass @FirImplementationDetail internal constructor(
      * dispatcher needs for the binary-Java arm of supertype-walking, **without** going through
      * the lazy [superTypeRefs] enhancement (which is unsafe to read while the symbol's own
      * `SUPER_TYPES` resolution is on the stack.
-     *
-     * Returns an empty list when [javaClass] is null (no AST backing — the FirJavaClass was
-     * built directly with explicit `superTypeRefs` rather than lazily).
      */
-    private val directSupertypeClassIdsCache: List<ClassId> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        val supertypes = javaClass?.supertypes ?: return@lazy emptyList()
-        supertypes.mapNotNull { (it.classifier as? JavaClass)?.classId }
+    private val directSupertypeClassIdsCache: List<ClassId>? by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        val supertypes = javaClass?.supertypes ?: return@lazy null
+        supertypes.map { (it.classifier as? JavaClass)?.classId ?: return@lazy null }
     }
 
-    fun directSupertypeClassIds(): List<ClassId> = directSupertypeClassIdsCache
+    fun directSupertypeClassIds(): List<ClassId>? = directSupertypeClassIdsCache
 
     // returns original visibility to avoid triggering status transformers application
     // NB: according to the assertions in the [applyStatusTransformerExtensions] the transformers should not change the visibility

--- a/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/FirBackedJavaClassAdapter.kt
+++ b/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/FirBackedJavaClassAdapter.kt
@@ -14,16 +14,11 @@ import org.jetbrains.kotlin.fir.declarations.FirOuterClassTypeParameterRef
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirTypeParameterRef
 import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
-import org.jetbrains.kotlin.fir.resolve.ScopeSession
-import org.jetbrains.kotlin.fir.resolve.providers.firProvider
-import org.jetbrains.kotlin.fir.resolve.transformers.FirSupertypeResolverVisitor
-import org.jetbrains.kotlin.fir.resolve.transformers.SupertypeComputationSession
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.java.direct.model.FirBackedJavaClassifierType
 import org.jetbrains.kotlin.load.java.structure.JavaAnnotation
 import org.jetbrains.kotlin.load.java.structure.JavaClass
@@ -121,20 +116,16 @@ internal class FirBackedJavaClassAdapter(
         }
 
     /**
-     * Resolved supertype chain, mirroring `FirJavaElementFinder.resolveSupertypesOnAir`: prefer
-     * already-resolved `superTypeRefs`, otherwise resolve on-air. Each cone type is exposed as a
+     * Resolved supertype chain, read through [supertypeRefsForJavaResolution] — the same
+     * prefer-resolved-then-on-air answer the resolution side uses. Each cone type is exposed as a
      * [FirBackedJavaClassifierType] so its arguments can be read back. Guarded by
      * [cycleGuardedSupertypeWalk]; symbol resolution funnels through [cycleSafeClassLikeSymbol].
      */
     override val supertypes: Collection<JavaClassifierType> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val fir = firRegularClass ?: return@lazy emptyList()
         session.cycleGuardedSupertypeWalk(resolvedClassId, default = emptyList()) {
-            val refs = if (fir.superTypeRefs.all { it is FirResolvedTypeRef }) {
-                fir.superTypeRefs
-            } else {
-                fir.resolveSupertypesOnAir(session)
-            }
-            refs.mapNotNull { (it as? FirResolvedTypeRef)?.coneType as? ConeClassLikeType }
+            fir.supertypeRefsForJavaResolution(session)
+                .mapNotNull { (it as? FirResolvedTypeRef)?.coneType as? ConeClassLikeType }
                 .map { FirBackedJavaClassifierType(it, session) }
         }
     }
@@ -228,18 +219,6 @@ internal class FirBackedJavaTypeParameter(
 
     override fun hashCode(): Int = firTypeParameterSymbol.hashCode()
     override fun toString(): String = "FirBackedJavaTypeParameter(${firTypeParameterSymbol.name})"
-}
-
-/**
- * Resolves this class's supertypes on-air with a fresh, throwaway [SupertypeComputationSession]
- * and [ScopeSession] against the shared, long-lived [session]. Mirrors
- * `FirJavaElementFinder.resolveSupertypesOnAir`.
- */
-private fun FirRegularClass.resolveSupertypesOnAir(session: FirSession): List<FirTypeRef> {
-    val visitor = FirSupertypeResolverVisitor(session, SupertypeComputationSession(), ScopeSession())
-    return visitor.withFile(session.firProvider.getFirClassifierContainerFile(this.symbol)) {
-        visitor.resolveSpecificClassLikeSupertypes(this, superTypeRefs, resolveRecursively = true)
-    }
 }
 
 /**

--- a/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/JavaModelSessionAccess.kt
+++ b/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/JavaModelSessionAccess.kt
@@ -16,10 +16,16 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirVarargArgumentsExpression
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
+import org.jetbrains.kotlin.fir.resolve.ScopeSession
 import org.jetbrains.kotlin.fir.resolve.providers.FirProvider
 import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProvider
+import org.jetbrains.kotlin.fir.resolve.providers.firProvider
+import org.jetbrains.kotlin.fir.resolve.transformers.FirSupertypeResolverVisitor
+import org.jetbrains.kotlin.fir.resolve.transformers.SupertypeComputationSession
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.name.ClassId
@@ -125,6 +131,15 @@ internal fun <R> FirSession.cycleGuardedSupertypeWalk(classId: ClassId, default:
     }
 }
 
+internal fun FirRegularClass.supertypeRefsForJavaResolution(session: FirSession): List<FirTypeRef> {
+    if (superTypeRefs.all { it is FirResolvedTypeRef }) return superTypeRefs
+    val containingFile = session.firProvider.getFirClassifierContainerFileIfAny(symbol) ?: return superTypeRefs
+    val visitor = FirSupertypeResolverVisitor(session, SupertypeComputationSession(), ScopeSession())
+    return visitor.withFile(containingFile) {
+        visitor.resolveSpecificClassLikeSupertypes(this, superTypeRefs, resolveRecursively = true)
+    }
+}
+
 /**
  * Per-session `ClassId -> List<ClassId>` cache of resolved direct-supertype `ClassId`s for
  * [directSupertypeClassIds]. A class's direct supertypes are a pure function of the class and
@@ -147,20 +162,15 @@ internal fun FirSession.registerJavaModelDirectSupertypeCacheIfAbsent() {
     }
 }
 
-/**
- * Memoizes [compute] per [classId] on the session. Only non-empty results are cached: an empty
- * result is what the cycle guards return for an in-flight [classId], so caching it could pin a
- * transient empty over a class that does have supertypes; recomputing an empty result is cheap.
- */
 internal fun FirSession.memoizedDirectSupertypeClassIds(
     classId: ClassId,
-    compute: () -> List<ClassId>,
+    compute: () -> List<ClassId>?,
 ): List<ClassId> {
-    val cache = javaModelDirectSupertypeCache?.classIdToSupertypes ?: return compute()
+    val cache = javaModelDirectSupertypeCache?.classIdToSupertypes ?: return compute().orEmpty()
     cache[classId]?.let { return it }
     val result = compute()
-    if (result.isNotEmpty()) cache[classId] = result
-    return result
+    if (result != null) cache[classId] = result
+    return result.orEmpty()
 }
 
 /**

--- a/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/JavaTypeResolver.kt
+++ b/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/JavaTypeResolver.kt
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
-import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.diagnostics.ConeSimpleDiagnostic
 import org.jetbrains.kotlin.fir.diagnostics.DiagnosticKind
 import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
@@ -19,7 +18,6 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirTypeAliasSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirTypeParameterSymbol
-import org.jetbrains.kotlin.fir.symbols.lazyResolveToPhase
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.java.direct.model.FirBackedJavaClassifierType
 import org.jetbrains.kotlin.java.direct.model.firBackedJavaType
@@ -540,18 +538,12 @@ private fun substituteTypeArgs(
  * Java-side supertype cycles terminate cleanly, and memoized per session. The memoization is
  * essential, not an optimization: the source arm re-enters resolution via `.classifier`, so
  * transitive walks would otherwise re-resolve ancestors exponentially.
- *
- *  1. **Source Java** — walk `JavaClass.supertypes` from the AST (no FIR phase involved).
- *  2. **Binary Java** — read the pre-resolved [FirJavaClass.directSupertypeClassIds] cache
- *     (never triggers the lazy enhancement).
- *  3. **Kotlin / built-in / deserialized** — `lazyResolveToPhase(SUPER_TYPES)`; cycles here are
- *     bounded by FIR's own `SupertypeComputationStatus.Computing` sentinel.
  */
 @OptIn(SymbolInternals::class)
 context(c: JavaResolutionContext)
 internal fun directSupertypeClassIds(classId: ClassId): List<ClassId> =
     c.fileContext.session.memoizedDirectSupertypeClassIds(classId) {
-        c.fileContext.session.cycleGuardedSupertypeWalk(classId, default = emptyList()) {
+        c.fileContext.session.cycleGuardedSupertypeWalk(classId, default = null) {
             // 1. Source Java arm.
             val finder = c.fileContext.classFinder
             if (finder != null && finder.isClassInIndex(classId)) {
@@ -561,8 +553,10 @@ internal fun directSupertypeClassIds(classId: ClassId): List<ClassId> =
                 }
             }
 
-            val symbol = c.fileContext.session.cycleSafeClassLikeSymbol(classId) ?: return@cycleGuardedSupertypeWalk emptyList()
-            val firClass = symbol.fir as? FirRegularClass ?: return@cycleGuardedSupertypeWalk emptyList()
+            // A missing symbol (no provider, unknown class, or a KT-74097 in-flight break) and a
+            // symbol that is not a class both mean "unknown".
+            val symbol = c.fileContext.session.cycleSafeClassLikeSymbol(classId) ?: return@cycleGuardedSupertypeWalk null
+            val firClass = symbol.fir as? FirRegularClass ?: return@cycleGuardedSupertypeWalk null
 
             // 2. Binary Java arm.
             if (firClass is FirJavaClass) {
@@ -570,9 +564,10 @@ internal fun directSupertypeClassIds(classId: ClassId): List<ClassId> =
             }
 
             // 3. Kotlin / built-in / deserialized arm.
-            symbol.lazyResolveToPhase(FirResolvePhase.SUPER_TYPES)
-            firClass.superTypeRefs.mapNotNull { ref ->
+            firClass.supertypeRefsForJavaResolution(c.fileContext.session).map { ref ->
+                // A ref that stayed unresolved makes this a partial answer, which must not be cached.
                 ((ref as? FirResolvedTypeRef)?.coneType as? ConeClassLikeType)?.lookupTag?.classId
+                    ?: return@cycleGuardedSupertypeWalk null
             }
         }
     }
@@ -582,9 +577,9 @@ internal fun directSupertypeClassIds(classId: ClassId): List<ClassId> =
  * [ClassId]s. Reads the materialised `classifier` field on each [JavaClassifierType] in
  * [JavaClass.supertypes], which is reliable for every reference (cross-file too).
  */
-private fun resolveSupertypeNames(enclosing: JavaClass): List<ClassId> =
-    enclosing.supertypes.mapNotNull { supertype ->
-        (supertype.classifier as? JavaClass)?.classId
+private fun resolveSupertypeNames(enclosing: JavaClass): List<ClassId>? =
+    enclosing.supertypes.map { supertype ->
+        (supertype.classifier as? JavaClass)?.classId ?: return null
     }
 
 /**

--- a/compiler/testData/diagnostics/tests/jvm/javaDirect/inheritedNestedClassThroughKotlinSupertype.kt
+++ b/compiler/testData/diagnostics/tests/jvm/javaDirect/inheritedNestedClassThroughKotlinSupertype.kt
@@ -1,0 +1,32 @@
+// RUN_PIPELINE_TILL: FRONTEND
+
+// FILE: a/JBase.java
+package a;
+
+public class JBase {
+    public static class Nested {
+        public int fromBase() { return 1; }
+    }
+}
+
+// FILE: a/J.java
+package a;
+
+public class J extends K {
+    public static class Inner extends Nested {
+    }
+}
+
+// FILE: main.kt
+package a
+
+class KotlinSub : J.Inner()
+
+fun test(inner: J.Inner) = inner.fromBase()
+
+// FILE: kotlinLink.kt
+package a
+
+open class K : JBase()
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, javaType */

--- a/compiler/testData/diagnostics/tests/jvm/javaDirect/protectedInheritedNestedClassThroughKotlinSupertype.kt
+++ b/compiler/testData/diagnostics/tests/jvm/javaDirect/protectedInheritedNestedClassThroughKotlinSupertype.kt
@@ -1,0 +1,41 @@
+// RUN_PIPELINE_TILL: FRONTEND
+
+// FILE: a/JBase.java
+package a;
+
+public class JBase {
+    protected static class Nested {
+        public int fromBase() { return 1; }
+    }
+}
+
+// FILE: a/JMid.java
+package a;
+
+public class JMid extends JBase {
+}
+
+// FILE: b/J.java
+package b;
+
+import a.JMid;
+import a.K;
+
+public class J extends K {
+    public static class Inner extends JMid.Nested {
+    }
+}
+
+// FILE: main.kt
+package b
+
+class KotlinSub : J.Inner()
+
+fun test(inner: J.Inner) = inner.fromBase()
+
+// FILE: kotlinLink.kt
+package a
+
+open class K : JBase()
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, javaType */


### PR DESCRIPTION
a missing fix in java-direct. See commit message for details.