### PR TITLE
KT-86830 [KGP] Migrate KotlinProjectStructureMetadata JSON path to kotlinx-serialization

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/KotlinProjectStructureMetadata.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/KotlinProjectStructureMetadata.kt
@@ -5,10 +5,6 @@
 
 package org.jetbrains.kotlin.gradle.plugin.mpp
 
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
-import com.google.gson.stream.JsonWriter
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
@@ -22,7 +18,6 @@ import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import java.io.Serializable
-import java.io.StringWriter
 import javax.xml.parsers.DocumentBuilderFactory
 
 // FIXME support module classifiers for PM2.0 or drop this class in favor of KotlinModuleIdentifier
@@ -242,32 +237,87 @@ internal fun KotlinProjectStructureMetadata.toXmlDocument(): Document {
 }
 
 internal fun KotlinProjectStructureMetadata.toJson(): String {
-    val gson = GsonBuilder().setPrettyPrinting().create()
-    val stringWriter = StringWriter()
-    with(gson.newJsonWriter(stringWriter)) {
-        val obj: JsonWriter.(String, JsonWriter.() -> Unit) -> Unit =
-            { name, content -> if (name.isNotEmpty()) name(name); beginObject(); content(); endObject() }
-        val property: JsonWriter.(String, String) -> Unit = { name, value -> name(name); value(value) }
-        val array: JsonWriter.(String, JsonWriter.() -> Unit) -> Unit =
-            { name, contents -> name(name); beginArray(); contents(); endArray() }
+    return KotlinProjectStructureMetadataJson(
+        projectStructure = ProjectStructureNodeJson(
+            formatVersion = formatVersion,
+            isPublishedAsRoot = isPublishedAsRoot.toString(),
+            variants = sourceSetNamesByVariantName.map { (variantName, sourceSets) ->
+                VariantNodeJson(
+                    name = variantName,
+                    sourceSet = sourceSets.toList(),
+                )
+            },
+            sourceSets = sourceSetNames.map { sourceSetName ->
+                SourceSetNodeJson(
+                    name = sourceSetName,
+                    dependsOn = sourceSetsDependsOnRelation[sourceSetName].orEmpty().toList(),
+                    moduleDependency = sourceSetModuleDependencies[sourceSetName].orEmpty().map { moduleDependency ->
+                        moduleDependency.groupId + ":" + moduleDependency.moduleId
+                    },
+                    sourceSetCInteropMetadataDirectory = sourceSetCInteropMetadataDirectory[sourceSetName],
+                    binaryLayout = sourceSetBinaryLayout[sourceSetName]?.name,
+                    hostSpecific = if (sourceSetName in hostSpecificSourceSets) "true" else null,
+                )
+            },
+        )
+    ).encodeToString()
+}
 
-        beginObject()
-        serialize(this, obj, array, { _, fn -> obj("", fn) }, property, { key, values -> array(key) { values.forEach { value(it) } } })
-        endObject()
+/**
+ * Parses a `"$groupId:$moduleId"` pair as written by [KotlinProjectStructureMetadata.toJson] and [serialize].
+ *
+ * Third-party producers write this file too, and some copies here are hand-patched, so name a bad entry instead
+ * of failing with an `IndexOutOfBoundsException` somewhere inside dependency resolution. Anything past the second
+ * segment is dropped, as the destructuring this replaces did.
+ */
+private fun parseModuleDependencyIdentifier(moduleDependency: String): ModuleDependencyIdentifier {
+    val parts = moduleDependency.split(":")
+    check(parts.size >= 2) {
+        "Malformed module dependency '$moduleDependency' in project structure metadata, expected '<groupId>:<moduleId>'"
     }
-    return stringWriter.toString()
+    return ModuleDependencyIdentifier(parts[0], parts[1])
 }
 
 private val NodeList.elements: Iterable<Element> get() = (0 until length).map { this@elements.item(it) }.filterIsInstance<Element>()
 
 internal fun parseKotlinSourceSetMetadataFromJson(string: String): KotlinProjectStructureMetadata {
-    @Suppress("DEPRECATION") // The replacement doesn't compile against old dependencies such as AS 4.0
-    val json = JsonParser().parse(string).asJsonObject
-    val valueNamed: JsonObject.(String) -> String? = { name -> get(name)?.asString }
-    val multiObjects: JsonObject.(String?) -> Iterable<JsonObject> = { name -> get(name).asJsonArray.map { it.asJsonObject } }
-    val multiValues: JsonObject.(String?) -> Iterable<String> = { name -> get(name).asJsonArray.map { it.asString } }
+    val projectStructure = decodeKotlinProjectStructureMetadataJson(string).projectStructure
 
-    return parseKotlinSourceSetMetadata({ json.get(ROOT_NODE_NAME).asJsonObject }, valueNamed, multiObjects, multiValues)
+    val sourceSetNames = mutableSetOf<String>()
+    val sourceSetsDependsOnRelation = mutableMapOf<String, Set<String>>()
+    val sourceSetModuleDependencies = mutableMapOf<String, Set<ModuleDependencyIdentifier>>()
+    val sourceSetCInteropMetadataDirectory = mutableMapOf<String, String>()
+    val sourceSetBinaryLayout = mutableMapOf<String, SourceSetMetadataLayout>()
+    val hostSpecificSourceSets = mutableSetOf<String>()
+
+    for (sourceSet in projectStructure.sourceSets) {
+        val sourceSetName = sourceSet.name
+        sourceSetNames.add(sourceSetName)
+        sourceSetsDependsOnRelation[sourceSetName] = sourceSet.dependsOn.toSet()
+        sourceSetModuleDependencies[sourceSetName] =
+            sourceSet.moduleDependency.mapTo(mutableSetOf(), ::parseModuleDependencyIdentifier)
+        sourceSet.sourceSetCInteropMetadataDirectory?.let { cinteropMetadataDirectory ->
+            sourceSetCInteropMetadataDirectory[sourceSetName] = cinteropMetadataDirectory
+        }
+        sourceSet.binaryLayout?.let { binaryLayout ->
+            SourceSetMetadataLayout.byName(binaryLayout)?.let { layout -> sourceSetBinaryLayout[sourceSetName] = layout }
+        }
+        if (sourceSet.hostSpecific?.toBoolean() == true) {
+            hostSpecificSourceSets.add(sourceSetName)
+        }
+    }
+
+    return KotlinProjectStructureMetadata(
+        sourceSetNamesByVariantName = projectStructure.variants.associate { variant -> variant.name to variant.sourceSet.toSet() },
+        sourceSetsDependsOnRelation = sourceSetsDependsOnRelation,
+        sourceSetBinaryLayout = sourceSetBinaryLayout,
+        sourceSetModuleDependencies = sourceSetModuleDependencies,
+        sourceSetCInteropMetadataDirectory = sourceSetCInteropMetadataDirectory,
+        hostSpecificSourceSets = hostSpecificSourceSets,
+        isPublishedAsRoot = projectStructure.isPublishedAsRoot.toBoolean(),
+        sourceSetNames = sourceSetNames,
+        formatVersion = projectStructure.formatVersion,
+    )
 }
 
 internal fun parseKotlinSourceSetMetadataFromXml(document: Document): KotlinProjectStructureMetadata {
@@ -320,10 +370,8 @@ internal fun <ParsingContext> parseKotlinSourceSetMetadata(
         sourceSetNames.add(sourceSetName)
 
         val dependsOn = sourceSetNode.multiValues(DEPENDS_ON_NODE_NAME).toSet()
-        val moduleDependencies = sourceSetNode.multiValues(MODULE_DEPENDENCY_NODE_NAME).mapTo(mutableSetOf()) {
-            val (groupId, moduleId) = it.split(":")
-            ModuleDependencyIdentifier(groupId, moduleId)
-        }
+        val moduleDependencies = sourceSetNode.multiValues(MODULE_DEPENDENCY_NODE_NAME)
+            .mapTo(mutableSetOf(), ::parseModuleDependencyIdentifier)
 
         sourceSetNode.valueNamed(SOURCE_SET_CINTEROP_METADATA_NODE_NAME)?.let { cinteropMetadataDirectory ->
             sourceSetCInteropMetadataDirectory[sourceSetName] = cinteropMetadataDirectory

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/KotlinProjectStructureMetadataJson.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/KotlinProjectStructureMetadataJson.kt
@@ -6,8 +6,16 @@
 package org.jetbrains.kotlin.gradle.plugin.mpp
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.kotlin.gradle.internal.json.KgpJson
 
 /**
@@ -20,6 +28,13 @@ import org.jetbrains.kotlin.gradle.internal.json.KgpJson
  *  - booleans ([ProjectStructureNodeJson.isPublishedAsRoot], [SourceSetNodeJson.hostSpecific]) are quoted strings;
  *  - [SourceSetNodeJson.hostSpecific] is omitted rather than set to `"false"`.
  *
+ * Reading stays as permissive as Gson was, because other producers and hand-patched files rely on it: unknown
+ * keys are ignored, a missing `isPublishedAsRoot` defaults to `"false"`, and the quoted booleans also accept the
+ * unquoted form (see [QuotedBooleanAsStringSerializer]). `JsonParser.parseReader` always parsed leniently, so
+ * `isLenient` is on and [decodeKotlinProjectStructureMetadataJson] drops the BOM its reader skipped. Gson went a
+ * little further and took single-quoted strings, which `isLenient` reads as literals with the quotes kept, but
+ * nothing is known to write those.
+ *
  * Property declaration order defines the order of keys in the output and must match
  * [org.jetbrains.kotlin.gradle.plugin.mpp.serialize], which the XML representation still uses.
  */
@@ -31,7 +46,8 @@ internal data class KotlinProjectStructureMetadataJson(
 @Serializable
 internal data class ProjectStructureNodeJson(
     val formatVersion: String,
-    val isPublishedAsRoot: String,
+    @Serializable(with = QuotedBooleanAsStringSerializer::class)
+    val isPublishedAsRoot: String = "false",
     val variants: List<VariantNodeJson> = emptyList(),
     val sourceSets: List<SourceSetNodeJson> = emptyList(),
 )
@@ -50,8 +66,24 @@ internal data class SourceSetNodeJson(
     val moduleDependency: List<String> = emptyList(),
     val sourceSetCInteropMetadataDirectory: String? = null,
     val binaryLayout: String? = null,
+    @Serializable(with = QuotedBooleanAsStringSerializer::class)
     val hostSpecific: String? = null,
 )
+
+/**
+ * Keeps reading of the quoted booleans as lenient as Gson's `asString` was: it accepted both `"true"` and a bare
+ * `true`, while kotlinx-serialization would reject the latter with a type mismatch (`coerceInputValues` does not
+ * help — it only substitutes defaults for an explicit `null`). Decoding goes through [kotlinx.serialization.json.JsonPrimitive.content],
+ * which is indifferent to quoting; encoding always emits the quoted form the on-disk format has always used.
+ */
+internal object QuotedBooleanAsStringSerializer : KSerializer<String> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("QuotedBoolean", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value)
+
+    override fun deserialize(decoder: Decoder): String =
+        if (decoder is JsonDecoder) decoder.decodeJsonElement().jsonPrimitive.content else decoder.decodeString()
+}
 
 /**
  * Gson's pretty printer, which used to produce this file, indents with two spaces, while kotlinx-serialization
@@ -77,14 +109,18 @@ internal data class SourceSetNodeJson(
 @OptIn(ExperimentalSerializationApi::class)
 private val projectStructureMetadataJson = Json(KgpJson.prettyPrinted) {
     prettyPrintIndent = "  "
+    isLenient = true
 }
 
 /** A JSON string token cannot contain a raw newline, so this matches nothing but an empty array. */
 private val PRETTY_PRINTED_EMPTY_ARRAY = """\[\s*\n\s*]""".toRegex()
+
+/** Gson's reader skipped the UTF-8 byte order mark; kotlinx-serialization chokes on it. */
+private const val BOM = "\uFEFF"
 
 internal fun KotlinProjectStructureMetadataJson.encodeToString(): String =
     projectStructureMetadataJson.encodeToString(KotlinProjectStructureMetadataJson.serializer(), this)
         .replace(PRETTY_PRINTED_EMPTY_ARRAY, "[]")
 
 internal fun decodeKotlinProjectStructureMetadataJson(string: String): KotlinProjectStructureMetadataJson =
-    projectStructureMetadataJson.decodeFromString(KotlinProjectStructureMetadataJson.serializer(), string)
+    projectStructureMetadataJson.decodeFromString(KotlinProjectStructureMetadataJson.serializer(), string.removePrefix(BOM))

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/KotlinProjectStructureMetadataJson.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/KotlinProjectStructureMetadataJson.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.jetbrains.kotlin.gradle.internal.json.KgpJson
+
+/**
+ * DTOs mirroring the on-disk shape of `kotlin-project-structure-metadata.json`, kept separate from
+ * [KotlinProjectStructureMetadata] so that the internal model can evolve without changing the wire format.
+ *
+ * The format is published inside metadata jars as `META-INF/kotlin-project-structure-metadata.json` and is read
+ * back during dependency resolution and IDE import, so it must stay compatible with what previous Kotlin versions
+ * wrote. Two legacy quirks are therefore reproduced verbatim:
+ *  - booleans ([ProjectStructureNodeJson.isPublishedAsRoot], [SourceSetNodeJson.hostSpecific]) are quoted strings;
+ *  - [SourceSetNodeJson.hostSpecific] is omitted rather than set to `"false"`.
+ *
+ * Property declaration order defines the order of keys in the output and must match
+ * [org.jetbrains.kotlin.gradle.plugin.mpp.serialize], which the XML representation still uses.
+ */
+@Serializable
+internal data class KotlinProjectStructureMetadataJson(
+    val projectStructure: ProjectStructureNodeJson,
+)
+
+@Serializable
+internal data class ProjectStructureNodeJson(
+    val formatVersion: String,
+    val isPublishedAsRoot: String,
+    val variants: List<VariantNodeJson> = emptyList(),
+    val sourceSets: List<SourceSetNodeJson> = emptyList(),
+)
+
+@Serializable
+internal data class VariantNodeJson(
+    val name: String,
+    val sourceSet: List<String> = emptyList(),
+)
+
+@Serializable
+internal data class SourceSetNodeJson(
+    val name: String,
+    val dependsOn: List<String> = emptyList(),
+    /** `"$groupId:$moduleId"` pairs, see [ModuleDependencyIdentifier]. */
+    val moduleDependency: List<String> = emptyList(),
+    val sourceSetCInteropMetadataDirectory: String? = null,
+    val binaryLayout: String? = null,
+    val hostSpecific: String? = null,
+)
+
+/**
+ * Gson's pretty printer, which used to produce this file, indents with two spaces, while kotlinx-serialization
+ * defaults to four. The indentation is part of the contract: `libraries/stdlib` and `libraries/kotlin.test` compare
+ * the generated file against checked-in expectations with exact string equality.
+ *
+ * One difference is patched up in [encodeToString]: empty arrays — and `encodeDefaults = true` means
+ * empty `dependsOn` / `moduleDependency` / `variants` / `sourceSets` are always written — come out as
+ *
+ *     "dependsOn": [
+ *     ],
+ *
+ * rather than Gson's `"dependsOn": []`. That is a pretty-printer bug in kotlinx-serialization-json 1.4.1, the
+ * version embedded into KGP for the Gradle 7.6 variant (`GradlePluginVariant.GRADLE_MIN`, pinned there because
+ * 1.4.1 is the last release built against the Kotlin 1.7.10 stdlib that Gradle 7.6 ships). 1.5.0 fixed it by
+ * calling `Composer.nextItemIfNotFirst()` instead of `nextItem()` in `StreamingJsonEncoder.endStructure`.
+ * They are rewritten here rather than left to the runtime, because the shipped plugin and the functionalTest
+ * classpath do not resolve the same version.
+ *
+ * Gson's HTML escaping is not reproduced: `GsonBuilder` writes `<`, `>`, `&`, `=` and `'` as `\uXXXX` by
+ * default. Those do not occur in variant or source set names, so the bytes only differ if one ever shows up.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+private val projectStructureMetadataJson = Json(KgpJson.prettyPrinted) {
+    prettyPrintIndent = "  "
+}
+
+/** A JSON string token cannot contain a raw newline, so this matches nothing but an empty array. */
+private val PRETTY_PRINTED_EMPTY_ARRAY = """\[\s*\n\s*]""".toRegex()
+
+internal fun KotlinProjectStructureMetadataJson.encodeToString(): String =
+    projectStructureMetadataJson.encodeToString(KotlinProjectStructureMetadataJson.serializer(), this)
+        .replace(PRETTY_PRINTED_EMPTY_ARRAY, "[]")
+
+internal fun decodeKotlinProjectStructureMetadataJson(string: String): KotlinProjectStructureMetadataJson =
+    projectStructureMetadataJson.decodeFromString(KotlinProjectStructureMetadataJson.serializer(), string)

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinProjectStructureMetadataSerializationTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinProjectStructureMetadataSerializationTest.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.SourceSetMetadataLayout.METADATA
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -47,6 +48,22 @@ class KotlinProjectStructureMetadataSerializationTest {
         assertEquals(sampleMetadata, deserialized)
     }
 
+    /**
+     * The emitted JSON is published inside metadata jars as `META-INF/kotlin-project-structure-metadata.json`
+     * and is compared with exact string equality against checked-in expectations by the `libraries/stdlib` and
+     * `libraries/kotlin.test` build scripts. Guard the exact bytes, not just the round trip.
+     *
+     * This classpath resolves `kotlinx-serialization-json-jvm` to a newer version than the plugin embeds, because
+     * `com.jetbrains.intellij.platform:util` wins over the `strictly`, which only pins the umbrella `-json` module.
+     * The two used to disagree on empty arrays; `encodeToString` normalizes that, so the golden holds for both.
+     */
+    @Test
+    fun `json output format is stable`() {
+        val expected = File("src/functionalTest/resources/kotlin-project-structure-metadata.golden.json")
+            .absoluteFile.readText()
+        assertEquals(expected.trim(), sampleMetadata.toJson().trim())
+    }
+
     @Test
     fun `serialize and deserialize - xml`() {
         val xml = sampleMetadata.toXmlDocument()
@@ -69,6 +86,33 @@ class KotlinProjectStructureMetadataSerializationTest {
         assertEquals(
             setOf("commonMain", "concurrentMain", "nativeDarwinMain", "nativeMain", "nativeOtherMain"),
             deserialized.sourceSetNames
+        )
+    }
+
+    /** An entry without a separator used to fail with an `IndexOutOfBoundsException` naming nothing. */
+    @Test
+    fun `deserialize - malformed module dependency is reported`() {
+        val json = """
+            {
+              "projectStructure": {
+                "formatVersion": "0.3.3",
+                "isPublishedAsRoot": "false",
+                "variants": [],
+                "sourceSets": [
+                  {
+                    "name": "commonMain",
+                    "dependsOn": [],
+                    "moduleDependency": ["no-separator-here"]
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val message = assertFailsWith<IllegalStateException> { parseKotlinSourceSetMetadataFromJson(json) }.message
+        assertEquals(
+            "Malformed module dependency 'no-separator-here' in project structure metadata, expected '<groupId>:<moduleId>'",
+            message
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinProjectStructureMetadataSerializationTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinProjectStructureMetadataSerializationTest.kt
@@ -12,6 +12,7 @@ import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -87,6 +88,86 @@ class KotlinProjectStructureMetadataSerializationTest {
             setOf("commonMain", "concurrentMain", "nativeDarwinMain", "nativeMain", "nativeOtherMain"),
             deserialized.sourceSetNames
         )
+    }
+
+    /**
+     * Gson read this key as `valueNamed(...)?.toBoolean() ?: false`, so a file without it parsed fine. Hand-patched
+     * files (this repo ships two) and pre-0.3.1 producers depend on that.
+     */
+    @Test
+    fun `deserialize - missing isPublishedAsRoot defaults to false`() {
+        val json = """
+            {
+              "projectStructure": {
+                "formatVersion": "0.3.3",
+                "variants": [],
+                "sourceSets": [
+                  {
+                    "name": "commonMain",
+                    "dependsOn": [],
+                    "moduleDependency": []
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val deserialized = parseKotlinSourceSetMetadataFromJson(json)
+        assertFalse(deserialized.isPublishedAsRoot)
+    }
+
+    /** KGP writes these booleans quoted, but Gson's `asString` took the unquoted form too, so keep accepting both. */
+    @Test
+    fun `deserialize - unquoted booleans are accepted`() {
+        val json = """
+            {
+              "projectStructure": {
+                "formatVersion": "0.3.3",
+                "isPublishedAsRoot": true,
+                "variants": [],
+                "sourceSets": [
+                  {
+                    "name": "commonMain",
+                    "dependsOn": [],
+                    "moduleDependency": [],
+                    "hostSpecific": true
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val deserialized = parseKotlinSourceSetMetadataFromJson(json)
+        assertTrue(deserialized.isPublishedAsRoot)
+        assertEquals(setOf("commonMain"), deserialized.hostSpecificSourceSets)
+    }
+
+    /**
+     * Gson parsed leniently and skipped a leading BOM. Only what `isLenient` covers is asserted here: unquoted
+     * member names and values. Gson also took single-quoted strings, see `KotlinProjectStructureMetadataJson.kt`.
+     */
+    @Test
+    fun `deserialize - lenient input and a leading BOM are accepted`() {
+        val lenient = """
+            {
+              projectStructure: {
+                formatVersion: 0.3.3,
+                isPublishedAsRoot: true,
+                variants: [],
+                sourceSets: [
+                  {
+                    name: commonMain,
+                    dependsOn: [],
+                    moduleDependency: []
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val deserialized = parseKotlinSourceSetMetadataFromJson("\uFEFF" + lenient)
+        assertTrue(deserialized.isPublishedAsRoot)
+        assertEquals(setOf("commonMain"), deserialized.sourceSetNames)
     }
 
     /** An entry without a separator used to fail with an `IndexOutOfBoundsException` naming nothing. */

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/resources/kotlin-project-structure-metadata.golden.json
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/resources/kotlin-project-structure-metadata.golden.json
@@ -1,0 +1,64 @@
+{
+  "projectStructure": {
+    "formatVersion": "0.3.3",
+    "isPublishedAsRoot": "true",
+    "variants": [
+      {
+        "name": "variant1",
+        "sourceSet": [
+          "commonMain",
+          "sourceSetA",
+          "sourceSetB"
+        ]
+      },
+      {
+        "name": "variant2",
+        "sourceSet": [
+          "commonMain",
+          "sourceSetC"
+        ]
+      }
+    ],
+    "sourceSets": [
+      {
+        "name": "commonMain",
+        "dependsOn": [],
+        "moduleDependency": []
+      },
+      {
+        "name": "sourceSetA",
+        "dependsOn": [
+          "commonMain"
+        ],
+        "moduleDependency": [
+          "aa:bb"
+        ],
+        "binaryLayout": "metadata"
+      },
+      {
+        "name": "sourceSetB",
+        "dependsOn": [
+          "commonMain",
+          "sourceSetA"
+        ],
+        "moduleDependency": [
+          "cc:dd",
+          "ee:ff"
+        ],
+        "sourceSetCInteropMetadataDirectory": "xx/cinterop/",
+        "binaryLayout": "klib"
+      },
+      {
+        "name": "sourceSetC",
+        "dependsOn": [
+          "commonMain",
+          "sourceSetB"
+        ],
+        "moduleDependency": [],
+        "sourceSetCInteropMetadataDirectory": "cinterops/C",
+        "binaryLayout": "klib",
+        "hostSpecific": "true"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This pull request refactors the serialization and deserialization of Kotlin project structure metadata JSON to use kotlinx.serialization instead of Gson, ensuring compatibility and stability of the on-disk format. It introduces a new DTO-based approach for (de)serialization, adds comprehensive tests to guarantee format stability and legacy compatibility, and removes all Gson dependencies from the codebase.

**Serialization and Deserialization Refactor:**

* Replaces manual Gson-based JSON (de)serialization in `KotlinProjectStructureMetadata.kt` with a new DTO-based approach using kotlinx.serialization, encapsulated in the new `KotlinProjectStructureMetadataJson.kt` file. The new implementation preserves legacy quirks for compatibility, such as quoted booleans and lenient parsing. [[1]](diffhunk://#diff-8f70dfb09808971706a4837941ae797591714464cf0df58ab957cf3b3579e16aL245-R320) [[2]](diffhunk://#diff-1fb19cbc9a858f8dbedd40a41236a8531e6384473fc7c326f3c5c1deb3eea348R1-R126)
* Removes all Gson-related imports and code from `KotlinProjectStructureMetadata.kt`, fully migrating to the new serialization mechanism. [[1]](diffhunk://#diff-8f70dfb09808971706a4837941ae797591714464cf0df58ab957cf3b3579e16aL8-L11) [[2]](diffhunk://#diff-8f70dfb09808971706a4837941ae797591714464cf0df58ab957cf3b3579e16aL25)

**Backward Compatibility and Robustness:**

* Ensures backward compatibility by handling missing fields, lenient input, and malformed module dependencies gracefully, including explicit error messages for malformed entries. [[1]](diffhunk://#diff-8f70dfb09808971706a4837941ae797591714464cf0df58ab957cf3b3579e16aL245-R320) [[2]](diffhunk://#diff-8f70dfb09808971706a4837941ae797591714464cf0df58ab957cf3b3579e16aL323-R374)

**Testing and Format Stability:**

* Adds new functional tests in `KotlinProjectStructureMetadataSerializationTest.kt` to verify round-trip serialization, strict format stability against a golden file, and legacy input handling (missing fields, unquoted booleans, BOM, malformed dependencies). [[1]](diffhunk://#diff-4ca0f62d3ec9f373e0e5c1e8d7625fddbdaaae0ed02bbce9df0df224bdc14ae3R52-R67) [[2]](diffhunk://#diff-4ca0f62d3ec9f373e0e5c1e8d7625fddbdaaae0ed02bbce9df0df224bdc14ae3R93-R199)
* Introduces a golden JSON file (`kotlin-project-structure-metadata.golden.json`) to assert the exact output format, ensuring future changes do not inadvertently alter the published format.