### PR TITLE
[Native] Fix deserialization of `KlibDAG`

### DIFF
--- a/native/cinterop.deserialization/src/main/kotlin/org/jetbrains/kotlin/backend/konan/library/KlibDAG.kt
+++ b/native/cinterop.deserialization/src/main/kotlin/org/jetbrains/kotlin/backend/konan/library/KlibDAG.kt
@@ -62,33 +62,44 @@ class KlibDAG(private val dag: Map<KotlinLibrary, KlibDAGNode>) {
 }
 
 /**
- * Deserialize DAG to [KlibDAG]:
+ * Deserialize [SerializedKlibDAG] to [KlibDAG]:
  * - [this] is used as the source of information about dependencies (via paths).
- * - [libraries] is used as the source of [KotlinLibrary] instances.
+ * - [librariesUsedInCurrentCompilation] is the list of [KotlinLibrary]s used in the current compilation.
  *
- * Note: If some library is represented in [libraries] but nbot represented in [this], it will
- * not be included into the resulting [KlibDAG].
+ * Note: The returned [KlibDAG] must include all libraries from [librariesUsedInCurrentCompilation].
+ * Which means that all libraries from [librariesUsedInCurrentCompilation] should be represented in
+ * the deserialized [SerializedKlibDAG].
  */
-fun SerializedKlibDAG.deserialize(libraries: Collection<KotlinLibrary>): KlibDAG {
-    val pathToLibrary: Map<Path, KotlinLibrary> = libraries.associateByCanonicalPathPreventingDuplicates()
+fun SerializedKlibDAG.deserialize(librariesUsedInCurrentCompilation: Collection<KotlinLibrary>): KlibDAG {
+    val pathToLibrary: Map<Path, KotlinLibrary> = librariesUsedInCurrentCompilation.associateByCanonicalPathPreventingDuplicates()
 
-    fun findLibrary(libraryPath: Path): KotlinLibrary =
-        pathToLibrary[libraryPath]
-            ?: error("Library $libraryPath from the serialized DAG is not in the list of the available libraries: ${libraries.joinToString { it.canonicalPath.pathString }}")
+    val librariesMissingInSerializedDag = pathToLibrary.keys - dag.keys
+    check(librariesMissingInSerializedDag.isEmpty()) {
+        "There are libraries that are used in the current compilation but are missing in the deserialized DAG: ${librariesMissingInSerializedDag.joinToString()}"
+    }
 
-    val dagUnderConstruction: Map<KotlinLibrary, KlibDAGNodeImpl> = libraries.associateWith(::KlibDAGNodeImpl)
-    val usedNodes = hashSetOf<KlibDAGNodeImpl>()
+    val dagUnderConstruction: Map<KotlinLibrary, KlibDAGNodeImpl> = librariesUsedInCurrentCompilation.associateWith(::KlibDAGNodeImpl)
 
-    dag.entries.forEach { [libraryPath: Path, directDependencyPaths: Set<Path>] ->
-        val node = dagUnderConstruction.getValue(findLibrary(libraryPath))
-        usedNodes += node
+    for ([libraryPath: Path, directDependencyPaths: Set<Path>] in dag.entries) {
+        val library = pathToLibrary[libraryPath] ?: run {
+            // The library in serialized DAG is not present among libraries used in the current compilation.
+            // So, we can skip it. It won't appear in the resulting DAG for the current compilation, and that's OK.
+            continue
+        }
 
-        for (directDependency in directDependencyPaths) {
-            node.targets += dagUnderConstruction.getValue(findLibrary(directDependency))
+        val node = dagUnderConstruction.getValue(library)
+
+        for (directDependencyPath in directDependencyPaths) {
+            val directDependencyLibrary = pathToLibrary[directDependencyPath] ?: error(
+                "Library $libraryPath has a dependency $directDependencyPath in the deserialized DAG " +
+                        "that is not in the list of the libraries used in the current compilation: " +
+                        librariesUsedInCurrentCompilation.joinToString { it.canonicalPath.pathString }
+            )
+            node.targets += dagUnderConstruction.getValue(directDependencyLibrary)
         }
     }
 
-    return KlibDAG(dagUnderConstruction.filterValues { it in usedNodes })
+    return KlibDAG(dagUnderConstruction)
 }
 
 /**

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderTest.kt
@@ -30,7 +30,6 @@ import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
-import org.jetbrains.kotlin.utils.filterToSetOrEmpty
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -189,8 +188,7 @@ class KlibDAGBuilderTest : AbstractNativeSimpleTest() {
         }
 
         // Check serialization/deserialization.
-        assertLosslessDeserialization(dag, libraries = dag.libraries)
-        assertLosslessDeserialization(dag, libraries = allLibraries)
+        assertLosslessDeserialization(dag)
 
         val userLibraries: Map</* name of test module */ String, /* use library */ KotlinLibrary> = allLibraries.mapNotNull { library ->
             val moduleName = userLibraryPathToModuleName[library.path] ?: return@mapNotNull null
@@ -367,7 +365,7 @@ class KlibDAGBuilderTest : AbstractNativeSimpleTest() {
     }
 
     @Test
-    fun `deserialization skips excessive libraries`() {
+    fun `DAG deserialization fails if there are libraries in current compilation that are missing in SerializedKlibDAG`() {
         val libraries: List<KotlinLibrary> = loadLibraries(platformLibs = true)
 
         val dag: KlibDAG = KlibDAGBuilder(libraries) { true }.build()
@@ -380,16 +378,27 @@ class KlibDAGBuilderTest : AbstractNativeSimpleTest() {
             name == "stdlib" || name.endsWith(".posix")
 
         val serializedDagWithOnlyStdlibAndPosix = SerializedKlibDAG(
-            serializedOriginal.dag
-                .filterKeys { it.isStdlibOrPosix() }
-                .mapValues { [_, dependencyPaths] -> dependencyPaths.filterToSetOrEmpty { it.isStdlibOrPosix() } }
+            serializedOriginal.dag.filterKeys { it.isStdlibOrPosix() }
         )
         assertEquals(2, serializedDagWithOnlyStdlibAndPosix.dag.size)
 
-        // Pass more libraries as the input that there are actually required:
-        val deserializedDag: KlibDAG = serializedDagWithOnlyStdlibAndPosix.deserialize(libraries)
+        // Pass the exact number of libraries:
+        val deserializedDag: KlibDAG = serializedDagWithOnlyStdlibAndPosix.deserialize(libraries.filter { it.path.isStdlibOrPosix() })
         assertEquals(2, deserializedDag.libraries.size)
         assertTrue(deserializedDag.libraries.all { it.canonicalPath.isStdlibOrPosix() })
+
+        // Pass more libraries as the input that there are actually required:
+        try {
+            serializedDagWithOnlyStdlibAndPosix.deserialize(libraries)
+            fail { "Normally unreachable" }
+        } catch (e: Exception) {
+            val message = e.message.orEmpty()
+            assertTrue(message.startsWith("There are libraries that are used in the current compilation but are missing in the deserialized DAG:"))
+
+            val libraryPaths = message.substringAfter(':').split(',').mapToSet { Path(it.trim()) }
+            assertTrue(libraryPaths.none { it.isStdlibOrPosix() })
+            assertEquals(libraries.size - 2, libraryPaths.size)
+        }
     }
 
     /**
@@ -493,9 +502,9 @@ class KlibDAGBuilderTest : AbstractNativeSimpleTest() {
         }
     }
 
-    private fun assertLosslessDeserialization(dag: KlibDAG, libraries: Collection<KotlinLibrary> = dag.libraries) {
+    private fun assertLosslessDeserialization(dag: KlibDAG) {
         val serializedOnce = dag.serialize()
-        val serializedTwice = serializedOnce.deserialize(libraries).serialize()
+        val serializedTwice = serializedOnce.deserialize(dag.libraries).serialize()
 
         assertEquals(serializedOnce, serializedTwice)
     }

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderTest.kt
@@ -329,27 +329,40 @@ class KlibDAGBuilderTest : AbstractNativeSimpleTest() {
     }
 
     @Test
-    fun `SerializedKlibDAG creation sanity test`() {
-        val properDag: Map<Path, Set<Path>> = buildMap {
-            this[Path("/foo")] = setOf(Path("/bar"))
-            this[Path("/bar")] = setOf(Path("/baz"))
-            this[Path("/baz")] = setOf()
+    fun `SerializedKlibDAG creation sanity test (positive)`() {
+        val foo = Path("__foo__")
+        val bar = Path("__bar__")
+        val baz = Path("__baz__")
+
+        val dag: Map<Path, Set<Path>> = buildMap {
+            this[foo] = setOf(bar)
+            this[bar] = setOf(baz)
+            this[baz] = setOf()
         }
 
-        val improperDag: Map<Path, Set<Path>> = buildMap {
-            this[Path("/foo")] = setOf(Path("/bar"))
-            this[Path("/bar")] = setOf(Path("/baz"))
-            //this[Path("/baz")] = setOf()
-        }
+        SerializedKlibDAG(dag)
+    }
 
-        SerializedKlibDAG(properDag)
+    @Test
+    fun `SerializedKlibDAG creation sanity test (negative)`() {
+        val foo = Path("__foo__")
+        val bar = Path("__bar__")
+        val baz = Path("__baz__")
+
+        val dag: Map<Path, Set<Path>> = buildMap {
+            this[foo] = setOf(bar)
+            this[bar] = setOf(baz)
+            // baz is missing in the graph
+        }
 
         try {
-            SerializedKlibDAG(improperDag)
+            SerializedKlibDAG(dag)
             fail { "Normally unreachable" }
         } catch (e: Exception) {
-            val message = e.message.orEmpty()
-            assertTrue(message.startsWith("There is a direct dependency ") && message.endsWith(" that is not in DAG"))
+            assertEquals(
+                "There is a direct dependency __baz__ of library __bar__ that is not in DAG",
+                e.message
+            )
         }
     }
 


### PR DESCRIPTION
This is a pre-requisite for https://github.com/JetBrains/kotlin/pull/8067

The deserialized `KlibDAG` should include all libraries that are used in the current compilation.

Fix the logic of DAG deserialization and adapt the tests.
    
KT-86840
