### PR TITLE
KAPT: Minor. Remove KaptStubConverter.bindings

### DIFF
--- a/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/FirKaptAnalysisHandlerExtension.kt
+++ b/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/FirKaptAnalysisHandlerExtension.kt
@@ -213,7 +213,7 @@ open class FirKaptAnalysisHandlerExtension(
         val [saveStubsTime] = measureTimeMillis { saveStubs(kaptContext, kaptStubs) }
         logger.info { "Java stub saving took $saveStubsTime ms" }
 
-        val [saveIncrementalDataTime] = measureTimeMillis { saveIncrementalData(kaptContext, converter) }
+        val [saveIncrementalDataTime] = measureTimeMillis { saveIncrementalData(kaptContext) }
         logger.info { "Incremental data saving took $saveIncrementalDataTime ms" }
     }
 
@@ -279,10 +279,7 @@ open class FirKaptAnalysisHandlerExtension(
         logger.info { "Source files: ${sourceFiles}" }
     }
 
-    protected open fun saveIncrementalData(
-        kaptContext: KaptContextForStubGeneration,
-        converter: KaptStubConverter,
-    ) {
+    protected open fun saveIncrementalData(kaptContext: KaptContextForStubGeneration) {
         val incrementalDataOutputDir = options.incrementalDataOutputDir ?: return
 
         val reportOutputFiles = kaptContext.configuration.reportOutputFiles

--- a/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/stubs/KaptStubConverter.kt
+++ b/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/stubs/KaptStubConverter.kt
@@ -145,9 +145,6 @@ class KaptStubConverter(val kaptContext: KaptContextForStubGeneration, val gener
     // processing) stubs. Currently, it is mostly a marker for the known cases of potentially incorrect syntax rather than a public flag
     private val avoidIncorrectJavaCode = false
 
-    val bindings: Map<String, KaptJavaFileObject>
-        field = mutableMapOf<String, KaptJavaFileObject>()
-
     private val typeMapper = KaptTypeMapper
 
     val treeMaker = TreeMaker.instance(kaptContext.context) as KaptTreeMaker
@@ -322,10 +319,7 @@ class KaptStubConverter(val kaptContext: KaptContextForStubGeneration, val gener
             append(classText)
         }
 
-        KaptJavaFileObject(topLevel, classDeclaration).apply {
-            topLevel.sourcefile = this
-            bindings[clazz.name] = this
-        }
+        topLevel.sourcefile = KaptJavaFileObject(topLevel, classDeclaration)
 
         postProcess(topLevel)
 

--- a/plugins/kapt/kapt-compiler/testFixtures/org/jetbrains/kotlin/kapt/test/integration/FirKaptExtensionProvider.kt
+++ b/plugins/kapt/kapt-compiler/testFixtures/org/jetbrains/kotlin/kapt/test/integration/FirKaptExtensionProvider.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.kapt.base.ProcessorLoader
 import org.jetbrains.kotlin.kapt.base.StubGenerationScheme
 import org.jetbrains.kotlin.kapt.base.incremental.DeclaredProcType
 import org.jetbrains.kotlin.kapt.base.incremental.IncrementalProcessor
-import org.jetbrains.kotlin.kapt.javac.KaptJavaFileObject
 import org.jetbrains.kotlin.kapt.stubs.KaptStubConverter
 import org.jetbrains.kotlin.kapt.test.handlers.KaptStubConverterHandler.Companion.FILE_SEPARATOR
 import org.jetbrains.kotlin.kapt.util.CompilerConfigurationBackedKaptLogger
@@ -73,8 +72,6 @@ class FirKaptExtensionForTests(
     val started: Boolean
         get() = _started
     var savedStubs: String? = null
-        private set
-    var savedBindings: Map<String, KaptJavaFileObject>? = null
         private set
 
     private val processor = object : Processor {
@@ -138,19 +135,6 @@ class FirKaptExtensionForTests(
             .joinToString(FILE_SEPARATOR)
 
         super.saveStubs(kaptContext, stubs)
-    }
-
-    override fun saveIncrementalData(
-        kaptContext: KaptContextForStubGeneration,
-        converter: KaptStubConverter
-    ) {
-        if (this.savedBindings != null) {
-            error("Bindings are already saved")
-        }
-
-        this.savedBindings = converter.bindings
-
-        super.saveIncrementalData(kaptContext, converter)
     }
 
     private class TestProcessorLoader(

--- a/plugins/kapt/kapt-compiler/tests/org/jetbrains/kotlin/kapt/test/integration/FirKotlinKaptIntegrationTest.kt
+++ b/plugins/kapt/kapt-compiler/tests/org/jetbrains/kotlin/kapt/test/integration/FirKotlinKaptIntegrationTest.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.analyzer.CompilationErrorException
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollectorImpl
 import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
-import org.jetbrains.kotlin.kapt.javac.KaptJavaFileObject
 import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertEquals
 import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertNotNull
 import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertTrue
@@ -85,33 +84,30 @@ class FirKotlinKaptIntegrationTest(private val testInfo: TestInfo) {
     }
 
     @Test
-    fun testSimpleStubsAndIncrementalData() = bindingsTest("Simple") { stubsOutputDir, incrementalDataOutputDir, bindings ->
+    fun testSimpleStubsAndIncrementalData() = stubsTest("Simple") { stubsOutputDir, incrementalDataOutputDir ->
         assertTrue(File(stubsOutputDir, "error/NonExistentClass.java").exists())
         assertTrue(File(stubsOutputDir, "test/Simple.java").exists())
         assertTrue(File(stubsOutputDir, "test/EnumClass.java").exists())
 
         assertTrue(File(incrementalDataOutputDir, "test/Simple.class").exists())
         assertTrue(File(incrementalDataOutputDir, "test/EnumClass.class").exists())
-
-        assertTrue(bindings.any { it.key == "test/Simple" && it.value.name == "test/Simple.java" })
-        assertTrue(bindings.any { it.key == "test/EnumClass" && it.value.name == "test/EnumClass.java" })
     }
 
     @Test
     fun testStubsAndIncrementalDataForNestedClasses() {
-        bindingsTest("NestedClasses") { stubsOutputDir, incrementalDataOutputDir, bindings ->
-            assertTrue(File(stubsOutputDir, "test/Simple.java").exists())
-            assertTrue(!File(stubsOutputDir, "test/Simple/InnerClass.java").exists())
-
+        stubsTest("NestedClasses") { stubsOutputDir, incrementalDataOutputDir ->
             assertTrue(File(incrementalDataOutputDir, "test/Simple.class").exists())
             assertTrue(File(incrementalDataOutputDir, $$"test/Simple$Companion.class").exists())
             assertTrue(File(incrementalDataOutputDir, $$"test/Simple$InnerClass.class").exists())
             assertTrue(File(incrementalDataOutputDir, $$"test/Simple$NestedClass.class").exists())
             assertTrue(File(incrementalDataOutputDir, $$"test/Simple$NestedClass$NestedNestedClass.class").exists())
 
-            assertTrue(bindings.any { it.key == "test/Simple" && it.value.name == "test/Simple.java" })
-            assertTrue(bindings.none { it.key.contains("Companion") })
-            assertTrue(bindings.none { it.key.contains("InnerClass") })
+            // One stub per top-level class: nested, inner and companion classes are folded into the
+            // stub of their outermost class rather than getting stubs of their own.
+            assertEquals(
+                sortedSetOf("error/NonExistentClass.java", "test/MyAnnotation.java", "test/Simple.java"),
+                generatedStubs(stubsOutputDir),
+            )
         }
     }
 
@@ -180,16 +176,20 @@ class FirKotlinKaptIntegrationTest(private val testInfo: TestInfo) {
     }
 
 
-    private fun bindingsTest(name: String, test: (File, File, Map<String, KaptJavaFileObject>) -> Unit) {
+    private fun stubsTest(name: String, test: (File, File) -> Unit) {
         test(name, "test.MyAnnotation") { _, _, _, kaptExtension ->
             val stubsOutputDir = kaptExtension.options.stubsOutputDir
             val incrementalDataOutputDir = kaptExtension.options.incrementalDataOutputDir
 
-            val bindings = kaptExtension.savedBindings!!
-
-            test(stubsOutputDir, incrementalDataOutputDir!!, bindings)
+            test(stubsOutputDir, incrementalDataOutputDir!!)
         }
     }
+
+    private fun generatedStubs(stubsOutputDir: File): Set<String> =
+        stubsOutputDir.walkTopDown()
+            .filter { it.extension == "java" }
+            .map { it.relativeTo(stubsOutputDir).invariantSeparatorsPath }
+            .toSortedSet()
 
     @Test
     fun testOptions() = test(


### PR DESCRIPTION
Initially, they were used for incremental compilation, later, the need for it disappeared, since the incremental data is currently being reported in `reportStubsOutputForIC`.