### PR TITLE
[Wasm, Stdlib, Tests] Enable assertions (^KT-89315)

### DIFF
--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -864,6 +864,7 @@ tasks {
         }
         named("compileTestDevelopmentExecutableKotlinWasm$wasmTarget", KotlinJsIrLink::class) {
             compilerOptions.freeCompilerArgs.add("-Xwasm-enable-array-range-checks")
+            compilerOptions.freeCompilerArgs.add("-Xwasm-enable-asserts")
         }
         named("compileTestProductionExecutableKotlinWasm$wasmTarget", KotlinJsIrLink::class) {
             enabled = false  // Causes out-of-memory in CI: KTI-2150


### PR DESCRIPTION
By adding `-Xwasm-enable-asserts` to the standard library test config.

^KT-89315 Fixed