### PR TITLE
[CODEOWNERS] Add Frontend team to AFU plugin codeowners

### DIFF
--- a/.space/CODEOWNERS
+++ b/.space/CODEOWNERS
@@ -438,7 +438,7 @@
 
 /plugins/allopen/ "Kotlin Frontend"
 /plugins/assign-plugin/ "Kotlin Frontend"
-/plugins/atomicfu/ vsevolod.tolstopyatov@jetbrains.com filipp.zhinkin@jetbrains.com leonid.startsev@jetbrains.com
+/plugins/atomicfu/ vsevolod.tolstopyatov@jetbrains.com filipp.zhinkin@jetbrains.com "Kotlin Frontend"
 /plugins/compose/ "Google Compose"
 /plugins/plugin-sandbox/ "Kotlin Frontend"
 /plugins/jvm-abi-gen/ "Kotlin JVM"


### PR DESCRIPTION
FTR, Filipp remains the main maintainer and owner of the plugin.