### PR TITLE
KT-85687: Add exposed and hidden dependency visibility overrides

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/ExportDslIT.kt
@@ -10,10 +10,13 @@ import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportVisibility
 import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.jetbrains.kotlin.gradle.uklibs.include
+import org.jetbrains.kotlin.gradle.util.SwiftSymbol
+import org.jetbrains.kotlin.gradle.util.assertSwiftModuleSymbols
 import org.jetbrains.kotlin.gradle.util.getNestedList
 import org.jetbrains.kotlin.gradle.util.parseJsonToMap
 import org.jetbrains.kotlin.gradle.util.swiftExportEmbedAndSignEnvVariables
@@ -354,11 +357,206 @@ class ExportDslIT : KGPBaseTest() {
         }
     }
 
+    @DisplayName("A hidden dependency is translated to empty stubs instead of a real Swift API")
+    @GradleTest
+    fun testHiddenDependencyIsTranslatedToStubs(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain {
+                        compileSource(
+                            """
+                            fun makeOne(): com.example.sub.One = com.example.sub.One()
+                            """.trimIndent()
+                        )
+                        dependencies {
+                            // Would be fully exported without the override.
+                            api(project(":sub"))
+                        }
+                    }
+                }
+                export.swift {
+                    moduleName.set("Shared")
+                    xcodeIntegration {
+                        configure(
+                            project.dependencies.project(mapOf("path" to ":sub")),
+                            SwiftExportVisibility.HIDDEN,
+                        )
+                    }
+                }
+            }
+
+            val subproject = project("empty", gradleVersion) {
+                buildScriptInjection {
+                    project.applyMultiplatform {
+                        iosArm64()
+                        sourceSets.commonMain.get().compileSource(
+                            """
+                            package com.example.sub
+                            class One {
+                                fun memberOfHiddenClass(): Int = 42
+                            }
+                            class UnreferencedFromShared
+                            """.trimIndent()
+                        )
+                    }
+                }
+            }
+
+            include(subproject, "sub")
+
+            build(
+                ":$EMBED_SWIFT_EXPORT_TASK_NAME",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
+            ) {
+                assertTasksExecuted(":iosArm64DebugSwiftExport")
+
+                // Hiding doesn't remove the module.
+                val builtProductsDir = projectPath.resolve("build/builtProductsDir")
+                assertDirectoriesExist(builtProductsDir.resolve("Sub.swiftmodule"))
+
+                // `One` is a stub without members; `UnreferencedFromShared` isn't there at all.
+                assertSwiftModuleSymbols(
+                    workingDir = projectPath.toFile(),
+                    moduleName = "Sub",
+                    target = "arm64-apple-ios$IOS_DEPLOYMENT_TARGET",
+                    searchPaths = listOf(builtProductsDir.toFile()),
+                    expectedSymbols = setOf(
+                        SwiftSymbol(
+                            demangledId = "(extension in Sub):ExportedKotlinPackages.com.example.sub.One",
+                            pathComponents = listOf("com", "example", "sub", "One")
+                        ),
+                    )
+                )
+
+                // The declaration referring to the hidden type is still exported.
+                assertSwiftModuleSymbols(
+                    workingDir = projectPath.toFile(),
+                    moduleName = "Shared",
+                    target = "arm64-apple-ios$IOS_DEPLOYMENT_TARGET",
+                    searchPaths = listOf(builtProductsDir.toFile()),
+                    expectedSymbols = setOf(
+                        SwiftSymbol(
+                            demangledId = "Shared.makeOne() -> (extension in Sub):ExportedKotlinPackages.com.example.sub.One",
+                            pathComponents = listOf("makeOne()")
+                        ),
+                    )
+                )
+            }
+        }
+    }
+
+    @DisplayName("An exposed transitive dependency is fully exported under its api-derived name")
+    @GradleTest
+    fun testExposedTransitiveDependencyIsFullyExported(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    sourceSets.commonMain {
+                        compileSource(
+                            """
+                            fun makeOne(): com.example.sub.One = com.example.sub.One()
+                            """.trimIndent()
+                        )
+                        dependencies {
+                            // Only transitively exported by default.
+                            implementation(project(":sub"))
+                        }
+                    }
+                }
+                export.swift {
+                    moduleName.set("Shared")
+                    xcodeIntegration {
+                        configure(
+                            project.dependencies.project(mapOf("path" to ":sub")),
+                            SwiftExportVisibility.EXPOSED,
+                        )
+                    }
+                }
+            }
+
+            val subproject = project("empty", gradleVersion) {
+                buildScriptInjection {
+                    project.applyMultiplatform {
+                        iosArm64()
+                        sourceSets.commonMain.get().compileSource(
+                            """
+                            package com.example.sub
+                            class One
+                            class TwoNeverReferenced
+                            """.trimIndent()
+                        )
+                    }
+                }
+            }
+
+            include(subproject, "sub")
+
+            build(
+                ":$EMBED_SWIFT_EXPORT_TASK_NAME",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
+            ) {
+                assertTasksExecuted(":iosArm64DebugSwiftExport")
+
+                // Named from the project path, as with `api(project(":sub"))`.
+                val builtProductsDir = projectPath.resolve("build/builtProductsDir")
+                assertDirectoriesExist(builtProductsDir.resolve("Sub.swiftmodule"))
+
+                // Full export, so the unreferenced class is there too.
+                assertSwiftModuleSymbols(
+                    workingDir = projectPath.toFile(),
+                    moduleName = "Sub",
+                    target = "arm64-apple-ios$IOS_DEPLOYMENT_TARGET",
+                    searchPaths = listOf(builtProductsDir.toFile()),
+                    expectedSymbols = setOf(
+                        SwiftSymbol(
+                            demangledId = "(extension in Sub):ExportedKotlinPackages.com.example.sub.One",
+                            pathComponents = listOf("com", "example", "sub", "One")
+                        ),
+                        SwiftSymbol(
+                            demangledId = "(extension in Sub):ExportedKotlinPackages.com.example.sub.One.init() -> (extension in Sub):ExportedKotlinPackages.com.example.sub.One",
+                            pathComponents = listOf("com", "example", "sub", "One", "init()")
+                        ),
+                        SwiftSymbol(
+                            demangledId = "(extension in Sub):ExportedKotlinPackages.com.example.sub.TwoNeverReferenced",
+                            pathComponents = listOf("com", "example", "sub", "TwoNeverReferenced")
+                        ),
+                        SwiftSymbol(
+                            demangledId = "(extension in Sub):ExportedKotlinPackages.com.example.sub.TwoNeverReferenced.init() -> (extension in Sub):ExportedKotlinPackages.com.example.sub.TwoNeverReferenced",
+                            pathComponents = listOf("com", "example", "sub", "TwoNeverReferenced", "init()")
+                        ),
+                    )
+                )
+            }
+        }
+    }
+
     private fun TestProject.isEmbedSwiftExportTaskRegistered(): Boolean = buildScriptReturn {
         project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME) != null
     }.buildAndReturn()
 
     private companion object {
         const val EMBED_SWIFT_EXPORT_TASK_NAME = "embedSwiftExportForXcode"
+        const val IOS_DEPLOYMENT_TARGET = "18.0"
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -1919,15 +1919,27 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/Sw
 	public abstract fun xcodeIntegration (Lorg/gradle/api/Action;)V
 }
 
+public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportDependencyOptionsDsl : org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportModuleOptionsDsl {
+	public abstract fun getVisibility ()Lorg/gradle/api/provider/Property;
+}
+
 public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportIntegration {
 	public abstract fun configure (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun configure (Ljava/lang/Object;Lorg/gradle/api/Action;)V
+	public abstract fun configure (Ljava/lang/Object;Lorg/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility;)V
 	public abstract fun getSettings ()Lorg/gradle/api/provider/MapProperty;
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportModuleOptionsDsl {
 	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getRootPackage ()Lorg/gradle/api/provider/Property;
+}
+
+public final class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility : java/lang/Enum {
+	public static final field EXPOSED Lorg/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility;
+	public static final field HIDDEN Lorg/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility;
+	public static fun values ()[Lorg/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility;
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportXcodeIntegration : org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportIntegration {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportAction.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.swiftexport.standalone.*
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
+import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleExportMode
 import java.time.Instant
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -44,7 +45,7 @@ internal abstract class SwiftExportAction : WorkAction<SwiftExportAction.SwiftEx
                 module.toInputModule(
                     createModuleConfig(
                         module.flattenPackage,
-                        module.shouldBeFullyExported,
+                        module.exportMode,
                         settings
                     )
                 )
@@ -62,14 +63,18 @@ internal abstract class SwiftExportAction : WorkAction<SwiftExportAction.SwiftEx
 
     private fun createModuleConfig(
         flattenPackage: String?,
-        shouldBeFullyExported: Boolean,
+        exportMode: SwiftExportedModuleMode,
         settings: Map<String, String>,
     ): SwiftModuleConfig {
         return SwiftModuleConfig(
             bridgeModuleName = parameters.bridgeModuleName.getOrElse(SwiftModuleConfig.DEFAULT_BRIDGE_MODULE_NAME),
             rootPackage = flattenPackage,
             experimentalFeatures = settings,
-            shouldBeFullyExported = shouldBeFullyExported,
+            exportMode = when (exportMode) {
+                SwiftExportedModuleMode.FULL -> SwiftModuleExportMode.Full
+                SwiftExportedModuleMode.TRANSITIVE -> SwiftModuleExportMode.Transitive
+                SwiftExportedModuleMode.HIDDEN -> SwiftModuleExportMode.Excluded
+            },
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
@@ -121,13 +122,23 @@ private class ResolvedArtifactWithVersionIdentifier(
     }
 
     fun defaultExportedModuleName(): String {
-        return when (val componentId = artifact.id.componentIdentifier) {
-            is ProjectComponentIdentifier -> componentId.projectPath
-            is ModuleComponentIdentifier -> moduleVersion.inheritedName
-            else -> error("Unexpected component identifier type: ${componentId::class}")
-        }
+        val componentId = artifact.id.componentIdentifier
+        return defaultSwiftExportModuleName(componentId, moduleVersion)
+            ?: error("Unexpected component identifier type: ${componentId::class}")
     }
 }
+
+/**
+ * Default name of a fully exported module, before normalization: the project path for a project, the coordinates
+ * for an external module, `null` for anything else. Also used by the consumer overrides, so a promoted dependency
+ * is named like an `api` one.
+ */
+internal fun defaultSwiftExportModuleName(id: ComponentIdentifier, moduleVersion: ModuleVersionIdentifier?): String? =
+    when (id) {
+        is ProjectComponentIdentifier -> id.projectPath
+        is ModuleComponentIdentifier -> moduleVersion?.inheritedName
+        else -> null
+    }
 
 private fun Project.swiftExportedModules(
     exportConfiguration: LazyResolvedConfigurationWithArtifacts,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -19,18 +19,36 @@ import java.io.File
 import java.io.Serializable
 
 /**
+ * KGP-side copy of `SwiftModuleExportMode`. The standalone type can't be used here: `swift-export-standalone` is
+ * `compileOnly` in KGP and this value is serialized into worker parameters. [SwiftExportAction] maps between the two.
+ */
+internal enum class SwiftExportedModuleMode {
+    /** The whole public API is translated. */
+    FULL,
+
+    /** Only what fully exported modules refer to is translated. */
+    TRANSITIVE,
+
+    /**
+     * Only the types other modules refer to are emitted, as empty stubs. The klib stays on the analysis path,
+     * so declarations in other modules that mention its types are still exported.
+     */
+    HIDDEN,
+}
+
+/**
  * Represents a module that will be exported to Swift.
  *
  * @property moduleName The name of the module in Swift
- * @property flattenPackage Optional package flattening configuration
+ * @property flattenPackage Optional package flattening configuration, only used for [SwiftExportedModuleMode.FULL]
  * @property artifact The artifact file containing the module
- * @property shouldBeFullyExported Whether this module was explicitly requested for export through the swiftExport { export("foo:bar") } DSL
+ * @property exportMode How Swift Export translates this module
  */
 internal interface SwiftExportedModule : Serializable {
     val moduleName: String
     val flattenPackage: String?
     val artifact: File
-    val shouldBeFullyExported: Boolean
+    val exportMode: SwiftExportedModuleMode
 }
 
 internal fun createFullyExportedSwiftExportedModule(
@@ -42,7 +60,7 @@ internal fun createFullyExportedSwiftExportedModule(
         moduleName,
         flattenPackage,
         artifact,
-        true
+        SwiftExportedModuleMode.FULL
     )
 }
 
@@ -54,7 +72,19 @@ internal fun createTransitiveSwiftExportedModule(
         moduleName,
         null,
         artifact,
-        false
+        SwiftExportedModuleMode.TRANSITIVE
+    )
+}
+
+internal fun createHiddenSwiftExportedModule(
+    moduleName: String,
+    artifact: File,
+): SwiftExportedModule {
+    return SwiftExportedModuleImp(
+        moduleName,
+        null,
+        artifact,
+        SwiftExportedModuleMode.HIDDEN
     )
 }
 
@@ -226,7 +256,7 @@ private data class SwiftExportedModuleImp(
     override val moduleName: String,
     override val flattenPackage: String?,
     override val artifact: File,
-    override val shouldBeFullyExported: Boolean,
+    override val exportMode: SwiftExportedModuleMode,
 ) : SwiftExportedModule
 
 private fun Project.normalizedAndValidatedModuleName(moduleName: String) =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
@@ -158,9 +158,27 @@ interface SwiftExportModuleOptionsDsl {
      * The root package to flatten.
      *
      * For a dependency, it takes precedence over the root package the dependency publishes. Ignored for
-     * transitively exported dependencies.
+     * transitively exported and for hidden dependencies.
      */
     val rootPackage: Property<String>
+}
+
+/**
+ * Swift Export options of a dependency. Adds [visibility] to [SwiftExportModuleOptionsDsl], which makes no
+ * sense for the exported module itself.
+ *
+ * This API is experimental and may change in future versions.
+ *
+ * @since 2.5.0
+ */
+@ExperimentalSwiftExportDsl
+@KotlinGradlePluginDsl
+interface SwiftExportDependencyOptionsDsl : SwiftExportModuleOptionsDsl {
+    /**
+     * How much of this dependency appears in the generated Swift API. Takes precedence over the default derived
+     * from the dependency graph, so a direct `api` dependency can be [SwiftExportVisibility.HIDDEN].
+     */
+    val visibility: Property<SwiftExportVisibility>
 }
 
 /**
@@ -228,7 +246,7 @@ interface SwiftExportIntegration {
      *
      * @since 2.5.0
      */
-    fun configure(dependency: Any, configure: SwiftExportModuleOptionsDsl.() -> Unit)
+    fun configure(dependency: Any, configure: SwiftExportDependencyOptionsDsl.() -> Unit)
 
     /**
      * Override the Swift Export options of [dependency].
@@ -236,7 +254,15 @@ interface SwiftExportIntegration {
      * @see configure
      * @since 2.5.0
      */
-    fun configure(dependency: Any, configure: Action<SwiftExportModuleOptionsDsl>)
+    fun configure(dependency: Any, configure: Action<SwiftExportDependencyOptionsDsl>)
+
+    /**
+     * Shorthand for `configure(dependency) { this.visibility.set(visibility) }`.
+     *
+     * @see configure
+     * @since 2.5.0
+     */
+    fun configure(dependency: Any, visibility: SwiftExportVisibility)
 }
 
 /**
@@ -287,16 +313,19 @@ private class DefaultSwiftExportXcodeIntegration(
     override val settings: MapProperty<String, String> = objectFactory.mapProperty(String::class.java, String::class.java)
 
     /** One `configure(dependency) { }` call each, in declaration order, so that a later call wins. */
-    private val pendingOverrides = mutableListOf<Pair<Provider<SwiftExportDependencySelector>, SwiftExportModuleOptionsDsl>>()
+    private val pendingOverrides = mutableListOf<Pair<Provider<SwiftExportDependencySelector>, SwiftExportDependencyOptionsDsl>>()
 
-    override fun configure(dependency: Any, configure: SwiftExportModuleOptionsDsl.() -> Unit) {
-        val dsl = objectFactory.newInstance<SwiftExportModuleOptionsDsl>()
+    override fun configure(dependency: Any, configure: SwiftExportDependencyOptionsDsl.() -> Unit) {
+        val dsl = objectFactory.newInstance<SwiftExportDependencyOptionsDsl>()
         dsl.configure()
         pendingOverrides += dependency.selectorProvider() to dsl
     }
 
-    override fun configure(dependency: Any, configure: Action<SwiftExportModuleOptionsDsl>) =
+    override fun configure(dependency: Any, configure: Action<SwiftExportDependencyOptionsDsl>) =
         configure(dependency) { configure.execute(this) }
+
+    override fun configure(dependency: Any, visibility: SwiftExportVisibility) =
+        configure(dependency) { this.visibility.set(visibility) }
 
     override val dependencyOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>> =
         providerFactory.provider {
@@ -307,6 +336,7 @@ private class DefaultSwiftExportXcodeIntegration(
                 overrides[selector] = SwiftExportDeclaredModuleOptions(
                     moduleName = dsl.moduleName.orNull ?: previous?.moduleName,
                     rootPackage = dsl.rootPackage.orNull ?: previous?.rootPackage,
+                    visibility = dsl.visibility.orNull ?: previous?.visibility,
                 )
             }
             overrides

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -104,7 +104,9 @@ internal interface SwiftExportConfigurationCompat {
                     get() = providers.provider { kotlinNativeCompilation.internal.configurations.compileDependencyConfiguration }
 
                 override val exportedModules: Provider<Set<SwiftExportedDependency>>
-                    get() = providers.provider { emptySet() } // TODO: KT-85687
+                    // The `export { }` DSL has no `export(...)`. Direct `api` dependencies are exported by the
+                    // collector, `configure(dependency, EXPOSED)` is applied on top in `adjustSwiftModules`.
+                    get() = providers.provider { emptySet() }
 
                 override fun adjustSwiftModules(
                     modules: Provider<List<SwiftExportedModule>>,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportVisibility.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export
+
+import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+
+/**
+ * How much of a dependency ends up in the generated Swift API.
+ *
+ * By default a direct `api` dependency is fully exported and everything else only as far as the exported
+ * modules refer to it. A declared visibility overrides that.
+ *
+ * This API is experimental and may change in future versions.
+ *
+ * @since 2.5.0
+ */
+@ExperimentalSwiftExportDsl
+enum class SwiftExportVisibility {
+    /**
+     * The whole public API is translated, as for a direct `api` dependency.
+     *
+     * The dependency must already be in the Swift Export graph; this doesn't add it.
+     */
+    EXPOSED,
+
+    /**
+     * Only empty stubs are generated for the types other modules refer to; members and unreferenced declarations
+     * are dropped. The dependency stays in the Swift Export graph, so declarations that mention its types are
+     * still exported.
+     */
+    HIDDEN,
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -11,6 +11,7 @@ import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.validateSwiftExportModuleName
@@ -44,7 +45,7 @@ internal fun Project.applySwiftExportConsumerOverrides(
         val component = componentByArtifact[module.artifact] ?: return@map module to null
         val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it) }
         val adjusted = when {
-            module.shouldBeFullyExported -> createFullyExportedSwiftExportedModule(
+            module.exportMode == SwiftExportedModuleMode.FULL -> createFullyExportedSwiftExportedModule(
                 moduleName = declaredName ?: module.moduleName,
                 flattenPackage = sources.declaredRootPackage(component) ?: module.flattenPackage,
                 artifact = module.artifact,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -15,6 +15,8 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftEx
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createHiddenSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.defaultSwiftExportModuleName
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.normalizedSwiftExportModuleName
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.validateSwiftExportModuleName
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportVisibility
 import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
@@ -46,26 +48,30 @@ internal fun Project.applySwiftExportConsumerOverrides(
     val exported = modules.get().map { module ->
         val component = componentByArtifact[module.artifact] ?: return@map module to null
         val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it) }
-        // A declared visibility overrides what the module's position in the graph implied.
-        val mode = when (sources.declaredVisibility(component)) {
+        val visibility = sources.declaredVisibility(component)
+        val mode = when (visibility) {
             SwiftExportVisibility.EXPOSED -> SwiftExportedModuleMode.FULL
             SwiftExportVisibility.HIDDEN -> SwiftExportedModuleMode.HIDDEN
             null -> module.exportMode
         }
+        // The collector names transitive modules from coordinates and fully exported ones from the component.
+        // With a declared visibility use the latter, so the name matches `api(project(...))` regardless of scope.
+        val derivedName =
+            if (visibility == null) module.moduleName else (component.defaultModuleName() ?: module.moduleName)
         val adjusted = when (mode) {
             SwiftExportedModuleMode.FULL -> createFullyExportedSwiftExportedModule(
-                moduleName = declaredName ?: module.moduleName,
+                moduleName = declaredName ?: derivedName,
                 flattenPackage = sources.declaredRootPackage(component) ?: module.flattenPackage,
                 artifact = module.artifact,
             )
             // A transitively exported module has no root package, so a declared one has no effect here.
             SwiftExportedModuleMode.TRANSITIVE -> createTransitiveSwiftExportedModule(
-                moduleName = declaredName ?: module.moduleName,
+                moduleName = declaredName ?: derivedName,
                 artifact = module.artifact,
             )
-            // A hidden module is still analyzed under this name, so the name is honored; nothing else is.
+            // The stub module is emitted under this name. A root package makes no sense for it, as for transitive.
             SwiftExportedModuleMode.HIDDEN -> createHiddenSwiftExportedModule(
-                moduleName = declaredName ?: module.moduleName,
+                moduleName = declaredName ?: derivedName,
                 artifact = module.artifact,
             )
         }
@@ -122,3 +128,7 @@ private fun componentByArtifact(
     }
     return result
 }
+
+/** What the collector would name this component if it were fully exported, `null` if that can't be derived. */
+private fun SwiftExportResolvedComponent.defaultModuleName(): String? =
+    defaultSwiftExportModuleName(id, moduleVersion)?.normalizedSwiftExportModuleName

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -13,8 +13,10 @@ import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createHiddenSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.validateSwiftExportModuleName
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportVisibility
 import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import java.io.File
 
@@ -44,14 +46,25 @@ internal fun Project.applySwiftExportConsumerOverrides(
     val exported = modules.get().map { module ->
         val component = componentByArtifact[module.artifact] ?: return@map module to null
         val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it) }
-        val adjusted = when {
-            module.exportMode == SwiftExportedModuleMode.FULL -> createFullyExportedSwiftExportedModule(
+        // A declared visibility overrides what the module's position in the graph implied.
+        val mode = when (sources.declaredVisibility(component)) {
+            SwiftExportVisibility.EXPOSED -> SwiftExportedModuleMode.FULL
+            SwiftExportVisibility.HIDDEN -> SwiftExportedModuleMode.HIDDEN
+            null -> module.exportMode
+        }
+        val adjusted = when (mode) {
+            SwiftExportedModuleMode.FULL -> createFullyExportedSwiftExportedModule(
                 moduleName = declaredName ?: module.moduleName,
                 flattenPackage = sources.declaredRootPackage(component) ?: module.flattenPackage,
                 artifact = module.artifact,
             )
             // A transitively exported module has no root package, so a declared one has no effect here.
-            else -> createTransitiveSwiftExportedModule(
+            SwiftExportedModuleMode.TRANSITIVE -> createTransitiveSwiftExportedModule(
+                moduleName = declaredName ?: module.moduleName,
+                artifact = module.artifact,
+            )
+            // A hidden module is still analyzed under this name, so the name is honored; nothing else is.
+            SwiftExportedModuleMode.HIDDEN -> createHiddenSwiftExportedModule(
                 moduleName = declaredName ?: module.moduleName,
                 artifact = module.artifact,
             )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportModuleOptionsSource.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportModuleOptionsSource.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportVisibility
 
 /**
  * A node of the resolved Swift Export graph.
@@ -30,6 +31,8 @@ internal data class SwiftExportResolvedComponent(
 internal data class SwiftExportDeclaredModuleOptions(
     val moduleName: String?,
     val rootPackage: String?,
+    /** Not published, so only consumer overrides can set it. */
+    val visibility: SwiftExportVisibility? = null,
 )
 
 /**
@@ -37,7 +40,7 @@ internal data class SwiftExportDeclaredModuleOptions(
  *
  * Layers are consulted in order and the first non-null value wins, per property:
  *
- *  1. consumer overrides from `xcodeIntegration { configure(dependency) { } }` (KT-87990)
+ *  1. consumer overrides from `xcodeIntegration { configure(dependency) { } }` (KT-87990); only they set visibility
  *  2. options published by the dependency itself (KT-87987)
  *
  * The derived default applies when no layer declares a value.
@@ -57,3 +60,10 @@ internal fun List<SwiftExportModuleOptionsSource>.declaredModuleName(component: 
  */
 internal fun List<SwiftExportModuleOptionsSource>.declaredRootPackage(component: SwiftExportResolvedComponent): String? =
     firstNotNullOfOrNull { it.optionsFor(component)?.rootPackage }
+
+/**
+ * The declared visibility for [component], or `null` to use the derived default.
+ */
+internal fun List<SwiftExportModuleOptionsSource>.declaredVisibility(
+    component: SwiftExportResolvedComponent,
+): SwiftExportVisibility? = firstNotNullOfOrNull { it.optionsFor(component)?.visibility }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -1593,6 +1593,215 @@ class ExportExtensionSwiftExportTests {
         project.assertNoDiagnostics(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
     }
 
+    @Test
+    fun `hidden visibility beats a direct api dependency`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0", SwiftExportVisibility.HIDDEN)
+                }
+            }
+        )
+
+        project.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    exportMode = SwiftExportedModuleMode.HIDDEN,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `hidden visibility applies to a transitive dependency`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0", SwiftExportVisibility.HIDDEN)
+                }
+            }
+        )
+
+        project.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    exportMode = SwiftExportedModuleMode.HIDDEN,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `exposed visibility promotes a transitive dependency and its root package now applies`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        visibility.set(SwiftExportVisibility.EXPOSED)
+                        rootPackage.set("kotlinx.io.bytestring")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    exportMode = SwiftExportedModuleMode.FULL,
+                    flattenPackage = "kotlinx.io.bytestring",
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `visibility and module name can be declared in the same block`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        visibility.set(SwiftExportVisibility.EXPOSED)
+                        moduleName.set("ByteString")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "ByteString",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    exportMode = SwiftExportedModuleMode.FULL,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `a hidden dependency keeps its root package unset`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        visibility.set(SwiftExportVisibility.HIDDEN)
+                        rootPackage.set("kotlinx.io.bytestring")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    exportMode = SwiftExportedModuleMode.HIDDEN,
+                    flattenPackage = null,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `a visibility override for a dependency absent from the graph is reported`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.example:not-in-the-graph:1.0", SwiftExportVisibility.EXPOSED)
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.realizeSwiftModules()
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.SwiftExportModuleResolutionError)
+    }
+
+    @Test
+    fun `a hidden module still participates in duplicate module name detection`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    api("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                moduleName.set("Shared")
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
+                        visibility.set(SwiftExportVisibility.HIDDEN)
+                        // Collides with the exported module itself: the name still names the analysis input.
+                        moduleName.set("Shared")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+
+        project.assertRealizingSwiftModulesFailsWith(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
+    }
+
     /** The export graph diagnostics are reported when the `swiftModules` provider is realized, not during configuration. */
     private fun Project.realizeSwiftModules(): List<SwiftExportedModule> =
         tasks.withType(SwiftExportTask::class.java).single().parameters.swiftModules.get()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftEx
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationDsl
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportVisibility
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
@@ -408,6 +409,132 @@ class ExportExtensionXcodeIntegrationTests {
         project.assertContainsDiagnostic(KotlinToolingDiagnostics.ConflictingSwiftExportDsls)
         assertNull(project.tasks.findByName(EMBED_SWIFT_EXPORT_TASK_NAME))
     }
+
+    @Test
+    fun `test visibility declared through the block is recorded`() {
+        val project = exportDslProject {
+            exportExtension.swift {
+                xcodeIntegration {
+                    configure("org.example:lib:1.0") {
+                        visibility.set(SwiftExportVisibility.HIDDEN)
+                    }
+                }
+            }
+        }
+
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportVisibility?>(
+                SwiftExportDependencySelector.Module("org.example", "lib") to SwiftExportVisibility.HIDDEN,
+            ),
+            project.declaredVisibilities(),
+        )
+    }
+
+    @Test
+    fun `test the shorthand records the same visibility as the block`() {
+        val project = exportDslProject {
+            exportExtension.swift {
+                xcodeIntegration {
+                    configure("org.example:lib:1.0", SwiftExportVisibility.EXPOSED)
+                }
+            }
+        }
+
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportVisibility?>(
+                SwiftExportDependencySelector.Module("org.example", "lib") to SwiftExportVisibility.EXPOSED,
+            ),
+            project.declaredVisibilities(),
+        )
+    }
+
+    @Test
+    fun `test a later call wins per property, so visibility and module name merge independently`() {
+        val project = exportDslProject {
+            exportExtension.swift {
+                xcodeIntegration {
+                    configure("org.example:lib:1.0") {
+                        moduleName.set("Lib")
+                        visibility.set(SwiftExportVisibility.EXPOSED)
+                    }
+                    configure("org.example:lib:1.0") {
+                        visibility.set(SwiftExportVisibility.HIDDEN)
+                    }
+                }
+            }
+        }
+
+        val selector = SwiftExportDependencySelector.Module("org.example", "lib")
+        val options = assertNotNull(project.declaredOverrides()[selector])
+        assertEquals(SwiftExportVisibility.HIDDEN, options.visibility)
+        assertEquals("Lib", options.moduleName)
+    }
+
+    @Test
+    fun `test an override that declares no visibility records null`() {
+        val project = exportDslProject {
+            exportExtension.swift {
+                xcodeIntegration {
+                    configure("org.example:lib:1.0") {
+                        moduleName.set("Lib")
+                    }
+                }
+            }
+        }
+
+        val selector = SwiftExportDependencySelector.Module("org.example", "lib")
+        assertNull(assertNotNull(project.declaredOverrides()[selector]).visibility)
+    }
+
+    @Test
+    fun `test the shorthand accepts a project dependency`() {
+        val project = exportDslProject {
+            exportExtension.swift {
+                xcodeIntegration {
+                    configure(dependencies.project(mapOf("path" to ":")), SwiftExportVisibility.HIDDEN)
+                }
+            }
+        }
+
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportVisibility?>(
+                SwiftExportDependencySelector.ProjectPath(":") to SwiftExportVisibility.HIDDEN,
+            ),
+            project.declaredVisibilities(),
+        )
+    }
+
+    @Test
+    fun `test the shorthand accepts a dependency provider, as a version catalog accessor is`() {
+        val project = exportDslProject {
+            // A version catalog accessor is a Provider<MinimalExternalModuleDependency>; this exercises the
+            // same lazy branch of the notation handling.
+            exportExtension.swift {
+                xcodeIntegration {
+                    configure(
+                        provider { dependencies.create("org.example:lib:1.0") },
+                        SwiftExportVisibility.HIDDEN,
+                    )
+                }
+            }
+        }
+
+        assertEquals(
+            mapOf<SwiftExportDependencySelector, SwiftExportVisibility?>(
+                SwiftExportDependencySelector.Module("org.example", "lib") to SwiftExportVisibility.HIDDEN,
+            ),
+            project.declaredVisibilities(),
+        )
+    }
+
+    private fun Project.declaredOverrides(): Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions> =
+        assertNotNull(
+            exportExtension.swiftExportConfiguration.activatedXcodeIntegration,
+            "Expected the Xcode integration to have been activated"
+        ).dependencyOverrides.get()
+
+    private fun Project.declaredVisibilities(): Map<SwiftExportDependencySelector, SwiftExportVisibility?> =
+        declaredOverrides().mapValues { (_, options) -> options.visibility }
 }
 
 class LegacySwiftExportDslDiagnosticsTests {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -507,8 +507,7 @@ class ExportExtensionXcodeIntegrationTests {
     @Test
     fun `test the shorthand accepts a dependency provider, as a version catalog accessor is`() {
         val project = exportDslProject {
-            // A version catalog accessor is a Provider<MinimalExternalModuleDependency>; this exercises the
-            // same lazy branch of the notation handling.
+            // Same lazy path a version catalog accessor (a Provider<MinimalExternalModuleDependency>) takes.
             exportExtension.swift {
                 xcodeIntegration {
                     configure(
@@ -1790,7 +1789,7 @@ class ExportExtensionSwiftExportTests {
                 xcodeIntegration {
                     configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0") {
                         visibility.set(SwiftExportVisibility.HIDDEN)
-                        // Collides with the exported module itself: the name still names the analysis input.
+                        // Collides with the exported module itself.
                         moduleName.set("Shared")
                     }
                 }
@@ -1800,6 +1799,156 @@ class ExportExtensionSwiftExportTests {
         project.evaluate()
 
         project.assertRealizingSwiftModulesFailsWith(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames)
+    }
+
+    @Test
+    fun `promoting a transitive project dependency derives the same name as an api dependency would`() {
+        val project = buildProject(
+            projectBuilder = { withName("shared") },
+            configureProject = { configureRepositoriesForTests() }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation(projectDependency)
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure(projectDependency, SwiftExportVisibility.EXPOSED)
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    // Same name as with `api(projectDependency)`, not the coordinate-derived `SharedSubproject`.
+                    moduleName = "Subproject",
+                    artifactName = "subproject",
+                    exportMode = SwiftExportedModuleMode.FULL,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `an explicit module name still wins over the re-derived one`() {
+        val project = buildProject(
+            projectBuilder = { withName("shared") },
+            configureProject = { configureRepositoriesForTests() }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation(projectDependency)
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure(projectDependency) {
+                        visibility.set(SwiftExportVisibility.EXPOSED)
+                        moduleName.set("Renamed")
+                    }
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    moduleName = "Renamed",
+                    artifactName = "subproject",
+                    exportMode = SwiftExportedModuleMode.FULL,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `hiding a project dependency names its stub module the same regardless of the gradle scope`() {
+        val project = buildProject(
+            projectBuilder = { withName("shared") },
+            configureProject = { configureRepositoriesForTests() }
+        )
+        val projectDependency = project.subProject("subproject") {
+            iosSimulatorArm64()
+        }
+        project.setupForSwiftExport(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation(projectDependency)
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure(projectDependency, SwiftExportVisibility.HIDDEN)
+                }
+            }
+        )
+
+        project.evaluate()
+        projectDependency.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    // `Subproject` as with `api(...)`, not `SharedSubproject` as for a plain implementation dependency.
+                    moduleName = "Subproject",
+                    artifactName = "subproject",
+                    exportMode = SwiftExportedModuleMode.HIDDEN,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
+    }
+
+    @Test
+    fun `promoting an external dependency keeps its derived name`() {
+        val project = swiftExportProject(
+            multiplatform = {
+                iosSimulatorArm64()
+                sourceSets.commonMain.dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0")
+                }
+            },
+            swiftExport = {
+                xcodeIntegration {
+                    configure("org.jetbrains.kotlinx:kotlinx-io-bytestring:0.7.0", SwiftExportVisibility.EXPOSED)
+                }
+            }
+        )
+
+        project.evaluate()
+
+        assertSetsEqual(
+            setOf(
+                ExportedSwiftModuleForAssertion(
+                    // External names come from the coordinates either way.
+                    moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
+                    artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
+                    exportMode = SwiftExportedModuleMode.FULL,
+                ),
+            ),
+            project.realizeSwiftModules().toModulesForAssertion(),
+        )
     }
 
     /** The export graph diagnostics are reported when the `swiftModules` provider is realized, not during configuration. */

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnosticFactory
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.EmbedSwiftExportForXcodeTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationDsl
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
@@ -583,7 +584,7 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
                 artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
         )
 
@@ -614,7 +615,7 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
                 artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
         )
 
@@ -656,7 +657,7 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "Subproject",
                 artifactName = "subproject",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
         )
 
@@ -698,7 +699,7 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "SharedSubproject",
                 artifactName = "subproject",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
         )
 
@@ -744,27 +745,27 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxAtomicfu",
                 artifactName = "atomicfu.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
                 artifactName = "kotlinx-coroutines-core.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxDatetime",
                 artifactName = "kotlinx-datetime.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxSerializationCore",
                 artifactName = "kotlinx-serialization-core.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "Subproject",
                 artifactName = "subproject",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
         )
 
@@ -832,17 +833,17 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxAtomicfu",
                 artifactName = "atomicfu.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
                 artifactName = "kotlinx-coroutines-core-iosSimulatorArm64Main-1.10.0.klib",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "SharedSubproject",
                 artifactName = "subproject",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
         )
 
@@ -888,17 +889,17 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxAtomicfu",
                 artifactName = "atomicfu.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
                 artifactName = "kotlinx-coroutines-core-iosSimulatorArm64Main-1.10.0.klib",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "SharedSubproject",
                 artifactName = "subproject",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
         )
 
@@ -938,22 +939,22 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "AppCashSqldelightRuntime",
                 artifactName = "runtime.klib",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsComposeRuntimeRuntime",
                 artifactName = "runtime-uikitSimArm64Main-1.8.2.klib",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxAtomicfu",
                 artifactName = "atomicfu.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
                 artifactName = "kotlinx-coroutines-core.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
         )
 
@@ -1003,17 +1004,17 @@ class ExportExtensionSwiftExportTests {
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxCoroutinesCore",
                 artifactName = "kotlinx-coroutines-core.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "OrgJetbrainsKotlinxKotlinxDatetime",
                 artifactName = "kotlinx-datetime.klib",
-                shouldBeFullyExported = false
+                exportMode = SwiftExportedModuleMode.TRANSITIVE
             ),
             ExportedSwiftModuleForAssertion(
                 moduleName = "Subproject",
                 artifactName = "subproject",
-                shouldBeFullyExported = true
+                exportMode = SwiftExportedModuleMode.FULL
             ),
         )
 
@@ -1050,7 +1051,7 @@ class ExportExtensionSwiftExportTests {
                 ExportedSwiftModuleForAssertion(
                     moduleName = "ByteString",
                     artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                    shouldBeFullyExported = true,
+                    exportMode = SwiftExportedModuleMode.FULL,
                 ),
             ),
             actualModules.toModulesForAssertion(),
@@ -1084,7 +1085,7 @@ class ExportExtensionSwiftExportTests {
                 ExportedSwiftModuleForAssertion(
                     moduleName = "OrgJetbrainsKotlinxKotlinxIoBytestring",
                     artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                    shouldBeFullyExported = true,
+                    exportMode = SwiftExportedModuleMode.FULL,
                     flattenPackage = "kotlinx.io.bytestring",
                 ),
             ),
@@ -1120,7 +1121,7 @@ class ExportExtensionSwiftExportTests {
                 ExportedSwiftModuleForAssertion(
                     moduleName = "ByteString",
                     artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                    shouldBeFullyExported = true,
+                    exportMode = SwiftExportedModuleMode.FULL,
                 ),
             ),
             actualModules.toModulesForAssertion(),
@@ -1156,7 +1157,7 @@ class ExportExtensionSwiftExportTests {
                 ExportedSwiftModuleForAssertion(
                     moduleName = "ByteString",
                     artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                    shouldBeFullyExported = true,
+                    exportMode = SwiftExportedModuleMode.FULL,
                 ),
             ),
             actualModules.toModulesForAssertion(),
@@ -1199,7 +1200,7 @@ class ExportExtensionSwiftExportTests {
                 ExportedSwiftModuleForAssertion(
                     moduleName = "Renamed",
                     artifactName = "subproject",
-                    shouldBeFullyExported = true,
+                    exportMode = SwiftExportedModuleMode.FULL,
                     flattenPackage = "org.example.subproject",
                 ),
             ),
@@ -1235,7 +1236,7 @@ class ExportExtensionSwiftExportTests {
                 ExportedSwiftModuleForAssertion(
                     moduleName = "ByteString",
                     artifactName = "kotlinx-io-bytestring-iosSimulatorArm64Main-0.7.0.klib",
-                    shouldBeFullyExported = false,
+                    exportMode = SwiftExportedModuleMode.TRANSITIVE,
                     flattenPackage = null,
                 ),
             ),
@@ -1571,7 +1572,7 @@ private fun List<SwiftExportedModule>.toModulesForAssertion() = mapToSetOrEmpty 
     ExportedSwiftModuleForAssertion(
         moduleName = module.moduleName,
         artifactName = module.artifact.name,
-        shouldBeFullyExported = module.shouldBeFullyExported,
+        exportMode = module.exportMode,
         flattenPackage = module.flattenPackage,
     )
 }
@@ -1579,6 +1580,6 @@ private fun List<SwiftExportedModule>.toModulesForAssertion() = mapToSetOrEmpty 
 private data class ExportedSwiftModuleForAssertion(
     val moduleName: String,
     val artifactName: String,
-    val shouldBeFullyExported: Boolean,
+    val exportMode: SwiftExportedModuleMode,
     val flattenPackage: String? = null,
 )

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.appleTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportConstants
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModuleMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.BuildSPMSwiftExportPackage
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.MergeStaticLibrariesTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SwiftExportTask
@@ -387,11 +388,11 @@ class SwiftExportUnitTests {
 
         assertEquals(
             expectedModules,
-            actualModules.filter { it.shouldBeFullyExported }.toModulesForAssertion(),
+            actualModules.filter { it.exportMode == SwiftExportedModuleMode.FULL }.toModulesForAssertion(),
         )
 
         val KotlinxIoCore = actualModules.single { it.moduleName == "OrgJetbrainsKotlinxKotlinxIoCore" }
-        assertFalse(KotlinxIoCore.shouldBeFullyExported, "Compilation dependency kotlinx-io-core should not be exported")
+        assertNotEquals(SwiftExportedModuleMode.FULL, KotlinxIoCore.exportMode, "Compilation dependency kotlinx-io-core should not be exported")
     }
 
     @Test
@@ -405,7 +406,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.shouldBeFullyExported }
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(SwiftExportModuleForAssertion("OrgJetbrainsKotlinxKotlinxDatetime", "kotlinx-datetime.klib", true))
@@ -438,7 +439,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.shouldBeFullyExported }
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -478,7 +479,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.shouldBeFullyExported }
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -518,7 +519,7 @@ class SwiftExportUnitTests {
         project.evaluate()
 
         val swiftExportTask = project.tasks.withType(SwiftExportTask::class.java).single()
-        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.shouldBeFullyExported }
+        val actualModules = swiftExportTask.parameters.swiftModules.getOrElse(emptyList()).filter { it.exportMode == SwiftExportedModuleMode.FULL }
 
         val expectedModules = SmartSet.create<SwiftExportModuleForAssertion>().apply {
             add(
@@ -1341,7 +1342,7 @@ private fun List<SwiftExportedModule>.toModulesForAssertion() = mapToSetOrEmpty 
     SwiftExportModuleForAssertion(
         module.moduleName,
         module.artifact.name,
-        module.shouldBeFullyExported
+        module.exportMode == SwiftExportedModuleMode.FULL
     )
 }
 


### PR DESCRIPTION
This pull request introduces new configuration options and behaviors for Swift Export in Kotlin Multiplatform projects, focusing on controlling the visibility of dependencies in the generated Swift API. The changes add support for marking dependencies as "hidden" or "exposed," affecting how their APIs appear in Swift, and provide corresponding DSL and internal implementation updates. New integration tests are included to verify these behaviors.

**Swift Export Dependency Visibility Enhancements:**

* Added a new `SwiftExportVisibility` enum (`EXPOSED`, `HIDDEN`) and updated the Swift Export DSL to allow explicit control over how dependencies are exported to Swift. This is exposed via the new `SwiftExportDependencyOptionsDsl` interface, which adds a `visibility` property for dependencies. [[1]](diffhunk://#diff-a7c45bd59e7c7d710d215a0d216f5bf39428cfcaa26f3798f59001e44d44e6faL161-R183) [[2]](diffhunk://#diff-a7c45bd59e7c7d710d215a0d216f5bf39428cfcaa26f3798f59001e44d44e6faL231-R265) [[3]](diffhunk://#diff-82f89dcaaec969cbfd68dbcf4a8d014a29f7eb05f99786f739f17ac53edf0bc9R1938-R1944)

* Updated the `SwiftExportIntegration` interface to support the new visibility options, including overloads for configuring dependencies with a visibility value directly. [[1]](diffhunk://#diff-a7c45bd59e7c7d710d215a0d216f5bf39428cfcaa26f3798f59001e44d44e6faL231-R265) [[2]](diffhunk://#diff-82f89dcaaec969cbfd68dbcf4a8d014a29f7eb05f99786f739f17ac53edf0bc9R1922-R1929)

**Internal Representation and Processing:**

* Introduced the internal `SwiftExportedModuleMode` enum to represent export modes (`FULL`, `TRANSITIVE`, `HIDDEN`) and refactored the internal module representation to use this instead of a boolean flag. This ensures the correct translation of visibility settings throughout the export pipeline. [[1]](diffhunk://#diff-62deb0198cfa65202dcb2aa069fa7420ad6d6a0838781b09c9d1e80d957b49d2R22-R52) [[2]](diffhunk://#diff-62deb0198cfa65202dcb2aa069fa7420ad6d6a0838781b09c9d1e80d957b49d2L45-R64) [[3]](diffhunk://#diff-62deb0198cfa65202dcb2aa069fa7420ad6d6a0838781b09c9d1e80d957b49d2L57-R88) [[4]](diffhunk://#diff-62deb0198cfa65202dcb2aa069fa7420ad6d6a0838781b09c9d1e80d957b49d2L229-R270)

* Updated the export action and module configuration logic to map the new export modes to the underlying `SwiftModuleExportMode` used by the standalone exporter. [[1]](diffhunk://#diff-70bbe8ce8b7b248353116ed742334dcab95d6c0ccd7e0717c94e0af78f6d52d6R17) [[2]](diffhunk://#diff-70bbe8ce8b7b248353116ed742334dcab95d6c0ccd7e0717c94e0af78f6d52d6L47-R48) [[3]](diffhunk://#diff-70bbe8ce8b7b248353116ed742334dcab95d6c0ccd7e0717c94e0af78f6d52d6L65-R77)

**Testing and Validation:**

* Added comprehensive integration tests to verify the new visibility behaviors:
  - Ensured that hidden dependencies are translated to empty stubs in Swift, and only referenced types are present.
  - Verified that exposed transitive dependencies are fully exported, including unreferenced classes.

**Utilities and Naming:**

* Refactored module naming logic to provide consistent naming for exported modules, used by both the producer and consumer sides, and ensured compatibility with the new visibility options.