### PR TITLE
[Native][test] Implicitly add stdlib in partial linkage tests

### DIFF
--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCompilerInvocationTest.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCompilerInvocationTest.kt
@@ -253,7 +253,6 @@ class NativeCompilerInvocationTestArtifactBuilder(
 
         private val COMPILER_ARGS = TestCompilerArgs(
             listOf(
-                "-nostdlib", // stdlib is passed explicitly.
                 "-Xdisable-ir-checkers=IrVisibilityChecker",
             )
         )


### PR DESCRIPTION
Required for https://github.com/JetBrains/kotlin/pull/8067

The standard library is treated differently in Native PL tests:
- When generating a KLIB or an executable: stdlib is passed as an explicit CLI arg (`-l`) together with `-nostdlib` parameter.
- When building static caches: It's not passed explicitly. Regardless the fact the `-nostdlib` CLI parameter is passed, it works just as a side effect of the KLIB resolver.

This will not be possible anymore when we replace the KLIB resolver by KlibLoader.

So, we need to be more consistent in passing stdlib to the compiler in Native PL tests. The less invasive way to fix this is to
- stop passing `-nostdlib` CLI parameter
- also, stop passing stdlib in KLIB & executable compilations

^KT-61096