### PR TITLE
[Native/Wasm] Remove range checks for FP parser and stringifier

### DIFF
--- a/kotlin-native/runtime/src/main/kotlin/kotlin/internal/dtoa/UnsafeArrays.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/internal/dtoa/UnsafeArrays.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.internal.dtoa
+
+import kotlin.native.internal.*
+import kotlin.native.internal.escapeAnalysis.Escapes
+
+@GCUnsafeCall("Kotlin_LongArray_get_without_BoundCheck")
+@Escapes.Nothing
+internal actual external fun longArrayGetUnsafe(array: LongArray, index: Int): Long
+
+@GCUnsafeCall("Kotlin_LongArray_set_without_BoundCheck")
+@Escapes.Nothing
+internal actual external fun longArraySetUnsafe(array: LongArray, index: Int, value: Long)
+
+@GCUnsafeCall("Kotlin_DoubleArray_get_without_BoundCheck")
+@Escapes.Nothing
+internal actual external fun doubleArrayGetUnsafe(array: DoubleArray, index: Int): Double
+
+@GCUnsafeCall("Kotlin_DoubleArray_set_without_BoundCheck")
+@Escapes.Nothing
+internal actual external fun doubleArraySetUnsafe(array: DoubleArray, index: Int, value: Double)
+
+@GCUnsafeCall("Kotlin_IntArray_get_without_BoundCheck")
+@Escapes.Nothing
+internal actual external fun intArrayGetUnsafe(array: IntArray, index: Int): Int
+
+@GCUnsafeCall("Kotlin_IntArray_set_without_BoundCheck")
+@Escapes.Nothing
+internal actual external fun intArraySetUnsafe(array: IntArray, index: Int, value: Int)
+
+internal actual fun copyIntoUnsafe(source: LongArray, destination: LongArray, destinationOffset: Int, startIndex: Int, endIndex: Int) {
+    source.copyInto(destination, destinationOffset, startIndex, endIndex)
+}

--- a/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/UnsafeArrays.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/UnsafeArrays.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalUnsignedTypes::class)
+@file:Suppress("NOTHING_TO_INLINE")
+
+package kotlin.internal.dtoa
+
+internal expect fun longArrayGetUnsafe(array: LongArray, index: Int): Long
+internal expect fun longArraySetUnsafe(array: LongArray, index: Int, value: Long)
+internal expect fun copyIntoUnsafe(source: LongArray, destination: LongArray, destinationOffset: Int, startIndex: Int, endIndex: Int)
+internal expect fun doubleArrayGetUnsafe(array: DoubleArray, index: Int): Double
+internal expect fun doubleArraySetUnsafe(array: DoubleArray, index: Int, value: Double)
+internal expect fun intArrayGetUnsafe(array: IntArray, index: Int): Int
+internal expect fun intArraySetUnsafe(array: IntArray, index: Int, value: Int)
+
+internal value class ULongUnsafeArray(val array: ULongArray)
+
+internal inline fun ULongArray.unsafe(): ULongUnsafeArray = ULongUnsafeArray(this)
+
+internal inline operator fun ULongUnsafeArray.get(index: Int): ULong =
+    longArrayGetUnsafe(array.storage, index).toULong()
+
+internal inline operator fun ULongUnsafeArray.set(index: Int, value: ULong):Unit =
+    longArraySetUnsafe(array.storage, index, value.toLong())
+
+internal inline fun ULongUnsafeArray.copyInto(destination: ULongUnsafeArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = array.size): ULongUnsafeArray {
+    copyIntoUnsafe(array.storage, destination.array.storage, startIndex, destinationOffset, endIndex)
+    return destination
+}
+
+internal inline fun ULongUnsafeArray.fill(element: ULong, fromIndex: Int = 0, toIndex: Int = array.size) {
+    for (index in fromIndex until toIndex) {
+        this[index] = element
+    }
+}
+
+internal value class DoubleUnsafeArray(val array: DoubleArray)
+
+internal inline fun DoubleArray.unsafe(): DoubleUnsafeArray = DoubleUnsafeArray(this)
+
+internal inline operator fun DoubleUnsafeArray.get(index: Int): Double =
+    doubleArrayGetUnsafe(array, index)
+
+internal inline operator fun DoubleUnsafeArray.set(index: Int, value: Double): Unit =
+    doubleArraySetUnsafe(array, index, value)
+
+internal value class IntUnsafeArray(val array: IntArray)
+
+internal inline fun IntArray.unsafe(): IntUnsafeArray = IntUnsafeArray(this)
+
+internal inline operator fun IntUnsafeArray.get(index: Int): Int =
+    intArrayGetUnsafe(array, index)
+
+internal inline operator fun IntUnsafeArray.set(index: Int, value: Int): Unit =
+    intArraySetUnsafe(array, index, value)

--- a/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/cbigint.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/cbigint.kt
@@ -43,13 +43,13 @@ private inline fun highInU64(value: ULong): ULong = value shr 32
 private inline fun lowInU64(value: ULong): ULong = value and 0x00000000FFFFFFFFUL
 internal inline fun lowU32FromVar(u64: ULong): UInt = (u64 and 0x00000000FFFFFFFFUL).toUInt()
 internal inline fun highU32FromVar(u64: ULong): UInt = (u64 shr 32).toUInt()
-internal inline fun lowU32FromPtr(arr: ULongArray, idx: Int): UInt = (arr[idx] and 0x00000000FFFFFFFFUL).toUInt()
-internal inline fun highU32FromPtr(arr: ULongArray, idx: Int): UInt = (arr[idx] shr 32).toUInt()
-internal inline fun setLowU32Ptr(arr: ULongArray, idx: Int, value: UInt) {
+internal inline fun lowU32FromPtr(arr: ULongUnsafeArray, idx: Int): UInt = (arr[idx] and 0x00000000FFFFFFFFUL).toUInt()
+internal inline fun highU32FromPtr(arr: ULongUnsafeArray, idx: Int): UInt = (arr[idx] shr 32).toUInt()
+internal inline fun setLowU32Ptr(arr: ULongUnsafeArray, idx: Int, value: UInt) {
     arr[idx] = (arr[idx] and 0xFFFFFFFF00000000UL) or value.toULong()
 }
 
-internal inline fun setHighU32Ptr(arr: ULongArray, idx: Int, value: UInt) {
+internal inline fun setHighU32Ptr(arr: ULongUnsafeArray, idx: Int, value: UInt) {
     arr[idx] = (arr[idx] and 0x00000000FFFFFFFFUL) or (value.toULong() shl 32)
 }
 
@@ -84,7 +84,7 @@ internal inline fun isDenormalDouble(double: Double): Boolean {
     return (high and EXPONENT_MASK_HI == 0u) && (high and MANTISSA_MASK_HI != 0u || low != 0u)
 }
 
-private fun simpleAddHighPrecision(arg1: ULongArray, length: Int, arg2: ULong): Int {
+private fun simpleAddHighPrecision(arg1: ULongUnsafeArray, length: Int, arg2: ULong): Int {
     /* assumes length > 0 */
     var index = 1
 
@@ -100,7 +100,7 @@ private fun simpleAddHighPrecision(arg1: ULongArray, length: Int, arg2: ULong): 
     return if (index == length) 1 else 0
 }
 
-internal fun addHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongArray, length2: Int): Int {
+internal fun addHighPrecision(arg1: ULongUnsafeArray, length1: Int, arg2: ULongUnsafeArray, length2: Int): Int {
     var length2 = length2
     // addition is limited by length of arg1 as it this function is
     // storing the result in arg1
@@ -136,7 +136,7 @@ internal fun addHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongArray, 
     return if (index == length1) 1 else 0
 }
 
-internal fun subtractHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongArray, length2: Int) {
+internal fun subtractHighPrecision(arg1: ULongUnsafeArray, length1: Int, arg2: ULongUnsafeArray, length2: Int) {
     var length2 = length2
     // assumes arg1 > arg2
     for (index in 0 until length1)
@@ -153,7 +153,7 @@ internal fun subtractHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongAr
     simpleAddHighPrecision(arg1, length1, 1UL)
 }
 
-private fun simpleMultiplyHighPrecision(arg1: ULongArray, length: Int, arg2: ULong): UInt {
+private fun simpleMultiplyHighPrecision(arg1: ULongUnsafeArray, length: Int, arg2: ULong): UInt {
     /* assumes arg2 only holds 32 bits of information */
     var product: ULong
     var index: Int
@@ -173,7 +173,7 @@ private fun simpleMultiplyHighPrecision(arg1: ULongArray, length: Int, arg2: ULo
     return highU32FromVar(product)
 }
 
-private value class ULongArrayView(val array: ULongArray)
+private value class ULongArrayView(val array: ULongUnsafeArray)
 
 private operator fun ULongArrayView.get(idx32: Int): UInt =
     if (idx32 % 2 == 0) lowU32FromPtr(array, idx32 / 2) else highU32FromPtr(array, idx32 / 2)
@@ -181,7 +181,7 @@ private operator fun ULongArrayView.get(idx32: Int): UInt =
 private operator fun ULongArrayView.set(idx32: Int, value: UInt) =
     if (idx32 % 2 == 0) setLowU32Ptr(array, idx32 / 2, value) else setHighU32Ptr(array, idx32 / 2, value)
 
-private fun simpleMultiplyAddHighPrecision(arg1: ULongArray, length: Int, arg2: ULong, result: ULongArrayView, resultOffset: Int) {
+private fun simpleMultiplyAddHighPrecision(arg1: ULongUnsafeArray, length: Int, arg2: ULong, result: ULongArrayView, resultOffset: Int) {
     /* Assumes result can hold the product and arg2 only holds 32 bits
        of information */
     var product: ULong
@@ -214,13 +214,13 @@ private fun simpleMultiplyAddHighPrecision(arg1: ULongArray, length: Int, arg2: 
     }
 }
 
-internal fun multiplyHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongArray, length2: Int, result: ULongArray, length: Int) {
+internal fun multiplyHighPrecision(arg1: ULongUnsafeArray, length1: Int, arg2: ULongUnsafeArray, length2: Int, result: ULongUnsafeArray, length: Int) {
     var arg1 = arg1
     var arg2 = arg2
     var length1 = length1
     var length2 = length2
     /* assumes result is large enough to hold product */
-    val temp: ULongArray
+    val temp: ULongUnsafeArray
     val count: Int
     var index: Int
 
@@ -245,7 +245,7 @@ internal fun multiplyHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongAr
     }
 }
 
-internal fun simpleAppendDecimalDigitHighPrecision(arg1: ULongArray, length: Int, digit: ULong): UInt {
+internal fun simpleAppendDecimalDigitHighPrecision(arg1: ULongUnsafeArray, length: Int, digit: ULong): UInt {
     var digit = digit
     /* assumes digit is less than 32 bits */
     var arg: ULong
@@ -265,7 +265,7 @@ internal fun simpleAppendDecimalDigitHighPrecision(arg1: ULongArray, length: Int
     return highU32FromVar(digit)
 }
 
-internal fun simpleShiftLeftHighPrecision(arg1: ULongArray, length: Int, arg2: Int) {
+internal fun simpleShiftLeftHighPrecision(arg1: ULongUnsafeArray, length: Int, arg2: Int) {
     var arg2 = arg2
     var length = length
     /* assumes length > 0 */
@@ -301,7 +301,7 @@ private fun highestSetBit(y: ULong): Int =
 private fun lowestSetBit(y: ULong): Int =
     if (y != 0UL) y.countTrailingZeroBits() + 1 else 0
 
-internal fun highestSetBitHighPrecision(arg: ULongArray, length: Int): Int {
+internal fun highestSetBitHighPrecision(arg: ULongUnsafeArray, length: Int): Int {
     var len = length
     while (--len >= 0) {
         val highBit = highestSetBit(arg[len])
@@ -310,7 +310,7 @@ internal fun highestSetBitHighPrecision(arg: ULongArray, length: Int): Int {
     return 0
 }
 
-internal fun lowestSetBitHighPrecision(arg: ULongArray, length: Int): Int {
+internal fun lowestSetBitHighPrecision(arg: ULongUnsafeArray, length: Int): Int {
     var index = -1
     while (++index < length) {
         val lowBit = lowestSetBit(arg[index])
@@ -319,7 +319,7 @@ internal fun lowestSetBitHighPrecision(arg: ULongArray, length: Int): Int {
     return 0
 }
 
-internal fun compareHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongArray, length2: Int): Int {
+internal fun compareHighPrecision(arg1: ULongUnsafeArray, length1: Int, arg2: ULongUnsafeArray, length2: Int): Int {
     var length1 = length1
     var length2 = length2
     while (--length1 >= 0 && arg1[length1] == 0UL) { /* no body */
@@ -343,7 +343,7 @@ internal fun compareHighPrecision(arg1: ULongArray, length1: Int, arg2: ULongArr
     return 0
 }
 
-internal fun toDoubleHighPrecision(arg: ULongArray, length: Int): Double {
+internal fun toDoubleHighPrecision(arg: ULongUnsafeArray, length: Int): Double {
     var length = length
     var highBit: Int
     var mantissa: ULong
@@ -427,7 +427,7 @@ internal fun toDoubleHighPrecision(arg: ULongArray, length: Int): Double {
     return result
 }
 
-internal fun timesTenToTheEHighPrecision(result: ULongArray, length: Int, e: Int): Int {
+internal fun timesTenToTheEHighPrecision(result: ULongUnsafeArray, length: Int, e: Int): Int {
     var length = length
     /* assumes result can hold value */
     var overflow: ULong
@@ -506,7 +506,7 @@ internal fun timesTenToTheEHighPrecision(result: ULongArray, length: Int, e: Int
     return length
 }
 
-private fun simpleMultiplyHighPrecision64(arg1: ULongArray, length: Int, arg2: ULong): ULong {
+private fun simpleMultiplyHighPrecision64(arg1: ULongUnsafeArray, length: Int, arg2: ULong): ULong {
     var intermediate: ULong
     var carry1: ULong
     var carry2: ULong

--- a/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/dblparse.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/dblparse.kt
@@ -36,7 +36,7 @@ private val TENS = doubleArrayOf(
     1.0, 1.0e1, 1.0e2, 1.0e3, 1.0e4, 1.0e5, 1.0e6, 1.0e7, 1.0e8, 1.0e9,
     1.0e10, 1.0e11, 1.0e12, 1.0e13, 1.0e14, 1.0e15, 1.0e16, 1.0e17, 1.0e18,
     1.0e19, 1.0e20, 1.0e21, 1.0e22
-)
+).unsafe()
 
 // Macro replacements as functions
 internal inline fun sizeOfTenToTheE(e: Int): Int = (e / 19) + 1
@@ -48,11 +48,11 @@ private fun createDouble(s: String, e: Int): Double {
     var e = e
     /* assumes s is a string with at least one
     * character in it */
-    val def = ULongArray(MAX_ACCURACY_WIDTH_DOUBLE)
-    val defBackup = ULongArray(MAX_ACCURACY_WIDTH_DOUBLE)
+    val def = ULongArray(MAX_ACCURACY_WIDTH_DOUBLE).unsafe()
+    val defBackup = ULongArray(MAX_ACCURACY_WIDTH_DOUBLE).unsafe()
 
-    val f: ULongArray
-    var fNoOverflow: ULongArray
+    val f: ULongUnsafeArray
+    var fNoOverflow: ULongUnsafeArray
 
     var overflow: UInt
     val result: Double
@@ -132,7 +132,7 @@ private fun createDouble(s: String, e: Int): Double {
 }
 
 
-private fun createDouble1(f: ULongArray, length: Int, e: Int): Double {
+private fun createDouble1(f: ULongUnsafeArray, length: Int, e: Int): Double {
     var numBits: Int
     var result = 0.0
 
@@ -196,17 +196,17 @@ private fun createDouble1(f: ULongArray, length: Int, e: Int): Double {
  * is currently set such that if the oscillation occurs more than twice
  * then return the original approximation.
  */
-private fun doubleAlgorithm(f: ULongArray, length: Int, e: Int, z: Double): Double {
+private fun doubleAlgorithm(f: ULongUnsafeArray, length: Int, e: Int, z: Double): Double {
     var z = z
     var m: ULong
     var k: Int
     var comparison: Int
     var comparison2: Int
 
-    var x: ULongArray
-    var y: ULongArray
-    var D: ULongArray
-    var D2: ULongArray
+    var x: ULongUnsafeArray
+    var y: ULongUnsafeArray
+    var D: ULongUnsafeArray
+    var D2: ULongUnsafeArray
 
     var xLength: Int
     var yLength: Int
@@ -218,47 +218,49 @@ private fun doubleAlgorithm(f: ULongArray, length: Int, e: Int, z: Double): Doub
     decApproxCount = 0
     incApproxCount = 0
 
+    val mArray = ULongArray(1).unsafe()
+
     do {
         m = doubleMantissa(z)
         k = doubleExponent(z)
 
         if (e >= 0 && k >= 0) {
             xLength = sizeOfTenToTheE(e) + length
-            x = ULongArray(xLength)
+            x = ULongArray(xLength).unsafe()
             f.copyInto(x, 0, 0, length)
             timesTenToTheEHighPrecision(x, xLength, e)
 
             yLength = (k shr 6) + 2
-            y = ULongArray(yLength)
+            y = ULongArray(yLength).unsafe()
             y[0] = m
             simpleShiftLeftHighPrecision(y, yLength, k)
         } else if (e >= 0) {
             xLength = sizeOfTenToTheE(e) + length + ((-k) shr 6) + 1
-            x = ULongArray(xLength)
+            x = ULongArray(xLength).unsafe()
             f.copyInto(x, 0, 0, length)
             timesTenToTheEHighPrecision(x, xLength, e)
             simpleShiftLeftHighPrecision(x, xLength, -k)
 
             yLength = 1
-            y = ULongArray(1)
+            y = ULongArray(1).unsafe()
             y[0] = m
         } else if (k >= 0) {
             xLength = length
             x = f
 
             yLength = sizeOfTenToTheE(-e) + 2 + (k shr 6)
-            y = ULongArray(yLength)
+            y = ULongArray(yLength).unsafe()
             y[0] = m
             timesTenToTheEHighPrecision(y, yLength, -e)
             simpleShiftLeftHighPrecision(y, yLength, k)
         } else {
             xLength = length + ((-k) shr 6) + 1
-            x = ULongArray(xLength)
+            x = ULongArray(xLength).unsafe()
             f.copyInto(x, 0, 0, length)
             simpleShiftLeftHighPrecision(x, xLength, -k)
 
             yLength = sizeOfTenToTheE(-e) + 1
-            y = ULongArray(yLength)
+            y = ULongArray(yLength).unsafe()
             y[0] = m
             timesTenToTheEHighPrecision(y, yLength, -e)
         }
@@ -266,24 +268,25 @@ private fun doubleAlgorithm(f: ULongArray, length: Int, e: Int, z: Double): Doub
         comparison = compareHighPrecision(x, xLength, y, yLength)
         if (comparison > 0) {                       /* x > y */
             DLength = xLength
-            D = ULongArray(DLength)
+            D = ULongArray(DLength).unsafe()
             x.copyInto(D, 0, 0, DLength)
             subtractHighPrecision(D, DLength, y, yLength)
         } else if (comparison != 0) {                       /* y > x */
             DLength = yLength
-            D = ULongArray(DLength)
+            D = ULongArray(DLength).unsafe()
             y.copyInto(D, 0, 0, DLength)
             subtractHighPrecision(D, DLength, x, xLength)
         } else {                       /* y == x */
             DLength = 1
-            D = ULongArray(1)
+            D = ULongArray(1).unsafe()
             D[0] = 0UL
         }
 
         D2Length = DLength + 1
-        D2 = ULongArray(D2Length)
+        D2 = ULongArray(D2Length).unsafe()
         m = m shl 1
-        multiplyHighPrecision(D, DLength, ulongArrayOf(m), 1, D2, D2Length)
+        mArray[0] = m
+        multiplyHighPrecision(D, DLength, mArray, 1, D2, D2Length)
         m = m shr 1
 
         comparison2 = compareHighPrecision(D2, D2Length, y, yLength)
@@ -427,11 +430,11 @@ internal fun bigIntDigitGeneratorInstImpl(
     mantissaIsZero: Boolean,
     p: Int,
 ) {
-    val R = ULongArray(RM_SIZE)
-    val S = ULongArray(STemp_SIZE)
-    val mplus = ULongArray(RM_SIZE)
-    val mminus = ULongArray(RM_SIZE)
-    val Temp = ULongArray(STemp_SIZE)
+    val R = ULongArray(RM_SIZE).unsafe()
+    val S = ULongArray(STemp_SIZE).unsafe()
+    val mplus = ULongArray(RM_SIZE).unsafe()
+    val mminus = ULongArray(RM_SIZE).unsafe()
+    val Temp = ULongArray(STemp_SIZE).unsafe()
 
     val fULong = f.toULong()
     if (e >= 0) {

--- a/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/fltparse.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/internal/dtoa/fltparse.kt
@@ -32,7 +32,7 @@ private const val E_OFFSET = 150
 private val TENS = intArrayOf(
     0x3f800000, 0x41200000, 0x42c80000, 0x447a0000, 0x461c4000,
     0x47c35000, 0x49742400, 0x4b189680, 0x4cbebc20, 0x4e6e6b28, 0x501502f9
-)
+).unsafe()
 
 // Macro replacements as functions
 private inline fun floatToIntBits(flt: Float): UInt = flt.toRawBits().toUInt()
@@ -65,11 +65,11 @@ private fun createFloat(s: String, e: Int): Float {
     var e = e
     /* assumes s is a string with at least one
      * character in it */
-    val def = ULongArray(MAX_ACCURACY_WIDTH_FLOAT)
-    val defBackup = ULongArray(MAX_ACCURACY_WIDTH_FLOAT)
+    val def = ULongArray(MAX_ACCURACY_WIDTH_FLOAT).unsafe()
+    val defBackup = ULongArray(MAX_ACCURACY_WIDTH_FLOAT).unsafe()
 
-    val f: ULongArray
-    var fNoOverflow: ULongArray
+    val f: ULongUnsafeArray
+    var fNoOverflow: ULongUnsafeArray
 
     var overflow: UInt
     var result: Float
@@ -144,7 +144,7 @@ private fun createFloat(s: String, e: Int): Float {
 
 }
 
-private fun createFloat1(f: ULongArray, length: Int, e: Int): Float {
+private fun createFloat1(f: ULongUnsafeArray, length: Int, e: Int): Float {
     val numBits: Int
     val dresult: Double
     var result = 0f
@@ -244,17 +244,17 @@ private fun createFloat1(f: ULongArray, length: Int, e: Int): Float {
  * is currently set such that if the oscillation occurs more than twice
  * then return the original approximation.
  */
-private fun floatAlgorithm(f: ULongArray, length: Int, e: Int, z: Float): Float {
+private fun floatAlgorithm(f: ULongUnsafeArray, length: Int, e: Int, z: Float): Float {
     var z = z
     var m: ULong
     var k: Int
     var comparison: Int
     var comparison2: Int
 
-    var x: ULongArray
-    var y: ULongArray
-    var D: ULongArray
-    var D2: ULongArray
+    var x: ULongUnsafeArray
+    var y: ULongUnsafeArray
+    var D: ULongUnsafeArray
+    var D2: ULongUnsafeArray
 
     var xLength: Int
     var yLength: Int
@@ -264,47 +264,49 @@ private fun floatAlgorithm(f: ULongArray, length: Int, e: Int, z: Float): Float 
     var decApproxCount = 0
     var incApproxCount = 0
 
+    val mArray = ULongArray(1).unsafe()
+
     do {
         m = floatMantissa(z).toULong()
         k = floatExponent(z)
 
         if (e >= 0 && k >= 0) {
             xLength = sizeOfTenToTheE(e) + length
-            x = ULongArray(xLength)
+            x = ULongArray(xLength).unsafe()
             f.copyInto(x, 0, 0, length)
             timesTenToTheEHighPrecision(x, xLength, e)
 
             yLength = (k shr 6) + 2
-            y = ULongArray(yLength)
+            y = ULongArray(yLength).unsafe()
             y[0] = m
             simpleShiftLeftHighPrecision(y, yLength, k)
         } else if (e >= 0) {
             xLength = sizeOfTenToTheE(e) + length + ((-k) shr 6) + 1
-            x = ULongArray(xLength)
+            x = ULongArray(xLength).unsafe()
             f.copyInto(x, 0, 0, length)
             timesTenToTheEHighPrecision(x, xLength, e)
             simpleShiftLeftHighPrecision(x, xLength, -k)
 
             yLength = 1
-            y = ULongArray(1)
+            y = ULongArray(1).unsafe()
             y[0] = m
         } else if (k >= 0) {
             xLength = length
             x = f
 
             yLength = sizeOfTenToTheE(-e) + 2 + (k shr 6)
-            y = ULongArray(yLength)
+            y = ULongArray(yLength).unsafe()
             y[0] = m
             timesTenToTheEHighPrecision(y, yLength, -e)
             simpleShiftLeftHighPrecision(y, yLength, k)
         } else {
             xLength = length + ((-k) shr 6) + 1
-            x = ULongArray(xLength)
+            x = ULongArray(xLength).unsafe()
             f.copyInto(x, 0, 0, length)
             simpleShiftLeftHighPrecision(x, xLength, -k)
 
             yLength = sizeOfTenToTheE(-e) + 1
-            y = ULongArray(yLength)
+            y = ULongArray(yLength).unsafe()
             y[0] = m
             timesTenToTheEHighPrecision(y, yLength, -e)
         }
@@ -312,24 +314,25 @@ private fun floatAlgorithm(f: ULongArray, length: Int, e: Int, z: Float): Float 
         comparison = compareHighPrecision(x, xLength, y, yLength)
         if (comparison > 0) {                       /* x > y */
             DLength = xLength
-            D = ULongArray(DLength)
+            D = ULongArray(DLength).unsafe()
             x.copyInto(D, 0, 0, DLength)
             subtractHighPrecision(D, DLength, y, yLength)
         } else if (comparison != 0) {                       /* y > x */
             DLength = yLength
-            D = ULongArray(DLength)
+            D = ULongArray(DLength).unsafe()
             y.copyInto(D, 0, 0, DLength)
             subtractHighPrecision(D, DLength, x, xLength)
         } else {                       /* y == x */
             DLength = 1
-            D = ULongArray(1)
+            D = ULongArray(1).unsafe()
             D[0] = 0UL
         }
 
         D2Length = DLength + 1
-        D2 = ULongArray(D2Length)
+        D2 = ULongArray(D2Length).unsafe()
         m = m shl 1
-        multiplyHighPrecision(D, DLength, ulongArrayOf(m), 1, D2, D2Length)
+        mArray[0] = m
+        multiplyHighPrecision(D, DLength, mArray, 1, D2, D2Length)
         m = m shr 1
 
         comparison2 = compareHighPrecision(D2, D2Length, y, yLength)

--- a/libraries/stdlib/wasm/src/kotlin/internal/dtoa/UnsafeArrays.kt
+++ b/libraries/stdlib/wasm/src/kotlin/internal/dtoa/UnsafeArrays.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.internal.dtoa
+
+import kotlin.wasm.internal.copyWasmArray
+
+internal actual fun longArrayGetUnsafe(array: LongArray, index: Int): Long =
+    array.storage.get(index)
+
+internal actual fun longArraySetUnsafe(array: LongArray, index: Int, value: Long): Unit =
+    array.storage.set(index, value)
+
+internal actual fun doubleArrayGetUnsafe(array: DoubleArray, index: Int): Double =
+    array.storage.get(index)
+
+internal actual fun doubleArraySetUnsafe(array: DoubleArray, index: Int, value: Double): Unit =
+    array.storage.set(index, value)
+
+internal actual fun intArrayGetUnsafe(array: IntArray, index: Int): Int =
+    array.storage.get(index)
+
+internal actual fun intArraySetUnsafe(array: IntArray, index: Int, value: Int): Unit =
+    array.storage.set(index, value)
+
+internal actual fun copyIntoUnsafe(source: LongArray, destination: LongArray, destinationOffset: Int, startIndex: Int, endIndex: Int) {
+    copyWasmArray(source.storage, destination.storage, startIndex, destinationOffset, endIndex - startIndex)
+}


### PR DESCRIPTION
Fix KT-89017

This makes Kotlin/Native benchmarks back to base performance:
<img width="716" height="71" alt="image_720" src="https://github.com/user-attachments/assets/86de49ad-2758-4441-88bc-1e12c2e6efa8" />

Wasm benchmark results are under their way.
