### PR TITLE
[Gradle] Consume Swift Export metadata for published external dependencies

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.native
+
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.uklibs.*
+import org.jetbrains.kotlin.gradle.util.swiftExportEmbedAndSignEnvVariables
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
+
+@OsCondition(supportedOn = [OS.MAC], enabledOnCI = [OS.MAC])
+@DisplayName("Tests for Swift Export metadata consumption with the export DSL")
+@SwiftExportGradlePluginTests
+@OptIn(ExperimentalExportDsl::class, ExperimentalSwiftExportDsl::class)
+class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct published dependency with moduleName override"
+    )
+    @GradleTest
+    fun directPublishedDependencyWithModuleNameOverride(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = true,
+            moduleNameOverride = "Foo",
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct published dependency with rootPackage override"
+    )
+    @GradleTest
+    fun directPublishedDependencyWithRootPackageOverride(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = true,
+            rootPackageOverride = "com.foo.bar",
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct published dependency with no overrides"
+    )
+    @GradleTest
+    fun directPublishedDependencyWithNoOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = true,
+        )
+    }
+
+    @DisplayName(
+        "Swift Export metadata consumed from a direct published dependency with moduleName and rootPackage overrides"
+    )
+    @GradleTest
+    fun directPublishedDependencyWithModuleNameAndRootPackageOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = true,
+            moduleNameOverride = "Bar",
+            rootPackageOverride = "com.bar.baz",
+        )
+    }
+
+    private fun testSwiftExportMetadataConsumption(
+        gradleVersion: GradleVersion,
+        testBuildDir: Path,
+        published: Boolean,
+        moduleNameOverride: String? = null,
+        rootPackageOverride: String? = null,
+    ) {
+        val rootPackage = rootPackageOverride ?: "com.foo.bar"
+        val subproject = project("empty", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    export.swift {
+                        this.moduleName.set(moduleNameOverride)
+                        this.rootPackage.set(rootPackageOverride)
+                    }
+
+                    sourceSets.commonMain {
+                        compileStubSourceWithSourceSetName()
+                        compileSource(
+                            """
+                            package $rootPackage
+                            class LibFoo
+                            """.trimIndent()
+                        )
+                    }
+                }
+            }
+        }
+        val publishedSubproject = if (published) {
+            subproject.publish(publisherConfiguration = PublisherConfiguration(group = rootPackage))
+        } else {
+            null
+        }
+
+        project(
+            "empty",
+            gradleVersion
+        ) {
+            if (publishedSubproject != null) {
+                addPublishedProjectToRepositories(publishedSubproject)
+            } else {
+                include(subproject, "subproject")
+            }
+
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                with(project) {
+                    applyMultiplatform {
+                        iosArm64()
+                        export.swift {
+                            xcodeIntegration()
+                        }
+
+                        sourceSets.commonMain {
+                            compileStubSourceWithSourceSetName()
+
+                            dependencies {
+                                if (publishedSubproject != null) {
+                                    api(publishedSubproject.rootCoordinate)
+                                } else {
+                                    api(project(":subproject"))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            build(
+                ":embedSwiftExportForXcode",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
+            ) {
+                val buildProductsDir = this@project.gradleRunner.environment?.get("BUILT_PRODUCTS_DIR")?.let { File(it) }
+                assertNotNull(buildProductsDir)
+
+                val expectedDependencyModuleName = when {
+                    moduleNameOverride != null -> moduleNameOverride
+                    published -> "ComFooBarEmpty"
+                    else -> "Subproject"
+                }
+                assertSubdirectoriesExist(
+                    buildProductsDir,
+                    // Default directories.
+                    "ExportedKotlinPackages.swiftmodule",
+                    "KotlinRuntime",
+                    // Exported :shared module.
+                    "Shared.swiftmodule",
+                    "SharedBridge_Shared",
+                    "$expectedDependencyModuleName.swiftmodule",
+                    "SharedBridge_$expectedDependencyModuleName",
+                )
+
+                assertFileExists(buildProductsDir.resolve("libShared.a"))
+
+                if (rootPackageOverride != null) {
+                    val subprojectSwiftPath =
+                        projectPath.resolve("build/SwiftExport/iosArm64/Debug/files/$expectedDependencyModuleName/$expectedDependencyModuleName.swift")
+                    assertContains(
+                        subprojectSwiftPath.readText(),
+                        "public typealias LibFoo = ExportedKotlinPackages.$rootPackageOverride.LibFoo"
+                    )
+                }
+            }
+        }
+    }
+
+    private fun assertSubdirectoriesExist(dir: File, vararg subdirNames: String) {
+        val subdirPaths = subdirNames.map { dir.resolve(it).toPath() }
+        assertDirectoriesExist(*subdirPaths.toTypedArray()) { defaultMessage ->
+            defaultMessage + "\n" + "Contents of dir:\n" + dir.list()!!.joinToString(separator = "\n")
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
@@ -90,6 +90,23 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
     }
 
     @DisplayName(
+        "moduleName override via config(...) takes precedence over moduleName override via metadata"
+    )
+    @GradleTest
+    fun directPublishedDependencyWithConfigModuleNameOverride(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = true,
+            configModuleNameOverride = "Bar",
+            moduleNameOverride = "Foo",
+        )
+    }
+
+    @DisplayName(
         "Swift Export metadata consumed from a transitive published dependency with moduleName and rootPackage overrides"
     )
     @GradleTest
@@ -112,6 +129,7 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
         gradleVersion: GradleVersion,
         testBuildDir: Path,
         published: Boolean,
+        configModuleNameOverride: String? = null,
         moduleNameOverride: String? = null,
         rootPackageOverride: String? = null,
         transitivePublished: Boolean = published,
@@ -234,19 +252,28 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
                 with(project) {
                     applyMultiplatform {
                         iosArm64()
+
+                        val subprojectDependency = if (publishedSubproject != null) {
+                            publishedSubproject.rootCoordinate
+                        } else {
+                            project(":subproject")
+                        }
+
                         export.swift {
-                            xcodeIntegration()
+                            xcodeIntegration {
+                                if (configModuleNameOverride != null) {
+                                    configure(subprojectDependency) {
+                                        moduleName.set(configModuleNameOverride)
+                                    }
+                                }
+                            }
                         }
 
                         sourceSets.commonMain {
                             compileStubSourceWithSourceSetName()
 
                             dependencies {
-                                if (publishedSubproject != null) {
-                                    api(publishedSubproject.rootCoordinate)
-                                } else {
-                                    api(project(":subproject"))
-                                }
+                                api(subprojectDependency)
                             }
                         }
                     }
@@ -271,6 +298,7 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
                 )
 
                 val expectedDirectDependencyModuleName = when {
+                    configModuleNameOverride != null -> configModuleNameOverride
                     moduleNameOverride != null -> moduleNameOverride
                     published -> "ComFooBarEmpty"
                     else -> "Subproject"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportMetadataConsumptionIT.kt
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
-import kotlin.io.path.readText
-import kotlin.test.assertContains
 import kotlin.test.assertNotNull
 
 @OsCondition(supportedOn = [OS.MAC], enabledOnCI = [OS.MAC])
@@ -91,15 +89,83 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
         )
     }
 
+    @DisplayName(
+        "Swift Export metadata consumed from a transitive published dependency with moduleName and rootPackage overrides"
+    )
+    @GradleTest
+    fun transitivePublishedDependencyWithModuleNameAndRootPackageOverrides(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        testSwiftExportMetadataConsumption(
+            gradleVersion = gradleVersion,
+            testBuildDir = testBuildDir,
+            published = true,
+            moduleNameOverride = "Bar",
+            rootPackageOverride = "com.bar.baz",
+            transitiveModuleNameOverride = "Baz",
+            transitiveRootPackageOverride = "com.foo.bar.baz",
+        )
+    }
+
     private fun testSwiftExportMetadataConsumption(
         gradleVersion: GradleVersion,
         testBuildDir: Path,
         published: Boolean,
         moduleNameOverride: String? = null,
         rootPackageOverride: String? = null,
+        transitivePublished: Boolean = published,
+        transitiveModuleNameOverride: String? = null,
+        transitiveRootPackageOverride: String? = null,
     ) {
+        var transitiveRootPackage: String? = null
+        var transitiveSubproject: TestProject? = null
+        var transitivePublishedSubproject: PublishedProject? = null
+        if (transitiveModuleNameOverride != null || transitiveRootPackageOverride != null) {
+            transitiveRootPackage = transitiveRootPackageOverride ?: "com.bar.baz"
+            transitiveSubproject = project("empty", gradleVersion) {
+                plugins {
+                    kotlin("multiplatform")
+                }
+                buildScriptInjection {
+                    project.applyMultiplatform {
+                        iosArm64()
+                        export.swift {
+                            this.moduleName.set(transitiveModuleNameOverride)
+                            this.rootPackage.set(transitiveRootPackageOverride)
+                        }
+
+                        sourceSets.commonMain {
+                            compileStubSourceWithSourceSetName()
+                            compileSource(
+                                """
+                            package $transitiveRootPackage
+                            class LibBar
+                            """.trimIndent()
+                            )
+                        }
+                    }
+                }
+            }
+            transitivePublishedSubproject = if (transitivePublished) {
+                transitiveSubproject.publish(publisherConfiguration = PublisherConfiguration(group = "com.bar.baz"))
+            } else {
+                null
+            }
+        }
+
         val rootPackage = rootPackageOverride ?: "com.foo.bar"
         val subproject = project("empty", gradleVersion) {
+            if (transitivePublishedSubproject != null) {
+                addPublishedProjectToRepositories(transitivePublishedSubproject)
+            } else if (transitiveSubproject != null) {
+                include(transitiveSubproject, "transitiveSubproject")
+            }
+            // transitivePublishedSubproject and transitiveSubproject can't be referenced directly inside buildScriptInjection as
+            // they're not Serializable, so extracting these variables to hold serialized values we need inside the block.
+            val transitivePublishedSubprojectRootCoordinate = transitivePublishedSubproject?.rootCoordinate
+            val hasTransitiveSubproject = transitiveSubproject != null
+
             plugins {
                 kotlin("multiplatform")
             }
@@ -113,18 +179,31 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
 
                     sourceSets.commonMain {
                         compileStubSourceWithSourceSetName()
+                        val transitiveClassReference = if (transitiveRootPackage != null) {
+                            "val libBar: $transitiveRootPackage.LibBar"
+                        } else {
+                            ""
+                        }
                         compileSource(
                             """
                             package $rootPackage
-                            class LibFoo
+                            class LibFoo($transitiveClassReference)
                             """.trimIndent()
                         )
+
+                        dependencies {
+                            if (transitivePublishedSubprojectRootCoordinate != null) {
+                                api(transitivePublishedSubprojectRootCoordinate)
+                            } else if (hasTransitiveSubproject) {
+                                api(project(":transitiveSubproject"))
+                            }
+                        }
                     }
                 }
             }
         }
         val publishedSubproject = if (published) {
-            subproject.publish(publisherConfiguration = PublisherConfiguration(group = rootPackage))
+            subproject.publish(publisherConfiguration = PublisherConfiguration(group = "com.foo.bar"))
         } else {
             null
         }
@@ -133,6 +212,12 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
             "empty",
             gradleVersion
         ) {
+            if (transitivePublishedSubproject != null) {
+                addPublishedProjectToRepositories(transitivePublishedSubproject)
+            } else if (transitiveSubproject != null) {
+                include(transitiveSubproject, "transitiveSubproject")
+            }
+
             if (publishedSubproject != null) {
                 addPublishedProjectToRepositories(publishedSubproject)
             } else {
@@ -175,11 +260,6 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
                 val buildProductsDir = this@project.gradleRunner.environment?.get("BUILT_PRODUCTS_DIR")?.let { File(it) }
                 assertNotNull(buildProductsDir)
 
-                val expectedDependencyModuleName = when {
-                    moduleNameOverride != null -> moduleNameOverride
-                    published -> "ComFooBarEmpty"
-                    else -> "Subproject"
-                }
                 assertSubdirectoriesExist(
                     buildProductsDir,
                     // Default directories.
@@ -188,18 +268,50 @@ class SwiftExportMetadataConsumptionIT : KGPBaseTest() {
                     // Exported :shared module.
                     "Shared.swiftmodule",
                     "SharedBridge_Shared",
-                    "$expectedDependencyModuleName.swiftmodule",
-                    "SharedBridge_$expectedDependencyModuleName",
                 )
+
+                val expectedDirectDependencyModuleName = when {
+                    moduleNameOverride != null -> moduleNameOverride
+                    published -> "ComFooBarEmpty"
+                    else -> "Subproject"
+                }
+                assertSubdirectoriesExist(
+                    buildProductsDir,
+                    "$expectedDirectDependencyModuleName.swiftmodule",
+                    "SharedBridge_$expectedDirectDependencyModuleName",
+                )
+
+                val expectedTransitiveDependencyModuleName = when {
+                    transitiveSubproject == null -> null
+                    transitiveModuleNameOverride != null -> transitiveModuleNameOverride
+                    transitivePublished -> "ComBarBazEmpty"
+                    else -> "SharedTransitiveSubproject"
+                }
+                if (expectedTransitiveDependencyModuleName != null) {
+                    assertSubdirectoriesExist(
+                        buildProductsDir,
+                        "$expectedTransitiveDependencyModuleName.swiftmodule",
+                        "SharedBridge_$expectedTransitiveDependencyModuleName",
+                    )
+                }
 
                 assertFileExists(buildProductsDir.resolve("libShared.a"))
 
                 if (rootPackageOverride != null) {
                     val subprojectSwiftPath =
-                        projectPath.resolve("build/SwiftExport/iosArm64/Debug/files/$expectedDependencyModuleName/$expectedDependencyModuleName.swift")
-                    assertContains(
-                        subprojectSwiftPath.readText(),
+                        projectPath.resolve("build/SwiftExport/iosArm64/Debug/files/$expectedDirectDependencyModuleName/$expectedDirectDependencyModuleName.swift")
+                    assertFileContains(
+                        subprojectSwiftPath,
                         "public typealias LibFoo = ExportedKotlinPackages.$rootPackageOverride.LibFoo"
+                    )
+                }
+                // Root package overrides for transitive dependencies are ignored!
+                if (expectedTransitiveDependencyModuleName != null && transitiveRootPackageOverride != null) {
+                    val subprojectSwiftPath =
+                        projectPath.resolve("build/SwiftExport/iosArm64/Debug/files/$expectedTransitiveDependencyModuleName/$expectedTransitiveDependencyModuleName.swift")
+                    assertFileDoesNotContain(
+                        subprojectSwiftPath,
+                        "public typealias LibBar = ExportedKotlinPackages.$transitiveRootPackageOverride.LibBar",
                     )
                 }
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/fileAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/fileAssertions.kt
@@ -183,26 +183,28 @@ fun GradleProject.assertDirectoryInProjectExists(
 fun assertDirectoryExists(
     dirPath: Path,
     message: String? = null,
-) = assertDirectoriesExist(dirPath, message = message)
+) = assertDirectoriesExist(dirPath, message = { message ?: it })
 
 fun assertDirectoriesExist(
     vararg dirPaths: Path,
-    message: String? = null,
+    message: (defaultMessage: String) -> String = { it },
 ) {
     val [exist, notExist] = dirPaths.partition { it.exists() }
     val notDirectories = exist.filterNot { it.isDirectory() }
 
     assert(notExist.isEmpty() && notDirectories.isEmpty()) {
-        message ?: buildString {
-            if (notExist.isNotEmpty()) {
-                appendLine("Following directories do not exist:")
-                appendLine(notExist.joinToString(separator = "\n"))
+        message(
+            buildString {
+                if (notExist.isNotEmpty()) {
+                    appendLine("Following directories do not exist:")
+                    appendLine(notExist.joinToString(separator = "\n"))
+                }
+                if (notDirectories.isNotEmpty()) {
+                    appendLine("Following files should be directories:")
+                    appendLine(notExist.joinToString(separator = "\n"))
+                }
             }
-            if (notDirectories.isNotEmpty()) {
-                appendLine("Following files should be directories:")
-                appendLine(notExist.joinToString(separator = "\n"))
-            }
-        }
+        )
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -1959,6 +1959,42 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    object SwiftExportUnsupportedMetadataSchemaVersion : ToolingDiagnosticFactory(WARNING, DiagnosticGroup.Kgp.Misconfiguration) {
+        /**
+         * @param component the dependency that published the metadata, rendered for the user
+         * @param foundSchemaVersion the schema version found in the published metadata
+         * @param supportedSchemaVersion the schema version supported by this Kotlin Gradle plugin
+         */
+        operator fun invoke(component: String, foundSchemaVersion: Int, supportedSchemaVersion: Int) = build {
+            title("Unsupported Swift Export Metadata Schema Version")
+                .description {
+                    "The Swift Export metadata published by '$component' uses schema version $foundSchemaVersion, " +
+                            "but this version of the Kotlin Gradle plugin only supports schema version $supportedSchemaVersion. " +
+                            "The metadata is ignored and default Swift Export options are used for this module."
+                }
+                .solution {
+                    "Please update the Kotlin Gradle plugin to a version that supports schema version $foundSchemaVersion."
+                }
+        }
+    }
+
+    object SwiftExportMalformedMetadata : ToolingDiagnosticFactory(WARNING, DiagnosticGroup.Kgp.Misconfiguration) {
+        /**
+         * @param component the dependency that published the metadata, rendered for the user
+         * @param reason the underlying decoding failure message, if available
+         */
+        operator fun invoke(component: String, reason: String?) = build {
+            title("Malformed Swift Export Metadata")
+                .description {
+                    "The Swift Export metadata published by '$component' could not be read because it is malformed" +
+                            (reason?.let { ": $it" } ?: ".")
+                }
+                .solution {
+                    "This is likely a bug, please report it to the relevant issue tracker for '$component'."
+                }
+        }
+    }
+
     object SwiftExportMinimumDeployTargetError : ToolingDiagnosticFactory(FATAL, DiagnosticGroup.Kgp.Misconfiguration) {
         operator fun invoke(
             deploymentTargetSettingName: String,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.whenSwiftPMImpor
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
-import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.applySwiftExportConsumerOverrides
 import org.jetbrains.kotlin.gradle.tasks.locateOrRegisterTask
 import org.jetbrains.kotlin.gradle.utils.*
 import org.jetbrains.kotlin.konan.target.Distribution
@@ -200,16 +199,12 @@ private fun Project.registerSwiftExportRun(
         task.parameters.bridgeModuleName.set("SharedBridge")
         task.parameters.swiftExportSettings.set(customSetting)
         task.parameters.swiftModules.set(
-            project.applySwiftExportConsumerOverrides(
-                modules = collectModules(
-                    exportConfigurationProvider,
-                    apiConfigurationProvider,
-                    exportedModules
-                ),
-                overrides = dependencyOptionsOverrides,
-                exportConfiguration = exportConfigurationProvider,
-                apiConfiguration = apiConfigurationProvider,
-                rootModuleName = swiftApiModuleName,
+            collectModules(
+                exportConfigurationProvider = exportConfigurationProvider,
+                apiConfigurationProvider = apiConfigurationProvider,
+                exportedModulesProvider = exportedModules,
+                dependencyOptionsOverridesProvider = dependencyOptionsOverrides,
+                rootModuleNameProvider = swiftApiModuleName,
             )
         )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -7,10 +7,16 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Usage
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
+import org.jetbrains.kotlin.gradle.plugin.categoryByName
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_USAGE
+import org.jetbrains.kotlin.gradle.plugin.usageByName
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractNativeLibrary
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -74,6 +80,7 @@ internal fun Project.registerSwiftExportTask(
         swiftApiModuleName = swiftApiModuleName,
         exportConfiguration = swiftExportConfiguration.exportConfiguration.get(),
         apiConfiguration = swiftExportConfiguration.apiConfiguration.orNull,
+        shouldResolvePublishedMetadata = swiftExportConfiguration.shouldResolveMetadata,
         mainCompilation = mainCompilation,
         swiftApiFlattenPackage = swiftExportConfiguration.rootPackage,
         exportedModules = swiftExportConfiguration.exportedModules,
@@ -166,6 +173,7 @@ private fun Project.registerSwiftExportRun(
     swiftApiModuleName: Provider<String>,
     exportConfiguration: Configuration,
     apiConfiguration: Configuration?,
+    shouldResolvePublishedMetadata: Boolean,
     mainCompilation: KotlinNativeCompilation,
     swiftApiFlattenPackage: Provider<String>,
     exportedModules: Provider<Set<SwiftExportedDependency>>,
@@ -182,6 +190,23 @@ private fun Project.registerSwiftExportRun(
     val serializedModules = outputs.map { it.dir("modules").file("${swiftApiModuleName.get()}.json") }
     val exportConfigurationProvider = provider { LazyResolvedConfigurationWithArtifacts(exportConfiguration) }
     val apiConfigurationProvider = provider { apiConfiguration?.let(::LazyResolvedConfigurationWithArtifacts) }
+    val metadataConfigurationProvider = provider {
+        if (shouldResolvePublishedMetadata) {
+            LazyResolvedConfigurationWithArtifacts(
+                exportConfiguration,
+                configureArtifactView = {
+                    withVariantReselection()
+                    componentFilter { it is ModuleComponentIdentifier }
+                },
+                configureArtifactViewAttributes = { attributes ->
+                    attributes.attribute(Usage.USAGE_ATTRIBUTE, usageByName(SWIFT_EXPORT_METADATA_USAGE))
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, categoryByName(Category.LIBRARY))
+                }
+            )
+        } else {
+            null
+        }
+    }
 
     return locateOrRegisterTask<SwiftExportTask>(swiftExportTaskName) { task ->
         task.description = "Run $taskNamePrefix Swift Export process"
@@ -203,6 +228,7 @@ private fun Project.registerSwiftExportRun(
                 exportConfigurationProvider = exportConfigurationProvider,
                 apiConfigurationProvider = apiConfigurationProvider,
                 exportedModulesProvider = exportedModules,
+                metadataConfigurationProvider = metadataConfigurationProvider,
                 dependencyOptionsOverridesProvider = dependencyOptionsOverrides,
                 rootModuleNameProvider = swiftApiModuleName,
             )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -24,6 +24,9 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.normali
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.whenSwiftPMImportAvailable
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportConfigurationCompat
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.applySwiftExportConsumerOverrides
 import org.jetbrains.kotlin.gradle.tasks.locateOrRegisterTask
 import org.jetbrains.kotlin.gradle.utils.*
 import org.jetbrains.kotlin.konan.target.Distribution
@@ -75,7 +78,7 @@ internal fun Project.registerSwiftExportTask(
         mainCompilation = mainCompilation,
         swiftApiFlattenPackage = swiftExportConfiguration.rootPackage,
         exportedModules = swiftExportConfiguration.exportedModules,
-        swiftExportConfiguration = swiftExportConfiguration,
+        dependencyOptionsOverrides = swiftExportConfiguration.dependencyOptionsOverrides,
         customSetting = swiftExportConfiguration.settings
     )
 
@@ -167,7 +170,7 @@ private fun Project.registerSwiftExportRun(
     mainCompilation: KotlinNativeCompilation,
     swiftApiFlattenPackage: Provider<String>,
     exportedModules: Provider<Set<SwiftExportedDependency>>,
-    swiftExportConfiguration: SwiftExportConfigurationCompat,
+    dependencyOptionsOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
     customSetting: Provider<Map<String, String>>,
 ): TaskProvider<SwiftExportTask> {
     val swiftExportTaskName = lowerCamelCaseName(
@@ -197,15 +200,16 @@ private fun Project.registerSwiftExportRun(
         task.parameters.bridgeModuleName.set("SharedBridge")
         task.parameters.swiftExportSettings.set(customSetting)
         task.parameters.swiftModules.set(
-            swiftExportConfiguration.adjustSwiftModules(
-                collectModules(
+            project.applySwiftExportConsumerOverrides(
+                modules = collectModules(
                     exportConfigurationProvider,
                     apiConfigurationProvider,
                     exportedModules
                 ),
-                exportConfigurationProvider,
-                apiConfigurationProvider,
-                swiftApiModuleName,
+                overrides = dependencyOptionsOverrides,
+                exportConfiguration = exportConfigurationProvider,
+                apiConfiguration = apiConfigurationProvider,
+                rootModuleName = swiftApiModuleName,
             )
         )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportAction.kt
@@ -44,7 +44,7 @@ internal abstract class SwiftExportAction : WorkAction<SwiftExportAction.SwiftEx
             modules.map { module ->
                 module.toInputModule(
                     createModuleConfig(
-                        module.flattenPackage,
+                        module.rootPackage,
                         module.exportMode,
                         settings
                     )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -14,6 +14,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_SCHEMA_VERSION
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
@@ -117,7 +118,7 @@ internal fun Project.collectModules(
             exportedModules = exportedModules,
         ),
         overrides = dependencyOptionsOverrides,
-        metadataByComponent = metadataConfiguration?.metadataByComponent() ?: emptyMap(),
+        metadataByComponent = metadataConfiguration?.metadataByComponent(project::reportDiagnostic) ?: emptyMap(),
         exportConfiguration = exportConfiguration,
         apiConfiguration = apiConfiguration,
         rootModuleName = rootModuleName,
@@ -184,18 +185,36 @@ private fun Project.swiftExportedModules(
  *
  * The receiver is expected to be resolved requesting the `swiftExportMetadata` variant, so [resolvedArtifacts] contains
  * only the metadata JSONs. Dependencies without such a variant are simply absent (lenient artifact view). Artifacts that
- * are missing on disk, fail to decode, or carry an incompatible [SwiftExportMetadata.schemaVersion] are skipped rather
- * than failing the build.
+ * are missing on disk are silently skipped. Metadata carrying an unsupported [SwiftExportMetadata.schemaVersion] is
+ * skipped with a warning ([KotlinToolingDiagnostics.SwiftExportUnsupportedMetadataSchemaVersion]), as well as metadata that
+ * fails to decode - ([KotlinToolingDiagnostics.SwiftExportMalformedMetadata]).
  */
-private fun LazyResolvedConfigurationWithArtifacts.metadataByComponent(): Map<ComponentIdentifier, SwiftExportMetadata> {
+internal fun LazyResolvedConfigurationWithArtifacts.metadataByComponent(
+    reportDiagnostic: (ToolingDiagnostic) -> Unit,
+): Map<ComponentIdentifier, SwiftExportMetadata> {
     return resolvedArtifacts.mapNotNull { artifact ->
         if (!artifact.file.exists()) return@mapNotNull null
         val metadata = try {
             artifact.file.inputStream().use(::deserializeSwiftExportMetadata)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            reportDiagnostic(
+                KotlinToolingDiagnostics.SwiftExportMalformedMetadata(
+                    artifact.id.componentIdentifier.displayName,
+                    e.message,
+                )
+            )
             return@mapNotNull null
         }
-        if (metadata.schemaVersion != SWIFT_EXPORT_METADATA_SCHEMA_VERSION) return@mapNotNull null
+        if (metadata.schemaVersion != SWIFT_EXPORT_METADATA_SCHEMA_VERSION) {
+            reportDiagnostic(
+                KotlinToolingDiagnostics.SwiftExportUnsupportedMetadataSchemaVersion(
+                    artifact.id.componentIdentifier.displayName,
+                    metadata.schemaVersion,
+                    SWIFT_EXPORT_METADATA_SCHEMA_VERSION,
+                )
+            )
+            return@mapNotNull null
+        }
         artifact.id.componentIdentifier to metadata
     }.toMap()
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -15,6 +15,9 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.applySwiftExportConsumerOverrides
 import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import java.io.File
 import java.io.Serializable
@@ -93,14 +96,27 @@ internal fun Project.collectModules(
     exportConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts>,
     apiConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
     exportedModulesProvider: Provider<Set<SwiftExportedDependency>>,
-): Provider<List<SwiftExportedModule>> = exportConfigurationProvider
-    .map { exportConfiguration ->
-        val apiConfiguration = apiConfigurationProvider.orNull
-        return@map exportConfiguration to apiConfiguration
-    }
-    .zip(exportedModulesProvider) { (exportConfiguration, apiConfiguration), modules ->
-        project.swiftExportedModules(exportConfiguration, apiConfiguration, modules)
-    }
+    dependencyOptionsOverridesProvider: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
+    rootModuleNameProvider: Provider<String>,
+): Provider<List<SwiftExportedModule>> = provider {
+    val exportConfiguration = exportConfigurationProvider.get()
+    val apiConfiguration = apiConfigurationProvider.orNull
+    val exportedModules = exportedModulesProvider.get()
+    val dependencyOptionsOverrides = dependencyOptionsOverridesProvider.get()
+    val rootModuleName = rootModuleNameProvider.get()
+
+    project.applySwiftExportConsumerOverrides(
+        modules = project.swiftExportedModules(
+            exportConfiguration = exportConfiguration,
+            apiConfiguration = apiConfiguration,
+            exportedModules = exportedModules,
+        ),
+        overrides = dependencyOptionsOverrides,
+        exportConfiguration = exportConfiguration,
+        apiConfiguration = apiConfiguration,
+        rootModuleName = rootModuleName,
+    )
+}
 
 private class ResolvedArtifactWithVersionIdentifier(
     val moduleVersion: ModuleVersionIdentifier,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/internal/SwiftExportedModule.kt
@@ -15,9 +15,12 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_SCHEMA_VERSION
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.applySwiftExportConsumerOverrides
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.deserializeSwiftExportMetadata
 import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 import java.io.File
 import java.io.Serializable
@@ -44,25 +47,25 @@ internal enum class SwiftExportedModuleMode {
  * Represents a module that will be exported to Swift.
  *
  * @property moduleName The name of the module in Swift
- * @property flattenPackage Optional package flattening configuration, only used for [SwiftExportedModuleMode.FULL]
+ * @property rootPackage Optional root package configuration, used for package flattening only with [SwiftExportedModuleMode.FULL]
  * @property artifact The artifact file containing the module
  * @property exportMode How Swift Export translates this module
  */
 internal interface SwiftExportedModule : Serializable {
     val moduleName: String
-    val flattenPackage: String?
+    val rootPackage: String?
     val artifact: File
     val exportMode: SwiftExportedModuleMode
 }
 
 internal fun createFullyExportedSwiftExportedModule(
     moduleName: String,
-    flattenPackage: String?,
+    rootPackage: String?,
     artifact: File,
 ): SwiftExportedModule {
     return SwiftExportedModuleImp(
         moduleName,
-        flattenPackage,
+        rootPackage,
         artifact,
         SwiftExportedModuleMode.FULL
     )
@@ -95,12 +98,14 @@ internal fun createHiddenSwiftExportedModule(
 internal fun Project.collectModules(
     exportConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts>,
     apiConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
+    metadataConfigurationProvider: Provider<LazyResolvedConfigurationWithArtifacts?>,
     exportedModulesProvider: Provider<Set<SwiftExportedDependency>>,
     dependencyOptionsOverridesProvider: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
     rootModuleNameProvider: Provider<String>,
 ): Provider<List<SwiftExportedModule>> = provider {
     val exportConfiguration = exportConfigurationProvider.get()
     val apiConfiguration = apiConfigurationProvider.orNull
+    val metadataConfiguration = metadataConfigurationProvider.orNull
     val exportedModules = exportedModulesProvider.get()
     val dependencyOptionsOverrides = dependencyOptionsOverridesProvider.get()
     val rootModuleName = rootModuleNameProvider.get()
@@ -112,6 +117,7 @@ internal fun Project.collectModules(
             exportedModules = exportedModules,
         ),
         overrides = dependencyOptionsOverrides,
+        metadataByComponent = metadataConfiguration?.metadataByComponent() ?: emptyMap(),
         exportConfiguration = exportConfiguration,
         apiConfiguration = apiConfiguration,
         rootModuleName = rootModuleName,
@@ -120,7 +126,7 @@ internal fun Project.collectModules(
 
 private class ResolvedArtifactWithVersionIdentifier(
     val moduleVersion: ModuleVersionIdentifier,
-    val artifact: ResolvedArtifactResult
+    val artifact: ResolvedArtifactResult,
 ) : Serializable {
     private val artifactFilePath: String get() = artifact.file.absolutePath
 
@@ -171,6 +177,28 @@ private fun Project.swiftExportedModules(
         }
         ?: emptySet(),
 )
+
+/**
+ * Reads the Swift Export metadata published by each resolved dependency, keyed by the owning component so it can be
+ * correlated with the klib artifacts collected from the same dependency graph.
+ *
+ * The receiver is expected to be resolved requesting the `swiftExportMetadata` variant, so [resolvedArtifacts] contains
+ * only the metadata JSONs. Dependencies without such a variant are simply absent (lenient artifact view). Artifacts that
+ * are missing on disk, fail to decode, or carry an incompatible [SwiftExportMetadata.schemaVersion] are skipped rather
+ * than failing the build.
+ */
+private fun LazyResolvedConfigurationWithArtifacts.metadataByComponent(): Map<ComponentIdentifier, SwiftExportMetadata> {
+    return resolvedArtifacts.mapNotNull { artifact ->
+        if (!artifact.file.exists()) return@mapNotNull null
+        val metadata = try {
+            artifact.file.inputStream().use(::deserializeSwiftExportMetadata)
+        } catch (_: Exception) {
+            return@mapNotNull null
+        }
+        if (metadata.schemaVersion != SWIFT_EXPORT_METADATA_SCHEMA_VERSION) return@mapNotNull null
+        artifact.id.componentIdentifier to metadata
+    }.toMap()
+}
 
 private fun LazyResolvedConfigurationWithArtifacts.filteredArtifacts(
     dependenciesSelector: LazyResolvedConfigurationWithArtifacts.() -> Iterable<ResolvedDependencyResult>
@@ -256,7 +284,7 @@ private fun Project.findAndCreateSwiftExportedModules(
         result.add(
             createFullyExportedSwiftExportedModule(
                 moduleName = artifact.defaultExportedModuleName().normalizedSwiftExportModuleName,
-                flattenPackage = null,
+                rootPackage = null,
                 artifact = artifact.artifact.file,
             )
         )
@@ -270,8 +298,8 @@ private fun Project.findAndCreateSwiftExportedModules(
         .forEach { artifact ->
             result.add(
                 createTransitiveSwiftExportedModule(
-                    artifact.moduleVersion.inheritedName.normalizedSwiftExportModuleName,
-                    artifact.artifact.file
+                    moduleName = artifact.moduleVersion.inheritedName.normalizedSwiftExportModuleName,
+                    artifact = artifact.artifact.file
                 )
             )
         }
@@ -281,7 +309,7 @@ private fun Project.findAndCreateSwiftExportedModules(
 
 private data class SwiftExportedModuleImp(
     override val moduleName: String,
-    override val flattenPackage: String?,
+    override val rootPackage: String?,
     override val artifact: File,
     override val exportMode: SwiftExportedModuleMode,
 ) : SwiftExportedModule

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
@@ -97,8 +97,8 @@ internal abstract class SwiftExportTask @Inject constructor(
                 if (cinteropModuleName.isPresent) {
                     add(
                         createTransitiveSwiftExportedModule(
-                            cinteropModuleName.get(),
-                            cinteropModuleArtifact.getFile()
+                            moduleName = cinteropModuleName.get(),
+                            artifact = cinteropModuleArtifact.getFile()
                         )
                     )
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -52,6 +52,11 @@ internal interface SwiftExportConfigurationCompat {
     val exportConfiguration: Provider<Configuration>
 
     /**
+     * Whether Swift Export configuration for this module should be resolved from metadata.
+     */
+    val shouldResolveMetadata: Boolean
+
+    /**
      * Returns a list of exported modules.
      */
     val exportedModules: Provider<Set<SwiftExportedDependency>>
@@ -93,6 +98,8 @@ internal interface SwiftExportConfigurationCompat {
 
                 override val exportConfiguration: Provider<Configuration>
                     get() = providers.provider { kotlinNativeCompilation.internal.configurations.compileDependencyConfiguration }
+
+                override val shouldResolveMetadata: Boolean = true
 
                 override val exportedModules: Provider<Set<SwiftExportedDependency>>
                     // The `export { }` DSL has no `export(...)`. Direct `api` dependencies are exported by the
@@ -137,6 +144,8 @@ internal interface SwiftExportConfigurationCompat {
 
                 override val dependencyOptionsOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>
                     get() = providers.provider { emptyMap() }
+
+                override val shouldResolveMetadata: Boolean = false
 
                 override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings
                 override val freeCompilerArgs: ListProperty<String> get() = extension.advancedConfiguration.freeCompilerArgs

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationCompat.kt
@@ -18,12 +18,11 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedDependency
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.exportedSwiftExportApiConfiguration
-import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.applySwiftExportConsumerOverrides
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDependencySelector
 import org.jetbrains.kotlin.gradle.plugin.mpp.internal
 import org.jetbrains.kotlin.gradle.targets.native.resolvableApiConfiguration
-import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
 
 /**
  * A common interface for [SwiftExportConfiguration] and [org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.SwiftExportExtension]
@@ -58,17 +57,9 @@ internal interface SwiftExportConfigurationCompat {
     val exportedModules: Provider<Set<SwiftExportedDependency>>
 
     /**
-     * Applies what this DSL declares on top of the [modules] collected from the export graph. The legacy DSL
-     * declares nothing and returns them as they are.
-     *
-     * @param rootModuleName the Swift module name of the module being exported
+     * User-supplied options overrides for exported modules.
      */
-    fun adjustSwiftModules(
-        modules: Provider<List<SwiftExportedModule>>,
-        exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
-        apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
-        rootModuleName: Provider<String>,
-    ): Provider<List<SwiftExportedModule>>
+    val dependencyOptionsOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>
 
     /**
      * Configure SwiftExportConfig.settings parameters
@@ -108,20 +99,8 @@ internal interface SwiftExportConfigurationCompat {
                     // collector, `configure(dependency, EXPOSED)` is applied on top in `adjustSwiftModules`.
                     get() = providers.provider { emptySet() }
 
-                override fun adjustSwiftModules(
-                    modules: Provider<List<SwiftExportedModule>>,
-                    exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
-                    apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
-                    rootModuleName: Provider<String>,
-                ): Provider<List<SwiftExportedModule>> = kotlinNativeCompilation.project.applySwiftExportConsumerOverrides(
-                    modules = modules,
-                    overrides = providers.provider {
-                        configuration.activatedXcodeIntegration?.dependencyOverrides?.orNull ?: emptyMap()
-                    },
-                    exportConfiguration = exportConfiguration,
-                    apiConfiguration = apiConfiguration,
-                    rootModuleName = rootModuleName,
-                )
+                override val dependencyOptionsOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>
+                    get() = configuration.activatedXcodeIntegration?.dependencyOverrides ?: providers.provider { emptyMap() }
 
                 override val settings: MapProperty<String, String>
                     get() = objects.mapProperty(String::class.java, String::class.java) // TODO: KT-87890
@@ -156,12 +135,8 @@ internal interface SwiftExportConfigurationCompat {
                         )
                     }
 
-                override fun adjustSwiftModules(
-                    modules: Provider<List<SwiftExportedModule>>,
-                    exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
-                    apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
-                    rootModuleName: Provider<String>,
-                ): Provider<List<SwiftExportedModule>> = modules
+                override val dependencyOptionsOverrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>
+                    get() = providers.provider { emptyMap() }
 
                 override val settings: MapProperty<String, String> get() = extension.advancedConfiguration.settings
                 override val freeCompilerArgs: ListProperty<String> get() = extension.advancedConfiguration.freeCompilerArgs

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/MetadataOptionsSource.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/MetadataOptionsSource.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+
+/**
+ * The second-highest precedence layer (after [ConsumerOverridesOptionsSource]): overrides coming from Gradle metadata.
+ */
+internal class MetadataOptionsSource(
+    private val metadataByComponent: Map<ComponentIdentifier, SwiftExportMetadata>,
+) : SwiftExportModuleOptionsSource {
+    override fun optionsFor(component: SwiftExportResolvedComponent): SwiftExportDeclaredModuleOptions? {
+        return metadataByComponent[component.rootComponentId]?.let { metadata ->
+            SwiftExportDeclaredModuleOptions(
+                moduleName = metadata.moduleName,
+                rootPackage = metadata.rootPackage,
+            )
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
@@ -35,14 +36,18 @@ private const val EXPORTED_MODULE_ITSELF = "the module being exported"
 internal fun Project.applySwiftExportConsumerOverrides(
     modules: List<SwiftExportedModule>,
     overrides: Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>,
+    metadataByComponent: Map<ComponentIdentifier, SwiftExportMetadata>,
     exportConfiguration: LazyResolvedConfigurationWithArtifacts,
     apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
     rootModuleName: String,
 ): List<SwiftExportedModule> {
-    if (overrides.isEmpty()) return modules
+    if (overrides.isEmpty() && metadataByComponent.isEmpty()) return modules
 
     // Declared option layers, highest precedence first. KT-87987 adds the producer source here.
-    val sources = listOf(ConsumerOverridesOptionsSource(overrides))
+    val sources = listOf(
+        ConsumerOverridesOptionsSource(overrides),
+        MetadataOptionsSource(metadataByComponent),
+    )
 
     val componentByArtifact = componentByArtifact(exportConfiguration, apiConfiguration)
     val exported = modules.map { module ->
@@ -61,7 +66,7 @@ internal fun Project.applySwiftExportConsumerOverrides(
         val adjusted = when (mode) {
             SwiftExportedModuleMode.FULL -> createFullyExportedSwiftExportedModule(
                 moduleName = declaredName ?: derivedName,
-                flattenPackage = sources.declaredRootPackage(component) ?: module.flattenPackage,
+                rootPackage = sources.declaredRootPackage(component) ?: module.rootPackage,
                 artifact = module.artifact,
             )
             // A transitively exported module has no root package, so a declared one has no effect here.
@@ -117,7 +122,11 @@ private fun componentByArtifact(
             for (artifact in configuration.getArtifacts(dependency.selected)) {
                 result.putIfAbsent(
                     artifact.file,
-                    SwiftExportResolvedComponent(artifact.id.componentIdentifier, dependency.selected.moduleVersion),
+                    SwiftExportResolvedComponent(
+                        id = artifact.id.componentIdentifier,
+                        rootComponentId = dependency.resolvedVariant.owner,
+                        moduleVersion = dependency.selected.moduleVersion,
+                    ),
                 )
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.export.internal
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
-import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportedModule
@@ -34,20 +33,19 @@ private const val EXPORTED_MODULE_ITSELF = "the module being exported"
  * @param rootModuleName the Swift module name of the module being exported, for collision detection
  */
 internal fun Project.applySwiftExportConsumerOverrides(
-    modules: Provider<List<SwiftExportedModule>>,
-    overrides: Provider<Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>>,
-    exportConfiguration: Provider<LazyResolvedConfigurationWithArtifacts>,
-    apiConfiguration: Provider<LazyResolvedConfigurationWithArtifacts?>,
-    rootModuleName: Provider<String>,
-): Provider<List<SwiftExportedModule>> = provider {
-    val overridesMap = overrides.get()
-    if (overridesMap.isEmpty()) return@provider modules.get()
+    modules: List<SwiftExportedModule>,
+    overrides: Map<SwiftExportDependencySelector, SwiftExportDeclaredModuleOptions>,
+    exportConfiguration: LazyResolvedConfigurationWithArtifacts,
+    apiConfiguration: LazyResolvedConfigurationWithArtifacts?,
+    rootModuleName: String,
+): List<SwiftExportedModule> {
+    if (overrides.isEmpty()) return modules
 
     // Declared option layers, highest precedence first. KT-87987 adds the producer source here.
-    val sources = listOf(ConsumerOverridesOptionsSource(overridesMap))
+    val sources = listOf(ConsumerOverridesOptionsSource(overrides))
 
-    val componentByArtifact = componentByArtifact(exportConfiguration.get(), apiConfiguration.orNull)
-    val exported = modules.get().map { module ->
+    val componentByArtifact = componentByArtifact(exportConfiguration, apiConfiguration)
+    val exported = modules.map { module ->
         val component = componentByArtifact[module.artifact] ?: return@map module to null
         val declaredName = sources.declaredModuleName(component)?.also { validateSwiftExportModuleName(it) }
         val visibility = sources.declaredVisibility(component)
@@ -81,7 +79,7 @@ internal fun Project.applySwiftExportConsumerOverrides(
     }
 
     val components = exported.mapNotNull { (_, component) -> component }
-    val unmatched = overridesMap.keys.filterNot { selector -> components.any(selector::matches) }
+    val unmatched = overrides.keys.filterNot { selector -> components.any(selector::matches) }
     if (unmatched.isNotEmpty()) {
         reportDiagnostic(
             KotlinToolingDiagnostics.SwiftExportModuleResolutionError(
@@ -91,7 +89,7 @@ internal fun Project.applySwiftExportConsumerOverrides(
         )
     }
 
-    val owners = listOf(rootModuleName.get() to EXPORTED_MODULE_ITSELF) +
+    val owners = listOf(rootModuleName to EXPORTED_MODULE_ITSELF) +
             exported.map { (module, component) -> module.moduleName to (component?.displayName ?: module.artifact.name) }
     // Ignoring case: the output directories are named after the modules, and the macOS file system is
     // case-insensitive by default.
@@ -103,7 +101,7 @@ internal fun Project.applySwiftExportConsumerOverrides(
         reportDiagnostic(KotlinToolingDiagnostics.SwiftExportDuplicateModuleNames(duplicates))
     }
 
-    exported.map { (module, _) -> module }
+    return exported.map { (module, _) -> module }
 }
 
 /**

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportConsumerOverrides.kt
@@ -41,6 +41,8 @@ internal fun Project.applySwiftExportConsumerOverrides(
     rootModuleName: Provider<String>,
 ): Provider<List<SwiftExportedModule>> = provider {
     val overridesMap = overrides.get()
+    if (overridesMap.isEmpty()) return@provider modules.get()
+
     // Declared option layers, highest precedence first. KT-87987 adds the producer source here.
     val sources = listOf(ConsumerOverridesOptionsSource(overridesMap))
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportMetadata.kt
@@ -24,7 +24,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.Serializable
 
-private const val SWIFT_EXPORT_METADATA_USAGE = "swiftExportMetadata"
+internal const val SWIFT_EXPORT_METADATA_USAGE = "swiftExportMetadata"
 
 /**
  * Version of the [SwiftExportMetadata] serialization format. Bump it whenever the serialized shape changes.

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportModuleOptionsSource.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/internal/SwiftExportModuleOptionsSource.kt
@@ -18,6 +18,12 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.export.SwiftExportVisibility
  */
 internal data class SwiftExportResolvedComponent(
     val id: ComponentIdentifier,
+    /**
+     * The component that owns this artifact as seen from the requesting dependency edge, i.e. before KMP
+     * `available-at` redirection to the platform component. Useful for accessing Swift Export metadata,
+     * which is published on the root component.
+     */
+    val rootComponentId: ComponentIdentifier,
     /** `null` when Gradle resolved the component without module coordinates. */
     val moduleVersion: ModuleVersionIdentifier?,
 ) {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExportExtensionUnitTests.kt
@@ -2058,7 +2058,7 @@ private fun List<SwiftExportedModule>.toModulesForAssertion() = mapToSetOrEmpty 
         moduleName = module.moduleName,
         artifactName = module.artifact.name,
         exportMode = module.exportMode,
-        flattenPackage = module.flattenPackage,
+        flattenPackage = module.rootPackage,
     )
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportDependencySelectorTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportDependencySelectorTests.kt
@@ -46,6 +46,13 @@ class SwiftExportDependencySelectorTests {
             override fun getModuleIdentifier() = moduleVersion(group, name, version).module
             override fun getDisplayName() = "$group:$name:$version"
         },
+        rootComponentId = object : ModuleComponentIdentifier {
+            override fun getGroup() = group
+            override fun getModule() = name
+            override fun getVersion() = version
+            override fun getModuleIdentifier() = moduleVersion(group, name, version).module
+            override fun getDisplayName() = "$group:$name:$version"
+        },
         moduleVersion = moduleVersion(group, name, version),
     )
 
@@ -62,12 +69,13 @@ class SwiftExportDependencySelectorTests {
         val resolvable = root.configurations.detachedConfiguration(
             root.dependencies.project(mapOf("path" to path, "configuration" to "forTest"))
         )
-        val selected = resolvable.incoming.resolutionResult.root.dependencies
+        val dependencyResult = resolvable.incoming.resolutionResult.root.dependencies
             .filterIsInstance<ResolvedDependencyResult>()
             .single()
-            .selected
+        val selected = dependencyResult.selected
         return SwiftExportResolvedComponent(
             id = selected.id,
+            rootComponentId = dependencyResult.resolvedVariant.owner,
             moduleVersion = publishedAs?.let { (group, module) -> moduleVersion(group, module, "1.0") },
         )
     }
@@ -167,7 +175,11 @@ class SwiftExportDependencySelectorTests {
 
     @Test
     fun `an unknown component identifier matches nothing`() {
-        val component = SwiftExportResolvedComponent(ComponentIdentifier { "opaque" }, moduleVersion = null)
+        val component = SwiftExportResolvedComponent(
+            id = { "opaque" },
+            rootComponentId = { "opaque" },
+            moduleVersion = null
+        )
 
         assertFalse(SwiftExportDependencySelector.Module(group = "org.example", name = "foo").matches(component))
         assertFalse(SwiftExportDependencySelector.ProjectPath(":foo").matches(component))

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportMetadataConsumptionUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportMetadataConsumptionUnitTests.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.unitTests
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnosticsSeverity
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.metadataByComponent
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SWIFT_EXPORT_METADATA_SCHEMA_VERSION
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportMetadata
+import org.jetbrains.kotlin.gradle.util.buildProject
+import org.jetbrains.kotlin.gradle.utils.LazyResolvedConfigurationWithArtifacts
+import org.jetbrains.kotlin.gradle.utils.createConsumable
+import org.jetbrains.kotlin.gradle.utils.createResolvable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests that exercise [metadataByComponent] directly: they feed a hand-crafted Swift Export metadata JSON as the
+ * single resolved artifact of a [LazyResolvedConfigurationWithArtifacts] and assert either that the metadata was parsed
+ * correctly or that the expected diagnostic was reported.
+ */
+class SwiftExportMetadataConsumptionUnitTests {
+
+    @Test
+    fun `valid metadata is parsed`() {
+        val result = consumeMetadata(
+            """
+            {"schemaVersion":$SWIFT_EXPORT_METADATA_SCHEMA_VERSION,"moduleName":"Foo","rootPackage":"com.foo.bar"}
+            """.trimIndent()
+        )
+
+        assertTrue(result.diagnostics.isEmpty(), "No diagnostics expected for valid metadata, got: ${result.diagnostics}")
+        val metadata = result.metadata.values.single()
+        assertEquals(SWIFT_EXPORT_METADATA_SCHEMA_VERSION, metadata.schemaVersion)
+        assertEquals("Foo", metadata.moduleName)
+        assertEquals("com.foo.bar", metadata.rootPackage)
+    }
+
+    @Test
+    fun `missing metadata is ignored`() {
+        val result = consumeMetadata(metadataJson = null)
+
+        assertTrue(result.diagnostics.isEmpty(), "No diagnostics expected for missing metadata, got: ${result.diagnostics}")
+        assertTrue(result.metadata.isEmpty(), "No metadata expected, got: ${result.metadata}")
+    }
+
+    @Test
+    fun `unknown fields in a supported schema are ignored`() {
+        val result = consumeMetadata(
+            """
+            {"schemaVersion":$SWIFT_EXPORT_METADATA_SCHEMA_VERSION,"moduleName":"Foo","rootPackage":null,"unknownField":42,"nested":{"a":1}}
+            """.trimIndent()
+        )
+
+        assertTrue(result.diagnostics.isEmpty(), "No diagnostics expected when ignoring unknown fields, got: ${result.diagnostics}")
+        val metadata = result.metadata.values.single()
+        assertEquals("Foo", metadata.moduleName)
+        assertNull(metadata.rootPackage)
+    }
+
+    @Test
+    fun `unsupported newer schema produces a warning and is ignored`() {
+        val newerSchemaVersion = SWIFT_EXPORT_METADATA_SCHEMA_VERSION + 1
+        val result = consumeMetadata(
+            """
+            {"schemaVersion":$newerSchemaVersion,"moduleName":"Foo","rootPackage":null}
+            """.trimIndent()
+        )
+
+        assertTrue(result.metadata.isEmpty(), "Metadata with an unsupported schema version must be ignored")
+        val diagnostic = result.diagnostics.single()
+        assertEquals(KotlinToolingDiagnostics.SwiftExportUnsupportedMetadataSchemaVersion.id, diagnostic.id)
+        assertEquals(KotlinToolingDiagnosticsSeverity.WARNING, diagnostic.severity)
+    }
+
+    @Test
+    fun `malformed metadata for a supported schema fails with a diagnostic`() {
+        val result = consumeMetadata("this is not valid json")
+
+        assertTrue(result.metadata.isEmpty(), "Malformed metadata must not be parsed")
+        val diagnostic = result.diagnostics.single()
+        assertEquals(KotlinToolingDiagnostics.SwiftExportMalformedMetadata.id, diagnostic.id)
+        assertEquals(KotlinToolingDiagnosticsSeverity.WARNING, diagnostic.severity)
+    }
+
+    private class MetadataConsumptionResult(
+        val metadata: Map<ComponentIdentifier, SwiftExportMetadata>,
+        val diagnostics: List<ToolingDiagnostic>,
+    )
+
+    /**
+     * Builds a [LazyResolvedConfigurationWithArtifacts] whose single resolved artifact is a metadata JSON file carrying
+     * [metadataJson], then reads it via [metadataByComponent], collecting any reported diagnostics.
+     */
+    private fun consumeMetadata(metadataJson: String?): MetadataConsumptionResult {
+        val project = buildProject()
+
+        // A resolvable configuration that depends on a consumable configuration of the same project, which exposes the
+        // metadata JSON as its only artifact (see LazyResolvedConfigurationTest for the same self-dependency pattern).
+        val resolvable = project.configurations.createResolvable("swiftExportMetadataForTest")
+        val consumable = project.configurations.createConsumable("swiftExportMetadataForTestElements")
+        project.dependencies.add(
+            resolvable.name,
+            project.dependencies.project(mapOf("path" to ":", "configuration" to consumable.name))
+        )
+        resolvable.extendsFrom(consumable)
+
+        if (metadataJson != null) {
+            val metadataFile = project.file("swift-export-metadata.json").apply { writeText(metadataJson) }
+            project.artifacts.add(consumable.name, metadataFile)
+        }
+
+        val diagnostics = mutableListOf<ToolingDiagnostic>()
+        val metadata = LazyResolvedConfigurationWithArtifacts(resolvable).metadataByComponent { diagnostics.add(it) }
+
+        return MetadataConsumptionResult(metadata, diagnostics)
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportModuleOptionsSourceTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportModuleOptionsSourceTests.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportDeclaredModuleOptions
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportModuleOptionsSource
 import org.jetbrains.kotlin.gradle.plugin.mpp.export.internal.SwiftExportResolvedComponent
@@ -21,7 +20,11 @@ import kotlin.test.assertNull
  */
 class SwiftExportModuleOptionsSourceTests {
 
-    private val component = SwiftExportResolvedComponent(ComponentIdentifier { "test-component" }, moduleVersion = null)
+    private val component = SwiftExportResolvedComponent(
+        id = { "test-component" },
+        rootComponentId = { "test-component" },
+        moduleVersion = null
+    )
 
     private fun layer(moduleName: String?, rootPackage: String?) =
         SwiftExportModuleOptionsSource { SwiftExportDeclaredModuleOptions(moduleName, rootPackage) }


### PR DESCRIPTION
Implements Swift Export metadata consumption for published external dependencies by reading it from the swiftExportMetadataElements configuration. Swift Export options overrides are applied via MetadataOptionsSource, which yields precedence to ConsumerOverridesOptionsSource. Metadata parsing is lenient, however there are warning diagnostics for cases of malformed metadata or metadata with unsupported version. Unit and integration tests are added to validate correct metadata consumption.

^KT-87987 Verification Pending