### PR TITLE
[Build] Move debugger-required modules from `fe10-for-ide` to `fir-fo…

### DIFF
--- a/prepare/ide-plugin-dependencies/kotlin-compiler-fe10-for-ide/build.gradle.kts
+++ b/prepare/ide-plugin-dependencies/kotlin-compiler-fe10-for-ide/build.gradle.kts
@@ -8,6 +8,8 @@ val fe10CompilerModules: Array<String> = CompilerModules.fe10CompilerModules
 
 val excludedCompilerModules = listOf(
     ":compiler:incremental-compilation-impl",
+    ":core:deserialization",
+    ":core:descriptors.jvm",
 )
 
 val extraCompilerModules = listOf(

--- a/prepare/ide-plugin-dependencies/kotlin-compiler-fir-for-ide/build.gradle.kts
+++ b/prepare/ide-plugin-dependencies/kotlin-compiler-fir-for-ide/build.gradle.kts
@@ -12,6 +12,11 @@ val excludedFirModules = listOf(
     ":compiler:multiplatform-parsing",
 )
 
-val projects = firCompilerModules.asList() + jvmCompilerModules - excludedFirModules
+val additionalK1Modules = listOf(
+    ":core:deserialization",
+    ":core:descriptors.jvm",
+)
+
+val projects = firCompilerModules.asList() + jvmCompilerModules + additionalK1Modules - excludedFirModules
 
 publishJarsForIde(projects)


### PR DESCRIPTION
…r-ide`

After this move it would be possible to completely get rid of dependency on `fe10-for-ide.jar` in intellij.