### PR TITLE
[JVM] Reuse stateless lambdas after inline regeneration

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/AnonymousObjectTransformer.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.codegen.coroutines.isCoroutineSuperClass
 import org.jetbrains.kotlin.codegen.inline.coroutines.CoroutineTransformer
 import org.jetbrains.kotlin.codegen.inline.coroutines.FOR_INLINE_SUFFIX
 import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.load.kotlin.FileBasedKotlinClass
 import org.jetbrains.kotlin.load.kotlin.header.KotlinClassHeader
@@ -23,6 +24,7 @@ import org.jetbrains.kotlin.protobuf.MessageLite
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.kotlin.util.toMetadataVersion
 import org.jetbrains.org.objectweb.asm.*
+import org.jetbrains.org.objectweb.asm.commons.InstructionAdapter
 import org.jetbrains.org.objectweb.asm.commons.Method
 import org.jetbrains.org.objectweb.asm.tree.*
 import java.util.*
@@ -142,6 +144,12 @@ class AnonymousObjectTransformer(
 
         generateConstructorAndFields(classBuilder, constructorParamBuilder, parentRemapper)
 
+        if (header?.kind == KotlinClassHeader.Kind.SYNTHETIC_CLASS) {
+            transformationInfo.computeLambdaTransformedIntoSingleton()
+        } else {
+            transformationInfo.notLambdaTransformedIntoSingleton()
+        }
+
         val coroutineTransformer = CoroutineTransformer(
             inliningContext,
             classBuilder,
@@ -211,6 +219,9 @@ class AnonymousObjectTransformer(
 
         if (header != null) {
             writeTransformedMetadata(header, classBuilder)
+            if (transformationInfo.isLambdaTransformedIntoSingleton) {
+                synthesizeSingletonMembers(classBuilder)
+            }
         }
 
         // debugMetadataAnnotation can be null in LV < 1.3
@@ -236,6 +247,28 @@ class AnonymousObjectTransformer(
         }
 
         return transformationResult
+    }
+
+    private fun synthesizeSingletonMembers(classBuilder: ClassBuilder) {
+        val internalClassName = transformationInfo.newClassName
+        val classType = Type.getObjectType(internalClassName)
+        classBuilder.newField(
+            null,
+            Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC or Opcodes.ACC_FINAL,
+            JvmAbi.INSTANCE_FIELD,
+            classType.descriptor,
+            null,
+            null
+        )
+        val clinit = classBuilder.newMethod(null, Opcodes.ACC_STATIC, "<clinit>", "()V", null, null)
+        val adapter = InstructionAdapter(clinit)
+        adapter.anew(classType)
+        adapter.dup()
+        adapter.invokespecial(internalClassName, "<init>", "()V", false)
+        adapter.putstatic(internalClassName, JvmAbi.INSTANCE_FIELD, classType.descriptor)
+        adapter.visitInsn(Opcodes.RETURN)
+        adapter.visitMaxs(-1, -1)
+        adapter.visitEnd()
     }
 
     private fun isAccessorOfSkippedCapturedParameter(

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/MethodInliner.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.codegen.inline
 
 import org.jetbrains.kotlin.codegen.*
+import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.codegen.coroutines.withInstructionAdapter
 import org.jetbrains.kotlin.codegen.inline.FieldRemapper.Companion.foldName
 import org.jetbrains.kotlin.codegen.inline.coroutines.CoroutineTransformer
@@ -21,7 +22,6 @@ import org.jetbrains.kotlin.codegen.optimization.nullCheck.isCheckParameterIsNot
 import org.jetbrains.kotlin.codegen.optimization.temporaryVals.TemporaryVariablesEliminationTransformer
 import org.jetbrains.kotlin.codegen.pseudoInsns.PseudoInsn
 import org.jetbrains.kotlin.config.LanguageFeature
-import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes
 import org.jetbrains.kotlin.utils.SmartList
 import org.jetbrains.kotlin.utils.SmartSet
@@ -241,6 +241,17 @@ class MethodInliner(
                     for (classBuilder in childInliningContext.continuationBuilders.values) {
                         classBuilder.done(inliningContext.state.config.generateSmapCopyToAnnotation)
                     }
+                } else if (!transformationInfo!!.wasAlreadyRegenerated) {
+                    result.addNotChangedClass(oldClassName)
+                    (transformationInfo as? AnonymousObjectTransformationInfo)?.notLambdaTransformedIntoSingleton()
+                } else if (transformationInfo is AnonymousObjectTransformationInfo) {
+                    val info = transformationInfo as AnonymousObjectTransformationInfo
+                    val existingInfo = generateSequence(inliningContext) { it.parent }
+                        .mapNotNull { it.transformationInfo as? AnonymousObjectTransformationInfo }
+                        .firstOrNull { it.oldClassName == info.oldClassName }
+                    if (existingInfo != null && existingInfo !== info) {
+                        info.inheritLambdaTransformedIntoSingleton(existingInfo)
+                    }
                 } else {
                     result.addNotChangedClass(oldClassName)
                 }
@@ -249,6 +260,10 @@ class MethodInliner(
             override fun anew(type: Type) {
                 if (isSamWrapper(type.internalName) || isAnonymousClass(type.internalName)) {
                     handleAnonymousObjectRegeneration()
+                    if ((transformationInfo as? AnonymousObjectTransformationInfo)?.isLambdaTransformedIntoSingleton == true) {
+                        super.visitFieldInsn(Opcodes.GETSTATIC, type.internalName, JvmAbi.INSTANCE_FIELD, type.descriptor)
+                        return
+                    }
                 }
 
                 //in case of regenerated transformationInfo type would be remapped to new one via remappingMethodAdapter
@@ -401,18 +416,22 @@ class MethodInliner(
                             as AnonymousObjectTransformationInfo?
                     val info = existingInfo ?: newInfo
                     if (info.shouldRegenerate(isSameModule)) {
-                        for (capturedParamDesc in info.allRecapturedParameters) {
-                            val realDesc = if (existingInfo != null && capturedParamDesc.fieldName == AsmUtil.THIS) {
-                                // The captures in `info` are relative to the parent context, so a normal `this` there
-                                // is a captured outer `this` here.
-                                CapturedParamDesc(Type.getObjectType(owner), AsmUtil.CAPTURED_THIS_FIELD, capturedParamDesc.type)
-                            } else capturedParamDesc
-                            visitFieldInsn(
-                                Opcodes.GETSTATIC, realDesc.containingLambdaName,
-                                foldName(realDesc.fieldName), realDesc.type.descriptor
-                            )
+                        if (info.isLambdaTransformedIntoSingleton) {
+                            visitInsn(Opcodes.POP)
+                        } else {
+                            for (capturedParamDesc in info.allRecapturedParameters) {
+                                val realDesc = if (existingInfo != null && capturedParamDesc.fieldName == AsmUtil.THIS) {
+                                    // The captures in `info` are relative to the parent context, so a normal `this` there
+                                    // is a captured outer `this` here.
+                                    CapturedParamDesc(Type.getObjectType(owner), AsmUtil.CAPTURED_THIS_FIELD, capturedParamDesc.type)
+                                } else capturedParamDesc
+                                visitFieldInsn(
+                                    Opcodes.GETSTATIC, realDesc.containingLambdaName,
+                                    foldName(realDesc.fieldName), realDesc.type.descriptor
+                                )
+                            }
+                            super.visitMethodInsn(opcode, info.oldClassName, name, info.newConstructorDescriptor, itf)
                         }
-                        super.visitMethodInsn(opcode, info.newClassName, name, info.newConstructorDescriptor, itf)
 
                         //TODO: add new inner class also for other contexts
                         if (inliningContext.parent is RegeneratedClassContext) {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TransformationInfo.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/TransformationInfo.kt
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.codegen.inline
 
+import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.tree.FieldInsnNode
 
 interface TransformationInfo {
@@ -25,6 +26,9 @@ interface TransformationInfo {
         get() = nameGenerator.generatorClass
 
     val nameGenerator: NameGenerator
+
+    val wasAlreadyRegenerated: Boolean
+        get() = false
 
     fun shouldRegenerate(sameModule: Boolean): Boolean
 
@@ -39,7 +43,6 @@ class WhenMappingTransformationInfo(
     private val alreadyRegenerated: Boolean,
     val fieldNode: FieldInsnNode
 ) : TransformationInfo {
-
     override val nameGenerator by lazy {
         parentNameGenerator.subGenerator(false, oldClassName.substringAfterLast("/").substringAfterLast(TRANSFORMED_WHEN_MAPPING_MARKER))
     }
@@ -72,6 +75,12 @@ class AnonymousObjectTransformationInfo internal constructor(
     private val capturesAnonymousObjectThatMustBeRegenerated: Boolean = false
 ) : TransformationInfo {
 
+    private var lambdaTransformedIntoSingletonDecider: (() -> Boolean)? = null
+
+    val isLambdaTransformedIntoSingleton: Boolean by lazy {
+        lambdaTransformedIntoSingletonDecider?.invoke() ?: false
+    }
+
     override val nameGenerator by lazy {
         parentNameGenerator.subGenerator(true, null)
     }
@@ -82,13 +91,37 @@ class AnonymousObjectTransformationInfo internal constructor(
 
     lateinit var capturedLambdasToInline: Map<String, LambdaInfo>
 
+    override val wasAlreadyRegenerated: Boolean
+        get() = alreadyRegenerated
+
+    fun notLambdaTransformedIntoSingleton() {
+        lambdaTransformedIntoSingletonDecider = { false }
+    }
+
+    fun inheritLambdaTransformedIntoSingleton(info: AnonymousObjectTransformationInfo) {
+        if (lambdaTransformedIntoSingletonDecider == null) {
+            lambdaTransformedIntoSingletonDecider = { info.isLambdaTransformedIntoSingleton }
+        }
+    }
+
+    fun computeLambdaTransformedIntoSingleton() {
+        lambdaTransformedIntoSingletonDecider = {
+            !wasSingletonOriginally && Type.getArgumentTypes(newConstructorDescriptor).isEmpty()
+        }
+    }
+
+    private val wasSingletonOriginally: Boolean
+        get() = constructorDesc == null
+
     constructor(
         ownerInternalName: String,
         needReification: Boolean,
         alreadyRegenerated: Boolean,
         isStaticOrigin: Boolean,
         nameGenerator: NameGenerator
-    ) : this(ownerInternalName, needReification, hashMapOf(), false, alreadyRegenerated, null, isStaticOrigin, nameGenerator)
+    ) : this(ownerInternalName, needReification, hashMapOf(), false, alreadyRegenerated, null, isStaticOrigin, nameGenerator) {
+        notLambdaTransformedIntoSingleton()
+    }
 
     // TODO: unconditionally regenerating an object if it has previously been regenerated is a hack that works around
     //   the fact that TypeRemapper cannot differentiate between different references to the same object. See the test

--- a/compiler/testData/codegen/boxInline/invokedynamic/sam/crossinlineLambda1.kt
+++ b/compiler/testData/codegen/boxInline/invokedynamic/sam/crossinlineLambda1.kt
@@ -13,8 +13,21 @@ fun interface IFoo {
 
 fun foo(iFoo: IFoo) = iFoo.foo()
 
+fun bar(f: (Array<String>) -> Unit): Any = f
+
+inline fun make(crossinline f: (String) -> Unit): Any = bar { f(it[0]) }
+
 // FILE: 2.kt
-fun box() =
-    cross {
-        foo { "OK" }
-    }.toString()
+private fun getBar() = bar { it.size }
+
+private fun getMake() = make { it.length }
+
+fun box(): String {
+    if (cross { foo { "OK" } }.toString() != "OK") return "Crossinline behavior failed"
+
+    if (getBar() !== getBar()) return "Stateless lambda was not reused"
+    if (getMake() !== getMake()) return "Regenerated stateless lambda was not reused"
+    if (getMake() === make { it.length }) return "Different lambdas were reused"
+
+    return "OK"
+}


### PR DESCRIPTION
When chained bytecode inlining removes all captures from a lambda class,
restore the singleton INSTANCE pattern instead of constructing a new
object at every call site. Track the transformed state across anonymous
object regeneration and preserve distinct instances for distinct lambda
classes.

Detect regenerated lambdas by SYNTHETIC_CLASS metadata kind alone: the IR
backend emits lambda metadata without d1/d2 data for lambdas inside inline
functions, so a data!=null check would never mark them as singletons.
The no-arg constructor check inside the decider already guards against
non-singleton cases.

Regression test: crossinlineLambda1 covers stateless lambda reuse after
inline regeneration and keeps distinct lambdas distinct.

^KT-23168

Continuation of #1577, which was never merged.