### PR TITLE
[K/N][perf] Mute volatile benchmarks

### DIFF
--- a/kotlin-native/performance/cinterop/src/nativeMain/kotlin/org/jetbrains/cinteropBenchmarks/typesBenchmark.kt
+++ b/kotlin-native/performance/cinterop/src/nativeMain/kotlin/org/jetbrains/cinteropBenchmarks/typesBenchmark.kt
@@ -117,7 +117,8 @@ class IntBenchmarkHideName : SkipWhenBaseOnly() {
     val size = 20
     val array = Array<Int>(size, { (0 until size).random() })
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun int(bh: Blackhole) {
         skipWhenBaseOnly()
         var result = 0.0
@@ -143,7 +144,8 @@ class BoxedIntBenchmarkHideName : SkipWhenBaseOnly() {
         }
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun boxedInt(bh: Blackhole) {
         skipWhenBaseOnly()
         var result = 0.0

--- a/kotlin-native/performance/logging/src/commonMain/kotlin/main.kt
+++ b/kotlin-native/performance/logging/src/commonMain/kotlin/main.kt
@@ -21,7 +21,8 @@ private const val BENCHMARK_SIZE = 10000
 @State(Scope.Benchmark)
 @Measurement(time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
 class LoopHideName {
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun Loop(bh: Blackhole) {
         for (i in 0..BENCHMARK_SIZE) {
             bh.consume(i)

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/CallsBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/CallsBenchmark.kt
@@ -176,7 +176,8 @@ class Calls : SkipWhenBaseOnly() {
         bh.consume(x)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun openMethodMonomorphic(bh: Blackhole) {
         var x = 0
         // TODO: optimize fields accesses
@@ -215,7 +216,8 @@ class Calls : SkipWhenBaseOnly() {
         bh.consume(x)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun interfaceMethodMonomorphic(bh: Blackhole) {
         var x = 0
         // TODO: optimize fields accesses

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/ClassListBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/ClassListBenchmark.kt
@@ -40,7 +40,8 @@ class ClassList : SkipWhenBaseOnly() {
         bh.consume(data.toList())
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun copyManual(bh: Blackhole) {
         skipWhenBaseOnly()
         val list = ArrayList<Value>(data.size)
@@ -68,7 +69,8 @@ class ClassList : SkipWhenBaseOnly() {
         bh.consume(data.filter { it.value % 2 == 0 })
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun mapWithLambda(bh: Blackhole) {
         bh.consume(data.map { it.toString() })
     }

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/ForLoopsBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/ForLoopsBenchmark.kt
@@ -52,7 +52,8 @@ class ForLoops : SkipWhenBaseOnly() {
         bh.consume(sum)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun intArrayLoop(bh: Blackhole) {
         skipWhenBaseOnly()
         var sum = 0L
@@ -62,7 +63,8 @@ class ForLoops : SkipWhenBaseOnly() {
         bh.consume(sum)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun charArrayLoop(bh: Blackhole) {
         skipWhenBaseOnly()
         var sum = 0L

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/InheritanceBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/InheritanceBenchmark.kt
@@ -495,7 +495,8 @@ class Inheritance {
     val f = F()
     val g = G()
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun baseCalls(bh: Blackhole) {
         var x = 0
         for (i in 0 until RUNS) {

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/IntBaselineBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/IntBaselineBenchmark.kt
@@ -40,14 +40,16 @@ class IntBaseline : SkipWhenBaseOnly() {
         bh.consume(list)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun allocateArray(bh: Blackhole) {
         skipWhenBaseOnly()
         val list = IntArray(BENCHMARK_SIZE)
         bh.consume(list)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun allocateListAndFill(bh: Blackhole) {
         skipWhenBaseOnly()
         val list = ArrayList<Int>(BENCHMARK_SIZE)

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/IntListBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/IntListBenchmark.kt
@@ -41,7 +41,8 @@ class IntList : SkipWhenBaseOnly() {
         bh.consume(data.toList())
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun copyManual(bh: Blackhole) {
         skipWhenBaseOnly()
         val list = ArrayList<Int>(data.size)

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/LinkedListWithAtomicsBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/LinkedListWithAtomicsBenchmark.kt
@@ -106,7 +106,8 @@ class LinkedListWithAtomicsBenchmarkHideName {
         }
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun LinkedListWithAtomicsBenchmark(bh: Blackhole) {
         bh.consume(ensureNext())
     }

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/LoopBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/LoopBenchmark.kt
@@ -44,7 +44,8 @@ class Loop : SkipWhenBaseOnly() {
         bh.consume(result)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun arrayIndexLoop(bh: Blackhole) {
         skipWhenBaseOnly()
         var result = 0
@@ -73,7 +74,8 @@ class Loop : SkipWhenBaseOnly() {
         bh.consume(result)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun arrayWhileLoop(bh: Blackhole) {
         var result = 0
         var i = 0

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/PrimeListBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/PrimeListBenchmark.kt
@@ -52,7 +52,8 @@ class PrimeList {
         bh.consume(primes)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun calcEratosthenes(bh: Blackhole) {
         primes.clear()
         primes.addAll(2..BENCHMARK_SIZE)

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/SingletonBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/SingletonBenchmark.kt
@@ -26,7 +26,8 @@ class Singleton {
         A.a
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun access(bh: Blackhole) {
         var result = 0
         for (i in 0 until BENCHMARK_SIZE) {

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/SubListBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/SubListBenchmark.kt
@@ -46,7 +46,8 @@ class SubList : SkipWhenBaseOnly() {
         bh.consume(getData(false) + getData(true))
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun concatenateManual(bh: Blackhole) {
         skipWhenBaseOnly()
         val list = ArrayList<Value>(2 * BENCHMARK_SIZE)

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/SwitchBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/SwitchBenchmark.kt
@@ -484,7 +484,8 @@ class Switch : SkipWhenBaseOnly() {
 
 
 
-    @Benchmark 
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun testSparseIntSwitch(bh: Blackhole) {
         skipWhenBaseOnly()
         var result = 0
@@ -524,7 +525,8 @@ class Switch : SkipWhenBaseOnly() {
         bh.consume(result)
     }
 
-    @Benchmark 
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun testVarSwitch(bh: Blackhole) {
         skipWhenBaseOnly()
         var result = 0
@@ -693,7 +695,8 @@ class Switch : SkipWhenBaseOnly() {
         }
 
 
-    @Benchmark 
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun testSealedWhenSwitch(bh: Blackhole) {
         val n = sealedClassData.size -1
         var result = 0

--- a/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/WeakRefBenchmark.kt
+++ b/kotlin-native/performance/ring/src/commonMain/kotlin/org/jetbrains/ring/WeakRefBenchmark.kt
@@ -70,14 +70,16 @@ class WeakRefBenchmark : SkipWhenBaseOnly() {
     }
 
     // Access alive reference.
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun aliveReference(bh: Blackhole) {
         skipWhenBaseOnly()
         bh.consume(aliveRef.stress())
     }
 
     // Access dead reference.
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun deadReference(bh: Blackhole) {
         skipWhenBaseOnly()
         bh.consume(deadRef.stress())

--- a/kotlin-native/performance/startup/src/commonMain/kotlin/org/jetbrains/startup/SingletonInitBenchmark.kt
+++ b/kotlin-native/performance/startup/src/commonMain/kotlin/org/jetbrains/startup/SingletonInitBenchmark.kt
@@ -1019,7 +1019,8 @@ private var singletonInitializeNestedRun = false
 // These benchmarks should not be repeated within a single process.
 @Measurement(time = 1, timeUnit = BenchmarkTimeUnit.NANOSECONDS)
 class Singleton {
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun initialize(bh: Blackhole) {
         if (singletonInitializeRun) {
             error("Function singletonInitialize can be called only once.")
@@ -1532,7 +1533,8 @@ class Singleton {
         bh.consume(total)
     }
 
-    @Benchmark
+    // TODO(KT-86736): Volatile benchmark; try to stabilize
+    // @Benchmark
     fun initializeNested(bh: Blackhole) {
         if (singletonInitializeNestedRun) {
             error("Function singletonInitializeNested can be called only once.")


### PR DESCRIPTION
A number of benchmarks are currently volatile and just result in a lot of noise. It's better to mute them.

Proper stabilization can be done in the scope of KT-86736.

^KT-89258