### PR TITLE
Introduce 'inferredExpectedType'

### DIFF
--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirExpressionTypeProvider.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirExpressionTypeProvider.kt
@@ -386,7 +386,11 @@ internal class KaFirExpressionTypeProvider(
         return firFunction.constructFunctionType(firFunction.specialFunctionTypeKind(resolutionFacade.useSiteFirSession)).asKaType()
     }
 
-    override fun expectedType(element: PsiElement): KaType? = element.withPsiValidityAssertion {
+    // Shares the implementation with 'inferredExpectedType' until 'expectedType' is reworked
+    // to only report declaration-based expectations (KT-87415).
+    override fun expectedType(element: PsiElement): KaType? = inferredExpectedType(element)
+
+    override fun inferredExpectedType(element: PsiElement): KaType? = element.withPsiValidityAssertion {
         val unwrapped = element.unwrap()
         val expectedType = getExpectedTypeByReturnExpression(unwrapped)
             ?: getExpectedTypeByIfOrBooleanCondition(unwrapped)
@@ -423,7 +427,7 @@ internal class KaFirExpressionTypeProvider(
             currentExpression in collectionLiteral.getInnerExpressions()
         } ?: return null
 
-        val collectionLiteralType = expectedType(collectionLiteral) ?: return null
+        val collectionLiteralType = inferredExpectedType(collectionLiteral) ?: return null
         return with(analysisSession) { collectionLiteralType.arrayElementType }
     }
 
@@ -447,7 +451,7 @@ internal class KaFirExpressionTypeProvider(
         val call = expression.getFunctionCallAsWithThisAsParameter()?.call ?: return null
         if (call.getOrBuildFir(resolutionFacade)?.unwrapSafeCall() !is FirCollectionLiteral) return null
 
-        val arrayType = expectedType(call) ?: return null
+        val arrayType = inferredExpectedType(call) ?: return null
         return with(analysisSession) { arrayType.arrayElementType }
     }
 
@@ -655,10 +659,10 @@ internal class KaFirExpressionTypeProvider(
 
         val functionLiteral = blockExpression.parent as? KtFunctionLiteral
         return if (functionLiteral != null) {
-            val functionType = expectedType(functionLiteral) as? KaFunctionType
+            val functionType = inferredExpectedType(functionLiteral) as? KaFunctionType
             functionType?.returnType
         } else {
-            expectedType(blockExpression)
+            inferredExpectedType(blockExpression)
         }
     }
 
@@ -666,7 +670,7 @@ internal class KaFirExpressionTypeProvider(
         val ifExpression = expression.unwrapQualified<KtIfExpression> { ifExpression, currentExpression ->
             currentExpression == ifExpression.then || currentExpression == ifExpression.`else`
         } ?: return null
-        expectedType(ifExpression)?.let { return it }
+        inferredExpectedType(ifExpression)?.let { return it }
 
         // if `KtIfExpression` doesn't have an expected type, get the expected type of the current branch from the other branch
         val otherBranch = (if (expression == ifExpression.then) ifExpression.`else` else ifExpression.then) ?: return null
@@ -678,7 +682,7 @@ internal class KaFirExpressionTypeProvider(
             currentExpression == whenEntry.expression
         } ?: return null
         val whenExpression = whenEntry.parent as? KtWhenExpression ?: return null
-        expectedType(whenExpression)?.let { return it }
+        inferredExpectedType(whenExpression)?.let { return it }
 
         // if `KtWhenExpression` doesn't have an expected type, get the expected type of the current entry from the other entries
         val entryExpressions = whenExpression.entries
@@ -692,7 +696,7 @@ internal class KaFirExpressionTypeProvider(
         val tryExpression = expression.unwrapQualified<KtTryExpression> { tryExpression, currentExpression ->
             currentExpression == tryExpression.tryBlock
         } ?: return null
-        return expectedType(tryExpression)
+        return inferredExpectedType(tryExpression)
     }
 
     private fun getExpectedTypeOfElvisOperand(expression: PsiElement): KaType? {
@@ -700,7 +704,7 @@ internal class KaFirExpressionTypeProvider(
             binaryExpression.operationToken == KtTokens.ELVIS && (operand == binaryExpression.left || operand == binaryExpression.right)
         } ?: return null
         if (expression !is KtExpression) return null
-        val type = expectedType(binaryExpression) ?: getElvisOperandExpectedTypeByOtherOperand(expression, binaryExpression)
+        val type = inferredExpectedType(binaryExpression) ?: getElvisOperandExpectedTypeByOtherOperand(expression, binaryExpression)
 
         return type?.applyIf(expression == binaryExpression.left) { withNullability(nullable = true) }
     }

--- a/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/components/expressionTypeProvider/AbstractExpectedExpressionTypeTest.kt
+++ b/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/cases/components/expressionTypeProvider/AbstractExpectedExpressionTypeTest.kt
@@ -6,12 +6,14 @@
 package org.jetbrains.kotlin.analysis.api.impl.base.test.cases.components.expressionTypeProvider
 
 import org.jetbrains.kotlin.analysis.api.expressions.expectedType
+import org.jetbrains.kotlin.analysis.api.expressions.inferredExpectedType
 import org.jetbrains.kotlin.analysis.api.session.useSiteSession
 import org.jetbrains.kotlin.analysis.api.symbols.KaDebugRenderer
 import org.jetbrains.kotlin.analysis.test.framework.base.AbstractAnalysisApiBasedTest
 import org.jetbrains.kotlin.analysis.test.framework.projectStructure.KtTestModule
 import org.jetbrains.kotlin.analysis.test.framework.services.expressionMarkerProvider
 import org.jetbrains.kotlin.analysis.test.framework.utils.executeOnPooledThreadInReadAction
+import org.jetbrains.kotlin.analysis.utils.printer.prettyPrint
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.test.services.TestServices
@@ -21,16 +23,24 @@ abstract class AbstractExpectedExpressionTypeTest : AbstractAnalysisApiBasedTest
     override fun doTestByMainFile(mainFile: KtFile, mainModule: KtTestModule, testServices: TestServices) {
         val expression = testServices.expressionMarkerProvider.getBottommostElementOfTypeAtCaret(mainFile) as KtExpression
 
-        val actualExpectedTypeText = executeOnPooledThreadInReadAction {
+        val [actualExpectedTypeText, actualInferredExpectedTypeText] = executeOnPooledThreadInReadAction {
             copyAwareAnalyzeForTest(expression) { contextExpression ->
-                val expectedType = contextExpression.expectedType ?: return@copyAwareAnalyzeForTest null
-                KaDebugRenderer().renderType(useSiteSession, expectedType)
+                val debugRenderer = KaDebugRenderer()
+                val expectedTypeText = contextExpression.expectedType?.let { debugRenderer.renderType(useSiteSession, it) }
+                val inferredExpectedTypeText = contextExpression.inferredExpectedType?.let { debugRenderer.renderType(useSiteSession, it) }
+                expectedTypeText to inferredExpectedTypeText
             }
         }
 
-        val actual = buildString {
-            appendLine("expression: ${expression.text}")
-            appendLine("expected type: $actualExpectedTypeText")
+        val actual = prettyPrint {
+            appendLine("expression:")
+            withIndent { appendLine(expression.text) }
+            appendLine()
+            appendLine("expectedType:")
+            withIndent { appendLine(actualExpectedTypeText) }
+            appendLine()
+            appendLine("inferredExpectedType:")
+            withIndent { appendLine(actualInferredExpectedTypeText) }
         }
 
         testServices.assertions.assertEqualsToTestOutputFile(actual)

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/expressions/expressionTypes.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/expressions/expressionTypes.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.analysis.api.expressions
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.internals.internals
@@ -70,6 +71,29 @@ public val PsiElement.expectedType: KaType?
     get() {
         @OptIn(KaImplementationDetail::class)
         return internals.expressionTypeProvider.expectedType(this)
+    }
+
+/**
+ * The [KaType] the compiler demands for the given [PsiElement] at its position in code after resolution and inference of the surrounding
+ * code have completed, or `null` if the element is not an expression or nothing is demanded from it.
+ *
+ * Unlike a purely declaration-based expectation, the result reflects the final inference results: parameter types are substituted with
+ * the inferred type arguments of the resolved call, return types of enclosing declarations may themselves be inferred from their bodies,
+ * and when no other expectation exists, the actual types of sibling expressions serve as a fallback (e.g., the type of the other branch
+ * for an `if` branch, or the type of the other operand for an elvis operand).
+ *
+ * Currently, [expectedType] behaves in the same way. As part of [KT-87415](https://youtrack.jetbrains.com/issue/KT-87415), it is planned
+ * to be re-implemented to only report expectations coming from declarations and explicit syntax, while [inferredExpectedType] will keep
+ * reporting what the fully resolved code demands.
+ *
+ * See [expressionType] for a discussion about the expression type vs. the expected type.
+ */
+@KaExperimentalApi
+context(session: KaSession)
+public val PsiElement.inferredExpectedType: KaType?
+    get() {
+        @OptIn(KaImplementationDetail::class)
+        return internals.expressionTypeProvider.inferredExpectedType(this)
     }
 
 /**

--- a/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/internals/KaInternalsExpressionTypeProvider.kt
+++ b/analysis/analysis-api/src/org/jetbrains/kotlin/analysis/api/internals/KaInternalsExpressionTypeProvider.kt
@@ -23,6 +23,8 @@ public interface KaInternalsExpressionTypeProvider {
 
     public fun expectedType(element: PsiElement): KaType?
 
+    public fun inferredExpectedType(element: PsiElement): KaType?
+
     public fun isDefinitelyNull(expression: KtExpression): Boolean
 
     public fun isDefinitelyNotNull(expression: KtExpression): Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/afterExclOperand.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/afterExclOperand.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/annotationPositionalArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/annotationPositionalArgument.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionGet.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionGet.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionGetWithTypeParameters.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionGetWithTypeParameters.txt
@@ -1,4 +1,12 @@
-expression: av
-expected type: KaTypeParameterType:
-  annotations: []
-  type: T
+expression:
+  av
+
+expectedType:
+  KaTypeParameterType:
+    annotations: []
+    type: T
+
+inferredExpectedType:
+  KaTypeParameterType:
+    annotations: []
+    type: T

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionSet.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionSet.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionSetWithTypeParameters.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayAccessExpressionSetWithTypeParameters.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayOfInAnnotationArrayType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayOfInAnnotationArrayType.txt
@@ -1,5 +1,14 @@
-expression: xyz
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: SomeEnum
+expression:
+  xyz
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: SomeEnum
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: SomeEnum

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayOfInAnnotationJavaArray.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/arrayOfInAnnotationJavaArray.txt
@@ -1,5 +1,14 @@
-expression: x
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  x
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/callableReference_consumer.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/callableReference_consumer.txt
@@ -1,13 +1,30 @@
-expression: consumer::accept
-expected type: KaFunctionType:
-  annotations: []
-  typeArguments: [
-    KaTypeParameterType:
-      annotations: []
-      type: T
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/Unit
-  ]
-  type: (T) -> kotlin/Unit
+expression:
+  consumer::accept
+
+expectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaTypeParameterType:
+        annotations: []
+        type: T
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: (T) -> kotlin/Unit
+
+inferredExpectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaTypeParameterType:
+        annotations: []
+        type: T
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: (T) -> kotlin/Unit

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/callableReference_function.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/callableReference_function.txt
@@ -1,12 +1,28 @@
-expression: function::apply
-expected type: KaFunctionType:
-  annotations: []
-  typeArguments: [
-    KaTypeParameterType:
-      annotations: []
-      type: T
-    KaFlexibleType:
-      annotations: []
-      type: ft<U & Any, U>
-  ]
-  type: (T) -> ft<U & Any, U>
+expression:
+  function::apply
+
+expectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaTypeParameterType:
+        annotations: []
+        type: T
+      KaFlexibleType:
+        annotations: []
+        type: ft<U & Any, U>
+    ]
+    type: (T) -> ft<U & Any, U>
+
+inferredExpectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaTypeParameterType:
+        annotations: []
+        type: T
+      KaFlexibleType:
+        annotations: []
+        type: ft<U & Any, U>
+    ]
+    type: (T) -> ft<U & Any, U>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotation.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotation.txt
@@ -1,10 +1,24 @@
-expression: []
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: [
-    out KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: MyEnum
-  ]
-  type: kotlin/Array<out MyEnum>
+expression:
+  []
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: MyEnum
+    ]
+    type: kotlin/Array<out MyEnum>
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: MyEnum
+    ]
+    type: kotlin/Array<out MyEnum>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotationArrayType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotationArrayType.txt
@@ -1,5 +1,14 @@
-expression: xyz
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: SomeEnum
+expression:
+  xyz
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: SomeEnum
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: SomeEnum

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotationIntArray.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotationIntArray.txt
@@ -1,5 +1,14 @@
-expression: x
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  x
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotationJavaArray.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/collectionLiteralInAnnotationJavaArray.txt
@@ -1,5 +1,14 @@
-expression: x
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  x
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/conditionInWhenWithSubject.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/conditionInWhenWithSubject.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: E
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: E
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: E

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/conditionInWhenWithoutSubject.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/conditionInWhenWithoutSubject.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/delegatedConstructorCall.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/delegatedConstructorCall.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/delegatedSuperEntry.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/delegatedSuperEntry.txt
@@ -1,5 +1,14 @@
-expression: a
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: SomeFace
+expression:
+  a
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: SomeFace
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: SomeFace

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionLeftOperand.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionLeftOperand.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int?
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int?
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int?

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionLeftOperandWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionLeftOperandWithoutExplicitType.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int?
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int?
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int?

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionRightOperand.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionRightOperand.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionRightOperandWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/elvisExpressionRightOperandWithoutExplicitType.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/enumEntryInitialization.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/enumEntryInitialization.txt
@@ -1,5 +1,14 @@
-expression: rgbValue
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  rgbValue
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/enumEntryInitializationGeneric.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/enumEntryInitializationGeneric.txt
@@ -1,4 +1,12 @@
-expression: message
-expected type: KaTypeParameterType:
-  annotations: []
-  type: T
+expression:
+  message
+
+expectedType:
+  KaTypeParameterType:
+    annotations: []
+    type: T
+
+inferredExpectedType:
+  KaTypeParameterType:
+    annotations: []
+    type: T

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/firstVarargArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/firstVarargArgument.txt
@@ -1,14 +1,32 @@
-expression: { it -> }
-expected type: KaFunctionType:
-  annotations: []
-  typeArguments: [
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/String
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/Unit
-  ]
-  type: (kotlin/String) -> kotlin/Unit
+expression:
+  { it -> }
+
+expectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: (kotlin/String) -> kotlin/Unit
+
+inferredExpectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: (kotlin/String) -> kotlin/Unit

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBody.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBody.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyBlockExpression.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyBlockExpression.txt
@@ -1,9 +1,15 @@
-expression: {
-    if (a < 5) return "5"
+expression:
+  {
+      if (a < 5) return "5"
 
-    if (a > 0)
-        return "1"
-    else
-        return "2"
-}
-expected type: null
+      if (a > 0)
+          return "1"
+      else
+          return "2"
+  }
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyQualified.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyWithTypeFromRHS.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyWithTypeFromRHS.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionExpressionBodyWithoutExplicitType.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionLambdaParam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionLambdaParam.txt
@@ -1,14 +1,32 @@
-expression: av
-expected type: KaFunctionType:
-  annotations: []
-  typeArguments: [
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/Int
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/String
-  ]
-  type: (kotlin/Int) -> kotlin/String
+expression:
+  av
+
+expectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Int
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: (kotlin/Int) -> kotlin/String
+
+inferredExpectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Int
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: (kotlin/Int) -> kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionNamedlParam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionNamedlParam.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionParamWithTypeParam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionParamWithTypeParam.txt
@@ -1,5 +1,14 @@
-expression: ab
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  ab
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionPositionalParam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionPositionalParam.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionPositionalParamQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionPositionalParamQualified.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionalTypeSubstitution.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/functionalTypeSubstitution.txt
@@ -1,11 +1,24 @@
-expression: {
-            s: String -> 0
-    }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: [
-    KaFlexibleType:
-      annotations: []
-      type: kotlin/String!
-  ]
-  type: java/lang/Comparable<kotlin/String!>
+expression:
+  {
+              s: String -> 0
+      }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      KaFlexibleType:
+        annotations: []
+        type: kotlin/String!
+    ]
+    type: java/lang/Comparable<kotlin/String!>
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      KaFlexibleType:
+        annotations: []
+        type: kotlin/String!
+    ]
+    type: java/lang/Comparable<kotlin/String!>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/ifCondition.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/ifCondition.txt
@@ -1,5 +1,14 @@
-expression: xy
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  xy
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/ifConditionQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/ifConditionQualified.txt
@@ -1,5 +1,14 @@
-expression: fdfd
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  fdfd
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionAsRegularCallParam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionAsRegularCallParam.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionParam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionParam.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionParamQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionParamQualified.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionTypeParameter.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/infixFunctionTypeParameter.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/intArrayOfInAnnotation.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/intArrayOfInAnnotation.txt
@@ -1,5 +1,14 @@
-expression: x
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  x
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/invokeOperatorCall.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/invokeOperatorCall.txt
@@ -1,5 +1,14 @@
-expression: arg
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  arg
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaReturnToExplicitLabel.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaReturnToExplicitLabel.txt
@@ -1,7 +1,16 @@
-expression: {
-        return@label makeCloseMe()
-    }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: test/pkg/ResourceFactory
+expression:
+  {
+          return@label makeCloseMe()
+      }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: test/pkg/ResourceFactory
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: test/pkg/ResourceFactory

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaReturnToImplicitLabel.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaReturnToImplicitLabel.txt
@@ -1,7 +1,16 @@
-expression: {
-        return@consumeCloseable makeCloseMe()
-    }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: test/pkg/ResourceFactory
+expression:
+  {
+          return@consumeCloseable makeCloseMe()
+      }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: test/pkg/ResourceFactory
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: test/pkg/ResourceFactory

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaWithExplicitTypeFromVariable.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaWithExplicitTypeFromVariable.txt
@@ -1,12 +1,26 @@
-expression: {
-    val (a, b) = listOf(1, 2)
-}
-expected type: KaFunctionType:
-  annotations: []
-  typeArguments: [
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/Unit
-  ]
-  type: () -> kotlin/Unit
+expression:
+  {
+      val (a, b) = listOf(1, 2)
+  }
+
+expectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: () -> kotlin/Unit
+
+inferredExpectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: () -> kotlin/Unit

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaWithoutReturnNorExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lambdaWithoutReturnNorExplicitType.txt
@@ -1,5 +1,11 @@
-expression: { a: Int ->
-    val b = 1
-    a + b
-}
-expected type: null
+expression:
+  { a: Int ->
+      val b = 1
+      a + b
+  }
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInFunctionBlockBody.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInFunctionBlockBody.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInLambda.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInLambda.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInLambdaWithTypeMismatch.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInLambdaWithTypeMismatch.txt
@@ -1,12 +1,28 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: [
-    KaTypeParameterType:
-      annotations: []
-      type: K
-    KaTypeParameterType:
-      annotations: []
-      type: V
-  ]
-  type: kotlin/Pair<K, V>
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      KaTypeParameterType:
+        annotations: []
+        type: K
+      KaTypeParameterType:
+        annotations: []
+        type: V
+    ]
+    type: kotlin/Pair<K, V>
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      KaTypeParameterType:
+        annotations: []
+        type: K
+      KaTypeParameterType:
+        annotations: []
+        type: V
+    ]
+    type: kotlin/Pair<K, V>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInLambdaWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInLambdaWithoutExplicitType.txt
@@ -1,4 +1,12 @@
-expression: av
-expected type: KaTypeParameterType:
-  annotations: []
-  type: R
+expression:
+  av
+
+expectedType:
+  KaTypeParameterType:
+    annotations: []
+    type: R
+
+inferredExpectedType:
+  KaTypeParameterType:
+    annotations: []
+    type: R

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInTry.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInTry.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInTryWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/lastStatementInTryWithoutExplicitType.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/multipleSpreadArguments.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/multipleSpreadArguments.txt
@@ -1,10 +1,24 @@
-expression: array
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: [
-    out KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/String
-  ]
-  type: kotlin/Array<out kotlin/String>
+expression:
+  array
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: kotlin/Array<out kotlin/String>
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: kotlin/Array<out kotlin/String>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/namedSpreadArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/namedSpreadArgument.txt
@@ -1,10 +1,24 @@
-expression: array
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: [
-    out KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/String
-  ]
-  type: kotlin/Array<out kotlin/String>
+expression:
+  array
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: kotlin/Array<out kotlin/String>
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: kotlin/Array<out kotlin/String>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/namedVarargArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/namedVarargArgument.txt
@@ -1,10 +1,24 @@
-expression: array
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: [
-    out KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/String
-  ]
-  type: kotlin/Array<out kotlin/String>
+expression:
+  array
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: kotlin/Array<out kotlin/String>
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: [
+      out KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+    ]
+    type: kotlin/Array<out kotlin/String>

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overrideFunctionWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overrideFunctionWithoutExplicitType.txt
@@ -1,5 +1,14 @@
-expression: result
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  result
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overrideFunctionWithoutExplicitTypeGeneric.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overrideFunctionWithoutExplicitTypeGeneric.txt
@@ -1,5 +1,14 @@
-expression: foo
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  foo
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overridePropertyGetterWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overridePropertyGetterWithoutExplicitType.txt
@@ -1,5 +1,14 @@
-expression: text
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  text
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overridePropertyWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/overridePropertyWithoutExplicitType.txt
@@ -1,5 +1,14 @@
-expression: somePrefix
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  somePrefix
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/parameterDefaultValue.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/parameterDefaultValue.txt
@@ -1,5 +1,14 @@
-expression: expr
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  expr
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyAssignmentQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyAssignmentQualified.txt
@@ -1,5 +1,14 @@
-expression: bar
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  bar
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyAssignmentThis.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyAssignmentThis.txt
@@ -1,5 +1,14 @@
-expression: value
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  value
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclaration.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclaration.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationNoExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationNoExplicitType.txt
@@ -1,2 +1,8 @@
-expression: ""
-expected type: null
+expression:
+  ""
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationQualified.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithSafeCast.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithSafeCast.txt
@@ -1,5 +1,14 @@
-expression: p0
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String?
+expression:
+  p0
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String?
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String?

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithTypeCast.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithTypeCast.txt
@@ -1,5 +1,14 @@
-expression: p0
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  p0
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithTypeFromRHS.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithTypeFromRHS.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyDeclarationWithoutExplicitType.txt
@@ -1,2 +1,8 @@
-expression: av
-expected type: null
+expression:
+  av
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetter.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetter.txt
@@ -1,5 +1,14 @@
-expression: somePrefix
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  somePrefix
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetterExpressionBody.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetterExpressionBody.txt
@@ -1,5 +1,14 @@
-expression: somePrefix
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  somePrefix
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetterExpressionBodyGetterExpectedType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetterExpressionBodyGetterExpectedType.txt
@@ -1,5 +1,14 @@
-expression: somePrefix
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  somePrefix
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetterExpressionBodyNoExpectedType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/propertyGetterExpressionBodyNoExpectedType.txt
@@ -1,2 +1,8 @@
-expression: somePrefix
-expected type: null
+expression:
+  somePrefix
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeToEndChar.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeToEndChar.txt
@@ -1,5 +1,14 @@
-expression: end
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Char
+expression:
+  end
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Char
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Char

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeToEndInt.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeToEndInt.txt
@@ -1,5 +1,14 @@
-expression: end
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  end
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeUntilEndChar.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeUntilEndChar.txt
@@ -1,5 +1,14 @@
-expression: end
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Char
+expression:
+  end
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Char
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Char

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeUntilEndInt.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/rangeUntilEndInt.txt
@@ -1,5 +1,14 @@
-expression: end
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  end
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromFunction.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromFunction.txt
@@ -1,5 +1,14 @@
-expression: a
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  a
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromFunctionQualifiedReceiver.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromFunctionQualifiedReceiver.txt
@@ -1,2 +1,8 @@
-expression: xfd
-expected type: null
+expression:
+  xfd
+
+expectedType:
+  null
+
+inferredExpectedType:
+  null

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromFunctionQualifiedSelector.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromFunctionQualifiedSelector.txt
@@ -1,5 +1,14 @@
-expression: a
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  a
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromLambda.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/returnFromLambda.txt
@@ -1,5 +1,14 @@
-expression: fd
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  fd
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/safeCallArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/safeCallArgument.txt
@@ -1,5 +1,14 @@
-expression: arg
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/String
+expression:
+  arg
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/String

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/sam.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/sam.txt
@@ -1,5 +1,14 @@
-expression: { /* SAM */ }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { /* SAM */ }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samAsArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samAsArgument.txt
@@ -1,5 +1,14 @@
-expression: { /* Argument */ }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { /* Argument */ }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samAsConstructorArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samAsConstructorArgument.txt
@@ -1,4 +1,12 @@
-expression: { println("hello1") }
-expected type: KaFlexibleType:
-  annotations: []
-  type: java/lang/Runnable!
+expression:
+  { println("hello1") }
+
+expectedType:
+  KaFlexibleType:
+    annotations: []
+    type: java/lang/Runnable!
+
+inferredExpectedType:
+  KaFlexibleType:
+    annotations: []
+    type: java/lang/Runnable!

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samAsReturn.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samAsReturn.txt
@@ -1,5 +1,14 @@
-expression: { /* Return */ }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { /* Return */ }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samReferenceAsArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samReferenceAsArgument.txt
@@ -1,5 +1,14 @@
-expression: ::dummy
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  ::dummy
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samReferenceAsVararg.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samReferenceAsVararg.txt
@@ -1,5 +1,14 @@
-expression: ::dummy
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  ::dummy
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samReferenceWithTypeCast.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samReferenceWithTypeCast.txt
@@ -1,5 +1,14 @@
-expression: ::dummy
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  ::dummy
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithExplicitTypeFromProperty.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithExplicitTypeFromProperty.txt
@@ -1,5 +1,14 @@
-expression: { /* Variable */ }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { /* Variable */ }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithReturnToExplicitLabel.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithReturnToExplicitLabel.txt
@@ -1,5 +1,14 @@
-expression: { return@l }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { return@l }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithReturnToImplicitLabel.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithReturnToImplicitLabel.txt
@@ -1,5 +1,14 @@
-expression: { return@Runnable }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { return@Runnable }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithTypeCast.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/samWithTypeCast.txt
@@ -1,5 +1,14 @@
-expression: { /* Type Cast */ }
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: java/lang/Runnable
+expression:
+  { /* Type Cast */ }
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: java/lang/Runnable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/secondVarargArgument.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/secondVarargArgument.txt
@@ -1,14 +1,32 @@
-expression: { it -> }
-expected type: KaFunctionType:
-  annotations: []
-  typeArguments: [
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/String
-    KaUsualClassType:
-      annotations: []
-      typeArguments: []
-      type: kotlin/Unit
-  ]
-  type: (kotlin/String) -> kotlin/Unit
+expression:
+  { it -> }
+
+expectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: (kotlin/String) -> kotlin/Unit
+
+inferredExpectedType:
+  KaFunctionType:
+    annotations: []
+    typeArguments: [
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/String
+      KaUsualClassType:
+        annotations: []
+        typeArguments: []
+        type: kotlin/Unit
+    ]
+    type: (kotlin/String) -> kotlin/Unit

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInIf.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInIf.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInIfBlockExpression.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInIfBlockExpression.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInIfWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInIfWithoutExplicitType.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInWhen.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInWhen.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInWhenBlockExpression.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInWhenBlockExpression.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInWhenWithoutExplicitType.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/statementInWhenWithoutExplicitType.txt
@@ -1,4 +1,12 @@
-expression: av
-expected type: KaIntersectionType:
-  annotations: []
-  type: it(kotlin/Int & kotlin/String)
+expression:
+  av
+
+expectedType:
+  KaIntersectionType:
+    annotations: []
+    type: it(kotlin/Int & kotlin/String)
+
+inferredExpectedType:
+  KaIntersectionType:
+    annotations: []
+    type: it(kotlin/Int & kotlin/String)

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/throwExpression.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/throwExpression.txt
@@ -1,5 +1,14 @@
-expression: exception
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Throwable
+expression:
+  exception
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Throwable
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Throwable

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/variableAssignment.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/variableAssignment.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/variableAssignmentQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/variableAssignmentQualified.txt
@@ -1,5 +1,14 @@
-expression: av
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Int
+expression:
+  av
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Int

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/whileCondition.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/whileCondition.txt
@@ -1,5 +1,14 @@
-expression: xy
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  xy
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean

--- a/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/whileConditionQualified.txt
+++ b/analysis/analysis-api/testData/components/expressionTypeProvider/expectedExpressionType/whileConditionQualified.txt
@@ -1,5 +1,14 @@
-expression: fdfd
-expected type: KaUsualClassType:
-  annotations: []
-  typeArguments: []
-  type: kotlin/Boolean
+expression:
+  fdfd
+
+expectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean
+
+inferredExpectedType:
+  KaUsualClassType:
+    annotations: []
+    typeArguments: []
+    type: kotlin/Boolean


### PR DESCRIPTION
'PsiElement.expectedType' mixes expectations coming from declarations and explicit syntax with inference results and sibling-expression heuristics, so its contract cannot be stated precisely. The plan is to split it into two endpoints: the declaration-based 'expectedType' and the inference-based 'inferredExpectedType'.

Introduce 'inferredExpectedType' as the first step. It takes over the current implementation, while 'expectedType' delegates to it until it is re-implemented with the declaration-based semantics. This allows migrating the callers that rely on inference-flavored answers before 'expectedType' changes behavior.

The expected type test now covers both endpoints; its output format is prettified along the way, as every file is regenerated anyway.

Related issue: KT-87415.