### PR TITLE
[stdlib] Add string-specific samples for groupBy and groupByTo

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -914,7 +914,7 @@ public inline fun <R, C : MutableCollection<in R>> CharSequence.flatMapTo(destin
  * 
  * The returned map preserves the entry iteration order of the keys produced from the original char sequence.
  * 
- * @sample samples.collections.Collections.Transformations.groupBy
+ * @sample samples.text.Strings.groupBy
  */
 public inline fun <K> CharSequence.groupBy(keySelector: (Char) -> K): Map<K, List<Char>> {
     return groupByTo(LinkedHashMap<K, MutableList<Char>>(), keySelector)
@@ -927,7 +927,7 @@ public inline fun <K> CharSequence.groupBy(keySelector: (Char) -> K): Map<K, Lis
  * 
  * The returned map preserves the entry iteration order of the keys produced from the original char sequence.
  * 
- * @sample samples.collections.Collections.Transformations.groupByKeysAndValues
+ * @sample samples.text.Strings.groupByKeysAndValues
  */
 public inline fun <K, V> CharSequence.groupBy(keySelector: (Char) -> K, valueTransform: (Char) -> V): Map<K, List<V>> {
     return groupByTo(LinkedHashMap<K, MutableList<V>>(), keySelector, valueTransform)
@@ -939,7 +939,7 @@ public inline fun <K, V> CharSequence.groupBy(keySelector: (Char) -> K, valueTra
  * 
  * @return The [destination] map.
  * 
- * @sample samples.collections.Collections.Transformations.groupBy
+ * @sample samples.text.Strings.groupBy
  */
 @IgnorableReturnValue
 public inline fun <K, M : MutableMap<in K, MutableList<Char>>> CharSequence.groupByTo(destination: M, keySelector: (Char) -> K): M {
@@ -958,7 +958,7 @@ public inline fun <K, M : MutableMap<in K, MutableList<Char>>> CharSequence.grou
  * 
  * @return The [destination] map.
  * 
- * @sample samples.collections.Collections.Transformations.groupByKeysAndValues
+ * @sample samples.text.Strings.groupByKeysAndValues
  */
 @IgnorableReturnValue
 public inline fun <K, V, M : MutableMap<in K, MutableList<V>>> CharSequence.groupByTo(destination: M, keySelector: (Char) -> K, valueTransform: (Char) -> V): M {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -101,6 +101,43 @@ class Strings {
     }
 
     @Sample
+    fun groupBy() {
+        val text = "a1B2c3"
+        val byCategory = text.groupBy { if (it.isDigit()) "digits" else "letters" }
+
+        assertPrints(byCategory, "{letters=[a, B, c], digits=[1, 2, 3]}")
+
+        val destination = mutableMapOf("letters" to mutableListOf('x'))
+        val result = text.groupByTo(destination) { if (it.isDigit()) "digits" else "letters" }
+
+        // Characters are appended to existing groups, and new groups are added as needed.
+        assertPrints(destination, "{letters=[x, a, B, c], digits=[1, 2, 3]}")
+        assertTrue(result === destination)
+    }
+
+    @Sample
+    fun groupByKeysAndValues() {
+        val text = "a1B2c3"
+        val uppercaseByCategory = text.groupBy(
+            keySelector = { if (it.isDigit()) "digits" else "letters" },
+            valueTransform = { it.uppercase() }
+        )
+
+        assertPrints(uppercaseByCategory, "{letters=[A, B, C], digits=[1, 2, 3]}")
+
+        val destination = mutableMapOf("letters" to mutableListOf("X"))
+        val result = text.groupByTo(
+            destination,
+            keySelector = { if (it.isDigit()) "digits" else "letters" },
+            valueTransform = { it.uppercase() }
+        )
+
+        // The destination contains the transformed strings rather than the original characters.
+        assertPrints(destination, "{letters=[X, A, B, C], digits=[1, 2, 3]}")
+        assertTrue(result === destination)
+    }
+
+    @Sample
     fun elementAt() {
         val string = "kotlin"
         assertPrints(string.elementAt(0), "k")

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Mapping.kt
@@ -504,6 +504,9 @@ object Mapping : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Collections.Transformations.groupBy")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.groupBy")
+        }
         sequenceClassification(terminal)
         typeParam("K")
         returns("Map<K, List<T>>")
@@ -528,6 +531,9 @@ object Mapping : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Collections.Transformations.groupBy")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.groupBy")
+        }
         annotation("@IgnorableReturnValue")
         sequenceClassification(terminal)
         returns("M")
@@ -560,6 +566,9 @@ object Mapping : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Collections.Transformations.groupByKeysAndValues")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.groupByKeysAndValues")
+        }
         sequenceClassification(terminal)
         typeParam("K")
         typeParam("V")
@@ -589,6 +598,9 @@ object Mapping : TemplateGroupBase() {
             """
         }
         sample("samples.collections.Collections.Transformations.groupByKeysAndValues")
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.groupByKeysAndValues")
+        }
         annotation("@IgnorableReturnValue")
         sequenceClassification(terminal)
         returns("M")


### PR DESCRIPTION
The `CharSequence.groupBy` and `groupByTo` documentation currently uses collection samples. Add two string-specific samples covering all four overloads, including value transformation and appending to an existing destination. Update the template references and regenerate `_Strings.kt`.

Part of [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867); this PR covers only the grouping overloads.

Validation: the standard library generator completed successfully, and `:kotlin-stdlib:samples:test --tests 'samples.text.Strings.groupBy*'` passed both tests. `git diff --check` also passed.

AI assistance was used to draft the code and PR description.
