### PR TITLE
[K/N] Add optional omit payloads and gzip to memory dump

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -108,7 +108,7 @@ clangNooptFlags.macos_x64 = -O1
 clangOptFlags.macos_x64 = -O3
 clangDebugFlags.macos_x64 = -O0
 
-linkerKonanFlags.macos_x64 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.macos_x64 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.macos_x64 = -dead_strip
 linkerNoDebugFlags.macos_x64 = -S
 stripFlags.macos_x64 = -S
@@ -148,7 +148,7 @@ clangOptFlags.macos_arm64 = -O3
 # TODO: Is it still necessary?
 clangDebugFlags.macos_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
 
-linkerKonanFlags.macos_arm64 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.macos_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.macos_arm64 = -dead_strip
 linkerNoDebugFlags.macos_arm64 = -S
 stripFlags.macos_arm64 = -S
@@ -182,7 +182,7 @@ clangDebugFlags.ios_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=fals
 linkerNoDebugFlags.ios_arm64 = -S
 stripFlags.ios_arm64 = -S
 linkerDynamicFlags.ios_arm64 = -dylib
-linkerKonanFlags.ios_arm64 = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit
+linkerKonanFlags.ios_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz -framework UIKit
 linkerOptimizationFlags.ios_arm64 = -dead_strip
 osVersionMin.ios_arm64 = $minVersion.ios
 sdkVersion.ios_arm64 = $sdkVersion.ios
@@ -205,7 +205,7 @@ clangNooptFlags.ios_x64 = -O1
 clangOptFlags.ios_x64 = -O3
 clangDebugFlags.ios_x64 = -O0
 
-linkerKonanFlags.ios_x64 = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit
+linkerKonanFlags.ios_x64 = -lSystem -lc++ -lobjc -framework Foundation -lz -framework UIKit
 linkerOptimizationFlags.ios_x64 = -dead_strip
 linkerNoDebugFlags.ios_x64 = -S
 stripFlags.ios_x64 = -S
@@ -228,7 +228,7 @@ clangNooptFlags.ios_simulator_arm64 = -O1
 clangOptFlags.ios_simulator_arm64 = -O3
 clangDebugFlags.ios_simulator_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
 
-linkerKonanFlags.ios_simulator_arm64 = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit
+linkerKonanFlags.ios_simulator_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz -framework UIKit
 linkerOptimizationFlags.ios_simulator_arm64 = -dead_strip
 linkerNoDebugFlags.ios_simulator_arm64 = -S
 stripFlags.ios_simulator_arm64 = -S
@@ -254,7 +254,7 @@ clangNooptFlags.tvos_x64 = -O1
 clangOptFlags.tvos_x64 = -O3
 clangDebugFlags.tvos_x64 = -O0
 
-linkerKonanFlags.tvos_x64 = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit
+linkerKonanFlags.tvos_x64 = -lSystem -lc++ -lobjc -framework Foundation -lz -framework UIKit
 linkerOptimizationFlags.tvos_x64 = -dead_strip
 linkerNoDebugFlags.tvos_x64 = -S
 stripFlags.tvos_x64 = -S
@@ -277,7 +277,7 @@ clangOptFlags.tvos_simulator_arm64 = -O3
 clangDebugFlags.tvos_simulator_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
 
 # -adhoc_codesign is needed due to the new linker in Xcode 15 forgetting to codesign: KT-62086
-linkerKonanFlags.tvos_simulator_arm64 = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit -adhoc_codesign
+linkerKonanFlags.tvos_simulator_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz -framework UIKit -adhoc_codesign
 linkerOptimizationFlags.tvos_simulator_arm64 = -dead_strip
 linkerNoDebugFlags.tvos_simulator_arm64 = -S
 stripFlags.tvos_simulator_arm64 = -S
@@ -305,7 +305,7 @@ clangDebugFlags.tvos_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=fal
 linkerNoDebugFlags.tvos_arm64 = -S
 stripFlags.tvos_arm64 = -S
 linkerDynamicFlags.tvos_arm64 = -dylib
-linkerKonanFlags.tvos_arm64 = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit
+linkerKonanFlags.tvos_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz -framework UIKit
 linkerOptimizationFlags.tvos_arm64 = -dead_strip
 osVersionMin.tvos_arm64 = $minVersion.tvos
 sdkVersion.tvos_arm64 = $sdkVersion.tvos
@@ -332,7 +332,7 @@ clangOptFlags.watchos_arm32 = -O3
 clangDebugFlags.watchos_arm32 = -O0
 llvmInlineThreshold.watchos_arm32 = 50
 
-linkerKonanFlags.watchos_arm32 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.watchos_arm32 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.watchos_arm32 = -dead_strip
 linkerNoDebugFlags.watchos_arm32 = -S
 stripFlags.watchos_arm32 = -S
@@ -354,7 +354,7 @@ clangNooptFlags.watchos_arm64 = -O1
 clangOptFlags.watchos_arm64 = -O3
 clangDebugFlags.watchos_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
 
-linkerKonanFlags.watchos_arm64 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.watchos_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.watchos_arm64 = -dead_strip
 linkerNoDebugFlags.watchos_arm64 = -S
 stripFlags.watchos_arm64 = -S
@@ -376,7 +376,7 @@ clangNooptFlags.watchos_device_arm64 = -O1
 clangOptFlags.watchos_device_arm64 = -O3
 clangDebugFlags.watchos_device_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
 
-linkerKonanFlags.watchos_device_arm64 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.watchos_device_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.watchos_device_arm64 = -dead_strip
 linkerNoDebugFlags.watchos_device_arm64 = -S
 stripFlags.watchos_device_arm64 = -S
@@ -402,7 +402,7 @@ clangNooptFlags.watchos_x64 = -O1
 clangOptFlags.watchos_x64 = -O3
 clangDebugFlags.watchos_x64 = -O0
 
-linkerKonanFlags.watchos_x64 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.watchos_x64 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.watchos_x64 = -dead_strip
 linkerNoDebugFlags.watchos_x64 = -S
 stripFlags.watchos_x64 = -S
@@ -424,7 +424,7 @@ clangNooptFlags.watchos_simulator_arm64 = -O1
 clangOptFlags.watchos_simulator_arm64 = -O3
 clangDebugFlags.watchos_simulator_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
 
-linkerKonanFlags.watchos_simulator_arm64 = -lSystem -lc++ -lobjc -framework Foundation
+linkerKonanFlags.watchos_simulator_arm64 = -lSystem -lc++ -lobjc -framework Foundation -lz
 linkerOptimizationFlags.watchos_simulator_arm64 = -dead_strip
 linkerNoDebugFlags.watchos_simulator_arm64 = -S
 stripFlags.watchos_simulator_arm64 = -S
@@ -471,7 +471,7 @@ clangDebugFlags.linux_x64 = -O0
 dynamicLibraryRelocationMode.linux_x64 = pic
 staticLibraryRelocationMode.linux_x64 = pic
 linkerKonanFlags.linux_x64 = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
-  --defsym __cxa_demangle=Konan_cxa_demangle --gc-sections
+  --defsym __cxa_demangle=Konan_cxa_demangle --gc-sections -lz
 linkerOptimizationFlags.linux_x64 =
 linkerNoDebugFlags.linux_x64 = -S
 linkerDynamicFlags.linux_x64 = -shared
@@ -522,7 +522,7 @@ linkerOptimizationFlags.linux_arm32_hfp = --gc-sections
 targetSysRoot.linux_arm32_hfp = $gccToolchain.linux_arm32_hfp/arm-unknown-linux-gnueabihf/sysroot
 # We could reuse host toolchain here.
 linkerKonanFlags.linux_arm32_hfp = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
-  --defsym __cxa_demangle=Konan_cxa_demangle
+  --defsym __cxa_demangle=Konan_cxa_demangle -lz
 # targetSysroot-relative.
 libGcc.linux_arm32_hfp = ../../lib/gcc/arm-unknown-linux-gnueabihf/8.3.0
 targetCpu.linux_arm32_hfp = arm1176jzf-s
@@ -580,7 +580,7 @@ linkerOptimizationFlags.linux_arm64 = --gc-sections
 targetSysRoot.linux_arm64 = $gccToolchain.linux_arm64/aarch64-unknown-linux-gnu/sysroot
 # We could reuse host toolchain here.
 linkerKonanFlags.linux_arm64 = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
-  --defsym __cxa_demangle=Konan_cxa_demangle
+  --defsym __cxa_demangle=Konan_cxa_demangle -lz
 # targetSysroot-relative.
 libGcc.linux_arm64 = ../../lib/gcc/aarch64-unknown-linux-gnu/8.3.0
 # "generic" in runtime modules
@@ -635,7 +635,7 @@ clangOptFlags.android_arm32 = -O3 -ffunction-sections
 linkerNoDebugFlags.android_arm32 = -Wl,-S
 clangNooptFlags.android_arm32 = -O1
 targetSysRoot.android_arm32 = target-sysroot-1-android_ndk
-linkerKonanFlags.android_arm32 = -lm -lc++_static -lc++abi -landroid -llog -latomic
+linkerKonanFlags.android_arm32 = -lm -lc++_static -lc++abi -landroid -llog -latomic -lz
 
 
 # Android ARM64, based on NDK.
@@ -664,7 +664,7 @@ clangFlags.android_arm64 = -cc1 -emit-obj -disable-llvm-passes -x ir -femulated-
 clangOptFlags.android_arm64 = -O3 -ffunction-sections
 clangNooptFlags.android_arm64 = -O1
 targetSysRoot.android_arm64 = target-sysroot-1-android_ndk
-linkerKonanFlags.android_arm64 = -lm -lc++_static -lc++abi -landroid -llog -latomic
+linkerKonanFlags.android_arm64 = -lm -lc++_static -lc++abi -landroid -llog -latomic -lz
 linkerNoDebugFlags.android_arm64 = -Wl,-S
 
 
@@ -695,7 +695,7 @@ clangFlags.android_x86 = -cc1 -emit-obj -disable-llvm-passes -x ir -femulated-tl
 clangOptFlags.android_x86 = -O3 -ffunction-sections
 clangNooptFlags.android_x86 = -O1
 targetSysRoot.android_x86 = target-sysroot-1-android_ndk
-linkerKonanFlags.android_x86 = -lm -lc++_static -lc++abi -landroid -llog -latomic
+linkerKonanFlags.android_x86 = -lm -lc++_static -lc++abi -landroid -llog -latomic -lz
 linkerNoDebugFlags.android_x86 = -Wl,-S
 
 
@@ -724,7 +724,7 @@ clangFlags.android_x64 = -cc1 -emit-obj -disable-llvm-passes -x ir -femulated-tl
 clangOptFlags.android_x64 = -O3 -ffunction-sections
 clangNooptFlags.android_x64 = -O1
 targetSysRoot.android_x64 = target-sysroot-1-android_ndk
-linkerKonanFlags.android_x64 = -lm -lc++_static -lc++abi -landroid -llog -latomic
+linkerKonanFlags.android_x64 = -lm -lc++_static -lc++abi -landroid -llog -latomic -lz
 linkerNoDebugFlags.android_x64 = -Wl,-S
 
 
@@ -775,7 +775,7 @@ linkerNoDebugFlags.mingw_x64 = -Wl,-S
 linkerDynamicFlags.mingw_x64 = -shared
 linkerKonanFlags.mingw_x64 = -static-libgcc -static-libstdc++ -lbcrypt \
   -Wl,--dynamicbase -Wl,--gc-sections \
-  -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic
+  -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic -lz
 linkerOptimizationFlags.mingw_x64 =
 
 # The version of Kotlin/Native compiler

--- a/kotlin-native/runtime/src/main/cpp/Memory.h
+++ b/kotlin-native/runtime/src/main/cpp/Memory.h
@@ -247,6 +247,8 @@ void Kotlin_native_internal_GC_collect(ObjHeader*);
 void Kotlin_native_internal_GC_setTuneThreshold(ObjHeader*, bool value);
 bool Kotlin_native_internal_GC_getTuneThreshold(ObjHeader*);
 RUNTIME_NOTHROW bool Kotlin_native_runtime_Debugging_dumpMemory(ObjHeader*, int fd);
+RUNTIME_NOTHROW bool Kotlin_native_runtime_Debugging_dumpMemoryWithOptions(
+        ObjHeader*, int fd, bool omitPayloads, bool gzip);
 
 void PerformFullGC(MemoryState* memory) RUNTIME_NOTHROW;
 

--- a/kotlin-native/runtime/src/main/cpp/mm/Memory.cpp
+++ b/kotlin-native/runtime/src/main/cpp/mm/Memory.cpp
@@ -6,6 +6,13 @@
 #include "Memory.h"
 #include "mm/MemoryPrivate.hpp"
 
+#ifndef KONAN_WINDOWS
+#include <errno.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 #include "alloc/Allocator.hpp"
 #include "CallsChecker.hpp"
 #include "Exceptions.h"
@@ -230,18 +237,60 @@ extern "C" void Kotlin_native_internal_GC_schedule(ObjHeader*) {
     mm::GlobalData::Instance().gcScheduler().schedule();
 }
 
-extern "C" RUNTIME_NOTHROW bool Kotlin_native_runtime_Debugging_dumpMemory(ObjHeader*, int fd) {
+namespace {
+
+bool dumpMemoryFromRuntime(int fd, bool omitPayloads, bool gzip, bool shortenPause) {
+    mm::DumpGuard dumpGuard;
+    if (!dumpGuard) {
+        return false;
+    }
+
     auto mainGCLock = mm::GlobalData::Instance().gc().gcLock();
 
     auto* threadData = mm::ThreadRegistry::Instance().CurrentThreadData();
     threadData->suspensionData().requestThreadsSuspension("Memory dump");
-    CallsCheckerIgnoreGuard guard;
+    CallsCheckerIgnoreGuard ignoreGuard;
     // We're in the runnable state, but everything else (including the GC thread) will be suspended.
     // It's fine to wait for that suspension and execute long-running operations (I/O) here.
     mm::WaitForThreadsSuspension();
-    bool success = mm::DumpMemory(fd);
+
+#if !KONAN_WINDOWS
+    if (shortenPause) {
+        pid_t pid = fork();
+        if (pid == 0) {
+            bool success = mm::DumpMemory(fd, omitPayloads, gzip);
+            _exit(success ? 0 : 1);
+        }
+        if (pid > 0) {
+            // Resume mutators immediately; the child writes the dump from a COW snapshot.
+            // Keep gcLock until waitpid returns so the parent GC cannot mutate pages
+            // the child is still reading.
+            mm::ResumeThreads();
+            int status = 0;
+            if (waitpid(pid, &status, 0) < 0) {
+                RuntimeLogError({kotlin::logging::Tag::kMemoryDump}, "waitpid failed: %s", strerror(errno));
+                return false;
+            }
+            return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+        }
+        RuntimeLogError({kotlin::logging::Tag::kMemoryDump}, "fork failed: %s", strerror(errno));
+        // Fall through to an in-process dump.
+    }
+#endif
+    bool success = mm::DumpMemory(fd, omitPayloads, gzip);
     mm::ResumeThreads();
     return success;
+}
+
+} // namespace
+
+extern "C" RUNTIME_NOTHROW bool Kotlin_native_runtime_Debugging_dumpMemory(ObjHeader*, int fd) {
+    return dumpMemoryFromRuntime(fd, false, false, /* shortenPause */ false);
+}
+
+extern "C" RUNTIME_NOTHROW bool Kotlin_native_runtime_Debugging_dumpMemoryWithOptions(
+        ObjHeader*, int fd, bool omitPayloads, bool gzip) {
+    return dumpMemoryFromRuntime(fd, omitPayloads, gzip, /* shortenPause */ true);
 }
 
 extern "C" void Kotlin_native_internal_GC_setTuneThreshold(ObjHeader*, KBoolean value) {

--- a/kotlin-native/runtime/src/main/cpp/mm/MemoryDump.cpp
+++ b/kotlin-native/runtime/src/main/cpp/mm/MemoryDump.cpp
@@ -6,10 +6,25 @@
 #include "mm/MemoryDump.hpp"
 
 #include <algorithm>
+#include <atomic>
+#include <cerrno>
 #include <cstdio>
 #include <cstring>
-#include <unordered_set>
+#include <limits>
 #include <queue>
+#include <unordered_set>
+
+#include <zlib.h>
+
+#if KONAN_WINDOWS
+#include <io.h>
+#define KN_DUP _dup
+#define KN_CLOSE _close
+#else
+#include <unistd.h>
+#define KN_DUP dup
+#define KN_CLOSE close
+#endif
 
 #include "Porting.h"
 #include "TypeInfo.h"
@@ -24,13 +39,110 @@ constexpr auto kTagMemDump = kotlin::logging::Tag::kMemoryDump;
 
 namespace kotlin::mm {
 
+namespace {
+
+std::atomic<bool> g_dumpInProgress{false};
+
+// Writes dump bytes either uncompressed or as a gzip member.
+class DumpWriter : private Pinned {
+public:
+    explicit DumpWriter(FILE* file) : file_(file) {}
+    explicit DumpWriter(gzFile gz) : gz_(gz) {}
+
+    void write(const void* data, size_t size) {
+        auto* bytes = static_cast<const uint8_t*>(data);
+        if (file_ != nullptr) {
+            size_t written = fwrite(bytes, 1, size, file_);
+            if (written != size) {
+                throw std::system_error(errno, std::generic_category());
+            }
+            return;
+        }
+        // gzwrite takes `unsigned`; split large spans so we never truncate the length.
+        while (size > 0) {
+            unsigned chunk = static_cast<unsigned>(std::min(size, static_cast<size_t>(std::numeric_limits<int>::max())));
+            int n = gzwrite(gz_, bytes, chunk);
+            if (n <= 0) {
+                int err = Z_ERRNO;
+                gzerror(gz_, &err);
+                throw std::system_error(err == Z_ERRNO ? errno : EIO, std::generic_category());
+            }
+            bytes += n;
+            size -= static_cast<size_t>(n);
+        }
+    }
+
+    void flush() {
+        if (file_ != nullptr && fflush(file_) == EOF) {
+            throw std::system_error(errno, std::generic_category());
+        }
+    }
+
+private:
+    FILE* file_ = nullptr;
+    gzFile gz_ = nullptr;
+};
+
+// Owns a gzip stream opened on a dup of `fd`, so gzclose does not close the caller's descriptor.
+class GzipStream : private Pinned {
+public:
+    explicit GzipStream(int fd) {
+        int dupFd = KN_DUP(fd);
+        if (dupFd < 0) {
+            throw std::system_error(errno, std::generic_category());
+        }
+        // "wb1": gzip container at Z_BEST_SPEED. The dump often runs in a forked
+        // child; finishing quickly limits how long COW pages stay duplicated.
+        gz_ = gzdopen(dupFd, "wb1");
+        if (gz_ == nullptr) {
+            KN_CLOSE(dupFd);
+            throw std::system_error(EIO, std::generic_category());
+        }
+    }
+
+    ~GzipStream() {
+        if (gz_ != nullptr) {
+            gzclose(gz_);
+        }
+    }
+
+    gzFile get() const { return gz_; }
+
+    void closeOrThrow() {
+        int rc = gzclose(gz_);
+        gz_ = nullptr;
+        if (rc != Z_OK) {
+            throw std::system_error(EIO, std::generic_category());
+        }
+    }
+
+private:
+    gzFile gz_ = nullptr;
+};
+
+} // namespace
+
+DumpGuard::DumpGuard() noexcept : acquired_(false) {
+    bool expected = false;
+    acquired_ = g_dumpInProgress.compare_exchange_strong(expected, true, std::memory_order_acq_rel);
+    if (!acquired_) {
+        RuntimeLogInfo({kTagMemDump}, "Another memory dump is in progress, skipping");
+    }
+}
+
+DumpGuard::~DumpGuard() {
+    if (acquired_) {
+        g_dumpInProgress.store(false, std::memory_order_release);
+    }
+}
+
 class MemoryDumper {
 public:
-    explicit MemoryDumper(FILE* file) : file_(file) {}
+    explicit MemoryDumper(DumpWriter& writer, bool omitPayloads) : writer_(writer), omitPayloads_(omitPayloads) {}
 
     // Dumps the memory and returns the success flag.
     void Dump() {
-        RuntimeLogInfo({kTagMemDump}, "Starting to dump memory into %p", file_);
+        RuntimeLogInfo({kTagMemDump}, "Starting to dump memory omitPayloads=%d", omitPayloads_ ? 1 : 0);
 
         DumpStr("Kotlin/Native dump 1.0.8");
         DumpBool(konan::isLittleEndian());
@@ -64,10 +176,7 @@ public:
 private:
     template <typename T>
     void DumpSpan(std_support::span<T> span) {
-        size_t written = fwrite(span.data(), sizeof(T), span.size(), file_);
-        if (written != span.size()) {
-            throw std::system_error(errno, std::generic_category());
-        }
+        writer_.write(span.data(), span.size() * sizeof(T));
     }
 
     template <typename T>
@@ -145,6 +254,14 @@ private:
         DumpU32(count);
 
         int32_t elementSize = -type->instanceSize_;
+
+        // Keep object and native-ptr arrays: they are the heap graph. Primitive
+        // arrays (including String contents) are the bulky/sensitive payloads.
+        if (omitPayloads_ && type != theArrayTypeInfo && type != theNativePtrArrayTypeInfo) {
+            DumpU32(0);
+            return;
+        }
+
         size_t dataOffset = alignUp(sizeof(ArrayHeader), elementSize);
         size_t dataSize = elementSize * count;
         DumpU32(dataSize);
@@ -335,8 +452,8 @@ private:
     const uint8_t TYPE_FLAG_EXTENDED = 1 << 1;
     const uint8_t TYPE_FLAG_OBJECT_ARRAY = 1 << 2;
 
-    // Target file.
-    FILE* file_;
+    DumpWriter& writer_;
+    bool omitPayloads_;
 
     // A set of already dumped type pointers.
     std::unordered_set<const TypeInfo*> dumpedTypes_;
@@ -352,25 +469,35 @@ void PrepareForMemoryDump() {
     mm::GlobalData::Instance().threadRegistry().PublishAll();
 }
 
-void DumpMemoryOrThrow(int fd) {
+void DumpMemoryOrThrow(int fd, bool omitPayloads, bool gzip) {
+    if (gzip) {
+        GzipStream gz(fd);
+        DumpWriter writer(gz.get());
+        MemoryDumper(writer, omitPayloads).Dump();
+        gz.closeOrThrow();
+        return;
+    }
+
     FILE* file = fdopen(fd, "w");
     if (file == nullptr) {
         throw std::system_error(errno, std::generic_category());
     }
 
-    MemoryDumper(file).Dump();
-
-    if (fflush(file) == EOF) {
-        throw std::system_error(errno, std::generic_category());
-    }
+    DumpWriter writer(file);
+    MemoryDumper(writer, omitPayloads).Dump();
+    writer.flush();
 }
 
 bool DumpMemory(int fd) noexcept {
+    return DumpMemory(fd, false, false);
+}
+
+bool DumpMemory(int fd, bool omitPayloads, bool gzip) noexcept {
     PrepareForMemoryDump();
 
     bool success = true;
     try {
-        DumpMemoryOrThrow(fd);
+        DumpMemoryOrThrow(fd, omitPayloads, gzip);
     } catch (const std::system_error& e) {
         success = false;
         RuntimeLogError({kTagMemDump}, "Memory dump error: %s", e.what());

--- a/kotlin-native/runtime/src/main/cpp/mm/MemoryDump.hpp
+++ b/kotlin-native/runtime/src/main/cpp/mm/MemoryDump.hpp
@@ -5,7 +5,25 @@
 
 #pragma once
 
+#include "Utils.hpp"
+
 namespace kotlin::mm {
+
+/**
+ * RAII guard ensuring only one dump runs at a time.
+ *
+ * Uses non-blocking try-lock semantics: if another dump is already in
+ * progress, acquisition fails and `operator bool()` returns false.
+ */
+class DumpGuard : private Pinned {
+public:
+    DumpGuard() noexcept;
+    ~DumpGuard();
+    explicit operator bool() const noexcept { return acquired_; }
+
+private:
+    bool acquired_;
+};
 
 /**
  * Dumps memory into the given POSIX file in Kotlin/Native Dump file format, and
@@ -15,8 +33,20 @@ namespace kotlin::mm {
  * with corresponding type layouts. The dump can be combined with additional
  * metadata emitted by the compiler and converted to the "hprof" format by an
  * external tool.
- *
  */
 bool DumpMemory(int fd) noexcept;
+
+/**
+ * Like [DumpMemory], with optional omitted primitive-array payloads and gzip
+ * wrapping. Must be called during STW.
+ *
+ * When `omitPayloads` is true, primitive array contents are omitted (count is
+ * preserved). Object arrays and native-pointer arrays are still written in full
+ * so the heap graph can be reconstructed.
+ *
+ * When `gzip` is true, the dump is written as a gzip member. `kdumputil` detects
+ * the gzip magic and decompresses before parsing.
+ */
+bool DumpMemory(int fd, bool omitPayloads, bool gzip) noexcept;
 
 } // namespace kotlin::mm

--- a/kotlin-native/runtime/src/main/cpp/mm/MemoryDump.md
+++ b/kotlin-native/runtime/src/main/cpp/mm/MemoryDump.md
@@ -118,3 +118,13 @@
 - thread_id (id): thread ID
 - object_id (id): object ID
 ```
+
+## Optional wrappers
+
+The dump body above is format `1.0.8`. Implementations may wrap the entire file in a
+single gzip member (`1f 8b` magic). `kdumputil` decompresses such files automatically.
+
+When primitive-array payloads are omitted, the ARRAY record still stores `count`, but
+the following size field is `0` and `element_data` is empty. Object arrays and
+native-pointer arrays are never omitted. `kdumputil` zero-fills omitted primitive
+arrays when converting to hprof.

--- a/kotlin-native/runtime/src/main/kotlin/kotlin/native/runtime/Debugging.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/native/runtime/Debugging.kt
@@ -10,6 +10,21 @@ import kotlin.native.internal.GCUnsafeCall
 import kotlin.native.internal.InternalForKotlinNative
 
 /**
+ * Options for [Debugging.dumpMemory].
+ *
+ * @param omitPayloads If `true`, primitive array contents are omitted from the dump.
+ *   Object arrays and native-pointer arrays are still written so the heap graph can be
+ *   reconstructed. `kdumputil` fills omitted primitive arrays with zeros when converting to hprof.
+ * @param gzip If `true`, the dump is written as a gzip member. `kdumputil` detects the gzip
+ *   magic and decompresses before parsing.
+ */
+@NativeRuntimeApi
+public class MemoryDumpOptions(
+        public val omitPayloads: Boolean = false,
+        public val gzip: Boolean = false,
+)
+
+/**
  * __Note__: this API is unstable and may change in any release.
  *
  * A set of utilities for debugging Kotlin/Native runtime.
@@ -33,10 +48,28 @@ public object Debugging {
     /**
      * Dump memory in binary format to the given POSIX file descriptor and
      * returns success flag.
+     *
+     * The dump is written uncompressed, with full object and array payloads,
+     * and completes before this function returns.
      */
     @GCUnsafeCall("Kotlin_native_runtime_Debugging_dumpMemory")
     @Escapes.Nothing
     public external fun dumpMemory(fd: Long): Boolean
+
+    /**
+     * Dump memory in binary format to the given POSIX file descriptor with [options]
+     * and returns success flag.
+     *
+     * The dump still completes before this function returns, so the caller may close
+     * [fd] afterwards. On POSIX, the implementation may write the dump in a forked
+     * child process so other threads can resume sooner; that is not a public option.
+     */
+    public fun dumpMemory(fd: Long, options: MemoryDumpOptions): Boolean =
+            dumpMemoryWithOptions(fd, options.omitPayloads, options.gzip)
+
+    @GCUnsafeCall("Kotlin_native_runtime_Debugging_dumpMemoryWithOptions")
+    @Escapes.Nothing
+    private external fun dumpMemoryWithOptions(fd: Long, omitPayloads: Boolean, gzip: Boolean): Boolean
 }
 
 @GCUnsafeCall("Kotlin_Debugging_isThreadStateRunnable")

--- a/kotlin-native/tools/kdumputil/src/kdump/file.kt
+++ b/kotlin-native/tools/kdumputil/src/kdump/file.kt
@@ -1,6 +1,32 @@
 package kdump
 
 import java.io.File
+import java.io.InputStream
 import java.io.PushbackInputStream
+import java.util.zip.GZIPInputStream
 
-fun File.readDump() = inputStream().buffered().run { PushbackInputStream(this) }.readDump()
+private val GZIP_MAGIC = byteArrayOf(0x1f.toByte(), 0x8b.toByte())
+
+/**
+ * Wraps [this] in a [GZIPInputStream] if the stream starts with the gzip magic bytes,
+ * otherwise returns the stream unchanged.
+ */
+fun InputStream.maybeDecompress(): InputStream {
+    val pb = PushbackInputStream(this, 2)
+    val header = ByteArray(2)
+    val read = pb.read(header)
+    return if (read == 2 && header[0] == GZIP_MAGIC[0] && header[1] == GZIP_MAGIC[1]) {
+        pb.unread(header, 0, read)
+        GZIPInputStream(pb)
+    } else {
+        if (read > 0) pb.unread(header, 0, read)
+        pb
+    }
+}
+
+fun File.readDump() =
+        inputStream()
+                .maybeDecompress()
+                .buffered()
+                .run { PushbackInputStream(this) }
+                .readDump()

--- a/kotlin-native/tools/kdumputil/src/kdump/hprof/converter.kt
+++ b/kotlin-native/tools/kdumputil/src/kdump/hprof/converter.kt
@@ -577,10 +577,17 @@ class Converter(
             else -> {
                 val [runtimeElementType, hprofElementType] =
                         type.relativeName.primitiveArrayClassNameToElementTypePair()
+                // Omitted primitive payloads: count is present, byteArray is empty.
+                // Zero-fill so MAT can still compute shallowSize from the hprof dump.
+                val payload = if (byteArray.isEmpty() && count > 0) {
+                    ByteArray(count * size(runtimeElementType))
+                } else {
+                    byteArray
+                }
                 hprofPrimitiveArrayDump(
                         objectId,
                         hprofElementType,
-                        byteArray,
+                        payload,
                         offset,
                         count,
                         runtimeElementType

--- a/kotlin-native/tools/kdumputil/src/main.kt
+++ b/kotlin-native/tools/kdumputil/src/main.kt
@@ -13,7 +13,6 @@ import kdump.item
 import kdump.readDump
 import text.prettyPrintln
 import java.io.File
-import java.io.PushbackInputStream
 
 fun main(args: Array<String>) {
     main(args.iterator())
@@ -72,9 +71,6 @@ fun mainPrintHprof(pathname: String) {
 
 fun mainConvertKdumpHprof(inPathname: String, outPathname: String) {
     File(inPathname)
-            .inputStream()
-            .buffered()
-            .let { PushbackInputStream(it) }
             .readDump()
             .toHProfProfile()
             .normalize()

--- a/kotlin-native/tools/kdumputil/test/kdump/fileTest.kt
+++ b/kotlin-native/tools/kdumputil/test/kdump/fileTest.kt
@@ -1,0 +1,34 @@
+package kdump
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class FileTest {
+    @Test
+    fun maybeDecompressGzip() {
+        val raw = "Kotlin/Native dump 1.0.8".encodeToByteArray()
+        val compressed = ByteArrayOutputStream().use { baos ->
+            GZIPOutputStream(baos).use { it.write(raw) }
+            baos.toByteArray()
+        }
+        val decompressed = ByteArrayInputStream(compressed).maybeDecompress().readBytes()
+        assertContentEquals(raw, decompressed)
+    }
+
+    @Test
+    fun maybeDecompressRaw() {
+        val raw = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+        val roundTrip = ByteArrayInputStream(raw).maybeDecompress().readBytes()
+        assertContentEquals(raw, roundTrip)
+    }
+
+    @Test
+    fun maybeDecompressEmpty() {
+        val roundTrip = ByteArrayInputStream(byteArrayOf()).maybeDecompress().readBytes()
+        assertEquals(0, roundTrip.size)
+    }
+}

--- a/native/native.tests/testData/gc/memoryDump.kt
+++ b/native/native.tests/testData/gc/memoryDump.kt
@@ -76,3 +76,60 @@ fun dumpToFile() {
 
     fclose(file)
 }
+
+@OptIn(ExperimentalNativeApi::class, NativeRuntimeApi::class, ExperimentalForeignApi::class)
+private fun dumpAndMeasureBytes(options: MemoryDumpOptions?): Long {
+    val file = requireNotNull(tmpfile()) { "Could not open temporary file" }
+    val fd = fileno(file)
+    assertTrue(fd > -1, "Failed to obtain a temporary file descriptor")
+    val local = Data()
+    val success = if (options == null) {
+        Debugging.dumpMemory(fd.toLong())
+    } else {
+        Debugging.dumpMemory(fd.toLong(), options)
+    }
+    assertTrue(success)
+    val size = lseek(fd, 0, SEEK_END)
+    fclose(file)
+    return size.toLong()
+}
+
+@Test
+@OptIn(ExperimentalNativeApi::class, NativeRuntimeApi::class, ExperimentalForeignApi::class)
+fun dumpOmitPayloadsIsSmaller() {
+    val full = dumpAndMeasureBytes(null)
+    val omitted = dumpAndMeasureBytes(MemoryDumpOptions(omitPayloads = true))
+    assertTrue(omitted < full, "omitted dump ($omitted) should be smaller than full dump ($full)")
+}
+
+@Test
+@OptIn(ExperimentalNativeApi::class, NativeRuntimeApi::class, ExperimentalForeignApi::class)
+fun dumpGzipHasMagic() {
+    val file = requireNotNull(tmpfile()) { "Could not open temporary file" }
+    val fd = fileno(file)
+    assertTrue(fd > -1, "Failed to obtain a temporary file descriptor")
+    val local = Data()
+    assertTrue(Debugging.dumpMemory(fd.toLong(), MemoryDumpOptions(gzip = true)))
+    assertTrue(hasGzipMagic(fd))
+    fclose(file)
+}
+
+@Test
+@OptIn(ExperimentalNativeApi::class, NativeRuntimeApi::class, ExperimentalForeignApi::class)
+fun dumpOmitPayloadsAndGzip() {
+    val file = requireNotNull(tmpfile()) { "Could not open temporary file" }
+    val fd = fileno(file)
+    assertTrue(fd > -1, "Failed to obtain a temporary file descriptor")
+    val local = Data()
+    assertTrue(Debugging.dumpMemory(fd.toLong(), MemoryDumpOptions(omitPayloads = true, gzip = true)))
+    assertTrue(hasGzipMagic(fd))
+    fclose(file)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun hasGzipMagic(fd: Int): Boolean = memScoped {
+    lseek(fd, 0, SEEK_SET)
+    val buf = allocArray<UByteVar>(2)
+    val n = read(fd, buf, 2.convert())
+    n.toLong() == 2L && buf[0] == 0x1fu.toUByte() && buf[1] == 0x8bu.toUByte()
+}


### PR DESCRIPTION
On large heaps, `Debugging.dumpMemory(fd)` keeps the application in a
stop-the-world pause until the full uncompressed snapshot is written.
The dump file also includes every primitive-array byte, so size grows
with retained data rather than only with the object graph, and those
bytes are often unnecessary for leak analysis or may contain sensitive
application data. Follow-up to KT-68544; the existing `dumpMemory(fd)`
API stays unchanged.

## Youtrack issue

https://youtrack.jetbrains.com/issue/KT-89272

## Cause

The current dump path always writes the complete heap snapshot in format
1.0.8: synchronous, uncompressed, with full instance and primitive-array
payloads. There is no way to omit bulky or sensitive bytes, compress the
output, or shorten the pause on POSIX while keeping the same public
one-shot API.

## Fix

Add an optional dump path next to the existing API:

* `MemoryDumpOptions(omitPayloads, gzip)` and
  `dumpMemory(fd, options)`.
* `omitPayloads`: skip primitive-array byte contents; keep types,
  references, and the object graph. `Array` / `NativePtrArray` payloads
  are still written in full.
* `gzip`: wrap the dump in gzip; format remains 1.0.8.
* POSIX: after the heap is stable, finish compression and I/O in a
  child created with `fork` so the parent can resume threads sooner.
  The function still returns only after the dump is complete. Windows
  performs the dump in-process (no `fork`).

Update `kdumputil` to auto-detect gzip for `print kdump` and
`convert kdump hprof`, and to zero-fill omitted primitive arrays when
converting to hprof. Link `-lz` for Native targets that use gzip.

Tests: `native/native.tests` memory dump cases (default, omit, gzip) and
`kdumputil` gzip detection.
