### PR TITLE
[K/N] Stop placing safepoints on trivial functions 

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -36,17 +36,19 @@ internal typealias ModuleLowering = NamedCompilerPhase<NativeGenerationState, Ir
 internal fun PhaseEngine<NativeGenerationState>.runLowerings(
         lowerings: LoweringList,
         module: IrModuleFragment,
-) = runLowerings(lowerings, listOf(module))
+        parentPhaseType: PhaseType,
+) = runLowerings(lowerings, listOf(module), parentPhaseType)
 
 internal fun PhaseEngine<NativeGenerationState>.runLowerings(
         lowerings: LoweringList,
         modules: List<IrModuleFragment>,
+        parentPhaseType: PhaseType = PhaseType.IrLowering,
 ) {
     for (module in modules) {
         for (file in module.files) {
             context.fileLowerState = FileLowerState()
             lowerings.fold(file) { loweredFile, lowering ->
-                context.performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
+                context.performanceManager.tryMeasureDynamicPhaseTime(lowering.name, parentPhaseType) {
                     try {
                         runPhase(lowering, loweredFile)
                     } catch (e: CompilationException) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.backend.konan.driver.utilities.createTempFiles
 import org.jetbrains.kotlin.backend.konan.ir.FunctionsWithoutBoundCheckGenerator
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.lower.*
+import org.jetbrains.kotlin.backend.konan.optimizations.SafepointApplicabilityAnalysis
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
 import org.jetbrains.kotlin.backend.konan.serialization.PartialCacheInfo
 import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
@@ -577,6 +578,7 @@ private fun PhaseEngine<NativeGenerationState>.runCodegen(module: IrModuleFragme
     runLowerings(
             createFilePhases(
                     ::CoroutinesVarSpillingLowering,
+                    ::SafepointApplicabilityAnalysis.takeIf { optimize },
             ),
             module,
             PhaseType.Backend,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -480,7 +480,7 @@ internal fun PhaseEngine<NativeGenerationState>.partiallyLowerModuleWithDependen
     // TODO: Does the order of files really matter with the new MM? (and with lazy top-levels initialization?)
     val allModulesToLower = listOf(module) + dependenciesToCompile.reversed()
 
-    runLowerings(loweringList, allModulesToLower)
+    runLowerings(loweringList, allModulesToLower, PhaseType.IrLowering)
 }
 
 internal fun PhaseEngine<NativeGenerationState>.partiallyLowerModuleWithDependencies(
@@ -555,6 +555,7 @@ private fun PhaseEngine<NativeGenerationState>.runCodegen(module: IrModuleFragme
                     ::InlineClassPropertyAccessorsLowering.takeIf { optimize },
             ),
             module,
+            PhaseType.Backend,
     )
     val moduleDFG = runAndMeasurePhase(BuildDFGPhase, module, disable = !runGlobalOptimizations)
     runAndMeasurePhase(RemoveRedundantCallsToStaticInitializersPhase, RedundantCallsInput(moduleDFG, module), disable = !enablePreCodegenInliner)
@@ -569,6 +570,7 @@ private fun PhaseEngine<NativeGenerationState>.runCodegen(module: IrModuleFragme
                     ::UnboxInlineLowering.takeIf { optimize },
             ),
             module,
+            PhaseType.Backend,
     )
     runAndMeasurePhase(PreCodegenInlinerPhase, PreCodegenInlinerInput(module, moduleDFG), disable = !enablePreCodegenInliner)
     val dceResult = runAndMeasurePhase(DCEPhase, DCEInput(module, moduleDFG), disable = !runGlobalOptimizations)
@@ -577,6 +579,7 @@ private fun PhaseEngine<NativeGenerationState>.runCodegen(module: IrModuleFragme
                     ::CoroutinesVarSpillingLowering,
             ),
             module,
+            PhaseType.Backend,
     )
     runAndMeasurePhase(CreateLLVMDeclarationsPhase, module)
     runAndMeasurePhase(GHAPhase, module, disable = !runGlobalOptimizations || context.config.produce.isCache)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.ThreadState.Native
 import org.jetbrains.kotlin.backend.konan.llvm.ThreadState.Runnable
 import org.jetbrains.kotlin.backend.konan.llvm.objc.ObjCDataGenerator
 import org.jetbrains.kotlin.backend.konan.lower.bridgeTarget
+import org.jetbrains.kotlin.backend.konan.optimizations.canOmitSafepoints
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
@@ -125,7 +126,7 @@ internal inline fun generateFunction(
             startLocation,
             endLocation,
             switchToRunnable = isCToKotlinBridge,
-            needSafePoint = true,
+            needSafePoint = !function.canOmitSafepoints,
             function)
     functionGenerationContext.needsRuntimeInit = isCToKotlinBridge
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/SafepointApplicabilityAnalysis.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/SafepointApplicabilityAnalysis.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.optimizations
+
+import org.jetbrains.kotlin.backend.common.BodyLoweringPass
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
+import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
+import org.jetbrains.kotlin.ir.IrBuiltIns
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrBranch
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrGetField
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.expressions.IrSetField
+import org.jetbrains.kotlin.ir.expressions.IrSetValue
+import org.jetbrains.kotlin.ir.expressions.IrWhen
+import org.jetbrains.kotlin.ir.irFlag
+import org.jetbrains.kotlin.ir.util.dump
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.visitors.IrVisitor
+
+/**
+ * `true`, when a function is simple enough to not need any safepoints (neither in the prologue, nor on loop back edges)
+ */
+internal var IrSimpleFunction.canOmitSafepoints: Boolean by irFlag(copyByDefault = false)
+
+/**
+ * Analyzes if a function is simple enough to skip safepoints.
+ *
+ * Sets [canOmitSafepoints] flag to be read by the code generator.
+ */
+internal class SafepointApplicabilityAnalysis(val context: NativeLoweringContext) : BodyLoweringPass {
+    override fun lower(irBody: IrBody, container: IrDeclaration) {
+        if (container !is IrSimpleFunction)
+            return
+        val canOmitSafepoints = irBody.accept(CanOmitSafepointsVisitor(context.symbols, context.irBuiltIns), null)
+        if (canOmitSafepoints) {
+            context.log {
+                "Can omit safepoints in ${container.kotlinFqName}: ${irBody.dump()}"
+            }
+        }
+        container.canOmitSafepoints = canOmitSafepoints
+    }
+}
+
+private class CanOmitSafepointsVisitor(private val symbols: BackendNativeSymbols, private val irBuiltIns: IrBuiltIns) : IrVisitor<Boolean, Nothing?>() {
+    override fun visitElement(element: IrElement, data: Nothing?): Boolean {
+        // Only explicitly allowed cases below are allowed
+        return false
+    }
+
+    override fun visitBlockBody(body: IrBlockBody, data: Nothing?) = body.statements.all { it.accept(this, data) }
+    override fun visitReturn(expression: IrReturn, data: Nothing?) = expression.value.accept(this, data)
+    override fun visitGetField(expression: IrGetField, data: Nothing?) = expression.receiver?.accept(this, data) ?: true
+    override fun visitSetField(expression: IrSetField, data: Nothing?) = listOfNotNull(expression.receiver, expression.value).all { it.accept(this, data) }
+    override fun visitGetValue(expression: IrGetValue, data: Nothing?) = true
+    override fun visitSetValue(expression: IrSetValue, data: Nothing?) = expression.value.accept(this, data)
+    override fun visitWhen(expression: IrWhen, data: Nothing?) = expression.branches.all { it.accept(this, data) }
+    override fun visitBranch(branch: IrBranch, data: Nothing?) = listOf(branch.condition, branch.result).all { it.accept(this, data) }
+    override fun visitConst(expression: IrConst, data: Nothing?) = true
+
+    override fun visitCall(expression: IrCall, data: Nothing?): Boolean {
+        // Calls in general are not allowed, because they may lead (indirectly) to recursion
+        // But some calls (e.g. well known intrinsics), are explicitly allowed
+        val allowedCalls = setOf(
+                irBuiltIns.eqeqeqSymbol,
+                symbols.theUnitInstance,
+        )
+        if (!allowedCalls.contains(expression.symbol)) {
+            return false
+        }
+        return expression.arguments.all { it?.accept(this, data) ?: true }
+    }
+}


### PR DESCRIPTION
Some functions are very short and simple. Adding a safepoint
in such functions doesn't really help the GC, but it can certainly
hurt performance if such a function is called very often.

This commit adds machinery to allow the code generator to skip
generating safepoints for such functions. The machinery is
currently very limited and is based on analysing primitive
getters, setters and unboxing functions.

^[KT-89307](https://youtrack.jetbrains.com/issue/KT-89307)