### PR TITLE
[Wasm] remove unnecessary tests muting (callableReferences/contextual)

### DIFF
--- a/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/equality.kt
+++ b/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/equality.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +ContextParameters +CallableReferencesToContextual
-// IGNORE_BACKEND: WASM_JS, WASM_WASI
 // ISSUE: KT-86452
 
 context(a: String, b: Int)

--- a/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/funInterfaceEquality.kt
+++ b/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/funInterfaceEquality.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +ContextParameters +CallableReferencesToContextual
-// IGNORE_BACKEND: WASM_JS, WASM_WASI
 
 fun interface F {
     fun run(): String

--- a/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/nullableContextArg.kt
+++ b/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/nullableContextArg.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +ContextParameters +CallableReferencesToContextual
-// IGNORE_BACKEND: WASM_JS, WASM_WASI
 
 context(c: String?)
 fun orDefault(): String = c ?: "default"

--- a/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/propertyEquality.kt
+++ b/compiler/testData/codegen/box/contextParameters/callableReferences/contextual/propertyEquality.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +ContextParameters +CallableReferencesToContextual
-// IGNORE_BACKEND: WASM_JS, WASM_WASI
 
 context(c: String, n: Int)
 val topProp: String


### PR DESCRIPTION
Tests are introduced yesterday with the support callable references to contextualized declarations ([PR](https://github.com/JetBrains/kotlin/pull/7639))

Fixes ^KT-89345