### PR TITLE
[JKlib] Use Kotlin signatures for fake overrides of Java platform cla…

### DIFF
--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.common.serialization.mangle.MangleMode
 import org.jetbrains.kotlin.backend.common.serialization.mangle.descriptor.DescriptorMangleComputer
 import org.jetbrains.kotlin.backend.common.serialization.mangle.ir.IrMangleComputer
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.FilteredByPredicateAnnotations
 import org.jetbrains.kotlin.idea.MainFunctionDetector
@@ -23,6 +24,7 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
@@ -219,13 +221,28 @@ private fun IrDeclaration.isDeclaredInJava(): Boolean {
     return ownerClass?.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB
 }
 
+private fun IrDeclaration.isJavaPlatformClassOrKotlinPackage(): Boolean {
+    // During the Fir2Ir conversion (K2), JDK platform methods present in common Kotlin stdlib
+    // built-in declarations (e.g. kotlin.collections.Iterable.iterator()) belong to "kotlin.*"
+    // packages but are still flagged as IR_EXTERNAL_JAVA_DECLARATION_STUB.
+    if (getPackageFragment().packageFqName.asString().isKotlinPackage()) return true
+
+    // JDK platform methods *not* present in common Kotlin stdlib (e.g. spliterator()) are resolved
+    // against their Java platform declaration stubs (e.g. java.lang.Iterable.spliterator(), with
+    // package "java.lang" and origin IR_EXTERNAL_JAVA_DECLARATION_STUB). For these methods,
+    // getPackageFragment().packageFqName is "java.lang" (so isKotlinPackage() is false), but
+    // JavaToKotlinClassMap.isJavaPlatformClass(ownerClass.kotlinFqName) returns true.
+    val ownerClass = (this as? IrClass) ?: parentClassOrNull ?: return false
+    return JavaToKotlinClassMap.isJavaPlatformClass(ownerClass.kotlinFqName)
+}
+
 @OptIn(UnsafeDuringIrConstructionAPI::class)
 private fun IrDeclaration.isJavaBackedCallable(): Boolean {
     if (isDeclaredInJava()) return true
 
     val functions = when (this) {
         is IrSimpleFunction -> {
-            // Check if the function a fake override of a Java declaration.
+            // Check if the function is a fake override of a Java declaration.
             listOf(this)
         }
         is IrProperty -> {
@@ -241,7 +258,12 @@ private fun IrDeclaration.isJavaBackedCallable(): Boolean {
             { current ->
                 if (current.isFakeOverride) current.overriddenSymbols.map { it.owner } else emptyList()
             },
-            { current -> current.isDeclaredInJava() },
+            { current ->
+                // Fake overrides of Java declarations must use JVM signatures, *except* when the overridden Java declaration is a platform
+                // class mapped to a Kotlin built-in collection (e.g. java.lang.Iterable). In that case, standard Kotlin signatures on the
+                // inheriting Kotlin class should be used.
+                current.isDeclaredInJava() && !current.isJavaPlatformClassOrKotlinPackage()
+            },
         )
     }
     return false

--- a/compiler/testData/ir/irText/fakeOverrides/collections/platformIterableFakeOverride.ir.txt
+++ b/compiler/testData/ir/irText/fakeOverrides/collections/platformIterableFakeOverride.ir.txt
@@ -1,0 +1,80 @@
+Module: lib
+FILE fqName:<root> fileName:/lib.kt
+  CLASS CLASS name:StringIterable modality:FINAL visibility:public superTypes:[<root>.MyIterable<kotlin.String>]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.StringIterable
+    CONSTRUCTOR visibility:public returnType:<root>.StringIterable [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:StringIterable modality:FINAL visibility:public superTypes:[<root>.MyIterable<kotlin.String>]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.MyIterable
+    FUN FAKE_OVERRIDE name:forEach visibility:public modality:OPEN returnType:kotlin.Unit [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.collections.Iterable<kotlin.String>
+      VALUE_PARAMETER kind:Regular name:p0 index:1 type:@[FlexibleNullability] java.util.function.Consumer<in @[FlexibleNullability] kotlin.String?>?
+      overridden:
+        public open fun forEach (p0: @[FlexibleNullability] java.util.function.Consumer<in @[FlexibleNullability] T of <root>.MyIterable?>?): kotlin.Unit declared in <root>.MyIterable
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.MyIterable
+    FUN FAKE_OVERRIDE name:spliterator visibility:public modality:OPEN returnType:@[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] kotlin.String> [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.collections.Iterable<kotlin.String>
+      overridden:
+        public open fun spliterator (): @[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] T of <root>.MyIterable> declared in <root>.MyIterable
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.MyIterable
+    FUN name:iterator visibility:public modality:OPEN returnType:kotlin.collections.Iterator<kotlin.String> [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.StringIterable
+      overridden:
+        public abstract fun iterator (): kotlin.collections.Iterator<T of <root>.MyIterable> declared in <root>.MyIterable
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun iterator (): kotlin.collections.Iterator<kotlin.String> declared in <root>.StringIterable'
+          TYPE_OP type=@[FlexibleMutability] kotlin.collections.MutableIterator<@[FlexibleNullability] kotlin.String?> origin=IMPLICIT_NOTNULL typeOperand=@[FlexibleMutability] kotlin.collections.MutableIterator<@[FlexibleNullability] kotlin.String?>
+            CALL 'public open fun emptyIterator <T> (): @[FlexibleNullability] @[FlexibleMutability] kotlin.collections.MutableIterator<@[FlexibleNullability] T of java.util.Collections.emptyIterator?>? declared in java.util.Collections' type=@[FlexibleNullability] @[FlexibleMutability] kotlin.collections.MutableIterator<@[FlexibleNullability] kotlin.String?>? origin=null
+              TYPE_ARG T: @[FlexibleNullability] kotlin.String?
+  CLASS INTERFACE name:MyIterable modality:ABSTRACT visibility:public superTypes:[kotlin.collections.Iterable<T of <root>.MyIterable>]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MyIterable<T of <root>.MyIterable>
+    TYPE_PARAMETER name:T index:0 variance: superTypes:[kotlin.Any?] reified:false
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.collections.Iterable
+    FUN FAKE_OVERRIDE name:forEach visibility:public modality:OPEN returnType:kotlin.Unit [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.collections.Iterable<T of <root>.MyIterable>
+      VALUE_PARAMETER kind:Regular name:p0 index:1 type:@[FlexibleNullability] java.util.function.Consumer<in @[FlexibleNullability] T of <root>.MyIterable?>?
+      overridden:
+        public open fun forEach (p0: @[FlexibleNullability] java.util.function.Consumer<in @[FlexibleNullability] T of kotlin.collections.Iterable?>?): kotlin.Unit declared in kotlin.collections.Iterable
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.collections.Iterable
+    FUN FAKE_OVERRIDE name:iterator visibility:public modality:ABSTRACT returnType:kotlin.collections.Iterator<T of <root>.MyIterable> [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.collections.Iterable<T of <root>.MyIterable>
+      overridden:
+        public abstract fun iterator (): kotlin.collections.Iterator<T of kotlin.collections.Iterable> declared in kotlin.collections.Iterable
+    FUN FAKE_OVERRIDE name:spliterator visibility:public modality:OPEN returnType:@[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] T of <root>.MyIterable> [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.collections.Iterable<T of <root>.MyIterable>
+      overridden:
+        public open fun spliterator (): @[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] T of kotlin.collections.Iterable> declared in kotlin.collections.Iterable
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.collections.Iterable
+Module: main
+FILE fqName:<root> fileName:/main.kt
+  FUN name:test visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:iterable index:0 type:<root>.MyIterable<kotlin.Int>
+    VALUE_PARAMETER kind:Regular name:stringIterable index:1 type:<root>.StringIterable
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public open fun spliterator (): @[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] T of <root>.MyIterable> declared in <root>.MyIterable' type=@[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] kotlin.Int> origin=null
+          ARG <this>: GET_VAR 'iterable: <root>.MyIterable<kotlin.Int> declared in <root>.test' type=<root>.MyIterable<kotlin.Int> origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public open fun spliterator (): @[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] kotlin.String> declared in <root>.StringIterable' type=@[EnhancedNullability] java.util.Spliterator<@[EnhancedNullability] kotlin.String> origin=null
+          ARG <this>: GET_VAR 'stringIterable: <root>.StringIterable declared in <root>.test' type=<root>.StringIterable origin=null

--- a/compiler/testData/ir/irText/fakeOverrides/collections/platformIterableFakeOverride.kt
+++ b/compiler/testData/ir/irText/fakeOverrides/collections/platformIterableFakeOverride.kt
@@ -1,0 +1,17 @@
+// TARGET_BACKEND: JVM
+// FULL_JDK
+
+// MODULE: lib
+// FILE: lib.kt
+interface MyIterable<T> : Iterable<T>
+
+class StringIterable : MyIterable<String> {
+    override fun iterator(): Iterator<String> = java.util.Collections.emptyIterator()
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+fun test(iterable: MyIterable<Int>, stringIterable: StringIterable) {
+    iterable.spliterator()
+    stringIterable.spliterator()
+}

--- a/compiler/testData/ir/irText/fakeOverrides/collections/platformIterableFakeOverride.kt.txt
+++ b/compiler/testData/ir/irText/fakeOverrides/collections/platformIterableFakeOverride.kt.txt
@@ -1,0 +1,27 @@
+// MODULE: lib
+// FILE: lib.kt
+
+class StringIterable : MyIterable<String> {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  override operator fun iterator(): Iterator<String> {
+    return emptyIterator<@FlexibleNullability String?>() /*!! @FlexibleMutability MutableIterator<@FlexibleNullability String?> */
+  }
+
+}
+
+interface MyIterable<T : Any?> : Iterable<T> {
+}
+
+// MODULE: main
+// FILE: main.kt
+
+fun test(iterable: MyIterable<Int>, stringIterable: StringIterable) {
+  iterable.spliterator() /*~> Unit */
+  stringIterable.spliterator() /*~> Unit */
+}
+


### PR DESCRIPTION
Fake overrides of mapped built-in collections (such as spliterator() on a Kotlin class implementing Iterable) must use standard Kotlin mangling signatures rather than JVM descriptor signatures during Klib IR serialization to ensure signatures match properly during IR linking.

During Fir2Ir conversion in K2, JDK platform methods not present in common Kotlin stdlib (e.g. java.lang.Iterable.spliterator()) are resolved against their Java platform declaration stubs with origin
IR_EXTERNAL_JAVA_DECLARATION_STUB. Without this check, isJavaBackedCallable() treats them as Java-backed callables and computes JVM descriptor signatures on the inheriting Kotlin class, leading to signature mismatch during deserialization/linking.

