### PR TITLE
KAPT: Get rid of 'compile' mode

### DIFF
--- a/plugins/kapt/kapt-base/src/org/jetbrains/kotlin/kapt/base/KaptOptions.kt
+++ b/plugins/kapt/kapt-base/src/org/jetbrains/kotlin/kapt/base/KaptOptions.kt
@@ -73,7 +73,7 @@ class KaptOptions(
         // Initialize this set with the flags that are enabled by default. This set may be changed later (with flags added or removed).
         val flags: MutableSet<KaptFlag> = KaptFlag.entries.filter { it.defaultValue }.toMutableSet()
 
-        var mode: AptMode = AptMode.WITH_COMPILATION
+        var mode: AptMode = AptMode.STUBS_AND_APT
         var detectMemoryLeaks: DetectMemoryLeaksMode = DetectMemoryLeaksMode.DEFAULT
         var stubGenerationScheme: StubGenerationScheme = StubGenerationScheme.JTREE
         var processorsStatsReportFile: File? = null
@@ -142,7 +142,6 @@ enum class StubGenerationScheme(override val stringValue: String) : KaptSelector
 }
 
 enum class AptMode(override val stringValue: String) : KaptSelector {
-    WITH_COMPILATION("compile"),
     STUBS_AND_APT("stubsAndApt"),
     STUBS_ONLY("stubs"),
     APT_ONLY("apt");

--- a/plugins/kapt/kapt-cli/src/KaptCli.kt
+++ b/plugins/kapt/kapt-cli/src/KaptCli.kt
@@ -116,11 +116,7 @@ private fun transformKaptToolArgs(args: List<String>, messageCollector: MessageC
     }
 
     if (!aptModePassed) {
-        val isK2 = "-Xuse-k2-kapt=false" !in transformed && transformed.none { it.startsWith("-language-version=1") } &&
-                transformed.lastIndexOf("-language-version").takeIf { it >= 0 }
-                    ?.let { transformed.getOrNull(it + 1)?.startsWith('1') } != true
-
-        transformed.addAll(0, kaptArg(KaptCliOption.APT_MODE_OPTION, if (isK2) "stubsAndApt" else "compile"))
+        transformed.addAll(0, kaptArg(KaptCliOption.APT_MODE_OPTION, "stubsAndApt"))
     }
 
     if (!isTest && !isAtLeastJava9() && !areJavacComponentsAvailable() && !toolsJarPassed) {

--- a/plugins/kapt/kapt-cli/src/KaptCliOption.kt
+++ b/plugins/kapt/kapt-cli/src/KaptCliOption.kt
@@ -38,8 +38,8 @@ enum class KaptCliOption(
     val cliToolOption: CliToolOption? = null
 ) : AbstractCliOption {
     APT_MODE_OPTION(
-        "aptMode", "<apt|stubs|stubsAndApt|compile>",
-        "Annotation processing mode: only apt, only stub generation, both, or with the subsequent compilation",
+        "aptMode", "<apt|stubs|stubsAndApt>",
+        "Annotation processing mode: only apt, only stub generation, or both",
         cliToolOption = CliToolOption("-Kapt-mode", VALUE)
     ),
 

--- a/plugins/kapt/kapt-cli/testData/argumentParsing/oldLanguageVersion.txt
+++ b/plugins/kapt/kapt-cli/testData/argumentParsing/oldLanguageVersion.txt
@@ -1,0 +1,11 @@
+# before
+-language-version
+1.9
+Test.kt
+
+# after
+-P
+plugin:org.jetbrains.kotlin.kapt3:aptMode=stubsAndApt
+-language-version
+1.9
+Test.kt

--- a/plugins/kapt/kapt-cli/testData/integration/compileModeUnsupported/build.txt
+++ b/plugins/kapt/kapt-cli/testData/integration/compileModeUnsupported/build.txt
@@ -6,4 +6,4 @@
 # after
 Return code: 1
 
-error: [kapt] KAPT "compile" mode is not supported in Kotlin 2.x. Run kapt with -Kapt-mode=stubsAndApt and use kotlinc for the final compilation step.
+error: unknown value compile for option aptMode

--- a/plugins/kapt/kapt-cli/tests-gen/org/jetbrains/kotlin/kapt/cli/test/ArgumentParsingTestGenerated.java
+++ b/plugins/kapt/kapt-cli/tests-gen/org/jetbrains/kotlin/kapt/cli/test/ArgumentParsingTestGenerated.java
@@ -52,6 +52,12 @@ public class ArgumentParsingTestGenerated extends AbstractArgumentParsingTest {
   }
 
   @Test
+  @TestMetadata("oldLanguageVersion.txt")
+  public void testOldLanguageVersion() {
+    run("oldLanguageVersion.txt");
+  }
+
+  @Test
   @TestMetadata("simple.txt")
   public void testSimple() {
     run("simple.txt");

--- a/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/FirKaptAnalysisHandlerExtension.kt
+++ b/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/FirKaptAnalysisHandlerExtension.kt
@@ -57,11 +57,6 @@ open class FirKaptAnalysisHandlerExtension(
             configuration,
         )
 
-        if (optionsBuilder.mode == AptMode.WITH_COMPILATION) {
-            logger.error("KAPT \"compile\" mode is not supported in Kotlin 2.x. Run kapt with -Kapt-mode=stubsAndApt and use kotlinc for the final compilation step.")
-            return false
-        }
-
         optionsBuilder.apply {
             projectBaseDir = projectBaseDir ?: project.basePath?.let(::File)
             val contentRoots = configuration.contentRoots


### PR DESCRIPTION
It was never documented, it does not work in K2 KAPT, it contradicts Gradle task model
 #KT-87758