### PR TITLE
[Compose] Drop module wise opt-in on `ObsoleteDescriptorBasedAPI`

### DIFF
--- a/plugins/compose/compiler-hosted/build.gradle.kts
+++ b/plugins/compose/compiler-hosted/build.gradle.kts
@@ -110,7 +110,6 @@ dependencies {
 }
 
 optInToUnsafeDuringIrConstructionAPI()
-optInToObsoleteDescriptorBasedAPI()
 
 kotlin {
     jvmToolchain(8)

--- a/plugins/compose/compiler-hosted/integration-tests/build.gradle.kts
+++ b/plugins/compose/compiler-hosted/integration-tests/build.gradle.kts
@@ -16,8 +16,6 @@ fun DependencyHandler.testImplementationArtifactOnly(dependency: String) {
     }
 }
 
-optInToObsoleteDescriptorBasedAPI()
-
 jvmToolchains {
     jdkVersion = JdkMajorVersion.JDK_11_0
     targetBytecodeVersion = JdkMajorVersion.JDK_11_0

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.IrImplementationDetail
 import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -163,10 +164,12 @@ class ClassStabilityTransformer(
             stableExpr = if (externalParameters)
                 irConst(UNSTABLE)
             else
+                @OptIn(ObsoleteDescriptorBasedAPI::class)
                 stability.irStableExpression(
                     resolve = { irConst(STABLE) },
                     reportUnknownStability = { unstableClassesWarning?.add(it.descriptor) }) ?: irConst(UNSTABLE)
         } else {
+            @OptIn(ObsoleteDescriptorBasedAPI::class)
             stableExpr =
                 stability.irStableExpression(reportUnknownStability = { unstableClassesWarning?.add(it.descriptor) }) ?: irConst(UNSTABLE)
             if (stability.knownStable()) {


### PR DESCRIPTION
There are just two known places where this opt-in is needed. It is better to put explicit annotation.

#KT-89310
#KT-89311