### PR TITLE
Cherry-pick "Fix parameter traversal in `ComposableLambdaTokenizer.captureInsnCount`" to `2.5.0-Beta1`

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/booleanCapturePassedThroughSuspendInlineFunction[mapping=false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/booleanCapturePassedThroughSuspendInlineFunction[mapping=false].txt
@@ -1,0 +1,33 @@
+//
+// Source
+// ------------------------------------------
+
+@Composable
+fun Test(bool1: Boolean, bool2: Boolean, string: String) {
+    LaunchedEffect(Unit) {
+        disposingComposition {
+             suspendContent {
+                println(bool1)
+                println(bool2)
+                println(string)
+            }
+        }
+    }
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+========= FunctionMeta: true, OptimizeGroups: true =========
+TestKt {
+    file: Test.kt
+    Test(ZZLjava/lang/String;Landroidx/compose/runtime/Composer;I)V
+        Root { key: <key>, line: 5 }
+}
+
+TestKt$Test$1$1 {
+    file: Test.kt
+    invokeSuspend$lambda$0$0(ZZLjava/lang/String;Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+        Root { key: <key>, line: 9 }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/booleanCapturePassedThroughSuspendInlineFunction[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/booleanCapturePassedThroughSuspendInlineFunction[mapping=true].txt
@@ -1,0 +1,25 @@
+//
+// Source
+// ------------------------------------------
+
+@Composable
+fun Test(bool1: Boolean, bool2: Boolean, string: String) {
+    LaunchedEffect(Unit) {
+        disposingComposition {
+             suspendContent {
+                println(bool1)
+                println(bool2)
+                println(string)
+            }
+        }
+    }
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+========= FunctionMeta: true, OptimizeGroups: true =========
+ComposeStackTrace -> $$compose:
+    1:1:void TestKt.Test(boolean,boolean,java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:kotlin.Unit TestKt$Test$1$1.invokeSuspend$lambda$0$0(boolean,boolean,java.lang.String,androidx.compose.runtime.Composer,int):9:9 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/GroupAnalysisCompilerTest.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/GroupAnalysisCompilerTest.kt
@@ -383,6 +383,41 @@ class GroupAnalysisCompilerTest(
         """
     )
 
+    /**
+     * This is a regression test against a bug that made stack trace mapping collection fail
+     * whenever a captured boolean variable was passed through a suspend inline function.
+     * For more details, see https://issuetracker.google.com/issues/555304803.
+     */
+    @Test
+    fun booleanCapturePassedThroughSuspendInlineFunction() = groups(
+        """
+            @Composable
+            fun Test(bool1: Boolean, bool2: Boolean, string: String) {
+                LaunchedEffect(Unit) {
+                    disposingComposition {
+                         suspendContent {
+                            println(bool1)
+                            println(bool2)
+                            println(string)
+                        }
+                    }
+                }
+            }
+        """,
+        """
+            suspend inline fun disposingComposition(f: suspend () -> Unit) {
+                f()
+            }
+
+            suspend inline fun suspendContent(noinline content: @Composable () -> Unit) {
+                waitForInit()
+            }
+
+            suspend fun waitForInit() {
+            }
+        """
+    )
+
     @Test
     fun inlineWithConditional() = groups(
         """

--- a/plugins/compose/group-mapping/src/main/kotlin/androidx/compose/compiler/mapping/bytecode/BytecodeTokenizer.kt
+++ b/plugins/compose/group-mapping/src/main/kotlin/androidx/compose/compiler/mapping/bytecode/BytecodeTokenizer.kt
@@ -227,12 +227,12 @@ private object ComposableLambdaTokenizer : BytecodeTokenizer {
 
     private fun captureInsnCount(context: TokenizerContext, capturesOffset: Int, desc: JvmDescriptor): Result<Int> {
         var offset = capturesOffset
-        repeat(desc.parameters.size) {
+        for (paramIndex in desc.parameters.lastIndex downTo 0) {
             when (val insn = context[offset]) {
                 is FieldInsnNode -> offset -= 2
                 is VarInsnNode -> offset -= 1
                 else -> {
-                    if (desc.parameters[it] == "Z" && (insn is FrameNode || insn is LabelNode)) {
+                    if (desc.parameters[paramIndex] == "Z" && (insn is FrameNode || insn is LabelNode)) {
                         // Kotlin generates if (field) true else false for some reason when
                         // boolean captures are passed through suspend inline functions.
                         // Traverse back to the last iload instruction to continue analyzing captures.


### PR DESCRIPTION
This PR makes `captureInsnCount` traverse `desc.parameters` in reverse, so that the traversed parameters correctly match up with `offset`.

Relnote: "Fixed a bug that made Compose stack trace mapping collection fail in certain cases in which a boolean variable was captured in a suspend lambda."

Test: `GroupAnalysisCompilerTest.booleanCapturePassedThroughSuspendInlineFunction`
Bug: 555304803