### PR TITLE
[NI] Clean up runtime warnings

### DIFF
--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -161,6 +161,7 @@ val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
         "-H:+UnlockExperimentalVMOptions",
         "-H:+AllowJRTFileSystem",
         "--enable-native-access=ALL-UNNAMED",
+        "--sun-misc-unsafe-memory-access=allow",
         "--add-opens", "java.base/java.lang=ALL-UNNAMED",
         "--add-opens", "java.base/java.io=ALL-UNNAMED",
         "--add-opens", "java.base/java.nio=ALL-UNNAMED",

--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -160,6 +160,7 @@ val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
         "-H:+AddAllCharsets",
         "-H:+UnlockExperimentalVMOptions",
         "-H:+AllowJRTFileSystem",
+        "--enable-native-access=ALL-UNNAMED",
         "--add-opens", "java.base/java.lang=ALL-UNNAMED",
         "--add-opens", "java.base/java.io=ALL-UNNAMED",
         "--add-opens", "java.base/java.nio=ALL-UNNAMED",


### PR DESCRIPTION
Remove the warnings about access to `java.lang.System::load` and `sun.misc.Unsafe::invokeCleaner` by explicitly allowing them.

^[KT-89308](https://youtrack.jetbrains.com/issue/KT-89308) Fixed
^[KT-89319](https://youtrack.jetbrains.com/issue/KT-89319) Fixed